### PR TITLE
STR-1309: Implement the RPC server V2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "strata-bridge-primitives",
  "strata-bridge-rpc",
  "strata-bridge-stake-chain",
+ "strata-bridge-tx-graph",
  "strata-p2p",
  "strata-p2p-types",
  "strata-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bdk_bitcoind_rpc",
+ "bincode",
  "bitcoin",
  "bitcoind-async-client",
  "btc-notify",

--- a/bin/alpen-bridge/Cargo.toml
+++ b/bin/alpen-bridge/Cargo.toml
@@ -29,6 +29,7 @@ strata-bridge-p2p-service.workspace = true
 strata-bridge-primitives.workspace = true
 strata-bridge-rpc.workspace = true
 strata-bridge-stake-chain.workspace = true
+strata-bridge-tx-graph.workspace = true
 strata-p2p.workspace = true
 strata-p2p-types.workspace = true
 strata-primitives.workspace = true

--- a/bin/alpen-bridge/Cargo.toml
+++ b/bin/alpen-bridge/Cargo.toml
@@ -19,6 +19,7 @@ rust.unused_must_use = "deny"
 
 [dependencies]
 alpen-bridge-params.workspace = true
+bincode.workspace = true
 btc-notify.workspace = true
 duty-tracker.workspace = true
 operator-wallet.workspace = true

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -14,8 +14,8 @@ use strata_bridge_primitives::operator_table::OperatorTable;
 use strata_bridge_rpc::{
     traits::{StrataBridgeControlApiServer, StrataBridgeMonitoringApiServer},
     types::{
-        RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositStatus, RpcOperatorStatus, RpcWithdrawalInfo,
-        RpcWithdrawalStatus,
+        RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositStatus, RpcOperatorStatus,
+        RpcReimbursementStatus, RpcWithdrawalInfo, RpcWithdrawalStatus,
     },
 };
 use strata_p2p::swarm::handle::P2PHandle;
