### PR TITLE
fix(p2p): more fault-tolerant establish_connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
  "duty-tracker",
  "hex",
  "jsonrpsee",
- "libp2p 0.55.0",
+ "libp2p",
  "musig2",
  "operator-wallet",
  "rustls-pemfile 2.2.0",
@@ -1844,7 +1844,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3100,7 +3100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5395,59 +5395,26 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.15",
- "libp2p-allow-block-list 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-connection-limits 0.5.0",
- "libp2p-core 0.43.0",
- "libp2p-dns 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-gossipsub 0.48.0",
- "libp2p-identify 0.46.0",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-mdns 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-metrics 0.16.0",
- "libp2p-noise 0.46.0",
- "libp2p-ping 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-quic 0.12.0",
- "libp2p-request-response 0.28.0",
- "libp2p-swarm 0.46.0",
- "libp2p-tcp 0.43.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-upnp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-yamux 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "libp2p-yamux",
  "multiaddr",
  "pin-project",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "libp2p"
-version = "0.55.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom 0.2.15",
- "libp2p-allow-block-list 0.5.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-connection-limits 0.5.1",
- "libp2p-core 0.43.1",
- "libp2p-dns 0.43.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-gossipsub 0.49.0",
- "libp2p-identify 0.47.0",
- "libp2p-identity",
- "libp2p-mdns 0.47.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-metrics 0.16.1",
- "libp2p-noise 0.46.1",
- "libp2p-ping 0.46.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-quic 0.12.1",
- "libp2p-request-response 0.28.1",
- "libp2p-swarm 0.47.0",
- "libp2p-tcp 0.43.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-upnp 0.4.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-yamux 0.47.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "multiaddr",
- "pin-project",
- "rw-stream-sink 0.4.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
+ "rw-stream-sink",
  "thiserror 2.0.12",
 ]
 
@@ -5457,19 +5424,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
 dependencies = [
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
-]
-
-[[package]]
-name = "libp2p-allow-block-list"
-version = "0.5.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
+ "libp2p-swarm",
 ]
 
 [[package]]
@@ -5478,19 +5435,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
 dependencies = [
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
-]
-
-[[package]]
-name = "libp2p-connection-limits"
-version = "0.5.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
+ "libp2p-swarm",
 ]
 
 [[package]]
@@ -5506,37 +5453,13 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "multihash",
- "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select",
  "once_cell",
  "parking_lot",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 2.0.12",
- "tracing",
- "unsigned-varint 0.8.0",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.43.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-identity",
- "multiaddr",
- "multihash",
- "multistream-select 0.13.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "parking_lot",
- "pin-project",
- "quick-protobuf",
- "rand 0.8.5",
- "rw-stream-sink 0.4.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
+ "rw-stream-sink",
  "thiserror 2.0.12",
  "tracing",
  "unsigned-varint 0.8.0",
