### PR TITLE
STR-1247: fully check the DRT in predicates

### DIFF
--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -415,8 +415,6 @@ impl ContractManagerCtx {
         block: Block,
     ) -> Result<Vec<OperatorDuty>, ContractManagerErr> {
         let height = block.bip34_block_height().unwrap_or(0);
-        let bridge_aggregated_pk = self.cfg.operator_table.aggregated_btc_key();
-        let network = self.cfg.network;
         // TODO(proofofkeags): persist entire block worth of states at once. Ensure all the state
         // transitions succeed before committing them to disk.
         let mut duties = Vec::new();
@@ -442,8 +440,7 @@ impl ContractManagerCtx {
                 &tx,
                 &self.cfg.sidesystem_params,
                 &self.cfg.pegout_graph_params,
-                bridge_aggregated_pk.x_only_public_key().0,
-                network,
+                &self.cfg.operator_table.tx_build_context(self.cfg.network),
                 stake_index,
             ) {
                 let deposit_request_txid = txid;

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -415,6 +415,8 @@ impl ContractManagerCtx {
         block: Block,
     ) -> Result<Vec<OperatorDuty>, ContractManagerErr> {
         let height = block.bip34_block_height().unwrap_or(0);
+        let bridge_aggregated_pk = self.cfg.operator_table.aggregated_btc_key();
+        let network = self.cfg.network;
         // TODO(proofofkeags): persist entire block worth of states at once. Ensure all the state
         // transitions succeed before committing them to disk.
         let mut duties = Vec::new();
@@ -440,6 +442,8 @@ impl ContractManagerCtx {
                 &tx,
                 &self.cfg.sidesystem_params,
                 &self.cfg.pegout_graph_params,
+                bridge_aggregated_pk.x_only_public_key().0,
+                network,
                 stake_index,
             ) {
                 let deposit_request_txid = txid;

--- a/crates/duty-tracker/src/predicates.rs
+++ b/crates/duty-tracker/src/predicates.rs
@@ -16,7 +16,7 @@ use strata_bridge_primitives::{
 use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::TxFilterConfig};
 use strata_primitives::params::RollupParams;
 use strata_state::batch::{Checkpoint, SignedCheckpoint};
-use tracing::error;
+use tracing::warn;
 
 fn op_return_data(script: &Script) -> Option<&[u8]> {
     let mut instructions = script.instructions();
@@ -86,7 +86,7 @@ pub(crate) fn deposit_request_info(
     deposit_info
         .compute_spend_infos(build_context, pegout_graph_params.refund_delay)
         .map_err(|e| {
-            error!("failed to compute spend info: {:?}", e);
+            warn!("failed to compute spend info: {:?}", e);
             None::<DepositInfo>
         })
         .ok()?;

--- a/crates/duty-tracker/src/predicates.rs
+++ b/crates/duty-tracker/src/predicates.rs
@@ -86,7 +86,7 @@ pub(crate) fn deposit_request_info(
     deposit_info
         .compute_spend_infos(build_context, pegout_graph_params.refund_delay)
         .map_err(|e| {
-            warn!("failed to compute spend info: {:?}", e);
+            warn!(err=%e, txid=%tx.compute_txid(), "failed to compute spend info, malformed DRT");
             None::<DepositInfo>
         })
         .ok()?;

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -147,6 +147,9 @@ impl DepositInfo {
         })
     }
 
+    /// Computes the witness data for spending the Deposit Request Transaction (DRT) and in the
+    /// process, also validates the following:
+    ///
     /// 1. The taproot address computed from the x-only public key in the DRT and the bridge
     ///    multisig address is the same as the output address in the DRT.
     /// 1. The control block computed from the DRT commits to the multisig script that the Deposit

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -147,8 +147,10 @@ impl DepositInfo {
         })
     }
 
-    /// 1. The taproot address computed from the x-only public key in the DRT and the bridge multisig address is the same as the output address in the DRT.
-    /// 1. The control block computed from the DRT commits to the multisig script that the Deposit Transaction (DT) spends.
+    /// 1. The taproot address computed from the x-only public key in the DRT and the bridge
+    ///    multisig address is the same as the output address in the DRT.
+    /// 1. The control block computed from the DRT commits to the multisig script that the Deposit
+    ///    Transaction (DT) spends.
     pub fn compute_spend_infos(
         &self,
         build_context: &impl BuildContext,

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -147,12 +147,19 @@ impl DepositInfo {
         })
     }
 
-    fn compute_spend_infos(
+    /// Computes the spend info for the Deposit Request Transaction (DRT).
+    ///
+    /// This also performs the following validations:
+    ///
+    /// 1. The script pubkey in the DRT matches the one provided in the [`DepositInfo`].
+    /// 1. The x-only public key in the DRT matches the one provided in the [`DepositInfo`].
+    /// 1. The script pubkey in the DRT is a valid taproot script.
+    pub fn compute_spend_infos(
         &self,
         build_context: &impl BuildContext,
         refund_delay: u16,
     ) -> BridgeTxBuilderResult<TaprootWitness> {
-        // The Deposit Request (DT) spends the n-of-n multisig leaf
+        // The Deposit Transaction (DT) spends the n-of-n multisig leaf
         let spend_script = n_of_n_script(&build_context.aggregated_pubkey()).compile();
 
         // Compute the merkle root using the x-only public key in the OP_RETURN

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -147,13 +147,8 @@ impl DepositInfo {
         })
     }
 
-    /// Computes the spend info for the Deposit Request Transaction (DRT).
-    ///
-    /// This also performs the following validations:
-    ///
-    /// 1. The script pubkey in the DRT matches the one provided in the [`DepositInfo`].
-    /// 1. The x-only public key in the DRT matches the one provided in the [`DepositInfo`].
-    /// 1. The script pubkey in the DRT is a valid taproot script.
+    /// 1. The taproot address computed from the x-only public key in the DRT and the bridge multisig address is the same as the output address in the DRT.
+    /// 1. The control block computed from the DRT commits to the multisig script that the Deposit Transaction (DT) spends.
     pub fn compute_spend_infos(
         &self,
         build_context: &impl BuildContext,

--- a/crates/primitives/src/operator_table.rs
+++ b/crates/primitives/src/operator_table.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use bitcoin::Network;
+use musig2::KeyAggContext;
 use serde::{Deserialize, Serialize};
 use strata_p2p_types::P2POperatorPubKey;
 use strata_primitives::bridge::PublickeyTable;
@@ -97,6 +98,10 @@ impl OperatorTable {
         self.idx_key.len()
     }
 
+    pub fn btc_keys(&self) -> BTreeSet<secp256k1::PublicKey> {
+        self.btc_key.keys().cloned().collect()
+    }
+
     pub fn p2p_keys(&self) -> BTreeSet<P2POperatorPubKey> {
         self.op_key.keys().cloned().collect()
     }
@@ -107,6 +112,12 @@ impl OperatorTable {
 
     pub fn public_key_table(&self) -> PublickeyTable {
         PublickeyTable(self.idx_key.iter().map(|(k, v)| (*k, v.1)).collect())
+    }
+
+    pub fn aggregated_btc_key(&self) -> secp256k1::PublicKey {
+        let pks: Vec<secp256k1::PublicKey> = self.btc_keys().into_iter().collect();
+
+        KeyAggContext::new(pks).unwrap().aggregated_pubkey()
     }
 
     pub fn tx_build_context(&self, network: Network) -> TxBuildContext {


### PR DESCRIPTION
## Description

Reconstructs the DRT from the `OP_RETURN` data in order to fully check that the DRT is compliant with the Strata Bridge specs.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I added some additional arguments to the `deposit_request_info` in `predicates` in order to reconstruct properly the DRT.
Also, I added some quality of life improvements to the `OperatorTable` to make it easier to get the aggregated pubkey and the BTC keys.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1247