@@ -444,11 +444,78 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
     }
 
     async fn get_claims(&self) -> RpcResult<Vec<Txid>> {
-        todo!()
+        // Check the database.
+        let all_entries = query!(r#"SELECT * FROM contracts"#)
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+        let mut claims = Vec::new();
+        for entry in all_entries {
+            let state = bincode::deserialize::<ContractState>(&entry.state).map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+            claims.extend(state.claim_txids());
+        }
+
+        Ok(claims)
     }
 
-    async fn get_claim_info(&self, _claim_txid: Txid) -> RpcResult<RpcClaimInfo> {
-        todo!()
+    async fn get_claim_info(&self, claim_txid: Txid) -> RpcResult<RpcClaimInfo> {
+        // Check the database.
+        let all_entries = query!(r#"SELECT * FROM contracts"#)
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+        for entry in all_entries {
+            let state = bincode::deserialize::<ContractState>(&entry.state).map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+            if state.claim_txids().contains(&claim_txid) {
+                let status = match state {
+                    ContractState::Requested { .. } => RpcReimbursementStatus::InProgress,
+                    ContractState::Deposited { .. } => RpcReimbursementStatus::InProgress,
+                    ContractState::Assigned { .. } => RpcReimbursementStatus::InProgress,
+                    ContractState::StakeTxReady { .. } => RpcReimbursementStatus::InProgress,
+                    ContractState::Fulfilled { .. } => RpcReimbursementStatus::InProgress,
+                    ContractState::Claimed { .. } => RpcReimbursementStatus::InProgress,
+                    ContractState::Challenged { .. } => RpcReimbursementStatus::Challenged,
+                    ContractState::Asserted { .. } => RpcReimbursementStatus::Challenged,
+                    ContractState::Disproved { .. } => RpcReimbursementStatus::Cancelled,
+                    ContractState::Resolved { .. } => RpcReimbursementStatus::Complete,
+                };
+                return Ok(RpcClaimInfo { claim_txid, status });
+            }
+        }
+
+        Err(ErrorObjectOwned::owned::<_>(
+            -32001,
+            "Claim not found",
+            Some(claim_txid),
+        ))
     }
 }
 

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -4,11 +4,13 @@ use anyhow::{bail, Context};
 use async_trait::async_trait;
 use bitcoin::{OutPoint, PublicKey, Txid};
 use chrono::{DateTime, Utc};
+use duty_tracker::contract_state_machine::ContractState;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned, RpcModule};
 use libp2p::{identity::PublicKey as LibP2pPublicKey, PeerId};
 use secp256k1::Parity;
 use sqlx::query;
 use strata_bridge_db::persistent::sqlite::SqliteDb;
+use strata_bridge_primitives::operator_table::OperatorTable;
 use strata_bridge_rpc::{
     traits::{StrataBridgeControlApiServer, StrataBridgeMonitoringApiServer},
     types::{
@@ -240,14 +242,162 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
     }
 
     async fn get_bridge_duties(&self) -> RpcResult<Vec<RpcBridgeDutyStatus>> {
-        todo!()
+        // we don't care about the hot state here, we only care about the database
+        let all_entries = query!(r#"SELECT * FROM contracts"#)
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+        let mut duties = Vec::new();
+        for entry in all_entries {
+            let state = bincode::deserialize::<ContractState>(&entry.state).map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+            match state {
+                ContractState::Requested {
+                    deposit_request_txid,
+                    ..
+                } => {
+                    duties.push(RpcBridgeDutyStatus::Deposit {
+                        deposit_request_txid,
+                    });
+                }
+                ContractState::Deposited {
+                    deposit_request_txid,
+                    ..
+                } => duties.push(RpcBridgeDutyStatus::Deposit {
+                    deposit_request_txid,
+                }),
+                ContractState::Assigned {
+                    assignment_txid,
+                    fulfiller,
+                    ..
+                } => duties.push(RpcBridgeDutyStatus::Withdrawal {
+                    withdrawal_request_txid: assignment_txid,
+                    assigned_operator_idx: fulfiller,
+                }),
+                ContractState::StakeTxReady {
+                    assignment_txid,
+                    fulfiller,
+                    ..
+                } => duties.push(RpcBridgeDutyStatus::Withdrawal {
+                    withdrawal_request_txid: assignment_txid,
+                    assigned_operator_idx: fulfiller,
+                }),
+                // Anything else is not a duty for the RPC server
+                _ => (),
+            }
+        }
+
+        Ok(duties)
     }
 
     async fn get_bridge_duties_by_operator_pk(
         &self,
-        _operator_pk: PublicKey,
+        operator_pk: PublicKey,
     ) -> RpcResult<Vec<RpcBridgeDutyStatus>> {
-        todo!()
+        // we don't care about the hot state here, we only care about the database
+        let all_entries = query!(r#"SELECT * FROM contracts"#)
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+        // NOTE: duties by operator pk is only for withdrawal duties,
+        //       it does not make sense for deposit duties
+        let mut duties = Vec::new();
+        for entry in all_entries {
+            let state = bincode::deserialize::<ContractState>(&entry.state).map_err(|_| {
+                ErrorObjectOwned::owned::<_>(
+                    -666,
+                    "Database error. Config dumped",
+                    Some(self.db.config()),
+                )
+            })?;
+
+            // First, get the operator_table from the record
+            let operator_table = bincode::deserialize::<OperatorTable>(&entry.operator_table)
+                .map_err(|_| {
+                    ErrorObjectOwned::owned::<_>(
+                        -666,
+                        "Database error. Config dumped",
+                        Some(self.db.config()),
+                    )
+                })?;
+
+            // Then, get the operator index from the operator table
+            let operator_index = operator_table
+                .btc_key_to_idx(&operator_pk.inner)
+                .ok_or_else(|| {
+                    ErrorObjectOwned::owned::<_>(
+                        -32001,
+                        "Operator public key not found in operator table",
+                        Some(operator_pk.to_string()),
+                    )
+                })?;
+
+            let operator_p2p_pk = operator_table
+                .idx_to_op_key(&operator_index)
+                .expect("we just checked that the index is valid");
+
+            // Then, only get the entries where the operator index matches
+            match state {
+                ContractState::Assigned {
+                    claim_txids,
+                    assignment_txid,
+                    ..
+                } => {
+                    if claim_txids.contains_key(operator_p2p_pk) {
+                        duties.push(RpcBridgeDutyStatus::Withdrawal {
+                            withdrawal_request_txid: assignment_txid,
+                            assigned_operator_idx: operator_index,
+                        });
+                    }
+                }
+                ContractState::StakeTxReady {
+                    claim_txids,
+                    assignment_txid,
+                    ..
+                } => {
+                    if claim_txids.contains_key(operator_p2p_pk) {
+                        duties.push(RpcBridgeDutyStatus::Withdrawal {
+                            withdrawal_request_txid: assignment_txid,
+                            assigned_operator_idx: operator_index,
+                        });
+                    }
+                }
+                ContractState::Fulfilled {
+                    claim_txids,
+                    withdrawal_fulfillment_txid,
+                    ..
+                } => {
+                    if claim_txids.contains_key(operator_p2p_pk) {
+                        duties.push(RpcBridgeDutyStatus::Withdrawal {
+                            withdrawal_request_txid: withdrawal_fulfillment_txid,
+                            assigned_operator_idx: operator_index,
+                        });
+                    }
+                }
+                _ => (),
+            }
+        }
+        Ok(duties)
     }
 
     async fn get_withdrawal_info(

--- a/crates/db/src/inmemory/tracker.rs
+++ b/crates/db/src/inmemory/tracker.rs
@@ -13,10 +13,13 @@ use crate::{
     tracker::{BitcoinBlockTrackerDb, DutyTrackerDb},
 };
 
+/// In-memory implementation of the duty tracker database.
 #[derive(Debug, Clone, Default)]
 pub struct DutyTrackerInMemory {
+    /// Last fetched duty index.
     last_fetched_duty_index: Arc<RwLock<u64>>,
 
+    /// Status of each duty.
     duty_status: Arc<RwLock<HashMap<Txid, BridgeDutyStatus>>>,
 }
 

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -573,6 +573,7 @@ impl ContractManagerCtx {
         &mut self,
         tx: &Transaction,
     ) -> Result<Vec<OperatorDuty>, ContractManagerErr> {
+        let assignment_txid = tx.compute_txid();
         let mut duties = Vec::new();
 
         if let Some(checkpoint) = parse_strata_checkpoint(tx, &self.cfg.sidesystem_params) {
@@ -604,9 +605,11 @@ impl ContractManagerCtx {
                         continue;
                     };
 
-                    match sm
-                        .process_contract_event(ContractEvent::Assignment(entry.clone(), stake_tx))
-                    {
+                    match sm.process_contract_event(ContractEvent::Assignment(
+                        entry.clone(),
+                        stake_tx,
+                        assignment_txid,
+                    )) {
                         Ok(new_duties) if !new_duties.is_empty() => {
                             info!("committing stake chain state");
                             self.state_handles

--- a/crates/duty-tracker/src/contract_persister.rs
+++ b/crates/duty-tracker/src/contract_persister.rs
@@ -47,11 +47,11 @@ impl ContractPersister {
             // TODO(proofofkeags): make state not opaque at the DB level
             r#"
             CREATE TABLE IF NOT EXISTS contracts (
-                deposit_txid CHAR(64) PRIMARY KEY,
+                deposit_txid TEXT PRIMARY KEY,
                 deposit_idx INTEGER NOT NULL UNIQUE,
-                deposit_tx VARBINARY NOT NULL,
-                operator_table VARBINARY NOT NULL,
-                state VARBINARY NOT NULL
+                deposit_tx BLOB NOT NULL,
+                operator_table BLOB NOT NULL,
+                state BLOB NOT NULL
             )
             "#,
         )

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -1873,15 +1873,7 @@ impl ContractSM {
 
     /// The txid of the original deposit request that kicked off this contract.
     pub fn deposit_request_txid(&self) -> Txid {
-        self.cfg
-            .deposit_tx
-            .psbt()
-            .unsigned_tx
-            .input
-            .first()
-            .unwrap()
-            .previous_output
-            .txid
+        self.cfg().deposit_request_txid()
     }
 
     /// Gives us a list of claim txids that can be used to reference this contract.

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -136,7 +136,7 @@ pub enum ContractEvent {
     RootSig(P2POperatorPubKey, PartialSignature),
 
     /// Signifies that this withdrawal has been assigned.
-    Assignment(DepositEntry, StakeTx),
+    Assignment(DepositEntry, StakeTx, Txid),
 
     /// Signifies that the deposit transaction has been confirmed, the second value is the global
     /// deposit index.
@@ -243,6 +243,9 @@ pub enum ContractState {
 
         /// The graph that belongs to the assigned operator.
         active_graph: (PegOutGraphInput, PegOutGraphSummary),
+
+        /// The transaction ID of the assignment transaction.
+        assignment_txid: Txid,
     },
 
     /// This state describes everything from the moment stake transaction corresponding to this
@@ -269,6 +272,9 @@ pub enum ContractState {
 
         /// The graph that belongs to the assigned operator.
         active_graph: (PegOutGraphInput, PegOutGraphSummary),
+
+        /// The transaction ID of the assignment transaction.
+        assignment_txid: Txid,
     },
 
     /// This state describes everything from the moment the fulfillment transaction confirms, to
@@ -288,6 +294,9 @@ pub enum ContractState {
 
         /// The graph that belongs to the assigned operator.
         active_graph: (PegOutGraphInput, PegOutGraphSummary),
+
+        /// The withdrawal fulfillment transaction ID.
+        withdrawal_fulfillment_txid: Txid,
     },
 
     /// This state describes everything from the moment the claim transaction confirms, to the
@@ -416,8 +425,8 @@ impl Display for ContractState {
                 "Asserted by operator {} at height {} ({})",
                 fulfiller, post_assert_height, active_graph.1.post_assert_txid
             ),
-            ContractState::Disproved {} => "Disproved".to_string(),
-            ContractState::Resolved {} => "Resolved".to_string(),
+            ContractState::Disproved { .. } => "Disproved".to_string(),
+            ContractState::Resolved { .. } => "Resolved".to_string(),
         };
 
         write!(f, "ContractState: {}", display_str)
@@ -442,8 +451,8 @@ impl ContractState {
             ContractState::Claimed { peg_out_graphs, .. } => get_summaries(peg_out_graphs),
             ContractState::Challenged { peg_out_graphs, .. } => get_summaries(peg_out_graphs),
             ContractState::Asserted { peg_out_graphs, .. } => get_summaries(peg_out_graphs),
-            ContractState::Disproved {} => vec![],
-            ContractState::Resolved {} => vec![],
+            ContractState::Disproved { .. } => vec![],
+            ContractState::Resolved { .. } => vec![],
         }
     }
 }
@@ -650,6 +659,13 @@ impl ContractCfg {
     /// Builds a TxBuildContext from the ContractCfg.
     pub fn tx_build_context(&self) -> TxBuildContext {
         self.operator_table.tx_build_context(self.network)
+    }
+
+    /// Returns the transaction ID of the deposit request for this contract.
+    pub fn deposit_request_txid(&self) -> Txid {
+        self.deposit_tx.psbt().unsigned_tx.input[0]
+            .previous_output
+            .txid
     }
 }
 
@@ -858,8 +874,8 @@ impl ContractSM {
             ContractEvent::AssertionFailure => self
                 .process_assertion_verification_failure()
                 .map(|x| x.into_iter().collect()),
-            ContractEvent::Assignment(deposit_entry, stake_tx) => self
-                .process_assignment(&deposit_entry, stake_tx)
+            ContractEvent::Assignment(deposit_entry, stake_tx, assignment_txid) => self
+                .process_assignment(&deposit_entry, stake_tx, assignment_txid)
                 .map(|x| x.into_iter().collect()),
         }
     }
@@ -1406,6 +1422,7 @@ impl ContractSM {
         &mut self,
         assignment: &DepositEntry,
         stake_tx: StakeTx,
+        assignment_txid: Txid,
     ) -> Result<Option<OperatorDuty>, TransitionErr> {
         if assignment.idx() != self.cfg.deposit_idx {
             return Err(TransitionErr(format!(
@@ -1465,6 +1482,7 @@ impl ContractSM {
                             deadline,
                             active_graph,
                             recipient: recipient.clone(),
+                            assignment_txid,
                         };
 
                         let stake_index = assignment.idx();
@@ -1504,6 +1522,7 @@ impl ContractSM {
                 recipient,
                 deadline,
                 active_graph,
+                assignment_txid,
             } => {
                 if tx.compute_txid() != active_graph.1.stake_txid {
                     return Err(TransitionErr(format!(
@@ -1518,6 +1537,7 @@ impl ContractSM {
                     recipient: recipient.clone(),
                     deadline,
                     active_graph,
+                    assignment_txid,
                 };
                 let is_assigned_to_me = fulfiller == self.cfg.operator_table.pov_idx();
 
@@ -1593,6 +1613,7 @@ impl ContractSM {
                     claim_txids,
                     fulfiller,
                     active_graph,
+                    withdrawal_fulfillment_txid: tx.compute_txid(),
                 };
 
                 Ok(duty)
@@ -1881,5 +1902,49 @@ impl ContractSM {
         .values()
         .copied()
         .collect()
+    }
+
+    /// The txid of the assignment transaction for this contract.
+    ///
+    /// Note that this is only available if the contract is in the [`ContractState::Assigned`] or
+    /// [`ContractState::StakeTxReady`] state.
+    pub fn assignment_txid(&self) -> Option<Txid> {
+        match &self.state().state {
+            ContractState::Requested { .. } => None,
+            ContractState::Deposited { .. } => None,
+            ContractState::Assigned {
+                assignment_txid, ..
+            } => Some(*assignment_txid),
+            ContractState::StakeTxReady {
+                assignment_txid, ..
+            } => Some(*assignment_txid),
+            ContractState::Fulfilled { .. } => None,
+            ContractState::Claimed { .. } => None,
+            ContractState::Challenged { .. } => None,
+            ContractState::Asserted { .. } => None,
+            ContractState::Disproved {} => None,
+            ContractState::Resolved {} => None,
+        }
+    }
+    /// The txid of the withdrawal fulfillment for this contract.
+    ///
+    /// Note that this is only available if the contract is in the [`ContractState::Fulfilled`]
+    /// state.
+    pub fn withdrawal_fulfillment_txid(&self) -> Option<Txid> {
+        match &self.state().state {
+            ContractState::Requested { .. } => None,
+            ContractState::Deposited { .. } => None,
+            ContractState::Assigned { .. } => None,
+            ContractState::StakeTxReady { .. } => None,
+            ContractState::Fulfilled {
+                withdrawal_fulfillment_txid,
+                ..
+            } => Some(*withdrawal_fulfillment_txid),
+            ContractState::Claimed { .. } => None,
+            ContractState::Challenged { .. } => None,
+            ContractState::Asserted { .. } => None,
+            ContractState::Disproved {} => None,
+            ContractState::Resolved {} => None,
+        }
     }
 }

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -666,7 +666,10 @@ pub struct MachineState {
 /// This is the core state machine for a given deposit contract.
 #[derive(Debug)]
 pub struct ContractSM {
+    /// The configuration of the contract.
     cfg: ContractCfg,
+
+    /// The state of the contract itself.
     state: MachineState,
 
     /// The peg out graphs associated with each operator for the given deposit.

--- a/crates/primitives/src/duties.rs
+++ b/crates/primitives/src/duties.rs
@@ -331,7 +331,7 @@ impl WithdrawalStatus {
 }
 
 /// Represents a valid reimbursement status
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ClaimStatus {
     /// Claim exists, challenge step is "Claim", no payout.
@@ -357,7 +357,7 @@ pub enum ClaimStatus {
 }
 
 /// Challenge step states for claims
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChallengeStep {
     /// Challenge step is "Claim".

--- a/crates/primitives/src/duties.rs
+++ b/crates/primitives/src/duties.rs
@@ -179,7 +179,10 @@ pub enum DepositRequestStatus {
 
     /// Deposit request has been fully processed and minted.
     Complete {
+        /// The transaction ID of the deposit request.
         deposit_request_txid: Txid,
+
+        /// The transaction ID of the deposit.
         deposit_txid: Txid,
     },
 }

--- a/crates/primitives/src/duties.rs
+++ b/crates/primitives/src/duties.rs
@@ -331,7 +331,7 @@ impl WithdrawalStatus {
 }
 
 /// Represents a valid reimbursement status
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ClaimStatus {
     /// Claim exists, challenge step is "Claim", no payout.
@@ -357,7 +357,7 @@ pub enum ClaimStatus {
 }
 
 /// Challenge step states for claims
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ChallengeStep {
     /// Challenge step is "Claim".

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -2,11 +2,10 @@
 
 use bitcoin::{OutPoint, PublicKey, Txid};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use strata_bridge_primitives::duties::{
-    BridgeDuty, ClaimStatus, DepositRequestStatus, WithdrawalStatus,
-};
 
-use crate::types::RpcOperatorStatus;
+use crate::types::{
+    RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositStatus, RpcOperatorStatus, RpcWithdrawalInfo,
+};
 
 /// RPCs related to information about the client itself.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "stratabridge"))]
@@ -34,25 +33,25 @@ pub trait StrataBridgeMonitoringApi {
     async fn get_deposit_request_info(
         &self,
         deposit_request_outpoint: OutPoint,
-    ) -> RpcResult<DepositRequestStatus>;
+    ) -> RpcResult<RpcDepositStatus>;
 
     /// Get bridge duties.
     #[method(name = "bridgeDuties")]
-    async fn get_bridge_duties(&self) -> RpcResult<Vec<BridgeDuty>>;
+    async fn get_bridge_duties(&self) -> RpcResult<Vec<RpcBridgeDutyStatus>>;
 
     /// Get bridge duties assigned to an operator by its [`PublicKey`].
     #[method(name = "bridgeDutiesByPk")]
     async fn get_bridge_duties_by_operator_pk(
         &self,
         operator_pk: PublicKey,
-    ) -> RpcResult<Vec<BridgeDuty>>;
+    ) -> RpcResult<Vec<RpcBridgeDutyStatus>>;
 
     /// Get withdrawal details using withdrawal outpoint.
     #[method(name = "withdrawalInfo")]
     async fn get_withdrawal_info(
         &self,
         withdrawal_outpoint: OutPoint,
-    ) -> RpcResult<WithdrawalStatus>;
+    ) -> RpcResult<RpcWithdrawalInfo>;
 
     /// Get all claim transaction IDs.
     #[method(name = "claims")]
@@ -60,5 +59,5 @@ pub trait StrataBridgeMonitoringApi {
 
     /// Get claim details for a given claim transaction ID.
     #[method(name = "claimInfo")]
-    async fn get_claim_info(&self, claim_txid: Txid) -> RpcResult<ClaimStatus>;
+    async fn get_claim_info(&self, claim_txid: Txid) -> RpcResult<RpcClaimInfo>;
 }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -78,25 +78,16 @@ pub enum RpcWithdrawalStatus {
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum RpcReimbursementStatus {
     /// Claim exists, challenge step is "Claim", no payout.
-    InProgress {
-        /// Challenge step.
-        challenge_step: ChallengeStep,
-    },
+    InProgress,
 
     /// Claim exists, challenge step is "Challenge" or "Assert", no payout.
-    Challenged {
-        /// Challenge step.
-        challenge_step: ChallengeStep,
-    },
+    Challenged,
 
     /// Operator was slashed, claim is no longer valid.
     Cancelled,
 
     /// Claim has been successfully reimbursed.
-    Complete {
-        /// Transaction ID of the payout transaction.
-        payout_txid: Txid,
-    },
+    Complete,
 }
 
 /// Represents deposit transaction details

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -2,6 +2,7 @@
 
 use bitcoin::Txid;
 use serde::{Deserialize, Serialize};
+use strata_bridge_primitives::types::OperatorIdx;
 
 /// Enum representing the status of a bridge operator
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,4 +121,23 @@ pub struct RpcClaimInfo {
 
     /// Status of the reimbursement.
     pub status: RpcReimbursementStatus,
+}
+
+/// Represents a valid bridge duty status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RpcBridgeDutyStatus {
+    /// Deposit duty
+    Deposit {
+        /// Transaction ID of the deposit request transaction (DRT).
+        deposit_request_txid: Txid,
+    },
+
+    /// Withdrawal duty
+    Withdrawal {
+        /// Transaction ID of the withdrawal request transaction (WRT).
+        withdrawal_request_txid: Txid,
+
+        /// Assigned operator index.
+        assigned_operator_idx: OperatorIdx,
+    },
 }

--- a/migrations/20241113060253_init_schema.sql
+++ b/migrations/20241113060253_init_schema.sql
@@ -1,5 +1,14 @@
 PRAGMA foreign_keys = ON;
 
+-- Table for contracts
+CREATE TABLE IF NOT EXISTS contracts (
+    deposit_txid TEXT PRIMARY KEY,       -- Store as hex string
+    deposit_idx INTEGER NOT NULL UNIQUE, -- Index of the deposit in the stake chain
+    deposit_tx BLOB NOT NULL,            -- Serialized with bincode
+    operator_table BLOB NOT NULL,        -- Serialized with bincode
+    state BLOB NOT NULL                  -- Serialized with bincode
+);
+
 -- Table for wots_public_keys with a compound index on (operator_id, deposit_txid)
 CREATE TABLE IF NOT EXISTS wots_public_keys (
     operator_id INTEGER NOT NULL,


### PR DESCRIPTION
## Description

Adds the RPC server that will grab a fresh state of the Contract Manager every 10 mins (block time) and cache it in-memory in a separate tokio thread. 

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- Changed the table schema of the `contracts` table (Contract Manager) to match all the other ones in the SQL schema file. Cc @ProofOfKeags.
- Why 10 mins? Because on every new block, after it is processed, the contract manager serializes the whole state of all contracts in the `contracts` table.
- This PR is free of demons.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1309

Closes #122
