### PR TITLE
fix: dead link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following is the system diagram for this repository:
 ### Prerequisites
 
 -   [cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html).
--   [SP1 Toolchain](https://docs.succinct.xyz/docs/getting-started/install) and associated [linkers](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/tag/v14.2.0-2).
+-   [SP1 Toolchain](https://docs.succinct.xyz/docs/sp1/getting-started/install) and associated [linkers](https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/tag/v14.2.0-2).
 -   Credentials to connect to SP1's [infra](https://explorer.succinct.xyz).
 -   [Docker](https://docs.docker.com/get-docker/).
 -   [`sqlx-cli`](https://lib.rs/crates/sqlx-cli) to run database migrations.


### PR DESCRIPTION
## Description

Hi! I fixes a dead link in the README.md file. The link to the SP1 Toolchain installation documentation was outdated and has been updated to the correct URL.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update


## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
