### PR TITLE
chore(tls) don't convert to der

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,5 +294,5 @@ provers/sp1/proofs/
 seed
 certs
 
-# certificates and private keys in der format
-*.der
+# certificates and private keys in pem format
+*.pem

--- a/docker/gen_s2_tls.sh
+++ b/docker/gen_s2_tls.sh
@@ -12,16 +12,16 @@ mkdir -p $S2_TLS_DIR $BRIDGE_TLS_DIR
 
 # Generate Bridge Node CA
 openssl genpkey -algorithm RSA -out bridge_node_ca.key
-openssl req -x509 -new -nodes -key bridge_node_ca.key -sha256 -days 365 -out bridge_node_ca.crt -subj "/CN=Bridge Node CA"
+openssl req -x509 -new -nodes -key bridge_node_ca.key -sha256 -days 365 -out $S2_TLS_DIR/bridge.ca.pem -subj "/CN=Bridge Node CA"
 
 # Generate Secret Service CA
 openssl genpkey -algorithm RSA -out secret_service_ca.key
-openssl req -x509 -new -nodes -key secret_service_ca.key -sha256 -days 365 -out secret_service_ca.crt -subj "/CN=Secret Service CA"
+openssl req -x509 -new -nodes -key secret_service_ca.key -sha256 -days 365 -out $BRIDGE_TLS_DIR/s2.ca.pem -subj "/CN=Secret Service CA"
 
 # Generate key pair for bridge operator
-openssl genpkey -algorithm RSA -out bridge_node.key
-openssl req -new -key bridge_node.key -out bridge_node.csr -subj "/CN=Bridge Operator"
-openssl x509 -req -in bridge_node.csr -CA bridge_node_ca.crt -CAkey bridge_node_ca.key -CAcreateserial -out bridge_node.crt -days 365 -sha256
+openssl genpkey -algorithm RSA -out $BRIDGE_TLS_DIR/key.pem
+openssl req -new -key $BRIDGE_TLS_DIR/key.pem -out bridge_node.csr -subj "/CN=Bridge Operator"
+openssl x509 -req -in bridge_node.csr -CA $S2_TLS_DIR/bridge.ca.pem -CAkey bridge_node_ca.key -CAcreateserial -out $BRIDGE_TLS_DIR/cert.pem -days 365 -sha256
 
 # Create config file for secret-service with SAN
 cat > secret_service.cnf << EOF
@@ -44,25 +44,17 @@ IP.1 = $IP
 EOF
 
 # Generate key pair for secret-service with domain name support
-openssl genpkey -algorithm RSA -out secret_service.key
-openssl req -new -key secret_service.key -out secret_service.csr -config secret_service.cnf
-openssl x509 -req -in secret_service.csr -CA secret_service_ca.crt -CAkey secret_service_ca.key -CAcreateserial -out secret_service.crt -days 365 -sha256 -extfile secret_service.cnf -extensions v3_req
-
-# Convert to DER format
-openssl x509 -outform der -in bridge_node.crt -out $BRIDGE_TLS_DIR/cert.der
-openssl rsa -outform der -in bridge_node.key -out $BRIDGE_TLS_DIR/key.der
-openssl x509 -outform der -in secret_service.crt -out $S2_TLS_DIR/cert.der
-openssl rsa -outform der -in secret_service.key -out $S2_TLS_DIR/key.der
-openssl x509 -outform der -in bridge_node_ca.crt -out $S2_TLS_DIR/bridge.ca.der
-openssl x509 -outform der -in secret_service_ca.crt -out $BRIDGE_TLS_DIR/s2.ca.der
+openssl genpkey -algorithm RSA -out $S2_TLS_DIR/key.pem
+openssl req -new -key $S2_TLS_DIR/key.pem -out secret_service.csr -config secret_service.cnf
+openssl x509 -req -in secret_service.csr -CA $BRIDGE_TLS_DIR/s2.ca.pem -CAkey secret_service_ca.key -CAcreateserial -out $S2_TLS_DIR/cert.pem -days 365 -sha256 -extfile secret_service.cnf -extensions v3_req
 
 # Verify certificates
-openssl verify -CAfile bridge_node_ca.crt bridge_node.crt
-openssl verify -CAfile secret_service_ca.crt secret_service.crt
+openssl verify -CAfile $S2_TLS_DIR/bridge.ca.pem $BRIDGE_TLS_DIR/cert.pem
+openssl verify -CAfile $BRIDGE_TLS_DIR/s2.ca.pem $S2_TLS_DIR/cert.pem
 
 # Display the certificate to confirm SAN extension
 echo "Verifying SAN extension for secret-service certificate:"
-openssl x509 -in secret_service.crt -text -noout | grep -A1 "Subject Alternative Name"
+openssl x509 -in $S2_TLS_DIR/cert.pem -text -noout | grep -A1 "Subject Alternative Name"
 
 # Clean up
