### PR TITLE
chore(deps): bump bitcoin to 0.32.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1872,9 +1872,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -6532,7 +6532,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7526,7 +7526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -7546,7 +7546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -10128,29 +10128,22 @@ dependencies = [
 
 [[package]]
 name = "strata-btcio"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64 0.22.1",
  "bitcoin",
+ "bitcoind-async-client",
  "borsh",
- "bytes",
- "digest 0.10.7",
  "hex",
  "musig2",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "secp256k1",
- "serde",
- "serde_json",
- "sha2 0.10.8",
  "strata-config",
  "strata-db",
  "strata-l1tx",
  "strata-primitives",
- "strata-rpc-types",
  "strata-state",
  "strata-status",
  "strata-storage",
@@ -10163,8 +10156,8 @@ dependencies = [
 
 [[package]]
 name = "strata-chaintsn"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -10180,8 +10173,8 @@ dependencies = [
 
 [[package]]
 name = "strata-common"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "deadpool",
@@ -10198,8 +10191,8 @@ dependencies = [
 
 [[package]]
 name = "strata-config"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "serde",
@@ -10207,8 +10200,8 @@ dependencies = [
 
 [[package]]
 name = "strata-consensus-logic"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10238,8 +10231,8 @@ dependencies = [
 
 [[package]]
 name = "strata-crypto"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "secp256k1",
  "sha2 0.10.8",
@@ -10251,8 +10244,8 @@ dependencies = [
 
 [[package]]
 name = "strata-db"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10272,8 +10265,8 @@ dependencies = [
 
 [[package]]
 name = "strata-eectl"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "strata-primitives",
  "strata-state",
@@ -10282,8 +10275,8 @@ dependencies = [
 
 [[package]]
 name = "strata-key-derivation"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "secp256k1",
@@ -10294,13 +10287,14 @@ dependencies = [
 
 [[package]]
 name = "strata-l1tx"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "bitcoin",
  "borsh",
  "musig2",
+ "secp256k1",
  "strata-primitives",
  "strata-state",
  "thiserror 2.0.12",
@@ -10309,8 +10303,8 @@ dependencies = [
 
 [[package]]
 name = "strata-mmr"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -10365,8 +10359,8 @@ dependencies = [
 
 [[package]]
 name = "strata-primitives"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10393,8 +10387,8 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-btc-blockspace"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -10410,8 +10404,8 @@ dependencies = [
 
 [[package]]
 name = "strata-rpc-api"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "hex",
@@ -10430,8 +10424,8 @@ dependencies = [
 
 [[package]]
 name = "strata-rpc-types"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "hex",
@@ -10447,8 +10441,8 @@ dependencies = [
 
 [[package]]
 name = "strata-sequencer"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10471,8 +10465,8 @@ dependencies = [
 
 [[package]]
 name = "strata-state"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10492,8 +10486,8 @@ dependencies = [
 
 [[package]]
 name = "strata-status"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "strata-primitives",
  "strata-rpc-types",
@@ -10505,8 +10499,8 @@ dependencies = [
 
 [[package]]
 name = "strata-storage"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10524,8 +10518,8 @@ dependencies = [
 
 [[package]]
 name = "strata-tasks"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#500a129bf57143256b4732302fcec4676b940ad2"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ bdk_esplora = { version = "0.20.1", features = [
 ], default-features = false }
 bdk_wallet = "1.1.0"
 bincode = "1.3.3"
+# TODO(proofofkeags): when updating `bitcoin` to >=0.33.0, go through btc-notify and update tests to no longer constrain heights.
 bitcoin = { version = "0.32.6", features = ["rand-std", "serde"] }
 bitcoin-bosd = "0.4.0"
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,7 @@ bdk_esplora = { version = "0.20.1", features = [
 ], default-features = false }
 bdk_wallet = "1.1.0"
 bincode = "1.3.3"
-# TODO(proofofkeags): when updating `bitcoin` to >=0.33.0, go through btc-notify and update tests to no longer constrain heights.
-bitcoin = { version = "0.32.5", features = ["rand-std", "serde"] }
+bitcoin = { version = "0.32.6", features = ["rand-std", "serde"] }
 bitcoin-bosd = "0.4.0"
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoind-async-client = "0.1.1"

--- a/bin/dev-cli/Cargo.toml
+++ b/bin/dev-cli/Cargo.toml
@@ -19,7 +19,7 @@ strata-bridge-common.workspace = true
 
 alloy = { version = "0.14", features = ["full", "node-bindings"] }
 alloy-signer = "0.14"
-bitcoin = "0.32.2"
+bitcoin.workspace = true
 bitcoincore-rpc = "0.19.0"
 miniscript = "12.2.0"
 

--- a/bin/secret-service/Cargo.toml
+++ b/bin/secret-service/Cargo.toml
@@ -18,7 +18,7 @@ secret-service-server = { version = "0.1.0", path = "../../crates/secret-service
 serde.workspace = true
 sha2.workspace = true
 strata-bridge-primitives.workspace = true
-strata-key-derivation = { git = "https://github.com/alpenlabs/strata", version = "0.1.0" }
+strata-key-derivation = { git = "https://github.com/alpenlabs/strata", version = "0.3.0-alpha.1" }
 
 tokio.workspace = true
 toml = "0.8.19"

--- a/bin/secret-service/src/seeded_impl/wallet.rs
+++ b/bin/secret-service/src/seeded_impl/wallet.rs
@@ -37,7 +37,7 @@ impl WalletSigner<Server> for GeneralWalletSigner {
     ) -> <Server as Origin>::Container<Signature> {
         self.kp
             .tap_tweak(SECP256K1, tweak)
-            .to_inner()
+            .to_keypair()
             .sign_schnorr(Message::from_digest_slice(digest).unwrap())
     }
 
@@ -77,7 +77,7 @@ impl WalletSigner<Server> for StakechainWalletSigner {
     ) -> <Server as Origin>::Container<Signature> {
         self.kp
             .tap_tweak(SECP256K1, tweak)
-            .to_inner()
+            .to_keypair()
             .sign_schnorr(Message::from_digest_slice(digest).unwrap())
     }
 

--- a/bin/secret-service/src/tests.rs
+++ b/bin/secret-service/src/tests.rs
@@ -97,7 +97,7 @@ async fn e2e() {
                     .await
                     .expect("good response");
                 assert!(secp_ctx
-                    .verify_schnorr(&sig, &msg, &general_tweaked_pubkey.to_inner())
+                    .verify_schnorr(&sig, &msg, &general_tweaked_pubkey.to_x_only_public_key())
                     .is_ok());
 
                 // sign general wallet no tweak
@@ -113,7 +113,11 @@ async fn e2e() {
                     .await
                     .expect("good response");
                 assert!(secp_ctx
-                    .verify_schnorr(&sig, &msg, &stakechain_tweaked_pubkey.to_inner())
+                    .verify_schnorr(
+                        &sig,
+                        &msg,
+                        &stakechain_tweaked_pubkey.to_x_only_public_key()
+                    )
                     .is_ok());
 
                 // sign stakechain wallet no tweak

--- a/bridge-guest-builder/bridge-guest/Cargo.lock
+++ b/bridge-guest-builder/bridge-guest/Cargo.lock
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
  "bech32",
@@ -1752,8 +1752,8 @@ dependencies = [
 
 [[package]]
 name = "strata-crypto"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#eee497157a0c4f1e330fd5a8eb3c1812b4f8dd5e"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "secp256k1",
  "sha2",
@@ -1765,13 +1765,14 @@ dependencies = [
 
 [[package]]
 name = "strata-l1tx"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#eee497157a0c4f1e330fd5a8eb3c1812b4f8dd5e"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "bitcoin",
  "borsh",
  "musig2",
+ "secp256k1",
  "strata-primitives",
  "strata-state",
  "thiserror 2.0.12",
@@ -1780,8 +1781,8 @@ dependencies = [
 
 [[package]]
 name = "strata-primitives"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#eee497157a0c4f1e330fd5a8eb3c1812b4f8dd5e"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1808,8 +1809,8 @@ dependencies = [
 
 [[package]]
 name = "strata-proofimpl-btc-blockspace"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#eee497157a0c4f1e330fd5a8eb3c1812b4f8dd5e"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -1825,8 +1826,8 @@ dependencies = [
 
 [[package]]
 name = "strata-state"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata.git#eee497157a0c4f1e330fd5a8eb3c1812b4f8dd5e"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/strata.git#34479ee782f74a5aaf43ed2c850dd215093fa580"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/crates/agent/src/proof_interop.rs
+++ b/crates/agent/src/proof_interop.rs
@@ -7,7 +7,7 @@ use bitcoin::{
     Transaction, Txid, Wtxid,
 };
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
-use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::TxFilterConfig};
+use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::types::TxFilterConfig};
 use strata_primitives::params::RollupParams;
 use strata_state::batch::{Checkpoint, SignedCheckpoint};
 
@@ -135,8 +135,8 @@ pub fn checkpoint_last_verified_l1_height(
 ) -> Option<u64> {
     let filter_config =
         TxFilterConfig::derive_from(rollup_params).expect("rollup params must be valid");
-    if let Some(script) = tx.input[0].witness.tapscript() {
-        let script = script.to_bytes();
+    if let Some(script) = tx.input[0].witness.taproot_leaf_script() {
+        let script = script.script.to_bytes();
         if let Ok(inscription) = parse_envelope_payloads(&script.into(), &filter_config) {
             if inscription.is_empty() {
                 return None;

--- a/crates/bridge-proof/protocol/src/tx_info.rs
+++ b/crates/bridge-proof/protocol/src/tx_info.rs
@@ -1,6 +1,6 @@
 use bitcoin::{consensus, ScriptBuf, Transaction, Txid};
 use strata_crypto::groth16_verifier::verify_rollup_groth16_proof_receipt;
-use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::TxFilterConfig};
+use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::types::TxFilterConfig};
 use strata_primitives::{
     batch::SignedCheckpoint, bridge::OperatorIdx, l1::BitcoinAmount, params::RollupParams,
 };
@@ -16,8 +16,8 @@ pub(crate) fn extract_valid_chainstate_from_checkpoint(
         .map_err(|e| BridgeProofError::InvalidParams(e.to_string()))?;
 
     for inp in &tx.input {
-        if let Some(scr) = inp.witness.tapscript() {
-            if let Ok(payload) = parse_envelope_payloads(&scr.into(), &filter_config) {
+        if let Some(scr) = inp.witness.taproot_leaf_script() {
+            if let Ok(payload) = parse_envelope_payloads(&scr.script.into(), &filter_config) {
                 if payload.is_empty() {
                     continue;
                 }

--- a/crates/connectors/src/connector_c0.rs
+++ b/crates/connectors/src/connector_c0.rs
@@ -224,7 +224,7 @@ mod tests {
                         let tweak = connector.generate_merkle_root();
                         (
                             TaprootWitness::Tweaked { tweak },
-                            keypair.tap_tweak(SECP256K1, Some(tweak)).to_inner(),
+                            keypair.tap_tweak(SECP256K1, Some(tweak)).to_keypair(),
                         )
                     }
                     ConnectorC0Path::Assert(_) => {

--- a/crates/duty-tracker/src/predicates.rs
+++ b/crates/duty-tracker/src/predicates.rs
@@ -12,7 +12,7 @@ use bitcoin_bosd::Descriptor;
 use btc_notify::client::TxPredicate;
 use strata_bridge_primitives::{build_context::BuildContext, types::OperatorIdx};
 use strata_bridge_tx_graph::transactions::deposit::DepositRequestData;
-use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::TxFilterConfig};
+use strata_l1tx::{envelope::parser::parse_envelope_payloads, filter::types::TxFilterConfig};
 use strata_primitives::params::RollupParams;
 use strata_state::batch::{verify_signed_checkpoint_sig, Checkpoint, SignedCheckpoint};
 use tracing::{debug, warn};
@@ -189,8 +189,8 @@ pub(crate) fn parse_strata_checkpoint(
     let filter_config =
         TxFilterConfig::derive_from(rollup_params).expect("rollup params must be valid");
 
-    if let Some(script) = tx.input[0].witness.tapscript() {
-        let script = script.to_bytes();
+    if let Some(script) = tx.input[0].witness.taproot_leaf_script() {
+        let script = script.script.to_bytes();
         if let Ok(inscription) = parse_envelope_payloads(&script.into(), &filter_config) {
             if inscription.is_empty() {
                 return None;

--- a/crates/tx-graph/src/peg_out_graph.rs
+++ b/crates/tx-graph/src/peg_out_graph.rs
@@ -1291,9 +1291,9 @@ mod tests {
         let messages = first_stake.sighashes(OPERATOR_STAKE, prevouts);
 
         let op_signature_0 =
-            SECP256K1.sign_schnorr(&messages[0], &tweaked_operator_keypair.to_inner());
+            SECP256K1.sign_schnorr(&messages[0], &tweaked_operator_keypair.to_keypair());
         let op_signature_1 =
-            SECP256K1.sign_schnorr(&messages[1], &tweaked_operator_keypair.to_inner());
+            SECP256K1.sign_schnorr(&messages[1], &tweaked_operator_keypair.to_keypair());
 
         let signed_first_stake_tx = first_stake
             .clone()


### PR DESCRIPTION
## Description

- [x] Bumps `rust-bitcoin` to `0.32.6`.
- [x] Fixes the deprecated methods.
- [x] Bumps `strata-l1tx` that had a `=0.32.5` bound in `bitcoin` that was fixed in https://github.com/alpenlabs/strata/pull/804.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Why upgrading?
First, we should always upgrade.
Second, `0.32.5` has:

- `Psbt::sign` for taproot using `<PublicKey, SecretKey>` maps https://github.com/rust-bitcoin/rust-bitcoin/pull/4238

We can start to use PSBTs with Taproot since the bug with signing them with a pk<->sk map.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
