### PR TITLE
feat!: DRT with X-Only PK metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9971,12 +9971,14 @@ dependencies = [
 name = "strata-bridge-primitives"
 version = "0.1.0"
 dependencies = [
+ "alpen-bridge-params",
  "anyhow",
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd",
  "bitcoin-script",
  "bitvm",
+ "miniscript",
  "musig2",
  "rkyv",
  "secp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ async-trait = "0.1.81"
 base64 = "0.22.1"
 bincode = "1.3.3"
 # TODO(proofofkeags): when updating `bitcoin` to >=0.33.0, go through btc-notify and update tests to no longer constrain heights.
-
 bitcoin = { version = "0.32.5", features = ["rand-std", "serde"] }
 bitcoin-bosd = "0.4.0"
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
@@ -137,6 +136,7 @@ libp2p-identity = { version = "0.2.10", default-features = false, features = [
   "peerid",
   "rand",
 ] }
+miniscript = "12.3.0"
 musig2 = { version = "0.1.0", features = [
   "serde",
   "rand",

--- a/bin/alpen-bridge/src/params.rs
+++ b/bin/alpen-bridge/src/params.rs
@@ -11,11 +11,6 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// behavior that will prevent the bridge from functioning.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct Params {
-    /// The tag that is used to identify bridge-specific transactions in the Bitcoin blockchain.
-    ///
-    /// This is chiefly used to identify Deposit Request and Deposit transactions.
-    pub tx_tag: String,
-
     /// The height at which the bridge node starts scanning for relevant transactions.
     pub genesis_height: u32,
 
@@ -120,7 +115,6 @@ mod tests {
         let deposit_amount = Amount::from_int_btc(1).to_sat();
         let params = format!(
             r#"
-            tx_tag = "bridge-tag"
             genesis_height = 101
 
             [keys]
@@ -128,6 +122,7 @@ mod tests {
             p2p = ["02e68354ebb3ef14caeac8f724fea1449d802133495ef1675f210b07421700a386", "03f79465fcc3ef14caeac8f724fea1449d802133495ef1675f210b07421811b497"]
 
             [tx_graph]
+            tag = "bridge-tag"
             deposit_amount = {}
             operator_fee = 1000000
             challenge_cost = 10000000

--- a/crates/params/src/default.rs
+++ b/crates/params/src/default.rs
@@ -2,6 +2,9 @@
 
 use bitcoin::{relative, Amount};
 
+/// The default tag for the bridge.
+pub(crate) const BRIDGE_TAG: &str = "alpen";
+
 /// The default denomination for each deposit to the bridge.
 pub(crate) const BRIDGE_DENOMINATION: Amount = Amount::from_int_btc(1);
 

--- a/crates/params/src/sidesystem.rs
+++ b/crates/params/src/sidesystem.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// The parameters related to the side system where the funds are bridge-in/minted.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SideSystemParams {
     /// The size of the address in the sidesystem's execution environment where the funds are
     /// minted.

--- a/crates/params/src/tx_graph.rs
+++ b/crates/params/src/tx_graph.rs
@@ -4,6 +4,7 @@ use bitcoin::Amount;
 use serde::{Deserialize, Serialize};
 
 use super::default::{BRIDGE_DENOMINATION, CHALLENGE_COST, OPERATOR_FEE, REFUND_DELAY};
+use crate::default::BRIDGE_TAG;
 
 /// The parameters required to construct a peg-out graph.
 ///
@@ -12,6 +13,9 @@ use super::default::{BRIDGE_DENOMINATION, CHALLENGE_COST, OPERATOR_FEE, REFUND_D
 // TODO: move this to the primitives crate.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PegOutGraphParams {
+    /// The tag, also known as "magic bytes".
+    pub tag: String,
+
     /// The amount that is locked in the bridge address at the deposit time.
     pub deposit_amount: Amount,
 
@@ -30,6 +34,7 @@ pub struct PegOutGraphParams {
 impl Default for PegOutGraphParams {
     fn default() -> Self {
         Self {
+            tag: BRIDGE_TAG.to_string(),
             deposit_amount: BRIDGE_DENOMINATION,
             operator_fee: OPERATOR_FEE,
             challenge_cost: CHALLENGE_COST,

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -11,6 +11,7 @@ rust.unused_crate_dependencies = "deny"
 rust.unused_must_use = "deny"
 
 [dependencies]
+alpen-bridge-params.workspace = true
 strata-primitives.workspace = true
 
 anyhow.workspace = true
@@ -19,6 +20,7 @@ bitcoin = { workspace = true, features = ["rand-std"] }
 bitcoin-bosd.workspace = true
 bitcoin-script.workspace = true
 bitvm.workspace = true
+miniscript.workspace = true
 musig2 = { workspace = true, features = ["serde"] }
 rkyv.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std"] }

--- a/crates/primitives/src/errors.rs
+++ b/crates/primitives/src/errors.rs
@@ -69,10 +69,10 @@ pub enum DepositTransactionError {
     #[error("invalid deposit request taproot address")]
     InvalidDRTAddress,
 
-    /// Invalid address size provided for the execution layer address where the bridged-in amount
-    /// is to be minted.
-    #[error("el size exceeds expected size: {0} > 20")]
-    InvalidElAddressSize(usize),
+    /// Invalid address size provided for the execution environment address where the bridged-in
+    /// amount is to be minted.
+    #[error("ee size mismatch, got {0} expected {1}")]
+    InvalidEeAddressSize(usize, usize),
 
     /// Error while generating the control block. This mostly means that the control block is
     /// invalid i.e., it does not have the right commitment.

--- a/crates/primitives/src/scripts/metadata.rs
+++ b/crates/primitives/src/scripts/metadata.rs
@@ -1,14 +1,6 @@
 //! Primitives for Bridge metadata.
 
-use std::mem;
-
-use bitcoin::{key::constants::SCHNORR_PUBLIC_KEY_SIZE, XOnlyPublicKey};
-
-/// Execution Environment address size in bytes.
-const EE_ADDRESS_SIZE: usize = 20;
-
-/// u32 size in bytes.
-const U32_SIZE: usize = mem::size_of::<u32>();
+use bitcoin::XOnlyPublicKey;
 
 /// Metadata bytes that the Bridge uses to read information from the bitcoin blockchain and the
 /// sidesystem.
@@ -30,7 +22,7 @@ pub enum DepositMetadata {
         // TODO: make this a BOSD Descriptor.
         takeback_pubkey: XOnlyPublicKey,
 
-        /// 20-byte Execution Environment address.
+        /// Execution Environment address.
         ee_address: Vec<u8>,
     },
     DepositTx {
@@ -41,7 +33,7 @@ pub enum DepositMetadata {
         /// This is a 4-byte big-endian encoded unsigned 32-bit integer.
         stake_index: u32,
 
-        /// 20-byte Execution Environment address.
+        /// Execution Environment address.
         ee_address: Vec<u8>,
     },
 }
@@ -49,13 +41,7 @@ pub enum DepositMetadata {
 impl<'tag> AuxiliaryData<'tag> {
     /// Extracts the metadata as bytes.
     pub fn to_vec(&'tag self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(
-            self.tag.len() // FIXME: make this known at compile time once the tag length is defined.
-                + match &self.metadata {
-                    DepositMetadata::DepositRequestTx { .. } => SCHNORR_PUBLIC_KEY_SIZE + EE_ADDRESS_SIZE,
-                    DepositMetadata::DepositTx { .. } => U32_SIZE + EE_ADDRESS_SIZE,
-                },
-        );
+        let mut bytes = Vec::new();
 
         bytes.extend_from_slice(self.tag);
 
@@ -63,6 +49,7 @@ impl<'tag> AuxiliaryData<'tag> {
             DepositMetadata::DepositRequestTx {
                 takeback_pubkey,
                 ee_address,
+                ..
             } => {
                 bytes.extend_from_slice(&takeback_pubkey.serialize());
                 bytes.extend_from_slice(ee_address);

--- a/crates/primitives/src/scripts/metadata.rs
+++ b/crates/primitives/src/scripts/metadata.rs
@@ -1,0 +1,81 @@
+//! Primitives for Bridge metadata.
+
+use std::mem;
+
+use bitcoin::{key::constants::SCHNORR_PUBLIC_KEY_SIZE, XOnlyPublicKey};
+
+/// Execution Environment address size in bytes.
+const EE_ADDRESS_SIZE: usize = 20;
+
+/// u32 size in bytes.
+const U32_SIZE: usize = mem::size_of::<u32>();
+
+/// Metadata bytes that the Bridge uses to read information from the bitcoin blockchain and the
+/// sidesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuxiliaryData<'tag> {
+    /// Tag, also known as "magic bytes".
+    pub tag: &'tag [u8],
+
+    /// Deposit-specific metadata.
+    pub metadata: DepositMetadata,
+}
+
+/// Deposit-specific metadata that the Bridge uses to read information from the bitcoin blockchain
+/// and the sidesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DepositMetadata {
+    DepositRequestTx {
+        /// 32-bit X-only public key.
+        // TODO: make this a BOSD Descriptor.
+        takeback_pubkey: XOnlyPublicKey,
+
+        /// 20-byte Execution Environment address.
+        ee_address: Vec<u8>,
+    },
+    DepositTx {
+        /// Stake index.
+        ///
+        /// # Implementation Notes
+        ///
+        /// This is a 4-byte big-endian encoded unsigned 32-bit integer.
+        stake_index: u32,
+
+        /// 20-byte Execution Environment address.
+        ee_address: Vec<u8>,
+    },
+}
+
+impl<'tag> AuxiliaryData<'tag> {
+    /// Extracts the metadata as bytes.
+    pub fn to_vec(&'tag self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(
+            self.tag.len() // FIXME: make this known at compile time once the tag length is defined.
+                + match &self.metadata {
+                    DepositMetadata::DepositRequestTx { .. } => SCHNORR_PUBLIC_KEY_SIZE + EE_ADDRESS_SIZE,
+                    DepositMetadata::DepositTx { .. } => U32_SIZE + EE_ADDRESS_SIZE,
+                },
+        );
+
+        bytes.extend_from_slice(self.tag);
+
+        match &self.metadata {
+            DepositMetadata::DepositRequestTx {
+                takeback_pubkey,
+                ee_address,
+            } => {
+                bytes.extend_from_slice(&takeback_pubkey.serialize());
+                bytes.extend_from_slice(ee_address);
+            }
+            DepositMetadata::DepositTx {
+                stake_index,
+                ee_address,
+            } => {
+                bytes.extend_from_slice(&stake_index.to_be_bytes());
+                bytes.extend_from_slice(ee_address);
+            }
+        }
+
+        bytes
+    }
+}

--- a/crates/primitives/src/scripts/mod.rs
+++ b/crates/primitives/src/scripts/mod.rs
@@ -1,5 +1,6 @@
 pub mod commitments;
 pub mod general;
+pub mod metadata;
 pub mod parse_witness;
 pub mod prelude;
 pub mod taproot;

--- a/crates/primitives/src/scripts/prelude.rs
+++ b/crates/primitives/src/scripts/prelude.rs
@@ -1,1 +1,1 @@
-pub use super::{commitments::*, general::*, taproot::*, transform::*};
+pub use super::{commitments::*, general::*, metadata::*, taproot::*, transform::*};

--- a/crates/primitives/src/test_utils.rs
+++ b/crates/primitives/src/test_utils.rs
@@ -10,7 +10,7 @@ use bitcoin::{
     taproot::LeafVersion,
     Network, TapNodeHash, XOnlyPublicKey,
 };
-use secp256k1::{rand::thread_rng, Parity};
+use secp256k1::rand::thread_rng;
 use strata_primitives::bridge::PublickeyTable;
 
 use crate::{
@@ -19,6 +19,7 @@ use crate::{
         general::{drt_take_back, get_aggregated_pubkey, n_of_n_script},
         prelude::{create_taproot_addr, SpendPath},
     },
+    secp::EvenSecretKey,
     types::OperatorIdx,
 };
 
@@ -62,12 +63,9 @@ pub(crate) fn generate_pubkey_table(table: &[PublicKey]) -> PublickeyTable {
 
 pub(crate) fn generate_xonly_pubkey() -> XOnlyPublicKey {
     let mut rng = thread_rng();
-    let mut sk = SecretKey::new(&mut rng);
-    // negate sk if odd
-    if sk.x_only_public_key(SECP256K1).1 == Parity::Odd {
-        sk = sk.negate();
-    }
-    sk.x_only_public_key(SECP256K1).0
+    let sk = SecretKey::new(&mut rng);
+    let even_sk: EvenSecretKey = sk.into();
+    even_sk.x_only_public_key(SECP256K1).0
 }
 
 pub(crate) fn create_drt_taproot_output(


### PR DESCRIPTION
## Description

Deposit Request Transactions (DRT) now need X-Only PK of recovery address instead of take back leaf hash.
This fixes the DRT metadata OP_RETURN construction/parsing.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor
- [x] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

The new `OP_RETURN` now is:

1. magic bytes
2. Second Element:
  a. DRT: 32-byte X-only PK for the recovery P2TR address
  b. DT: 4-byte big-endian `u32` stake index
4. 20-byte EL address

This PR needs polishing. It is not ready, but the main ideas are here.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1776
