### PR TITLE
log: warn if we see unknown gossip MuSig2 sessions

### DIFF
--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -227,9 +227,10 @@ impl ContractManager {
                                     .any(|txid| txid == session_id_as_txid) {
 
                                     let _ = ctx.execute_duty(OperatorDuty::PublishRootNonce).await;
+                                } else {
+                                    // otherwise ignore this message.
+                                    warn!(txid=%session_id_as_txid, "received a musig2 nonces exchange for an unknown session");
                                 }
-
-                                // otherwise ignore this message.
                             }
                             GetMessageRequest::Musig2SignaturesExchange { session_id, .. } => {
                                 let session_id_as_txid = Txid::from_raw_hash(*sha256d::Hash::from_bytes_ref(session_id.as_ref()));
@@ -242,9 +243,10 @@ impl ContractManager {
                                     .any(|txid| txid == session_id_as_txid) {
 
                                     let _ = ctx.execute_duty(OperatorDuty::PublishRootSignature).await;
+                                } else {
+                                    // otherwise ignore this message.
+                                    warn!(txid=%session_id_as_txid, "received a musig2 signatures exchange for an unknown session");
                                 }
-
-                                // otherwise ignore this message.
                             }
                         }
                         Err(e) => {


### PR DESCRIPTION
## Description

adds a `warn` log if we receive gossip messages from an uknown MuSig2 txid.

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] MOAH LOGS!

## Notes to Reviewers

Feel free to change the log message if you want

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
