### PR TITLE
Add method to generate peg-out graph message hashes

### DIFF
--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -39,10 +39,6 @@ use strata_bridge_primitives::{
         taproot::{create_message_hash, TaprootWitness},
     },
 };
-use strata_bridge_tx_graph::{
-    errors::TxGraphError,
-    peg_out_graph::{PegOutGraph, PegOutGraphSighashes},
-};
 use strata_bridge_stake_chain::prelude::{STAKE_VOUT, WITHDRAWAL_FULFILLMENT_VOUT};
 use strata_bridge_tx_graph::{
     errors::TxGraphError,
@@ -1323,8 +1319,9 @@ impl ContractManagerCtx {
                     }
                 }
 
+                let session_id = SessionId::from_bytes(deposit_txid.to_byte_array());
                 self.p2p_msg_handle
-                    .send_musig2_nonces(deposit_txid, nonces)
+                    .send_musig2_nonces(session_id, nonces)
                     .await;
 
                 Ok(())

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -639,11 +639,14 @@ impl ContractSM {
 
                 stake_txs.insert(signer.clone(), new_stake_tx);
                 wots_keys.insert(signer.clone(), new_wots_keys);
-                peg_out_graphs.insert(signer, pog_summary);
+                peg_out_graphs.insert(signer.clone(), pog_summary);
 
                 Ok(
                     if stake_txs.len() == self.cfg.operator_table.cardinality() {
-                        Some(OperatorDuty::PublishGraphNonces)
+                        Some(OperatorDuty::PublishGraphNonces {
+                            deposit_txid: self.deposit_txid(),
+                            operator_p2p_key: signer,
+                        })
                     } else {
                         None
                     },

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -282,6 +282,9 @@ pub enum OperatorDuty {
     PublishGraphNonces {
         /// Transaction ID of the DT
         deposit_txid: Txid,
+
+        /// The p2p key of the operator for whom to publish the graph nonces.
+        operator_p2p_key: P2POperatorPubKey,
     },
 
     /// Instructs us to send out signatures for the peg out graph.
@@ -291,12 +294,18 @@ pub enum OperatorDuty {
     PublishRootNonce {
         /// Transaction ID of the DRT
         deposit_request_txid: Txid,
+
+        /// The schnorr key that locks the funds in the DRT for the user to take back after a
+        /// parameterized refund delay.
         takeback_key: XOnlyPublicKey,
     },
 
     /// Instructs us to send out signatures for the deposit transaction.
     PublishRootSignature {
+        /// The nonces received from peers.
         nonces: BTreeMap<P2POperatorPubKey, PubNonce>,
+
+        /// The data required to construct the deposit transaction.
         deposit_info: DepositInfo,
     },
 

--- a/crates/tx-graph/src/transactions/challenge.rs
+++ b/crates/tx-graph/src/transactions/challenge.rs
@@ -73,6 +73,7 @@ impl ChallengeTx<Unfunded> {
 
         let input_index = tapleaf.get_input_index() as usize;
         psbt.inputs[input_index].witness_utxo = Some(prevouts[0].clone());
+        psbt.inputs[input_index].sighash_type = Some(TapSighashType::SinglePlusAnyoneCanPay.into());
 
         Self {
             psbt,

--- a/crates/tx-graph/src/transactions/challenge.rs
+++ b/crates/tx-graph/src/transactions/challenge.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use bitcoin::{
     key::TapTweak, psbt::ExtractTxError, sighash::Prevouts, taproot, Address, Amount, Network,
-    OutPoint, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    OutPoint, Psbt, ScriptBuf, Sequence, TapSighashType, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use secp256k1::XOnlyPublicKey;
 use strata_bridge_connectors::prelude::{ConnectorC1, ConnectorC1Path};
@@ -21,9 +21,16 @@ use super::{
 /// Data needed to construct a [`ChallengeTx`].
 #[derive(Debug, Clone)]
 pub struct ChallengeTxInput {
+    /// The outpoint of the claim transaction that the challenge tx spends.
     pub claim_outpoint: OutPoint,
+
+    /// The output amount on the challenge transaction.
     pub challenge_amt: Amount,
+
+    /// The public key of the operator that locks the output of the challenge transaction.
     pub operator_pubkey: XOnlyPublicKey,
+
+    /// The network where the constructed challenge transaction is valid.
     pub network: Network,
 }
 

--- a/crates/tx-graph/src/transactions/payout.rs
+++ b/crates/tx-graph/src/transactions/payout.rs
@@ -134,6 +134,7 @@ impl PayoutTx {
 
         for (input, utxo) in psbt.inputs.iter_mut().zip(prevouts.clone()) {
             input.witness_utxo = Some(utxo);
+            input.sighash_type = Some(TapSighashType::Default.into());
         }
 
         let (connector_a3_script, connector_a3_control_block) =

--- a/crates/tx-graph/src/transactions/payout_optimistic.rs
+++ b/crates/tx-graph/src/transactions/payout_optimistic.rs
@@ -139,6 +139,7 @@ impl PayoutOptimisticTx {
 
         for (input, utxo) in psbt.inputs.iter_mut().zip(prevouts.clone()) {
             input.witness_utxo = Some(utxo);
+            input.sighash_type = Some(TapSighashType::Default.into());
         }
 
         let (payout_script, control_block) = connector_c1.generate_spend_info();

--- a/crates/tx-graph/src/transactions/post_assert.rs
+++ b/crates/tx-graph/src/transactions/post_assert.rs
@@ -1,4 +1,7 @@
-use bitcoin::{sighash::Prevouts, transaction, Amount, OutPoint, Psbt, Transaction, TxOut, Txid};
+use bitcoin::{
+    sighash::Prevouts, transaction, Amount, OutPoint, Psbt, TapSighashType, Transaction, TxOut,
+    Txid,
+};
 use secp256k1::schnorr::Signature;
 use serde::{Deserialize, Serialize};
 use strata_bridge_connectors::prelude::*;
@@ -92,6 +95,7 @@ impl PostAssertTx {
 
         for (input, utxo) in psbt.inputs.iter_mut().zip(prevouts.clone()) {
             input.witness_utxo = Some(utxo);
+            input.sighash_type = Some(TapSighashType::Default.into());
         }
 
         let witnesses = vec![TaprootWitness::Key; NUM_ASSERT_DATA_TX];

--- a/crates/tx-graph/src/transactions/pre_assert.rs
+++ b/crates/tx-graph/src/transactions/pre_assert.rs
@@ -1,5 +1,6 @@
 use bitcoin::{
-    sighash::Prevouts, transaction, Amount, OutPoint, Psbt, Sequence, Transaction, TxOut, Txid,
+    sighash::Prevouts, transaction, Amount, OutPoint, Psbt, Sequence, TapSighashType, Transaction,
+    TxOut, Txid,
 };
 use secp256k1::schnorr;
 use serde::{Deserialize, Serialize};
@@ -153,6 +154,7 @@ impl PreAssertTx {
 
         for (input, utxo) in psbt.inputs.iter_mut().zip(prevouts.clone()) {
             input.witness_utxo = Some(utxo);
+            input.sighash_type = Some(TapSighashType::Default.into());
         }
 
         let (script_buf, control_block) = connector_c0.generate_spend_info();


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR:

* Adds a method on the `PegOutGraph` to generate message hashes.
* Also adds the code to generate the peg out graph inside the duty execution context.
* And fixes all the lint issues (for now).

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
