### PR TITLE
manual paths for p2p and operator keys

### DIFF
--- a/bin/secret-service/src/seeded_impl/mod.rs
+++ b/bin/secret-service/src/seeded_impl/mod.rs
@@ -85,11 +85,11 @@ impl SecretService<Server, ServerFirstRound, ServerSecondRound> for Service {
     type StakeChainPreimages = StakeChain;
 
     fn operator_signer(&self) -> Self::OperatorSigner {
-        Operator::new(self.keys.wallet_xpriv().private_key)
+        Operator::new(self.keys.base_xpriv())
     }
 
     fn p2p_signer(&self) -> Self::P2PSigner {
-        ServerP2PSigner::new(self.keys.message_xpriv().private_key)
+        ServerP2PSigner::new(self.keys.base_xpriv())
     }
 
     fn musig2_signer(&self) -> Self::Musig2Signer {

--- a/bin/secret-service/src/seeded_impl/p2p.rs
+++ b/bin/secret-service/src/seeded_impl/p2p.rs
@@ -1,8 +1,11 @@
 //! In-memory persistence for operator's P2P secret data.
 
-use musig2::secp256k1::SecretKey;
+use bitcoin::bip32::Xpriv;
+use musig2::secp256k1::{SecretKey, SECP256K1};
 use secret_service_proto::v1::traits::{Origin, P2PSigner, Server};
 use strata_bridge_primitives::secp::EvenSecretKey;
+
+use super::paths::P2P_KEY_PATH;
 
 /// Secret data for the P2P signer.
 #[derive(Debug)]
@@ -13,7 +16,11 @@ pub struct ServerP2PSigner {
 
 impl ServerP2PSigner {
     /// Creates a new [`ServerP2PSigner`] with the given secret key.
-    pub fn new(sk: SecretKey) -> Self {
+    pub fn new(base: &Xpriv) -> Self {
+        let sk = base
+            .derive_priv(SECP256K1, &P2P_KEY_PATH)
+            .expect("good child key")
+            .private_key;
         Self {
             sk: *EvenSecretKey::from(sk),
         }

--- a/bin/secret-service/src/seeded_impl/paths.rs
+++ b/bin/secret-service/src/seeded_impl/paths.rs
@@ -31,3 +31,15 @@ pub const STAKECHAIN_PREIMG_IKM_PATH: &[ChildNumber] = &[
     ChildNumber::Hardened { index: 80 },
     ChildNumber::Hardened { index: 0 },
 ];
+
+/// Path for the P2P key
+pub const P2P_KEY_PATH: &[ChildNumber] = &[
+    ChildNumber::Hardened { index: 20 },
+    ChildNumber::Hardened { index: 100 },
+];
+
+/// Path for the operator key
+pub const OPERATOR_KEY_PATH: &[ChildNumber] = &[
+    ChildNumber::Hardened { index: 20 },
+    ChildNumber::Hardened { index: 102 },
+];


### PR DESCRIPTION
## Description

This provides a fix for STR-1148 where the secret service wasn't using hardened paths due to some upstream issues in strata-key-derivation by hardcoding the paths.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
