### PR TITLE
STR-1177: Adds Stake Index Metadata to Deposit Transaction `OP_RETURN`

### DIFF
--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -150,9 +150,13 @@ impl ContractManagerCtx {
             }
 
             let txid = tx.compute_txid();
-            if let Some(deposit_info) =
-                deposit_request_info(&tx, &self.sidesystem_params, &self.pegout_graph_params)
-            {
+            let stake_index = self.next_deposit_idx;
+            if let Some(deposit_info) = deposit_request_info(
+                &tx,
+                &self.sidesystem_params,
+                &self.pegout_graph_params,
+                stake_index,
+            ) {
                 let deposit_tx = match deposit_info.construct_signing_data(
                     &self.operator_table.tx_build_context(self.network),
                     self.pegout_graph_params.deposit_amount,

--- a/crates/duty-tracker/src/predicates.rs
+++ b/crates/duty-tracker/src/predicates.rs
@@ -41,6 +41,7 @@ pub(crate) fn deposit_request_info(
     tx: &Transaction,
     sidesystem_params: &SideSystemParams,
     pegout_graph_params: &PegOutGraphParams,
+    stake_index: u32,
 ) -> Option<DepositInfo> {
     let deposit_request_output = tx.output.first()?;
     if deposit_request_output.value <= pegout_graph_params.deposit_amount {
@@ -62,6 +63,7 @@ pub(crate) fn deposit_request_info(
 
     Some(DepositInfo::new(
         OutPoint::new(tx.compute_txid(), 0),
+        stake_index,
         el_addr.to_vec(),
         deposit_request_output.value,
         TapNodeHash::from_slice(take_back_leaf_hash).unwrap(),

--- a/crates/primitives/src/scripts/general.rs
+++ b/crates/primitives/src/scripts/general.rs
@@ -55,10 +55,29 @@ pub fn get_aggregated_pubkey(pubkeys: impl IntoIterator<Item = PublicKey>) -> XO
 }
 
 /// Create the metadata script that "stores" a tag and the execution layer address information.
-pub fn metadata_script(el_address: &[u8; 20], tag: &[u8]) -> ScriptBuf {
+///
+/// # Note
+///
+/// For deposit request transactions (DRT), the stake index is not required.
+/// However, for deposit transactions (DT), the stake index is required.
+pub fn metadata_script(
+    stake_index: Option<&[u8; 4]>,
+    el_address: &[u8; 20],
+    tag: &[u8],
+) -> ScriptBuf {
     let mut data = PushBytesBuf::new();
+
+    // Adding the magic bytes
     data.extend_from_slice(tag)
         .expect("MAGIC_BYTES should be within the limit");
+
+    // Conditionally adding the stake index if provided
+    if let Some(bytes) = stake_index {
+        data.extend_from_slice(bytes)
+            .expect("stake_index_bytes should be within the limit");
+    }
+
+    // Adding the execution layer address
     data.extend_from_slice(&el_address[..])
         .expect("el_address should be within the limit");
 

--- a/crates/primitives/src/test_utils.rs
+++ b/crates/primitives/src/test_utils.rs
@@ -57,7 +57,7 @@ pub(crate) fn create_drt_taproot_output(pubkeys: PublickeyTable) -> (BitcoinAddr
     // in actual DRT, this will be the take-back leaf.
     // for testing, this could be any script as we only care about its hash.
     let tag = b"alpen";
-    let op_return_script = metadata_script(&[0u8; 20], &tag[..]);
+    let op_return_script = metadata_script(None, &[0u8; 20], &tag[..]);
     let op_return_script_hash =
         TapNodeHash::from_script(&op_return_script, taproot::LeafVersion::TapScript);
 


### PR DESCRIPTION
## Description

Adds the Stake index that is tied to a deposit transaction (DT) as the metadata in the DT inside the `OP_RETURN` as a 4-byte big-endian encoding.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This changes the `metadata_script` to take an `Option<&[u8; 4]>` as the stake index metadata. You can pass `None` for the DRT and `Some` for the DT.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1177
