### PR TITLE
Move WOTS pubkeys to `PegOutGraphInput`

### DIFF
--- a/crates/agent/src/operator.rs
+++ b/crates/agent/src/operator.rs
@@ -283,6 +283,13 @@ where
             .unwrap(); // FIXME: Handle me
 
         info!(action = "composing peg out graph input", %deposit_txid, %own_index);
+        let wots_public_keys = self
+            .public_db
+            .get_wots_public_keys(own_index, deposit_txid)
+            .await
+            .expect("should be able to get wots public keys")
+            .unwrap(); // FIXME: Handle me
+
         let peg_out_graph_input = PegOutGraphInput {
             deposit_amount: BRIDGE_DENOMINATION,
             operator_pubkey: self.agent.public_key().x_only_public_key().0,
@@ -296,24 +303,17 @@ where
                 vout: WITHDRAWAL_FULFILLMENT_VOUT,
             },
             stake_hash: stake_data.hash,
+            prev_claim_txids: vec![],
+            wots_public_keys,
         };
 
         info!(action = "generating pegout graph and connectors", %deposit_txid, %own_index);
-        let wots_public_keys = self
-            .public_db
-            .get_wots_public_keys(own_index, deposit_txid)
-            .await
-            .expect("should be able to get wots public keys")
-            .unwrap(); // FIXME: Handle me
-
         let (peg_out_graph, _connectors) = PegOutGraph::generate(
             peg_out_graph_input.clone(),
             &self.build_context,
             deposit_txid,
             own_index,
             StakeChainParams::default(),
-            vec![],
-            wots_public_keys,
         )
         .expect("must be able to generate tx graph");
 
@@ -551,12 +551,6 @@ where
                     } = details;
                     info!(event = "received covenant request for nonce", %deposit_txid, %sender_id, %own_index);
 
-                    let wots_public_keys = self
-                        .public_db
-                        .get_wots_public_keys(sender_id, deposit_txid)
-                        .await
-                        .expect("should be able to get wots public keys")
-                        .unwrap(); // FIXME: Handle me
                     let (
                         PegOutGraph {
                             assert_chain,
@@ -571,8 +565,6 @@ where
                         deposit_txid,
                         sender_id,
                         StakeChainParams::default(),
-                        vec![],
-                        wots_public_keys,
                     )
                     .expect("should be able to generate tx graph");
 
@@ -954,20 +946,12 @@ where
                         peg_out_graph_input,
                     } = details;
                     info!(event = "received covenant request for signatures", %deposit_txid, %sender_id, %own_index);
-                    let wots_public_keys = self
-                        .public_db
-                        .get_wots_public_keys(sender_id, deposit_txid)
-                        .await
-                        .expect("should be able to get wots public keys")
-                        .unwrap(); // FIXME: Handle me
                     let (peg_out_graph, _connectors) = PegOutGraph::generate(
                         peg_out_graph_input,
                         &self.build_context,
                         deposit_txid,
                         sender_id,
                         StakeChainParams::default(),
-                        vec![],
-                        wots_public_keys,
                     )
                     .expect("should be able to generate tx graph");
 
@@ -1595,6 +1579,12 @@ where
             .unwrap()
             .unwrap(); // FIXME:
                        // Handle me
+        let wots_public_keys = self
+            .public_db
+            .get_wots_public_keys(own_index, deposit_txid)
+            .await
+            .unwrap()
+            .unwrap();
 
         info!(action = "reconstructing pegout graph", %deposit_txid, %own_index);
         let peg_out_graph_input = PegOutGraphInput {
@@ -1611,22 +1601,16 @@ where
                 vout: WITHDRAWAL_FULFILLMENT_VOUT,
             },
             stake_hash: stake_data.hash,
+            prev_claim_txids: vec![],
+            wots_public_keys,
         };
 
