### PR TITLE
MICRO: Chore/debug assert warnings

### DIFF
--- a/crates/tx-graph/src/peg_out_graph.rs
+++ b/crates/tx-graph/src/peg_out_graph.rs
@@ -29,7 +29,7 @@ use crate::{
 ///
 /// This data is shared between various operators and verifiers and is used to construct the peg out
 /// graph deterministically.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PegOutGraphInput {
     /// The [`OutPoint`] of the stake transaction
     pub stake_outpoint: OutPoint,

--- a/crates/tx-graph/src/pog_musig_functor.rs
+++ b/crates/tx-graph/src/pog_musig_functor.rs
@@ -12,7 +12,7 @@ use crate::transactions::{
 
 /// Functor like data structure for holding an arbitrary data structure that is matched with each of
 /// the inputs of the peg-out graph.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PogMusigF<T> {
     /// Data associated with the challenge transaction input.
     pub challenge: T,


### PR DESCRIPTION
## Description

This PR adds debug assertions to the warning logs in the CSM. This is helpful if we ever want to run the bridge in strict mode to get out ahead of potential issues, even if we think we know how to handle them.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This is based on #128 and so it should be reviewed after. I briefly tried to rebase it directly onto main but it's not worth it.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
