### PR TITLE
STR-1083 : switch over to sha256_u4_stack.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5867,7 +5867,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6495,7 +6495,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9560,7 +9560,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "bitvm"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/BitVM.git?branch=testnet-i#b8d349f789b59f2e6fd45738d281c713f3d68328"
+source = "git+https://github.com/alpenlabs/BitVM.git?branch=testnet-i#f7fd93e9c9187100e7c9b7b68e07f9f7c568a843"
 dependencies = [
  "ark-bn254",
  "ark-crypto-primitives",
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "bitvm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/BitVM.git?branch=testnet-i#b8d349f789b59f2e6fd45738d281c713f3d68328"
+source = "git+https://github.com/alpenlabs/BitVM.git?branch=testnet-i#f7fd93e9c9187100e7c9b7b68e07f9f7c568a843"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.19",
@@ -2184,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5867,7 +5867,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6495,7 +6495,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8662,7 +8662,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9560,7 +9560,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/tx-graph/src/connectors/connector_a31.rs
+++ b/crates/tx-graph/src/connectors/connector_a31.rs
@@ -19,7 +19,7 @@ use strata_bridge_primitives::{
 
 use crate::partial_verification_scripts::PARTIAL_VERIFIER_SCRIPTS;
 
-// define a U512 type to enable transformation fucntions on the 64 byte inputs to the hash functions
+// define a U512 type to enable transformation functions on the 64 byte inputs to the hash functions
 pub type U512 = BigIntImpl<512, 8>;
 
 /// Connector from the PostAssert transaction to the Disprove transaction.
@@ -88,7 +88,7 @@ impl ConnectorA31Leaf {
 
                     // OPTIMIZE: Currently, treated the code above as a blackbox and a drop in replacement
                     // to the previous version of sha256 to get ensure there are no more hiccups in switching over to
-                    // sha256_u4_stack. Will look into above stack elememts and get rid of redundant stack operations.
+                    // sha256_u4_stack. Will look into above stack elements and get rid of redundant stack operations.
 
 
                     //The stack version of sha256 requires that the most significant nibble be on the top of the stack

--- a/crates/tx-graph/src/connectors/connector_a31.rs
+++ b/crates/tx-graph/src/connectors/connector_a31.rs
@@ -90,7 +90,7 @@ impl ConnectorA31Leaf {
                     {U256::transform_limbsize(8, 4)}
 
 
-                    //The stack version of sha256 requires that the most significant nibble be on the top of the stack
+                    // The stack version of sha256 requires that the most significant nibble be on the top of the stack
                     // the 128 nibbles to be hashed is reversed first
                     for i in (1..=127).rev(){
                         {i} OP_ROLL

--- a/crates/tx-graph/src/connectors/connector_a31.rs
+++ b/crates/tx-graph/src/connectors/connector_a31.rs
@@ -84,35 +84,35 @@ impl ConnectorA31Leaf {
 
                     // since sha256_stack requires input in nibble form.
                     // convert 32 bytes (256 bits) deposit txid to nibbles
-                    {U256::transform_limbsize(8, 4)}
+                    { U256::transform_limbsize(8, 4) }
 
 
                     // The stack version of sha256 requires that the most significant nibble be on the top of the stack
                     // the 128 nibbles to be hashed is reversed first
                     for i in (1..=127).rev(){
-                        {i} OP_ROLL
+                        { i } OP_ROLL
                         OP_TOALTSTACK
                     }
                     for _ in 1..=127{ OP_FROMALTSTACK }
 
                     // change the endianness
                     for _ in (0..128).step_by(2) {
-                        OP_SWAP 
-                        OP_TOALTSTACK 
+                        OP_SWAP
+                        OP_TOALTSTACK
                         OP_TOALTSTACK
                     }
-                    for _ in 0..128 {OP_FROMALTSTACK}
+                    for _ in 0..128 { OP_FROMALTSTACK }
 
                     // hash the deposit txid and the withdrawal fulfillment txid to get the public
                     // inputs hash
                     { sha256_script(2 * 32)}
 
                     // convert the hash from nibble representation to bytes
-                    {U256::transform_limbsize(4, 8)}
+                    { U256::transform_limbsize(4, 8) }
 
                     //reverse the hash on stack
                     for i in (1..=31).rev(){
-                        {i} OP_ROLL
+                        { i } OP_ROLL
                         OP_TOALTSTACK
                     }
                     for _ in 1..=31 { OP_FROMALTSTACK }
@@ -123,7 +123,7 @@ impl ConnectorA31Leaf {
                     // verify that the computed hash and the committed inputs hash don't match
                     for i in (1..32).rev() {
                         // compare the last bytes first
-                        {i + 1} OP_ROLL
+                        { i + 1 } OP_ROLL
                         // check if they are equal and push the result to the altstack
                         OP_EQUAL OP_TOALTSTACK
                     }

--- a/crates/tx-graph/src/connectors/connector_a31.rs
+++ b/crates/tx-graph/src/connectors/connector_a31.rs
@@ -93,10 +93,14 @@ impl ConnectorA31Leaf {
                         {i} OP_ROLL
                         OP_TOALTSTACK
                     }
-                    for _ in 0..127{ OP_FROMALTSTACK }
+                    for _ in 1..=127{ OP_FROMALTSTACK }
 
                     // change the endianness
-                    for _ in 0..64{OP_SWAP OP_TOALTSTACK OP_TOALTSTACK}
+                    for _ in (0..128).step_by(2) {
+                        OP_SWAP 
+                        OP_TOALTSTACK 
+                        OP_TOALTSTACK
+                    }
                     for _ in 0..128 {OP_FROMALTSTACK}
 
                     // hash the deposit txid and the withdrawal fulfillment txid to get the public
@@ -111,7 +115,7 @@ impl ConnectorA31Leaf {
                         {i} OP_ROLL
                         OP_TOALTSTACK
                     }
-                    for _ in 0..31{ OP_FROMALTSTACK }
+                    for _ in 1..=31 { OP_FROMALTSTACK }
 
                     // convert the hash to a bn254 field element
                     hash_to_bn254_fq

--- a/crates/tx-graph/src/connectors/connector_a31.rs
+++ b/crates/tx-graph/src/connectors/connector_a31.rs
@@ -59,43 +59,55 @@ impl ConnectorA31Leaf {
             ConnectorA31Leaf::DisprovePublicInputsCommitment { deposit_txid, .. } => {
                 script! {
                     // first, verify that the WOTS for withdrawal fulfillment txid is correct.
+                    // `checksig_verify` pushes the committed data onto the stack as nibbles in big-endian form.
+                    // Assuming front as the top of stack we get Stack : [a,b,...,1,2] ; Alt-stack : []
                     { wots256::compact::checksig_verify(withdrawal_fulfillment_pk.0) }
 
-                    // `checksig_verify` pushes the committed data onto the stack as nibbles.
                     // send the 64 nibbles to altstack
+                    // Stack : [] ; Alt-Stack : [2,1,...,b,a]
                     for _ in 0..64{ OP_TOALTSTACK }
 
                     // second, verify that the WOTS for public inputs hash is correct.
+                    // Stack : [c,d,...,3,4] Alt-stack : [2,1,...,b,a]
                     { wots256::compact::checksig_verify(public_inputs_hash_public_key) }
-                    // `checksig_verify` pushes the committed data onto the stack as nibbles.
+
                     // multiply each nibble by 16 and add them to together to get the byte.
                     // finally, push the byte to the ALTSTACK.
+                    // Stack : [] Alt-stack : [34,...,cd,2,1,...,b,a]
                     for _ in 0..32 { { NMUL(1 << 4) } OP_ADD OP_TOALTSTACK }
 
-                    // get the committed public inputs hash from the altstack.
+                    // get the 32 bytes of committed public inputs hash from the altstack.
+                    // Stack : [cd,...,34] Alt-stack : [2,1,...,b,a]
                     for _ in 0..32 { OP_FROMALTSTACK }
-                    // get the committed withdrawal fulfillment txid from the altstack.
+
+                    // get the 64 nibbles of committed withdrawal fulfillment txid from the altstack.
+                    // Stack : [a,b,...,1,2,cd,...,34] Alt-stack : []
                     for _ in 0..64 { OP_FROMALTSTACK }
 
                     // include the deposit txid in the script to couple proofs with deposits.
                     // this is part of the commitment to the public inputs (along with the
                     // withdrawal_fulfillment txid.
+                    // Stack : [ef,...,56,a,b,...,1,2,cd,...,34] Alt-stack : []
                     for &b in deposit_txid.to_byte_array().iter().rev() { { b } } // add_bincode_padding_bytes32
 
                     // since sha256_stack requires input in nibble form.
                     // convert 32 bytes (256 bits) deposit txid to nibbles
+                    // Stack : [e,f,...,5,6,a,b,...,1,2,cd,...,34] Alt-stack : []
                     { U256::transform_limbsize(8, 4) }
 
 
                     // The stack version of sha256 requires that the most significant nibble be on the top of the stack
                     // the 128 nibbles to be hashed is reversed first
+                    // Stack : [2,1,...,b,a,6,5,...,f,e,cd,...,34] Alt-stack : []
                     for i in (1..=127).rev(){
                         { i } OP_ROLL
                         OP_TOALTSTACK
                     }
                     for _ in 1..=127{ OP_FROMALTSTACK }
 
-                    // change the endianness
+                    // The above message is in little-endian which needs to be converted to big-endian.
+                    // This is done by swapping the adjacent nibbles of each byte
+                    // Stack : [1,2,...,a,b,5,6,...,e,f,cd,...,34] Alt-stack : []
                     for _ in (0..128).step_by(2) {
                         OP_SWAP
                         OP_TOALTSTACK

--- a/crates/tx-graph/src/connectors/connector_a31.rs
+++ b/crates/tx-graph/src/connectors/connector_a31.rs
@@ -5,7 +5,7 @@ use bitcoin::{
     Address, Network, ScriptBuf, Txid,
 };
 use bitvm::{
-    bigint::{BigIntImpl, U256},
+    bigint::U256,
     groth16::g16::{self, N_TAPLEAVES},
     hash::sha256_u4_stack::sha256_script,
     pseudo::NMUL,
@@ -18,9 +18,6 @@ use strata_bridge_primitives::{
 };
 
 use crate::partial_verification_scripts::PARTIAL_VERIFIER_SCRIPTS;
-
-// define a U512 type to enable transformation functions on the 64 byte inputs to the hash functions
-pub type U512 = BigIntImpl<512, 8>;
 
 /// Connector from the PostAssert transaction to the Disprove transaction.
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
The current connector_a31 used a script inefficient version of SHA-256 implementation from the BitVM library. The `sha256` has been switched to `sha256_u4_stack`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes: [STR-1083](https://alpenlabs.atlassian.net/browse/STR-1083)


[STR-1083]: https://alpenlabs.atlassian.net/browse/STR-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