@@ -5552,22 +5475,7 @@ dependencies = [
  "async-trait",
  "futures",
  "hickory-resolver",
- "libp2p-core 0.43.0",
- "libp2p-identity",
- "parking_lot",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-dns"
-version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "async-trait",
- "futures",
- "hickory-resolver",
- "libp2p-core 0.43.1",
+ "libp2p-core",
  "libp2p-identity",
  "parking_lot",
  "smallvec",
@@ -5592,42 +5500,12 @@ dependencies = [
  "getrandom 0.2.15",
  "hashlink 0.9.1",
  "hex_fmt",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.5",
- "regex",
- "sha2 0.10.8",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-gossipsub"
-version = "0.49.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "async-channel",
- "asynchronous-codec",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "getrandom 0.2.15",
- "hashlink 0.9.1",
- "hex_fmt",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "prometheus-client",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
  "sha2 0.10.8",
@@ -5646,31 +5524,11 @@ dependencies = [
  "futures",
  "futures-bounded",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
+ "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec",
- "thiserror 2.0.12",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-identify"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "asynchronous-codec",
- "either",
- "futures",
- "futures-bounded",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
+ "quick-protobuf-codec",
  "smallvec",
  "thiserror 2.0.12",
  "tracing",
@@ -5705,27 +5563,9 @@ dependencies = [
  "futures",
  "hickory-proto",
  "if-watch",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
- "rand 0.8.5",
- "smallvec",
- "socket2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "hickory-proto",
- "if-watch",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "socket2",
@@ -5740,29 +5580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
 dependencies = [
  "futures",
- "libp2p-core 0.43.0",
- "libp2p-gossipsub 0.48.0",
- "libp2p-identify 0.46.0",
+ "libp2p-core",
+ "libp2p-gossipsub",
+ "libp2p-identify",
  "libp2p-identity",
- "libp2p-ping 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-swarm 0.46.0",
- "pin-project",
- "prometheus-client",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-metrics"
-version = "0.16.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "libp2p-core 0.43.1",
- "libp2p-gossipsub 0.49.0",
- "libp2p-identify 0.47.0",
- "libp2p-identity",
- "libp2p-ping 0.46.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
- "libp2p-swarm 0.47.0",
+ "libp2p-ping",
+ "libp2p-swarm",
  "pin-project",
  "prometheus-client",
  "web-time",
@@ -5777,33 +5600,11 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "futures",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
  "multiaddr",
  "multihash",
  "once_cell",
- "quick-protobuf",
- "rand 0.8.5",
- "snow",
- "static_assertions",
- "thiserror 2.0.12",
- "tracing",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "libp2p-noise"
-version = "0.46.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "futures",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "multiaddr",
- "multihash",
  "quick-protobuf",
  "rand 0.8.5",
  "snow",
@@ -5822,24 +5623,9 @@ checksum = "7b2529993ff22deb2504c0130a58b60fb77f036be555053922db1a0490b5798b"
 dependencies = [
  "futures",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
- "rand 0.8.5",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-ping"
-version = "0.46.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "tracing",
  "web-time",
@@ -5854,30 +5640,9 @@ dependencies = [
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-tls 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quinn",
- "rand 0.8.5",
- "ring",
- "rustls 0.23.25",
- "socket2",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-quic"
-version = "0.12.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-tls 0.6.1 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
+ "libp2p-tls",
  "quinn",
  "rand 0.8.5",
  "ring",
@@ -5897,25 +5662,9 @@ dependencies = [
  "async-trait",
  "futures",
  "futures-bounded",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm 0.46.0",
- "rand 0.8.5",
- "smallvec",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-request-response"
-version = "0.28.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "async-trait",
- "futures",
- "futures-bounded",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm 0.47.0",
+ "libp2p-swarm",
  "rand 0.8.5",
  "smallvec",
  "tracing",
@@ -5931,33 +5680,12 @@ dependencies = [
  "fnv",
  "futures",
  "futures-timer",
- "libp2p-core 0.43.0",
+ "libp2p-core",
  "libp2p-identity",
- "libp2p-swarm-derive 0.35.0",
+ "libp2p-swarm-derive",
  "lru 0.12.5",
- "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select",
  "once_cell",
- "rand 0.8.5",
- "smallvec",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "libp2p-swarm"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "either",
- "fnv",
- "futures",
- "futures-timer",
- "libp2p-core 0.43.1",
- "libp2p-identity",
- "libp2p-swarm-derive 0.35.1",
- "lru 0.12.5",
- "multistream-select 0.13.0 (git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac)",
  "rand 0.8.5",
  "smallvec",
  "tokio",
@@ -5978,16 +5706,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-swarm-derive"
-version = "0.35.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "heck 0.5.0",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "libp2p-tcp"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5997,22 +5715,7 @@ dependencies = [
  "futures-timer",
  "if-watch",
  "libc",
- "libp2p-core 0.43.0",
- "socket2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-tcp"
-version = "0.43.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "futures-timer",
- "if-watch",
- "libc",
- "libp2p-core 0.43.1",
+ "libp2p-core",
  "socket2",
  "tokio",
  "tracing",
@@ -6026,25 +5729,7 @@ checksum = "42bbf5084fb44133267ad4caaa72a253d68d709edd2ed1cf9b42431a8ead8fd5"
 dependencies = [
  "futures",
  "futures-rustls",
- "libp2p-core 0.43.0",
- "libp2p-identity",
- "rcgen",
- "ring",
- "rustls 0.23.25",
- "rustls-webpki 0.101.7",
- "thiserror 2.0.12",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
-name = "libp2p-tls"
-version = "0.6.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "futures-rustls",
- "libp2p-core 0.43.1",
+ "libp2p-core",
  "libp2p-identity",
  "rcgen",
  "ring",
@@ -6064,22 +5749,8 @@ dependencies = [
  "futures",
  "futures-timer",
  "igd-next",
- "libp2p-core 0.43.0",
- "libp2p-swarm 0.46.0",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "libp2p-upnp"
-version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "futures",
- "futures-timer",
- "igd-next",
- "libp2p-core 0.43.1",
- "libp2p-swarm 0.47.0",
+ "libp2p-core",
+ "libp2p-swarm",
  "tokio",
  "tracing",
 ]
@@ -6092,21 +5763,7 @@ checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.43.0",
- "thiserror 2.0.12",
- "tracing",
- "yamux 0.12.1",
- "yamux 0.13.4",
-]
-
-[[package]]
-name = "libp2p-yamux"
-version = "0.47.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "either",
- "futures",
- "libp2p-core 0.43.1",
+ "libp2p-core",
  "thiserror 2.0.12",
  "tracing",
  "yamux 0.12.1",
@@ -6514,19 +6171,6 @@ dependencies = [
  "pin-project",
  "smallvec",
  "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multistream-select"
-version = "0.13.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "bytes",
- "futures",
- "pin-project",
- "smallvec",
- "tracing",
- "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -7880,8 +7524,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -7901,7 +7545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7982,18 +7626,6 @@ dependencies = [
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
-dependencies = [
- "asynchronous-codec",
- "bytes",
- "quick-protobuf",
- "thiserror 2.0.12",
  "unsigned-varint 0.8.0",
 ]
 
@@ -8870,16 +8502,6 @@ name = "rw-stream-sink"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
-dependencies = [
- "futures",
- "pin-project",
- "static_assertions",
-]
-
-[[package]]
-name = "rw-stream-sink"
-version = "0.4.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git?rev=b685b63dc6b98355d75234ff83a935ffa23d8eac#b685b63dc6b98355d75234ff83a935ffa23d8eac"
 dependencies = [
  "futures",
  "pin-project",
@@ -10326,7 +9948,7 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "futures",
- "libp2p 0.55.0",
+ "libp2p",
  "musig2",
  "strata-bridge-common",
  "strata-bridge-test-utils",
@@ -10700,12 +10322,12 @@ dependencies = [
 [[package]]
 name = "strata-p2p"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#f90722f993462d35d5294d0f6a407085016b6bdf"
+source = "git+https://github.com/alpenlabs/strata-p2p.git?branch=fix%2Fbetter-retries#5ce79e793e651510c3b74b6355771ea5d229e79b"
 dependencies = [
  "async-trait",
  "bitcoin",
  "futures",
- "libp2p 0.55.1",
+ "libp2p",
  "musig2",
  "prost",
  "strata-p2p-types",
@@ -10719,21 +10341,21 @@ dependencies = [
 [[package]]
 name = "strata-p2p-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#f90722f993462d35d5294d0f6a407085016b6bdf"
+source = "git+https://github.com/alpenlabs/strata-p2p.git?branch=fix%2Fbetter-retries#5ce79e793e651510c3b74b6355771ea5d229e79b"
 dependencies = [
  "bitcoin",
  "hex",
- "libp2p 0.55.1",
+ "libp2p-identity",
  "serde",
 ]
 
 [[package]]
 name = "strata-p2p-wire"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-p2p.git#f90722f993462d35d5294d0f6a407085016b6bdf"
+source = "git+https://github.com/alpenlabs/strata-p2p.git?branch=fix%2Fbetter-retries#5ce79e793e651510c3b74b6355771ea5d229e79b"
 dependencies = [
  "bitcoin",
- "libp2p 0.55.1",
+ "libp2p",
  "musig2",
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,10 @@ strata-rpc-api = { git = "https://github.com/alpenlabs/strata.git" }
 strata-rpc-types = { git = "https://github.com/alpenlabs/strata.git" }
 strata-state = { git = "https://github.com/alpenlabs/strata.git" }
 
-strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git" }
-strata-p2p-types = { git = "https://github.com/alpenlabs/strata-p2p.git" }
-strata-p2p-wire = { git = "https://github.com/alpenlabs/strata-p2p.git" }
+# TODO(@storopoli): remove these once the PR is ready
+strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git", branch = "fix/better-retries" }
+strata-p2p-types = { git = "https://github.com/alpenlabs/strata-p2p.git", branch = "fix/better-retries" }
+strata-p2p-wire = { git = "https://github.com/alpenlabs/strata-p2p.git", branch = "fix/better-retries" }
 
 zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc10" }
 zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc10" }

--- a/bin/alpen-bridge/src/config.rs
+++ b/bin/alpen-bridge/src/config.rs
@@ -101,6 +101,22 @@ pub(crate) struct P2PConfig {
     /// Default is
     /// [`DEFAULT_NUM_THREADS`](strata_bridge_p2p_service::constants::DEFAULT_NUM_THREADS).
     pub num_threads: Option<usize>,
+
+    /// Dial timeout.
+    ///
+    /// The default is [`DEFAULT_DIAL_TIMEOUT`](strata_p2p::swarm::DEFAULT_DIAL_TIMEOUT).
+    pub dial_timeout: Option<Duration>,
+
+    /// General timeout for operations.
+    ///
+    /// The default is [`DEFAULT_GENERAL_TIMEOUT`](strata_p2p::swarm::DEFAULT_GENERAL_TIMEOUT).
+    pub general_timeout: Option<Duration>,
+
+    /// Connection check interval.
+    ///
+    /// The default is
+    /// [`DEFAULT_CONNECTION_CHECK_INTERVAL`](strata_p2p::swarm::DEFAULT_CONNECTION_CHECK_INTERVAL).
+    pub connection_check_interval: Option<Duration>,
 }
 
 /// Operator wallet configuration.

--- a/bin/alpen-bridge/src/mode/operator.rs
+++ b/bin/alpen-bridge/src/mode/operator.rs
@@ -247,6 +247,9 @@ async fn init_p2p_handle(
         listening_addr,
         connect_to,
         num_threads,
+        dial_timeout,
+        general_timeout,
+        connection_check_interval,
     } = config.p2p.clone();
 
     let config = P2PConfiguration::new_with_secret_key(
@@ -257,6 +260,9 @@ async fn init_p2p_handle(
         connect_to,
         signers_allowlist,
         num_threads,
+        dial_timeout,
+        general_timeout,
+        connection_check_interval,
     );
     let (p2p_handle, _cancel, listen_task) = p2p_bootstrap(&config).await?;
     Ok((p2p_handle, listen_task))

--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ x-base-bridge-node: &base-bridge-node
     dockerfile: ./docker/alpen-bridge/Dockerfile
   environment:
     - MODE=operator
-    - RUST_LOG=info,duty_tracker=debug,alpen_bridge=debug,strata_bridge_tx_graph=debug,bitvm=error
+    - RUST_LOG=info,duty_tracker=debug,alpen_bridge=debug,strata_bridge_tx_graph=debug,bitvm=error,strata_bridge_p2p_service=debug,strata_p2p=warn
     - LOG_FILE=0
     - LOG_LINE_NUM=0
     - RUST_BACKTRACE=full

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -859,6 +859,7 @@ impl ContractManagerCtx {
         &mut self,
         req: GetMessageRequest,
     ) -> Result<Option<OperatorDuty>, ContractManagerErr> {
+        info!("processing p2p request");
         Ok(match req {
             GetMessageRequest::StakeChainExchange { .. } => {
                 info!("received request for stake chain exchange");

--- a/crates/p2p-service/src/bootstrap.rs
+++ b/crates/p2p-service/src/bootstrap.rs
@@ -2,7 +2,10 @@
 
 use std::time::Duration;
 
-use strata_p2p::swarm::{self, handle::P2PHandle, P2PConfig, P2P};
+use strata_p2p::swarm::{
+    self, handle::P2PHandle, P2PConfig, DEFAULT_CONNECTION_CHECK_INTERVAL, DEFAULT_DIAL_TIMEOUT,
+    DEFAULT_GENERAL_TIMEOUT, P2P,
+};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -23,6 +26,13 @@ pub async fn bootstrap(
         allowlist: config.allowlist.clone(),
         connect_to: config.connect_to.clone(),
         signers_allowlist: config.signers_allowlist.clone(),
+        dial_timeout: Some(config.dial_timeout.unwrap_or(DEFAULT_DIAL_TIMEOUT)),
+        general_timeout: Some(config.general_timeout.unwrap_or(DEFAULT_GENERAL_TIMEOUT)),
+        connection_check_interval: Some(
+            config
+                .connection_check_interval
+                .unwrap_or(DEFAULT_CONNECTION_CHECK_INTERVAL),
+        ),
     };
     let cancel = CancellationToken::new();
 

--- a/crates/p2p-service/src/config.rs
+++ b/crates/p2p-service/src/config.rs
@@ -34,10 +34,27 @@ pub struct Configuration {
     ///
     /// Default is [`DEFAULT_NUM_THREADS`](crate::constants::DEFAULT_NUM_THREADS).
     pub num_threads: Option<usize>,
+
+    /// Dial timeout.
+    ///
+    /// The default is [`DEFAULT_DIAL_TIMEOUT`](strata_p2p::swarm::DEFAULT_DIAL_TIMEOUT).
+    pub dial_timeout: Option<Duration>,
+
+    /// General timeout for operations.
+    ///
+    /// The default is [`DEFAULT_GENERAL_TIMEOUT`](strata_p2p::swarm::DEFAULT_GENERAL_TIMEOUT).
+    pub general_timeout: Option<Duration>,
+
+    /// Connection check interval.
+    ///
+    /// The default is
+    /// [`DEFAULT_CONNECTION_CHECK_INTERVAL`](strata_p2p::swarm::DEFAULT_CONNECTION_CHECK_INTERVAL).
+    pub connection_check_interval: Option<Duration>,
 }
 
 impl Configuration {
     /// Creates a new [`Configuration`] by using a [`SecretKey`].
+    #[expect(clippy::too_many_arguments)]
     pub fn new_with_secret_key(
         sk: SecretKey,
         idle_connection_timeout: Option<Duration>,
@@ -46,6 +63,9 @@ impl Configuration {
         connect_to: Vec<Multiaddr>,
         signers_allowlist: Vec<P2POperatorPubKey>,
         num_threads: Option<usize>,
+        dial_timeout: Option<Duration>,
+        general_timeout: Option<Duration>,
+        connection_check_interval: Option<Duration>,
     ) -> Self {
         let sk = Libp2pSecpSecretKey::try_from_bytes(sk.secret_bytes()).expect("infallible");
         let keypair = Libp2pSecpKeypair::from(sk);
@@ -57,6 +77,9 @@ impl Configuration {
             connect_to,
             signers_allowlist,
             num_threads,
+            dial_timeout,
+            general_timeout,
+            connection_check_interval,
         }
     }
 
@@ -90,6 +113,9 @@ mod tests {
             vec![],
             vec![],
             vec![],
+            None,
+            None,
+            None,
             None,
         );
         assert_eq!(config.public_key().inner, pk);

--- a/crates/p2p-service/src/tests/common.rs
+++ b/crates/p2p-service/src/tests/common.rs
@@ -31,6 +31,7 @@ pub(crate) struct Operator {
 }
 
 impl Operator {
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         keypair: SecpKeypair,
         allowlist: Vec<PeerId>,
@@ -38,6 +39,9 @@ impl Operator {
         local_addr: Multiaddr,
         cancel: CancellationToken,
         signers_allowlist: Vec<P2POperatorPubKey>,
+        dial_timeout: Option<Duration>,
+        general_timeout: Option<Duration>,
+        connection_check_interval: Option<Duration>,
     ) -> anyhow::Result<Self> {
         let config = P2PConfig {
             keypair: keypair.clone(),
@@ -47,6 +51,9 @@ impl Operator {
             allowlist,
             connect_to,
             signers_allowlist,
+            dial_timeout,
+            general_timeout,
+            connection_check_interval,
         };
 
         let swarm = swarm::with_inmemory_transport(&config)?;
@@ -101,6 +108,9 @@ impl Setup {
                 addr.clone(),
                 cancel.child_token(),
                 signers_allowlist.clone(),
+                None,
+                None,
+                None,
             )?;
 
             operators.push(operator);
@@ -149,6 +159,9 @@ impl Setup {
                 addr.clone(),
                 cancel.child_token(),
                 signers_allowlist.clone(),
+                None,
+                None,
+                None,
             )?;
 
             operators.push(operator);

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -28,6 +28,9 @@ idle_connection_timeout = { secs = 1000, nanos = 0 }
 listening_addr = "/ip4/172.28.0.5/tcp/5679"
 connect_to = ["/ip4/172.28.0.6/tcp/5679", "/ip4/172.28.0.7/tcp/5679"]
 num_threads = 4
+dial_timeout = { secs = 0, nanos = 250_000_000 }
+general_timeout = { secs = 0, nanos = 250_000_000 }
+connection_check_interval = { secs = 0, nanos = 500_000_000 }
 
 [operator_wallet]
 stake_funding_pool_size = 32

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -28,6 +28,9 @@ idle_connection_timeout = { secs = 1000, nanos = 0 }
 listening_addr = "/ip4/172.28.0.6/tcp/5679"
 connect_to = ["/ip4/172.28.0.5/tcp/5679", "/ip4/172.28.0.7/tcp/5679"]
 num_threads = 4
+dial_timeout = { secs = 0, nanos = 250_000_000 }
+general_timeout = { secs = 0, nanos = 250_000_000 }
+connection_check_interval = { secs = 0, nanos = 500_000_000 }
 
 [operator_wallet]
 stake_funding_pool_size = 32

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -28,6 +28,9 @@ idle_connection_timeout = { secs = 1000, nanos = 0 }
 listening_addr = "/ip4/172.28.0.7/tcp/5679"
 connect_to = ["/ip4/172.28.0.5/tcp/5679", "/ip4/172.28.0.6/tcp/5679"]
 num_threads = 4
+dial_timeout = { secs = 0, nanos = 250_000_000 }
+general_timeout = { secs = 0, nanos = 250_000_000 }
+connection_check_interval = { secs = 0, nanos = 500_000_000 }
 
 [operator_wallet]
 stake_funding_pool_size = 32


### PR DESCRIPTION
## Description

WIP trying to make more fault-tolerant `establish_connections`.
See also https://github.com/alpenlabs/strata-p2p/pull/62.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