-rm *.crt *.key *.csr *.srl *.cnf
+rm *.csr $BRIDGE_TLS_DIR/*.srl $S2_TLS_DIR/*.srl *.cnf *ca.key

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -9,9 +9,9 @@ nag_interval = { secs = 120, nanos = 0 }
 server_addr = "172.28.1.5:69"
 server_hostname = "secret-service"
 timeout = 1000
-cert = "/app/tls/cert.der"
-key = "/app/tls/key.der"
-service_ca = "/app/tls/s2.ca.der"
+cert = "/app/tls/cert.pem"
+key = "/app/tls/key.pem"
+service_ca = "/app/tls/s2.ca.pem"
 
 [btc_client]
 url = "http://172.28.1.8:18443"

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -9,9 +9,9 @@ nag_interval = { secs = 120, nanos = 0 }
 server_addr = "172.28.1.6:69"
 server_hostname = "secret-service"
 timeout = 1000
-cert = "/app/tls/cert.der"
-key = "/app/tls/key.der"
-service_ca = "/app/tls/s2.ca.der"
+cert = "/app/tls/cert.pem"
+key = "/app/tls/key.pem"
+service_ca = "/app/tls/s2.ca.pem"
 
 [btc_client]
 url = "http://172.28.1.8:18443"

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -9,9 +9,9 @@ nag_interval = { secs = 120, nanos = 0 }
 server_addr = "172.28.1.7:69"
 server_hostname = "secret-service"
 timeout = 1000
-cert = "/app/tls/cert.der"
-key = "/app/tls/key.der"
-service_ca = "/app/tls/s2.ca.der"
+cert = "/app/tls/cert.pem"
+key = "/app/tls/key.pem"
+service_ca = "/app/tls/s2.ca.pem"
 
 [btc_client]
 url = "http://172.28.1.8:18443"

--- a/docker/vol/secret-service-1/config.toml
+++ b/docker/vol/secret-service-1/config.toml
@@ -2,9 +2,9 @@ seed = "/app/seed"
 network = "regtest"
 
 [tls]
-key = "/app/tls/key.der"
-cert = "/app/tls/cert.der"
-ca = "/app/tls/bridge.ca.der"
+key = "/app/tls/key.pem"
+cert = "/app/tls/cert.pem"
+ca = "/app/tls/bridge.ca.pem"
 
 [transport]
 addr = "0.0.0.0:69"

--- a/docker/vol/secret-service-2/config.toml
+++ b/docker/vol/secret-service-2/config.toml
@@ -2,9 +2,9 @@ seed = "/app/seed"
 network = "regtest"
 
 [tls]
-key = "/app/tls/key.der"
-cert = "/app/tls/cert.der"
-ca = "/app/tls/bridge.ca.der"
+key = "/app/tls/key.pem"
+cert = "/app/tls/cert.pem"
+ca = "/app/tls/bridge.ca.pem"
 
 [transport]
 addr = "0.0.0.0:69"

--- a/docker/vol/secret-service-3/config.toml
+++ b/docker/vol/secret-service-3/config.toml
@@ -2,9 +2,9 @@ seed = "/app/seed"
 network = "regtest"
 
 [tls]
-key = "/app/tls/key.der"
-cert = "/app/tls/cert.der"
-ca = "/app/tls/bridge.ca.der"
+key = "/app/tls/key.pem"
+cert = "/app/tls/cert.pem"
+ca = "/app/tls/bridge.ca.pem"
 
 [transport]
 addr = "0.0.0.0:69"

--- a/scripts/ca-and-tls.sh
+++ b/scripts/ca-and-tls.sh
@@ -32,18 +32,11 @@ for i in $(seq 1 $N); do
     openssl req -new -key secret_service.key -out secret_service.csr -subj "/CN=Secret Service $i"
     openssl x509 -req -in secret_service.csr -CA secret_service_ca.crt -CAkey secret_service_ca.key -CAcreateserial -out secret_service.crt -days 365 -sha256
 
-    # Convert to DER format
-    openssl x509 -outform der -in bridge_node.crt -out bridge_node.der
-    openssl rsa -outform der -in bridge_node.key -out bridge_node.key.der
-    openssl x509 -outform der -in secret_service.crt -out secret_service.der
-    openssl rsa -outform der -in secret_service.key -out secret_service.key.der
-    openssl x509 -outform der -in bridge_node_ca.crt -out bridge.ca.der
-
     # Verify certificates
     openssl verify -CAfile bridge_node_ca.crt bridge_node.crt
     openssl verify -CAfile secret_service_ca.crt secret_service.crt
 
-    echo "Iteration $i certificates generated successfully and converted to DER format."
+    echo "Iteration $i certificates generated successfully."
 
     # Return to base directory
     cd ../../


### PR DESCRIPTION
## Description

Changes the TLS certificate generation script to not convert into der and rather keep the pem encoded certs/keys. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
