### PR TITLE
Replace x-only pk in dt metadata with merkle proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,7 +3302,7 @@ dependencies = [
  "miniscript",
  "serde_json",
  "strata-bridge-common",
- "strata-bridge-primitives",
+ "strata-primitives",
  "tokio",
  "tracing",
 ]
@@ -10497,6 +10497,7 @@ dependencies = [
  "strata-bridge-test-utils",
  "strata-btcio",
  "strata-p2p-types",
+ "strata-primitives",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/bin/dev-cli/Cargo.toml
+++ b/bin/dev-cli/Cargo.toml
@@ -16,7 +16,8 @@ rust.unused_must_use = "deny"
 
 [dependencies]
 strata-bridge-common.workspace = true
-strata-bridge-primitives.workspace = true
+
+strata-primitives.workspace = true
 
 alloy = { version = "0.3.6", features = ["full", "node-bindings"] }
 alloy-signer = "0.3.6"

--- a/bin/dev-cli/src/bridge_in/deposit_request.rs
+++ b/bin/dev-cli/src/bridge_in/deposit_request.rs
@@ -10,7 +10,7 @@ use bitcoin::{
     ScriptBuf, TapNodeHash,
 };
 use miniscript::Miniscript;
-use strata_bridge_primitives::constants::UNSPENDABLE_INTERNAL_KEY;
+use strata_primitives::constants::UNSPENDABLE_PUBLIC_KEY;
 use tracing::info;
 
 use crate::constants::{AGGREGATED_PUBKEY, LOCKTIME, MAGIC_BYTES, NETWORK};
@@ -34,11 +34,11 @@ pub(crate) fn generate_taproot_address(
         TapNodeHash::from_script(&timelock_script, bitcoin::taproot::LeafVersion::TapScript);
 
     let taproot_info = taproot_builder
-        .finalize(secp, *UNSPENDABLE_INTERNAL_KEY)
+        .finalize(secp, *UNSPENDABLE_PUBLIC_KEY)
         .unwrap();
     let merkle_root = taproot_info.merkle_root();
 
-    let tr_address = Address::p2tr(secp, *UNSPENDABLE_INTERNAL_KEY, merkle_root, NETWORK);
+    let tr_address = Address::p2tr(secp, *UNSPENDABLE_PUBLIC_KEY, merkle_root, NETWORK);
     (script_hash, tr_address)
 }
 

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -41,14 +41,8 @@
 //! | Hash          | 10                 |  33         | 1            | 330   |
 //! | Hash          | 11                 |  3          | 1            | 33    |
 
-use std::sync::LazyLock;
-
-use bitcoin::{
-    hashes::{sha256, Hash},
-    Amount,
-};
+use bitcoin::Amount;
 use bitvm::chunk::api::{NUM_HASH, NUM_PUBS, NUM_U256};
-use secp256k1::XOnlyPublicKey;
 
 /// The maximum number of field elements that are bitcommitted per UTXO.
 pub const NUM_FIELD_ELEMS_PER_CONNECTOR_BATCH_1: usize = 5;
@@ -128,20 +122,3 @@ pub const SEGWIT_MIN_AMOUNT: Amount = Amount::from_sat(330);
 /// |---------------|----------------------------------------|----------------|------------|
 /// | Total         |                                        | 41             | 27060      |
 pub const FUNDING_AMOUNT: Amount = Amount::from_sat(2 * 39 * 330 + 330 + 3 * 330);
-
-const UNSPENDABLE_PUBLIC_KEY_INPUT: &[u8] = b"Strata Bridge Unspendable";
-
-/// A verifiably unspendable public key, produced by hashing a fixed string to a curve group
-/// generator.
-///
-/// This is related to the technique used in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs).
-///
-/// Note that this is _not_ necessarily a uniformly-sampled curve point!
-///
-/// But this is fine; we only need a generator with no efficiently-computable discrete logarithm
-/// relation against the standard generator.
-pub static UNSPENDABLE_INTERNAL_KEY: LazyLock<XOnlyPublicKey> =
-    LazyLock::new(|| -> XOnlyPublicKey {
-        XOnlyPublicKey::from_slice(sha256::Hash::hash(UNSPENDABLE_PUBLIC_KEY_INPUT).as_byte_array())
-            .expect("valid xonly public key")
-    });

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -133,6 +133,7 @@ impl DepositInfo {
             *deposit_amount,
             tag.as_bytes(),
             sidesystem_params.address_length as usize,
+            pegout_graph_params.refund_delay,
         )?;
 
         let mut psbt = Psbt::from_unsigned_tx(unsigned_tx)?;
@@ -224,6 +225,7 @@ impl DepositInfo {
         deposit_amt: Amount,
         tag: &[u8],
         ee_address_size: usize,
+        refund_delay: u16,
     ) -> BridgeTxBuilderResult<Transaction> {
         // First, create the inputs
         let outpoint = self.deposit_request_outpoint();
@@ -241,12 +243,16 @@ impl DepositInfo {
             .into());
         }
 
+        let takeback_script = drt_take_back(*self.x_only_public_key(), refund_delay);
+        let takeback_script_hash =
+            TapNodeHash::from_script(&takeback_script, LeafVersion::TapScript);
+
         let metadata = AuxiliaryData {
             tag,
             metadata: DepositMetadata::DepositTx {
                 stake_index: self.stake_index(),
                 ee_address: self.ee_address.to_vec(),
-                takeback_pubkey: self.x_only_public_key,
+                takeback_hash: takeback_script_hash,
                 input_amount: self.total_amount,
             },
         };
@@ -386,9 +392,9 @@ mod tests {
         let deposit_request_outpoint = OutPoint::null();
         let recovery_xonly_pk = generate_xonly_pubkey();
 
-        let refuned_delay = 1008;
+        let refund_delay = 1008;
         let (drt_output_address, _take_back_leaf_hash) =
-            create_drt_taproot_output(operator_pubkeys.clone(), recovery_xonly_pk, refuned_delay);
+            create_drt_taproot_output(operator_pubkeys.clone(), recovery_xonly_pk, refund_delay);
         let self_index = 0;
 
         let tx_builder = TxBuildContext::new(Network::Regtest, operator_pubkeys, self_index);
@@ -405,7 +411,8 @@ mod tests {
 
         let tag = b"alpen";
         let deposit_amt = Amount::from_int_btc(1);
-        let result = deposit_info.create_unsigned_tx(&tx_builder, deposit_amt, tag, 20);
+        let result =
+            deposit_info.create_unsigned_tx(&tx_builder, deposit_amt, tag, 20, refund_delay);
         assert!(
             result.is_ok(),
             "should build the prevout for DT from the deposit info, error: {:?}",
@@ -528,6 +535,8 @@ mod tests {
         let n_of_n_script = n_of_n_script(&tx_build_context.aggregated_pubkey()).compile();
         let take_back_script =
             drt_take_back(recovery_xonly_pubkey, pegout_graph_params.refund_delay);
+        let take_back_script_hash =
+            TapNodeHash::from_script(&take_back_script, LeafVersion::TapScript);
 
         let spend_path = SpendPath::ScriptSpend {
             scripts: &[n_of_n_script, take_back_script],
@@ -557,7 +566,7 @@ mod tests {
             pegout_graph_params.tag.as_bytes(),
             &stake_index.to_be_bytes(),
             &ee_address,
-            &recovery_xonly_pubkey.serialize(),
+            take_back_script_hash.as_ref(),
             &total_amount.to_sat().to_be_bytes(),
         ]
         .concat();

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -391,7 +391,7 @@ mod tests {
         let deposit_request_outpoint = OutPoint::null();
         let recovery_xonly_pk = generate_xonly_pubkey();
 
-        let refund_delay = 1008;
+        let refund_delay = 1_008;
         let (drt_output_address, _take_back_leaf_hash) =
             create_drt_taproot_output(operator_pubkeys.clone(), recovery_xonly_pk, refund_delay);
         let self_index = 0;

--- a/crates/primitives/src/deposit.rs
+++ b/crates/primitives/src/deposit.rs
@@ -11,11 +11,10 @@ use bitcoin::{
     Amount, OutPoint, Psbt, ScriptBuf, TapNodeHash, Transaction, TxOut, XOnlyPublicKey,
 };
 use serde::{Deserialize, Serialize};
-use strata_primitives::params::RollupParams;
+use strata_primitives::{constants::UNSPENDABLE_PUBLIC_KEY, params::RollupParams};
 
 use crate::{
     build_context::BuildContext,
-    constants::UNSPENDABLE_INTERNAL_KEY,
     errors::{BridgeTxBuilderError, BridgeTxBuilderResult, DepositTransactionError},
     scripts::{
         general::{create_tx, create_tx_ins, create_tx_outs},
@@ -185,11 +184,11 @@ impl DepositInfo {
             ));
         }
 
-        let (output_key, parity) = UNSPENDABLE_INTERNAL_KEY.tap_tweak(SECP256K1, merkle_root);
+        let (output_key, parity) = UNSPENDABLE_PUBLIC_KEY.tap_tweak(SECP256K1, merkle_root);
 
         let control_block = ControlBlock {
             leaf_version: taproot::LeafVersion::TapScript,
-            internal_key: *UNSPENDABLE_INTERNAL_KEY,
+            internal_key: *UNSPENDABLE_PUBLIC_KEY,
             merkle_branch: vec![takeback_script_hash].try_into().map_err(|_| {
                 BridgeTxBuilderError::DepositTransaction(
                     DepositTransactionError::InvalidTapLeafHash,

--- a/crates/primitives/src/scripts/metadata.rs
+++ b/crates/primitives/src/scripts/metadata.rs
@@ -1,6 +1,6 @@
 //! Primitives for Bridge metadata.
 
-use bitcoin::{Amount, XOnlyPublicKey};
+use bitcoin::{Amount, TapNodeHash, XOnlyPublicKey};
 
 /// Metadata bytes that the Bridge uses to read information from the bitcoin blockchain and the
 /// sidesystem.
@@ -36,13 +36,12 @@ pub enum DepositMetadata {
         /// Execution Environment address.
         ee_address: Vec<u8>,
 
-        /// The take back key which is the public key of the depositer included in the Deposit
-        /// Request Metadata.
+        /// The hash of the takeback script that can be used by the depositer to retrieve their
+        /// funds if the deposit is not completed after a certain time.
         ///
         /// This information is required to reconstruct the prevout script pubkey on the output in
         /// the Deposit Request Transaction being spent.
-        //  TODO: (@Rajil1213) make this a BOSD Descriptor.
-        takeback_pubkey: XOnlyPublicKey,
+        takeback_hash: TapNodeHash,
 
         /// The input amount for the Deposit Transaction.
         ///
@@ -74,12 +73,12 @@ impl<'tag> AuxiliaryData<'tag> {
             DepositMetadata::DepositTx {
                 stake_index,
                 ee_address,
-                takeback_pubkey,
+                takeback_hash,
                 input_amount,
             } => {
                 bytes.extend_from_slice(&stake_index.to_be_bytes());
                 bytes.extend_from_slice(ee_address);
-                bytes.extend_from_slice(&takeback_pubkey.serialize());
+                bytes.extend_from_slice(takeback_hash.as_ref());
                 bytes.extend_from_slice(&input_amount.to_sat().to_be_bytes());
             }
         }

--- a/crates/primitives/src/scripts/taproot.rs
+++ b/crates/primitives/src/scripts/taproot.rs
@@ -17,11 +17,9 @@ use bitcoin::{
 use bitvm::treepp::*;
 use secp256k1::{rand::rngs::OsRng, Keypair, Message, Parity, SecretKey};
 use serde::{Deserialize, Serialize};
+use strata_primitives::constants::UNSPENDABLE_PUBLIC_KEY;
 
-use crate::{
-    constants::UNSPENDABLE_INTERNAL_KEY,
-    errors::{BridgeTxBuilderError, BridgeTxBuilderResult},
-};
+use crate::errors::{BridgeTxBuilderError, BridgeTxBuilderResult};
 
 /// Different spending paths for a taproot.
 ///
@@ -34,7 +32,7 @@ pub enum SpendPath<'path> {
         internal_key: UntweakedPublicKey,
     },
     /// Script path spend that only allows spending via scripts in the taproot tree, with the
-    /// internal key being the [`static@UNSPENDABLE_INTERNAL_KEY`].
+    /// internal key being the [`static@UNSPENDABLE_PUBLIC_KEY`].
     ScriptSpend {
         /// The scripts that live in the leaves of the taproot tree.
         scripts: &'path [ScriptBuf],
@@ -65,7 +63,7 @@ pub fn create_taproot_addr<'creator>(
                 return Err(BridgeTxBuilderError::EmptyTapscript);
             }
 
-            build_taptree(*UNSPENDABLE_INTERNAL_KEY, *network, scripts)
+            build_taptree(*UNSPENDABLE_PUBLIC_KEY, *network, scripts)
         }
         SpendPath::Both {
             internal_key,

--- a/crates/tx-graph/Cargo.toml
+++ b/crates/tx-graph/Cargo.toml
@@ -16,6 +16,7 @@ strata-bridge-connectors.workspace = true
 strata-bridge-primitives.workspace = true
 
 strata-p2p-types.workspace = true
+strata-primitives.workspace = true
 
 bitcoin = { workspace = true, features = ["rand-std"] }
 bitcoin-bosd.workspace = true

--- a/crates/tx-graph/src/transactions/disprove.rs
+++ b/crates/tx-graph/src/transactions/disprove.rs
@@ -5,7 +5,8 @@ use bitcoin::{
     Amount, Network, OutPoint, Psbt, TapSighashType, Transaction, TxOut, Txid,
 };
 use strata_bridge_connectors::prelude::*;
-use strata_bridge_primitives::{constants::*, scripts::prelude::*};
+use strata_bridge_primitives::scripts::prelude::*;
+use strata_primitives::constants::UNSPENDABLE_PUBLIC_KEY;
 
 use super::covenant_tx::CovenantTx;
 
@@ -63,7 +64,7 @@ impl DisproveTx {
         let (burn_address, _) = create_taproot_addr(
             &data.network,
             SpendPath::KeySpend {
-                internal_key: *UNSPENDABLE_INTERNAL_KEY,
+                internal_key: *UNSPENDABLE_PUBLIC_KEY,
             },
         )
         .expect("should be able to create taproot address");

--- a/crates/tx-graph/src/transactions/slash_stake.rs
+++ b/crates/tx-graph/src/transactions/slash_stake.rs
@@ -6,12 +6,13 @@ use bitcoin::{
 use secp256k1::schnorr;
 use strata_bridge_connectors::prelude::{ConnectorNOfN, ConnectorStake, StakeSpendPath};
 use strata_bridge_primitives::{
-    constants::{SEGWIT_MIN_AMOUNT, UNSPENDABLE_INTERNAL_KEY},
+    constants::SEGWIT_MIN_AMOUNT,
     scripts::{
         prelude::{create_tx, create_tx_ins},
         taproot::{create_taproot_addr, SpendPath, TaprootWitness},
     },
 };
+use strata_primitives::constants::UNSPENDABLE_PUBLIC_KEY;
 
 use super::prelude::CovenantTx;
 
@@ -59,7 +60,7 @@ impl SlashStakeTx {
         let (burn_address, _) = create_taproot_addr(
             &data.network,
             SpendPath::KeySpend {
-                internal_key: *UNSPENDABLE_INTERNAL_KEY,
+                internal_key: *UNSPENDABLE_PUBLIC_KEY,
             },
         )
         .expect("must be able to create taproot address");


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR replaces the x-only public key in the deposit tx metadata with the merkle proof required to spend the DRT via the $$N/N$$ script spend path. This merkle proof is basically the hash of the take back script that can be used by the depositor to retrieve their funds should the deposit not succeed within a given time period.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

