### PR TITLE
add height support to transaction events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ ark-std = { git = "https://github.com/arkworks-rs/std/" }
 async-trait = "0.1.81"
 base64 = "0.22.1"
 bincode = "1.3.3"
+# TODO(proofofkeags): when updating `bitcoin` to >=0.33.0, go through btc-notify and update tests to no longer constrain heights.
 bitcoin = { version = "0.32.5", features = ["rand-std", "serde"] }
 bitcoin-bosd = "0.4.0"
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }

--- a/crates/btc-notify/src/client.rs
+++ b/crates/btc-notify/src/client.rs
@@ -450,7 +450,13 @@ mod e2e_tests {
             .remove(0);
         let observed = tx_sub.next().await.unwrap();
         assert_eq!(observed.rawtx.compute_txid(), txid);
-        assert_eq!(observed.status, TxStatus::Mined { blockhash });
+        assert_eq!(
+            observed.status,
+            TxStatus::Mined {
+                blockhash,
+                height: 102
+            }
+        );
 
         // Now we invalidate the block we just mined, simulating a reorg. We should now get an
         // Unknown event for that transaction as it is evicted from the landscape.
@@ -490,9 +496,21 @@ mod e2e_tests {
             .0
             .remove(0);
         let observed = tx_sub.next().await.unwrap();
-        assert_eq!(observed.status, TxStatus::Mined { blockhash });
+        assert_eq!(
+            observed.status,
+            TxStatus::Mined {
+                blockhash,
+                height: 102
+            }
+        );
         let observed = tx_sub.next().await.unwrap();
-        assert_eq!(observed.status, TxStatus::Mined { blockhash });
+        assert_eq!(
+            observed.status,
+            TxStatus::Mined {
+                blockhash,
+                height: 102
+            }
+        );
 
         // Explicitly drop the client here to prevent rustc from "optimizing" the code and dropping
         // it earlier, aborting the producer thread.

--- a/crates/btc-notify/src/event.rs
+++ b/crates/btc-notify/src/event.rs
@@ -23,6 +23,9 @@ pub enum TxStatus {
     Mined {
         /// This is the block hash of the block in which this transaction is included.
         blockhash: BlockHash,
+
+        /// This is the height of the block in which this transaction is included.
+        height: u64,
     },
     /// Terminal status. It will be emitted once the transaction's containing block has
     /// been buried under a sufficient number of subsequent blocks.
@@ -33,6 +36,11 @@ pub enum TxStatus {
         ///
         /// It is the same as the block hash in which it was mined but is included for redundancy.
         blockhash: BlockHash,
+
+        /// This is the height of the block in which this transaction is included.
+        ///
+        /// It is the same as the height in which it was mined but it is included for redundancy.
+        height: u64,
     },
 }
 


### PR DESCRIPTION
## Description

It has been in the backlog to have transaction events include block heights. It turns out that bip34 offers a consensus enforced way of getting this in the block data itself. It is brittle in the context of testnet4 and regtest right now. For that reason this implementation will set this value to zero if it cannot be recovered which confers a responsibility on the consumer to check for that for the time being.

Once rust-bitcoin 0.33.0 lands, this won't be necessary any longer since that is the first release where this bug will be fixed. For now we dodge the scenarios where this value isn't properly defined by enforcing that the test code doesn't use block heights between 0 and 16.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