-        let wots_public_keys = self
-            .public_db
-            .get_wots_public_keys(own_index, deposit_txid)
-            .await
-            .expect("should be able to get wots public keys")
-            .unwrap(); // FIXME: Handle me
         let (peg_out_graph, connectors) = PegOutGraph::generate(
             peg_out_graph_input,
             &self.build_context,
             deposit_txid,
             own_index,
             StakeChainParams::default(),
-            vec![],
-            wots_public_keys,
         )
         .expect("should be able to generate tx graph");
 

--- a/crates/agent/src/operator.rs
+++ b/crates/agent/src/operator.rs
@@ -2112,7 +2112,6 @@ where
             .0;
 
         let l1_start_height = (checkpoint_info.l1_range.1.height() + 1) as u32;
-        let mut block_count = 0;
 
         let btc_params = get_btc_params();
 
@@ -2133,6 +2132,7 @@ where
         let mut checkpoint = None;
 
         info!(action = "scanning blocks...", %deposit_txid, %withdrawal_fulfillment_txid, start_height=%height);
+        let mut num_blocks_after_fulfillment = 0;
         let poll_interval = Duration::from_secs(self.btc_poll_interval.as_secs() / 2);
         loop {
             let block = self.agent.btc_client.get_block_at(height.into()).await;
@@ -2194,9 +2194,11 @@ where
             blocks.push(block);
             height += 1;
 
-            block_count += 1;
+            if withdrawal_fulfillment.is_some() {
+                num_blocks_after_fulfillment += 1;
+            }
 
-            if block_count >= EXPECTED_BLOCK_COUNT {
+            if num_blocks_after_fulfillment > EXPECTED_BLOCK_COUNT {
                 info!(event = "blocks period complete", total_blocks = %headers.len());
                 break;
             }

--- a/crates/agent/src/operator.rs
+++ b/crates/agent/src/operator.rs
@@ -45,7 +45,9 @@ use strata_bridge_primitives::{
     wots::{Assertions, PublicKeys as WotsPublicKeys, Signatures as WotsSignatures},
 };
 use strata_bridge_proof_primitives::L1TxWithProofBundle;
-use strata_bridge_proof_protocol::BridgeProofInput;
+use strata_bridge_proof_protocol::{
+    BridgeProofInput, REQUIRED_NUM_OF_HEADERS_AFTER_WITHDRAWAL_FULFILLMENT_TX,
+};
 use strata_bridge_proof_snark::{bridge_vk, prover};
 use strata_bridge_stake_chain::{
     prelude::{PreStakeTx, OPERATOR_FUNDS, STAKE_VOUT, WITHDRAWAL_FULFILLMENT_VOUT},
@@ -2198,7 +2200,9 @@ where
                 num_blocks_after_fulfillment += 1;
             }
 
-            if num_blocks_after_fulfillment > EXPECTED_BLOCK_COUNT {
+            if num_blocks_after_fulfillment
+                > REQUIRED_NUM_OF_HEADERS_AFTER_WITHDRAWAL_FULFILLMENT_TX
+            {
                 info!(event = "blocks period complete", total_blocks = %headers.len());
                 break;
             }

--- a/crates/bridge-proof/protocol/src/lib.rs
+++ b/crates/bridge-proof/protocol/src/lib.rs
@@ -137,3 +137,4 @@ pub fn process_bridge_proof_outer(zkvm: &impl ZkVmEnv) {
 }
 
 pub use prover::{get_native_host, BridgeProver};
+pub use statement::REQUIRED_NUM_OF_HEADERS_AFTER_WITHDRAWAL_FULFILLMENT_TX;

--- a/crates/bridge-proof/protocol/src/statement.rs
+++ b/crates/bridge-proof/protocol/src/statement.rs
@@ -15,7 +15,7 @@ use crate::{
 /// input
 ///
 /// TODO: update this once this is fixed
-const REQUIRED_NUM_OF_HEADERS_AFTER_WITHDRAWAL_FULFILLMENT_TX: usize = 30;
+pub const REQUIRED_NUM_OF_HEADERS_AFTER_WITHDRAWAL_FULFILLMENT_TX: usize = 30;
 
 /// The fixed withdrawal fee for Bitcoin transactions.
 ///

--- a/crates/primitives/src/params/connectors.rs
+++ b/crates/primitives/src/params/connectors.rs
@@ -104,17 +104,11 @@ const _: [(); 0] = [(); (NUM_PKS_A256 + NUM_PKS_A160 - TOTAL_VALUES)];
 
 pub const BLOCK_TIME: Duration = Duration::from_secs(30);
 
-/// The number of blocks expected after the block that contains the withdrawal fulfillment
-/// transaction for a valid proof.
-pub const EXPECTED_BLOCK_COUNT: u32 = 50; // blocks
-
 pub const PAYOUT_OPTIMISTIC_TIMELOCK: u32 = 500;
 
 pub const PRE_ASSERT_TIMELOCK: u32 = PAYOUT_OPTIMISTIC_TIMELOCK + 100; // 100 is slack
 
 // compile-time checks
 const _: () = assert!(PRE_ASSERT_TIMELOCK > PAYOUT_OPTIMISTIC_TIMELOCK);
-
-const _: u32 = PAYOUT_OPTIMISTIC_TIMELOCK - (EXPECTED_BLOCK_COUNT + 100); // 100 is slack
 
 pub const PAYOUT_TIMELOCK: u32 = 288; // 2 day's worth of blocks in mainnet

--- a/crates/primitives/src/params/connectors.rs
+++ b/crates/primitives/src/params/connectors.rs
@@ -104,6 +104,8 @@ const _: [(); 0] = [(); (NUM_PKS_A256 + NUM_PKS_A160 - TOTAL_VALUES)];
 
 pub const BLOCK_TIME: Duration = Duration::from_secs(30);
 
+/// The number of blocks expected after the block that contains the withdrawal fulfillment
+/// transaction for a valid proof.
 pub const EXPECTED_BLOCK_COUNT: u32 = 50; // blocks
 
 pub const PAYOUT_OPTIMISTIC_TIMELOCK: u32 = 500;

--- a/crates/primitives/src/params/connectors.rs
+++ b/crates/primitives/src/params/connectors.rs
@@ -104,7 +104,7 @@ const _: [(); 0] = [(); (NUM_PKS_A256 + NUM_PKS_A160 - TOTAL_VALUES)];
 
 pub const BLOCK_TIME: Duration = Duration::from_secs(30);
 
-pub const EXPECTED_BLOCK_COUNT: u32 = 100; // blocks
+pub const EXPECTED_BLOCK_COUNT: u32 = 50; // blocks
 
 pub const PAYOUT_OPTIMISTIC_TIMELOCK: u32 = 500;
 

--- a/crates/tx-graph/src/transactions/assert_chain.rs
+++ b/crates/tx-graph/src/transactions/assert_chain.rs
@@ -1,6 +1,6 @@
 use bitcoin::{Amount, Txid};
 use strata_bridge_connectors::prelude::*;
-use strata_bridge_primitives::{params::connectors::*, types::OperatorIdx};
+use strata_bridge_primitives::params::connectors::*;
 use tracing::trace;
 
 use super::prelude::*;
@@ -30,10 +30,8 @@ impl AssertChain {
     /// Constructs a new instance of the assert chain.
     ///
     /// This method constructs the pre-assert, assert data, and post-assert transactions in order.
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         data: AssertChainData,
-        operator_idx: OperatorIdx,
         connector_c0: ConnectorC0,
         connector_a2: ConnectorNOfN,
         connector_a3: ConnectorA3,
@@ -59,7 +57,7 @@ impl AssertChain {
             connector_a160_factory,
         );
         let pre_assert_txid = pre_assert.compute_txid();
-        trace!(event = "created pre-assert tx", %pre_assert_txid, %operator_idx);
+        trace!(event = "created pre-assert tx", %pre_assert_txid);
 
         let assert_data_input = AssertDataTxInput {
             pre_assert_txid,
@@ -70,7 +68,7 @@ impl AssertChain {
         let assert_data = AssertDataTxBatch::new(assert_data_input, connector_a2, connector_cpfp);
 
         let assert_data_txids = assert_data.compute_txids().to_vec();
-        trace!(event = "created assert_data tx batch", ?assert_data_txids, %operator_idx);
+        trace!(event = "created assert_data tx batch", ?assert_data_txids);
 
         let input_amount = assert_data
             .psbts()
@@ -86,15 +84,10 @@ impl AssertChain {
             deposit_txid: data.deposit_txid,
         };
 
-        let post_assert = PostAssertTx::new(
-            post_assert_data,
-            operator_idx,
-            connector_a2,
-            connector_a3,
-            connector_cpfp,
-        );
+        let post_assert =
+            PostAssertTx::new(post_assert_data, connector_a2, connector_a3, connector_cpfp);
 
-        trace!(event = "created post_assert tx", post_assert_txid = ?post_assert.compute_txid(), %operator_idx);
+        trace!(event = "created post_assert tx", post_assert_txid = ?post_assert.compute_txid());
 
         Self {
             pre_assert,

--- a/crates/tx-graph/src/transactions/post_assert.rs
+++ b/crates/tx-graph/src/transactions/post_assert.rs
@@ -2,7 +2,7 @@ use bitcoin::{sighash::Prevouts, transaction, Amount, OutPoint, Psbt, Transactio
 use secp256k1::schnorr::Signature;
 use serde::{Deserialize, Serialize};
 use strata_bridge_connectors::prelude::*;
-use strata_bridge_primitives::{params::prelude::*, scripts::prelude::*, types::OperatorIdx};
+use strata_bridge_primitives::{params::prelude::*, scripts::prelude::*};
 use tracing::trace;
 
 use super::covenant_tx::CovenantTx;
@@ -42,7 +42,6 @@ impl PostAssertTx {
     /// Constructs a new instance of the post-assert transaction.
     pub fn new(
         data: PostAssertTxData,
-        operator_idx: OperatorIdx,
         connector_a2: ConnectorNOfN,
         connector_a3: ConnectorA3,
         connector_cpfp: ConnectorCpfp,
@@ -55,12 +54,12 @@ impl PostAssertTx {
 
         let tx_ins = create_tx_ins(utxos);
 
-        trace!(event = "created tx ins", count = tx_ins.len(), %operator_idx);
+        trace!(event = "created tx ins", count = tx_ins.len());
 
         let connector_a31_script = connector_a3.generate_locking_script(data.deposit_txid);
         trace!(
             event = "generated a31 locking script",
-            size = connector_a31_script.len(), %operator_idx,
+            size = connector_a31_script.len(),
         );
 
         let cpfp_script = connector_cpfp.generate_locking_script();
@@ -73,7 +72,7 @@ impl PostAssertTx {
         ];
 
         let tx_outs = create_tx_outs(scripts_and_amounts);
-        trace!(event = "created tx outs", count = tx_outs.len(), %operator_idx);
+        trace!(event = "created tx outs", count = tx_outs.len());
 
         let mut tx = create_tx(tx_ins, tx_outs);
         tx.version = transaction::Version(3);
@@ -89,7 +88,7 @@ impl PostAssertTx {
             })
             .collect::<Vec<TxOut>>();
 
-        trace!(event = "created prevouts", count = prevouts.len(), %operator_idx);
+        trace!(event = "created prevouts", count = prevouts.len());
 
         for (input, utxo) in psbt.inputs.iter_mut().zip(prevouts.clone()) {
             input.witness_utxo = Some(utxo);


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR:

* makes `wots::PublicKeys` a part of the `PegOutGraphInput` struct so that it corresponds more directly to `DepositSetup` message in `strata-p2p`.
* fixes a bug in the `agent` crate where the bitcoin chain segment only counted blocks after the last verified bitcoin height  for the given strata checkpoint.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
