### PR TITLE
chore(deps): update strata-p2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,7 +662,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 0.11.1",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -2884,7 +2884,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
- "parking_lot 0.12.3",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -3030,7 +3030,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3868,16 +3868,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3960,7 +3950,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4057,15 +4047,6 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "gcd"
@@ -4462,7 +4443,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
@@ -4483,7 +4464,7 @@ dependencies = [
  "ipconfig",
  "moka",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "rand 0.9.0",
  "resolv-conf",
  "smallvec",
@@ -5155,15 +5136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5279,7 +5251,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand 0.8.5",
  "rustc-hash 2.1.1",
@@ -5542,7 +5514,6 @@ dependencies = [
  "libp2p-gossipsub 0.49.0",
  "libp2p-identify 0.47.0",
  "libp2p-identity",
- "libp2p-kad",
  "libp2p-mdns 0.47.0",
  "libp2p-metrics 0.16.1",
  "libp2p-noise 0.46.1",
@@ -5618,7 +5589,7 @@ dependencies = [
  "multihash",
  "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5644,7 +5615,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select 0.13.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5666,7 +5637,7 @@ dependencies = [
  "hickory-resolver 0.24.4",
  "libp2p-core 0.42.0",
  "libp2p-identity",
- "parking_lot 0.12.3",
+ "parking_lot",
  "smallvec",
  "tracing",
 ]
@@ -5681,7 +5652,7 @@ dependencies = [
  "hickory-resolver 0.25.0-alpha.5",
  "libp2p-core 0.43.1",
  "libp2p-identity",
- "parking_lot 0.12.3",
+ "parking_lot",
  "smallvec",
  "tracing",
 ]
@@ -5742,7 +5713,6 @@ dependencies = [
  "quick-protobuf-codec 0.3.1 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
  "rand 0.8.5",
  "regex",
- "serde",
  "sha2 0.10.8",
  "tracing",
  "web-time",
@@ -5805,38 +5775,10 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
- "serde",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.8",
- "smallvec",
- "thiserror 2.0.12",
- "tracing",
- "uint 0.10.0",
- "web-time",
 ]
 
 [[package]]
@@ -6007,7 +5949,7 @@ dependencies = [
  "libp2p-core 0.42.0",
  "libp2p-identity",
  "libp2p-tls 0.5.0",
- "parking_lot 0.12.3",
+ "parking_lot",
  "quinn",
  "rand 0.8.5",
  "ring 0.17.14",
@@ -6278,7 +6220,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -6610,7 +6552,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "loom",
- "parking_lot 0.12.3",
+ "parking_lot",
  "portable-atomic",
  "rustc_version 0.4.1",
  "smallvec",
@@ -6656,7 +6598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
- "serde",
  "unsigned-varint 0.8.0",
 ]
 
@@ -7550,37 +7491,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -7591,7 +7507,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -7874,7 +7790,7 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "uint 0.9.5",
+ "uint",
 ]
 
 [[package]]
@@ -7959,7 +7875,7 @@ checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
 dependencies = [
  "dtoa",
  "itoa",
- "parking_lot 0.12.3",
+ "parking_lot",
  "prometheus-client-derive-encode",
 ]
 
@@ -8011,7 +7927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -8031,7 +7947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -8354,15 +8270,6 @@ name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -9458,7 +9365,7 @@ dependencies = [
  "futures",
  "log",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot",
  "scc",
  "serial_test_derive",
 ]
@@ -9603,22 +9510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -10490,14 +10381,11 @@ dependencies = [
  "libp2p 0.54.1",
  "libp2p-identity",
  "musig2",
- "sled",
  "strata-bridge-test-utils",
  "strata-common",
  "strata-p2p",
- "strata-p2p-db",
  "strata-p2p-types",
  "strata-p2p-wire",
- "threadpool",
  "tokio",
  "tokio-util",
  "tracing",
@@ -10796,7 +10684,7 @@ dependencies = [
  "borsh",
  "hex",
  "musig2",
- "parking_lot 0.12.3",
+ "parking_lot",
  "serde",
  "strata-mmr",
  "strata-primitives",
@@ -10859,16 +10747,14 @@ dependencies = [
 [[package]]
 name = "strata-p2p"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#26ed893e9d00d45bff0023cbc3d6b26cf245b2fd"
+source = "git+https://github.com/alpenlabs/strata-p2p.git#4283476e9f4d60276253fe1d9263de75f4e0ecc7"
 dependencies = [
  "async-trait",
  "bitcoin",
  "futures",
- "itertools 0.14.0",
  "libp2p 0.55.1",
  "musig2",
  "prost",
- "strata-p2p-db",
  "strata-p2p-types",
  "strata-p2p-wire",
  "thiserror 2.0.12",
@@ -10878,29 +10764,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "strata-p2p-db"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#26ed893e9d00d45bff0023cbc3d6b26cf245b2fd"
-dependencies = [
- "async-trait",
- "bitcoin",
- "libp2p 0.55.1",
- "musig2",
- "prost",
- "serde",
- "serde_json",
- "sled",
- "strata-p2p-types",
- "thiserror 2.0.12",
- "threadpool",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "strata-p2p-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#26ed893e9d00d45bff0023cbc3d6b26cf245b2fd"
+source = "git+https://github.com/alpenlabs/strata-p2p.git#4283476e9f4d60276253fe1d9263de75f4e0ecc7"
 dependencies = [
  "bitcoin",
  "hex",
@@ -10911,9 +10777,10 @@ dependencies = [
 [[package]]
 name = "strata-p2p-wire"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#26ed893e9d00d45bff0023cbc3d6b26cf245b2fd"
+source = "git+https://github.com/alpenlabs/strata-p2p.git#4283476e9f4d60276253fe1d9263de75f4e0ecc7"
 dependencies = [
  "bitcoin",
+ "libp2p 0.55.1",
  "musig2",
  "prost",
  "prost-build",
@@ -11069,7 +10936,7 @@ dependencies = [
  "async-trait",
  "bitcoin",
  "lru",
- "parking_lot 0.12.3",
+ "parking_lot",
  "paste",
  "strata-db",
  "strata-primitives",
@@ -11499,7 +11366,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.0.3",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -11928,18 +11795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uint"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12296,7 +12151,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall 0.5.10",
+ "redox_syscall",
  "wasite",
 ]
 
@@ -12924,7 +12779,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand 0.8.5",
  "static_assertions",
@@ -12939,7 +12794,7 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.3",
+ "parking_lot",
  "pin-project",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ strata-rpc-types = { git = "https://github.com/alpenlabs/strata.git" }
 strata-state = { git = "https://github.com/alpenlabs/strata.git" }
 
 strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git" }
-strata-p2p-db = { git = "https://github.com/alpenlabs/strata-p2p.git" }
 strata-p2p-types = { git = "https://github.com/alpenlabs/strata-p2p.git" }
 strata-p2p-wire = { git = "https://github.com/alpenlabs/strata-p2p.git" }
 
@@ -158,7 +157,6 @@ serde_json = { version = "1.0", default-features = false, features = [
 ] }
 serde_with = "3.12.0"
 sha2 = "0.10"
-sled = "0.34.7"
 sp1-sdk = "4.0.0"
 sp1-verifier = "4.1.1"
 sqlx = { version = "0.8.2", features = [
@@ -172,7 +170,6 @@ sqlx = { version = "0.8.2", features = [
 tempfile = "3.10.1"
 terrors = "0.3.2"
 thiserror = "2.0.3"
-threadpool = "1.8.1"
 tokio = { version = "1.37", features = ["full"] }
 tokio-util = { version = "0.7.13", default-features = false, features = ["rt"] }
 toml = "0.8.20"

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -159,6 +159,8 @@ impl ContractManager {
                         Err(e) => {
                             tracing::error!("{}", e);
                         }
+                        // TODO: fix me with the get request events
+                        _ => {}
                     },
                     _ = interval.tick() => {
                         let nags = ctx.nag();

--- a/crates/p2p-service/Cargo.toml
+++ b/crates/p2p-service/Cargo.toml
@@ -12,7 +12,6 @@ rust.unused_must_use = "deny"
 
 [dependencies]
 strata-p2p.workspace = true
-strata-p2p-db.workspace = true
 strata-p2p-types.workspace = true
 strata-p2p-wire.workspace = true
 
@@ -21,8 +20,6 @@ bitcoin.workspace = true
 libp2p.workspace = true
 libp2p-identity.workspace = true
 musig2.workspace = true
-sled.workspace = true
-threadpool.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 

--- a/crates/p2p-service/src/bootstrap.rs
+++ b/crates/p2p-service/src/bootstrap.rs
@@ -1,17 +1,12 @@
 //! Module to bootstrap the p2p node by hooking up all the required services.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use strata_p2p::swarm::{self, handle::P2PHandle, P2PConfig, P2P};
-use strata_p2p_db::sled::AsyncDB;
-use threadpool::ThreadPool;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{
-    config::Configuration,
-    constants::{DEFAULT_IDLE_CONNECTION_TIMEOUT, DEFAULT_NUM_THREADS},
-};
+use crate::{config::Configuration, constants::DEFAULT_IDLE_CONNECTION_TIMEOUT};
 
 /// Bootstrap the p2p node by hooking up all the required services.
 pub async fn bootstrap(config: &Configuration) -> anyhow::Result<(P2PHandle, CancellationToken)> {
@@ -27,18 +22,11 @@ pub async fn bootstrap(config: &Configuration) -> anyhow::Result<(P2PHandle, Can
     };
     let cancel = CancellationToken::new();
 
-    info!("creating an in-memory sled database");
-    let db = sled::Config::new().temporary(true).open()?;
-    let db = AsyncDB::new(
-        ThreadPool::new(config.num_threads.unwrap_or(DEFAULT_NUM_THREADS)),
-        Arc::new(db),
-    );
-
     info!("creating a swarm");
     let swarm = swarm::with_tcp_transport(&p2p_config)?;
 
     info!("creating a p2p node");
-    let (mut p2p, handle) = P2P::from_config(p2p_config, cancel.clone(), db, swarm, None)?;
+    let (mut p2p, handle) = P2P::from_config(p2p_config, cancel.clone(), swarm, None)?;
 
     info!("establishing connections");
     let _ = p2p.establish_connections().await;

--- a/crates/p2p-service/src/tests/request.rs
+++ b/crates/p2p-service/src/tests/request.rs
@@ -1,13 +1,8 @@
+//! GetMessage tests.
+
 use anyhow::bail;
 use strata_common::logging::{self, LoggerConfig};
-use strata_p2p::{
-    commands::{Command, UnsignedPublishMessage},
-    events::Event,
-};
-use strata_p2p_db::{
-    sled::AsyncDB, DepositSetupEntry, NoncesEntry, PartialSignaturesEntry, RepositoryExt,
-    StakeChainEntry,
-};
+use strata_p2p::{commands::Command, events::Event};
 use strata_p2p_types::{P2POperatorPubKey, Scope, SessionId, StakeChainId};
 use strata_p2p_wire::p2p::v1::{GetMessageRequest, UnsignedGossipsubMsg};
 use tracing::info;
@@ -18,6 +13,7 @@ use super::common::{
     mock_stake_chain_info, Setup,
 };
 
+/// Tests the get message request-response flow.
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn request_response() -> anyhow::Result<()> {
     const OPERATORS_NUM: usize = 2;
@@ -62,8 +58,8 @@ async fn request_response() -> anyhow::Result<()> {
     )
     .await?;
 
-    // create command to request info from the last operator
-    let operator_pk: P2POperatorPubKey = operators[OPERATORS_NUM - 1].kp.public().clone().into();
+    // create command to request info from the first operator
+    let operator_pk: P2POperatorPubKey = operators[0].kp.public().clone().into();
     let command_stake_chain = Command::RequestMessage(GetMessageRequest::StakeChainExchange {
         stake_chain_id,
         operator_pk: operator_pk.clone(),
@@ -82,32 +78,36 @@ async fn request_response() -> anyhow::Result<()> {
             operator_pk: operator_pk.clone(),
         });
 
-    // put data in the last operator, so that he can respond it
-    match mock_stake_chain_info(&operators[OPERATORS_NUM - 1].kp.clone(), stake_chain_id) {
-        Command::PublishMessage(msg) => match msg.msg {
-            UnsignedPublishMessage::StakeChainExchange {
-                stake_chain_id,
-                pre_stake_txid,
-                pre_stake_vout,
-            } => {
-                let entry = StakeChainEntry {
-                    entry: (pre_stake_txid, pre_stake_vout),
-                    signature: msg.signature,
-                    key: msg.key,
-                };
-                <AsyncDB as RepositoryExt>::set_stake_chain_info_if_not_exists::<'_, '_>(
-                    &operators[OPERATORS_NUM - 1].db,
-                    stake_chain_id,
-                    entry,
-                )
-                .await?;
-            }
-            _ => unreachable!(),
-        },
-        _ => unreachable!(),
-    }
-    operators[0].handle.send_command(command_stake_chain).await;
+    // Send stake chain request and handle response from the last operator
+    operators[OPERATORS_NUM - 1]
+        .handle
+        .send_command(command_stake_chain)
+        .await;
+
+    // Wait for request on the first operator
     let event = operators[0].handle.next_event().await?;
+    match event {
+        Event::ReceivedRequest(request) => match request {
+            GetMessageRequest::StakeChainExchange {
+                stake_chain_id: req_stake_chain_id,
+                operator_pk: req_operator_pk,
+            } if req_stake_chain_id == stake_chain_id && req_operator_pk == operator_pk => {
+                // Construct and send response
+                let mock_msg = mock_stake_chain_info(&operators[0].kp.clone(), stake_chain_id);
+                if let Command::PublishMessage(msg) = mock_msg {
+                    operators[0]
+                        .handle
+                        .send_command(Command::PublishMessage(msg))
+                        .await;
+                }
+            }
+            _ => bail!("Got unexpected request in the first operator"),
+        },
+        _ => bail!("Got unexpected event in the first operator"),
+    }
+
+    // Wait for response on the last operator
+    let event = operators[OPERATORS_NUM - 1].handle.next_event().await?;
     match event {
         Event::ReceivedMessage(msg) => match &msg.unsigned {
             UnsignedGossipsubMsg::StakeChainExchange {
@@ -116,46 +116,41 @@ async fn request_response() -> anyhow::Result<()> {
             } if msg.key == operator_pk && *received_id == stake_chain_id => {
                 info!("Got stake chain info from the last operator")
             }
-            _ => bail!("Got event other than expected 'stake_chain_info'",),
+            _ => bail!("Got event other than expected 'stake_chain_info' in the last operator"),
         },
+        _ => bail!("Got event other than expected 'stake_chain_info' in the last operator"),
     }
 
-    // put data in the last operator, so that he can respond it
-    match mock_deposit_setup(&operators[OPERATORS_NUM - 1].kp.clone(), scope) {
-        Command::PublishMessage(msg) => match msg.msg {
-            UnsignedPublishMessage::DepositSetup {
-                scope,
-                hash,
-                funding_txid,
-                funding_vout,
-                operator_pk,
-                wots_pks,
-            } => {
-                let entry = DepositSetupEntry {
-                    signature: msg.signature,
-                    key: msg.key,
-                    hash,
-                    funding_txid,
-                    funding_vout,
-                    operator_pk,
-                    wots_pks,
-                };
-                <AsyncDB as RepositoryExt>::set_deposit_setup_if_not_exists::<'_, '_>(
-                    &operators[OPERATORS_NUM - 1].db,
-                    scope,
-                    entry,
-                )
-                .await?;
-            }
-            _ => unreachable!(),
-        },
-        _ => unreachable!(),
-    }
-    operators[0]
+    // Send deposit setup request and handle response from the last operator
+    operators[OPERATORS_NUM - 1]
         .handle
         .send_command(command_deposit_setup)
         .await;
+
+    // Wait for request on the first operator
     let event = operators[0].handle.next_event().await?;
+    match event {
+        Event::ReceivedRequest(request) => match request {
+            GetMessageRequest::DepositSetup {
+                scope: req_scope,
+                operator_pk: req_operator_pk,
+            } if req_scope == scope && req_operator_pk == operator_pk => {
+                // Construct and send response
+                let mock_msg = mock_deposit_setup(&operators[0].kp.clone(), scope);
+                if let Command::PublishMessage(msg) = mock_msg {
+                    operators[0]
+                        .handle
+                        .send_command(Command::PublishMessage(msg))
+                        .await;
+                }
+            }
+            _ => bail!("Got unexpected request in the first operator"),
+        },
+        _ => bail!("Got unexpected event in the first operator"),
+    }
+
+    // Wait for response on the last operator
+    let event = operators[OPERATORS_NUM - 1].handle.next_event().await?;
     match event {
         Event::ReceivedMessage(msg) => match &msg.unsigned {
             UnsignedGossipsubMsg::DepositSetup {
@@ -164,38 +159,41 @@ async fn request_response() -> anyhow::Result<()> {
             } if msg.key == operator_pk && *received_scope == scope => {
                 info!("Got deposit setup info from the last operator")
             }
-            _ => bail!("Got event other than expected 'deposit_setup'",),
+            _ => bail!("Got event other than expected 'deposit_setup' in the last operator"),
         },
+        _ => bail!("Got event other than expected 'deposit_setup' in the last operator"),
     }
 
-    // put data in the last operator, so that he can respond it
-    match mock_deposit_nonces(&operators[OPERATORS_NUM - 1].kp.clone(), session_id) {
-        Command::PublishMessage(msg) => match msg.msg {
-            UnsignedPublishMessage::Musig2NoncesExchange {
-                session_id,
-                pub_nonces,
-            } => {
-                let entry = NoncesEntry {
-                    signature: msg.signature,
-                    key: msg.key,
-                    entry: pub_nonces,
-                };
-                <AsyncDB as RepositoryExt>::set_pub_nonces_if_not_exist::<'_, '_>(
-                    &operators[OPERATORS_NUM - 1].db,
-                    session_id,
-                    entry,
-                )
-                .await?;
-            }
-            _ => unreachable!(),
-        },
-        _ => unreachable!(),
-    }
-    operators[0]
+    // Send deposit nonces request and handle response from the last operator
+    operators[OPERATORS_NUM - 1]
         .handle
         .send_command(command_deposit_nonces)
         .await;
+
+    // Wait for request on the first operator
     let event = operators[0].handle.next_event().await?;
+    match event {
+        Event::ReceivedRequest(request) => match request {
+            GetMessageRequest::Musig2NoncesExchange {
+                session_id: req_session_id,
+                operator_pk: req_operator_pk,
+            } if req_session_id == session_id && req_operator_pk == operator_pk => {
+                // Construct and send response
+                let mock_msg = mock_deposit_nonces(&operators[0].kp.clone(), session_id);
+                if let Command::PublishMessage(msg) = mock_msg {
+                    operators[0]
+                        .handle
+                        .send_command(Command::PublishMessage(msg))
+                        .await;
+                }
+            }
+            _ => bail!("Got unexpected request in the first operator"),
+        },
+        _ => bail!("Got unexpected event in the first operator"),
+    }
+
+    // Wait for response on the last operator
+    let event = operators[OPERATORS_NUM - 1].handle.next_event().await?;
     match event {
         Event::ReceivedMessage(msg) => match &msg.unsigned {
             UnsignedGossipsubMsg::Musig2NoncesExchange {
@@ -204,35 +202,41 @@ async fn request_response() -> anyhow::Result<()> {
             } if msg.key == operator_pk && *received_session_id == session_id => {
                 info!("Got deposit pubnonces from the last operator")
             }
-            _ => bail!("Got event other than expected 'deposit_pubnonces'",),
+            _ => bail!("Got event other than expected 'deposit_pubnonces' in the last operator"),
         },
+        _ => bail!("Got event other than expected 'deposit_pubnonces' in the last operator"),
     }
 
-    // put data in the last operator, so that he can respond it
-    match mock_deposit_sigs(&operators[OPERATORS_NUM - 1].kp.clone(), session_id) {
-        Command::PublishMessage(msg) => match msg.msg {
-            UnsignedPublishMessage::Musig2SignaturesExchange {
-                session_id,
-                partial_sigs,
-            } => {
-                let entry = PartialSignaturesEntry {
-                    signature: msg.signature,
-                    key: msg.key,
-                    entry: partial_sigs,
-                };
-                <AsyncDB as RepositoryExt>::set_partial_signatures_if_not_exists::<'_, '_>(
-                    &operators[OPERATORS_NUM - 1].db,
-                    session_id,
-                    entry,
-                )
-                .await?;
-            }
-            _ => unreachable!(),
-        },
-        _ => unreachable!(),
-    }
-    operators[0].handle.send_command(command_deposit_sigs).await;
+    // Send deposit signatures request and handle response from the last operator
+    operators[OPERATORS_NUM - 1]
+        .handle
+        .send_command(command_deposit_sigs)
+        .await;
+
+    // Wait for request on the first operator
     let event = operators[0].handle.next_event().await?;
+    match event {
+        Event::ReceivedRequest(request) => match request {
+            GetMessageRequest::Musig2SignaturesExchange {
+                session_id: req_session_id,
+                operator_pk: req_operator_pk,
+            } if req_session_id == session_id && req_operator_pk == operator_pk => {
+                // Construct and send response
+                let mock_msg = mock_deposit_sigs(&operators[0].kp.clone(), session_id);
+                if let Command::PublishMessage(msg) = mock_msg {
+                    operators[0]
+                        .handle
+                        .send_command(Command::PublishMessage(msg))
+                        .await;
+                }
+            }
+            _ => bail!("Got unexpected request in the first operator"),
+        },
+        _ => bail!("Got unexpected event in the first operator"),
+    }
+
+    // Wait for response on the last operator
+    let event = operators[OPERATORS_NUM - 1].handle.next_event().await?;
     match event {
         Event::ReceivedMessage(msg) => match &msg.unsigned {
             UnsignedGossipsubMsg::Musig2SignaturesExchange {
@@ -241,11 +245,12 @@ async fn request_response() -> anyhow::Result<()> {
             } if msg.key == operator_pk && *received_session_id == session_id => {
                 info!("Got deposit partial signatures from the last operator")
             }
-            _ => bail!("Got event other than expected 'deposit_partial_sigs'",),
+            _ => bail!("Got event other than expected 'deposit_partial_sigs' in the last operator"),
         },
+        _ => bail!("Got event other than expected 'deposit_partial_sigs' in the last operator"),
     }
-    cancel.cancel();
 
+    cancel.cancel();
     tasks.wait().await;
 
     Ok(())


### PR DESCRIPTION
## Description

Updates the `strata-p2p` dependency that removes the database in the P2P (removing `threadpool` and `sled` deps) and also moving the responsibility of handling the get request messages to the duty tracker.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

We need after this to implement the correct handling of get requests in the duty tracker (contract manager)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues


