### PR TITLE
STR-1344: rpc state cache does not get updated

### DIFF
--- a/bin/alpen-bridge/Cargo.toml
+++ b/bin/alpen-bridge/Cargo.toml
@@ -19,7 +19,6 @@ rust.unused_must_use = "deny"
 
 [dependencies]
 alpen-bridge-params.workspace = true
-bincode.workspace = true
 btc-notify.workspace = true
 duty-tracker.workspace = true
 operator-wallet.workspace = true
@@ -39,6 +38,7 @@ strata-bridge-common.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 bdk_bitcoind_rpc.workspace = true
+bincode.workspace = true
 bitcoin.workspace = true
 bitcoind-async-client.workspace = true
 chrono.workspace = true

--- a/bin/alpen-bridge/src/constants.rs
+++ b/bin/alpen-bridge/src/constants.rs
@@ -1,7 +1,16 @@
 use std::time::Duration;
 
+/// Default startup delay for the bridge node.
 pub(crate) const STARTUP_DELAY: Duration = Duration::from_secs(2);
 
+/// Default thread count for the bridge node.
 pub(crate) const DEFAULT_THREAD_COUNT: u8 = 4;
 
+/// Default thread stack size for the bridge node.
 pub(crate) const DEFAULT_THREAD_STACK_SIZE: usize = 100 * 1024 * 1024;
+
+/// Default RPC state cache refresh interval for the bridge node.
+///
+/// The rationale is to use 10 minutes since on every new block that the Duty Tracker scans,
+/// it refreshes the state.
+pub(crate) const DEFAULT_RPC_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);

