### PR TITLE
Update public input hash method of SP1 verifier

### DIFF
--- a/crates/agent/src/verifier.rs
+++ b/crates/agent/src/verifier.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, sync::Arc};
 use alpen_bridge_params::prelude::StakeChainParams;
 use bitcoin::{relative, taproot, OutPoint, TxOut};
 use bitvm::chunk::api::{api_generate_full_tapscripts, validate_assertions};
-use sp1_verifier::hash_public_inputs;
+use sp1_verifier::{blake3_hash, hash_public_inputs_with_fn};
 use strata_bridge_connectors::{
     partial_verification_scripts::PARTIAL_VERIFIER_SCRIPTS,
     prelude::{
@@ -143,7 +143,8 @@ where
 
                     // NOTE: This is zkvm-specific logic
                     let serialized_public_inputs = borsh::to_vec(&public_inputs).unwrap();
-                    let public_inputs_hash = hash_public_inputs(&serialized_public_inputs);
+                    let public_inputs_hash =
+                        hash_public_inputs_with_fn(&serialized_public_inputs, blake3_hash);
 
                     let committed_public_inputs_hash = wots_to_byte_array(groth16.0[0]);
 

--- a/crates/bridge-proof/snark/src/prover.rs
+++ b/crates/bridge-proof/snark/src/prover.rs
@@ -3,7 +3,7 @@ use ark_bn254::{Bn254, Fr};
 use ark_ff::PrimeField;
 use ark_groth16::Proof;
 use sp1_sdk::{HashableKey, SP1VerifyingKey};
-use sp1_verifier::hash_public_inputs;
+use sp1_verifier::{blake3_hash, hash_public_inputs_with_fn};
 use strata_bridge_guest_builder::GUEST_BRIDGE_ELF;
 use strata_bridge_proof_protocol::{
     get_native_host, BridgeProgram, BridgeProofInput, BridgeProofPublicOutput,
@@ -40,8 +40,9 @@ pub fn sp1_prove(
     // SP1 prepends the raw Groth16 proof with the first 4 bytes of the groth16 vkey
     // The use of correct vkey is checked in verify_groth16 function above
     let proof = sp1::load_groth16_proof_from_bytes(&proof_receipt.proof().as_bytes()[4..]);
-    let public_inputs = [Fr::from_be_bytes_mod_order(&hash_public_inputs(
+    let public_inputs = [Fr::from_be_bytes_mod_order(&hash_public_inputs_with_fn(
         proof_receipt.public_values().as_bytes(),
+        blake3_hash,
     ))];
     info!(action = "loaded proof and public params");
 


### PR DESCRIPTION
## Description

<!--
The SP1 verifier provides method to hash public inputs to use blake3 which originally used sha256.-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