--- a/bin/alpen-bridge/src/mode/operator.rs
+++ b/bin/alpen-bridge/src/mode/operator.rs
@@ -56,7 +56,7 @@ use tokio::{net::lookup_host, spawn, sync::broadcast, task::JoinHandle, try_join
 use tracing::{debug, info};
 
 use crate::{
-    config::{Config, P2PConfig, SecretServiceConfig},
+    config::{Config, P2PConfig, RpcConfig, SecretServiceConfig},
     params::Params,
     rpc_server::{start_rpc, BridgeRpc},
 };
@@ -157,8 +157,9 @@ pub(crate) async fn bootstrap(params: Params, config: Config) -> anyhow::Result<
     info!("initialized the contract manager");
 
     info!("starting the RPC server");
-    let rpc_address = config.rpc_addr.clone();
-    let rpc_task = start_rpc_server(rpc_address, db_rpc, p2p_handle_rpc, params.clone()).await?;
+    let rpc_config = config.rpc.clone();
+    let rpc_params = params.clone();
+    let rpc_task = start_rpc_server(db_rpc, p2p_handle_rpc, rpc_params, rpc_config).await?;
     info!("started the RPC server");
 
     // Wait for all tasks to run
@@ -411,14 +412,15 @@ async fn init_duty_tracker(
 }
 
 async fn start_rpc_server(
-    rpc_address: String,
     db: SqliteDb,
     p2p_handle: P2PHandle,
     params: Params,
+    config: RpcConfig,
 ) -> anyhow::Result<JoinHandle<()>> {
-    let rpc_client = BridgeRpc::new(db, p2p_handle, params);
+    let rpc_addr = config.rpc_addr.clone();
+    let rpc_client = BridgeRpc::new(db, p2p_handle, params, config);
     let handle = spawn(async move {
-        start_rpc(&rpc_client, rpc_address.as_str())
+        start_rpc(&rpc_client, rpc_addr.as_str())
             .await
             .expect("failed to start RPC server");
     });

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -91,6 +91,7 @@ pub(crate) struct ContractRecord {
 }
 
 impl ContractRecord {
+    /// Converts this record into a strongly-typed in-memory representation.
     fn into_typed(self) -> anyhow::Result<TypedContractRecord> {
         Ok(TypedContractRecord {
             deposit_txid: self.deposit_txid.parse::<Txid>()?,
@@ -102,12 +103,22 @@ impl ContractRecord {
     }
 }
 
+/// Strongly-typed in-memory representation of contract records from the database.
 #[derive(Debug, Clone)]
 pub(crate) struct TypedContractRecord {
+    /// The deposit transaction ID with respect to this contract.
     pub(crate) deposit_txid: Txid,
+
+    /// The deposit transaction with respect to this contract.
     pub(crate) deposit_tx: DepositTx,
+
+    /// The deposit index with respect to this contract.
     pub(crate) deposit_idx: u32,
+
+    /// The operator table that was in place when this contract was created.
     pub(crate) operator_table: OperatorTable,
+
+    /// The latest state of the contract.
     pub(crate) state: ContractState,
 }
 
@@ -202,7 +213,15 @@ impl BridgeRpc {
             // Initial cache fill
             if let Ok(contracts) = query_as!(
                 ContractRecord,
-                r#"SELECT deposit_txid as "deposit_txid!", deposit_tx as "deposit_tx!", deposit_idx as "deposit_idx!", operator_table as "operator_table!", state as "state!" FROM contracts"#
+                r#"
+                SELECT
+                    deposit_txid,
+                    deposit_idx,
+                    deposit_tx,
+                    operator_table,
+                    state
+                FROM contracts
+                "#,
             )
             .fetch_all(db.pool())
             .await
@@ -236,7 +255,6 @@ impl BridgeRpc {
                 drop(cache_lock);
 
                 info!(%after_num_contracts, "RPC server Contracts cache initialized");
-
             } else {
                 error!("Failed to initialize contracts cache");
             }
@@ -247,7 +265,15 @@ impl BridgeRpc {
 
                 match query_as!(
                     ContractRecord,
-                    r#"SELECT deposit_txid as "deposit_txid!", deposit_tx as "deposit_tx!", deposit_idx as "deposit_idx!", operator_table as "operator_table!", state as "state!" FROM contracts"#
+                    r#"
+                    SELECT
+                        deposit_txid,
+                        deposit_idx,
+                        deposit_tx,
+                        operator_table,
+                        state
+                    FROM contracts
+                    "#,
                 )
                 .fetch_all(db.pool())
                 .await

--- a/crates/duty-tracker/src/contract_persister.rs
+++ b/crates/duty-tracker/src/contract_persister.rs
@@ -124,7 +124,9 @@ impl ContractPersister {
         &self,
         active_contracts: impl Iterator<Item = (&Txid, &ContractSM)>,
     ) -> Result<(), ContractPersistErr> {
-        debug!("committing all active contracts");
+        // NOTE: this is an pessimistic lower bound on the size of the iterator.
+        let num_contracts = active_contracts.size_hint().0;
+        debug!(%num_contracts, "committing all active contracts");
 
         for (txid, contract_sm) in active_contracts {
             let machine_state = contract_sm.state();

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -1,5 +1,4 @@
 datadir = "/app/data"
-rpc_addr = "0.0.0.0:5678"
 # stub option ftm
 is_faulty = false
 nag_interval = { secs = 60, nanos = 0 }
@@ -34,6 +33,10 @@ connection_check_interval = { secs = 0, nanos = 500_000_000 }
 
 [operator_wallet]
 stake_funding_pool_size = 32
+
+[rpc]
+rpc_addr = "localhost:5678"
+refresh_interval = { secs = 600, nanos = 0 }
 
 [btc_zmq]
 bury_depth = 2

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -1,5 +1,4 @@
 datadir = "/app/data"
-rpc_addr = "0.0.0.0:5678"
 # stub option ftm
 is_faulty = false
 nag_interval = { secs = 60, nanos = 0 }
@@ -34,6 +33,10 @@ connection_check_interval = { secs = 0, nanos = 500_000_000 }
 
 [operator_wallet]
 stake_funding_pool_size = 32
+
+[rpc]
+rpc_addr = "localhost:5678"
+refresh_interval = { secs = 600, nanos = 0 }
 
 [btc_zmq]
 bury_depth = 2

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -1,5 +1,4 @@
 datadir = "/app/data"
-rpc_addr = "0.0.0.0:5678"
 # stub option ftm
 is_faulty = false
 nag_interval = { secs = 60, nanos = 0 }
@@ -34,6 +33,10 @@ connection_check_interval = { secs = 0, nanos = 500_000_000 }
 
 [operator_wallet]
 stake_funding_pool_size = 32
+
+[rpc]
+rpc_addr = "localhost:5678"
+refresh_interval = { secs = 600, nanos = 0 }
 
 [btc_zmq]
 bury_depth = 2

--- a/migrations/20241113060253_init_schema.sql
+++ b/migrations/20241113060253_init_schema.sql
@@ -2,11 +2,11 @@ PRAGMA foreign_keys = ON;
 
 -- Table for contracts
 CREATE TABLE IF NOT EXISTS contracts (
-    deposit_txid TEXT PRIMARY KEY,       -- Store as hex string
-    deposit_idx INTEGER NOT NULL UNIQUE, -- Index of the deposit in the stake chain
-    deposit_tx BLOB NOT NULL,            -- Serialized with bincode
-    operator_table BLOB NOT NULL,        -- Serialized with bincode
-    state BLOB NOT NULL                  -- Serialized with bincode
+    deposit_txid TEXT NOT NULL PRIMARY KEY, -- Store as hex string
+    deposit_idx INTEGER NOT NULL UNIQUE,    -- Index of the deposit in the stake chain
+    deposit_tx BLOB NOT NULL,               -- Serialized with bincode
+    operator_table BLOB NOT NULL,           -- Serialized with bincode
+    state BLOB NOT NULL                     -- Serialized with bincode
 );
 
 -- Table for wots_public_keys with a compound index on (operator_id, deposit_txid)


### PR DESCRIPTION
## Description

Turns out that the RPC server was trying to deserialize the `MachineState` as `ContractState`. That would never had worked.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The duty tracker serializes all the contracts:

```console
bridge-1-1          | 2025-05-14T19:13:20.780672Z DEBUG duty_tracker::contract_persister: committing all active contracts num_contracts=1
bridge-1-1          | 2025-05-14T19:13:40.848958Z  INFO alpen_bridge::rpc_server: initializing the RPC server initial contract cache fill before_num_contracts=1
bridge-1-1          | 2025-05-14T19:13:40.863640Z DEBUG alpen_bridge::rpc_server: Contracts cache refreshed after_num_contracts=1
```

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1344