### PR TITLE
STR-1342: `io` error when loading contracts from disk upon restart

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -8,4 +8,5 @@ include = ["**/Cargo.toml"]
 keys = ["workspace.dependencies", "dependencies"]
 
 [rule.formatting]
+indent_string = "  "
 reorder_keys = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "secret-service-client",
  "secret-service-proto",
  "serde",
+ "serde_json",
  "sqlx",
  "strata-bridge-common",
  "strata-bridge-db",

--- a/bin/alpen-bridge/Cargo.toml
+++ b/bin/alpen-bridge/Cargo.toml
@@ -51,6 +51,7 @@ rustls-pemfile = "2.2.0"
 secp256k1.workspace = true
 secret-service-proto.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/bin/alpen-bridge/src/mode/operator.rs
+++ b/bin/alpen-bridge/src/mode/operator.rs
@@ -395,7 +395,8 @@ async fn init_duty_tracker(
     let tx_driver = TxDriver::new(zmq_client.clone(), rpc_client.clone()).await;
 
     info!("initializing the contract persister");
-    let contract_persister = ContractPersister::new(db.pool().clone()).await?;
+    let db_pool = db.pool().clone();
+    let contract_persister = ContractPersister::new(db_pool, config.db).await?;
 
     info!("initializing the stake chain persister");
     let stake_chain_persister = StakeChainPersister::new(db.clone()).await?;

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -16,7 +16,13 @@ use libp2p::{identity::PublicKey as LibP2pPublicKey, PeerId};
 use secp256k1::Parity;
 use serde::Serialize;
 use sqlx::{query_as, FromRow};
-use strata_bridge_db::persistent::sqlite::SqliteDb;
+use strata_bridge_db::{
+    errors::DbError,
+    persistent::{
+        errors::StorageError,
+        sqlite::{execute_with_retries, SqliteDb},
+    },
+};
 use strata_bridge_primitives::operator_table::OperatorTable;
 use strata_bridge_rpc::{
     traits::{
@@ -213,6 +219,7 @@ impl BridgeRpc {
     fn start_cache_refresh_task(&self) {
         let db = self.db.clone();
         let cached_contracts = self.cached_contracts.clone();
+        let db_config = *self.db.config();
 
         // Clone the params we need before spawning the task
         let network = self.params.network;
@@ -228,30 +235,105 @@ impl BridgeRpc {
 
         // Spawn a background task to refresh the cache
         tokio::spawn(async move {
-            let mut interval = interval(period);
             info!(
                 ?period,
                 "initializing the background task for refreshing the RPC server cache"
             );
 
             // Initial cache fill
-            if let Ok(contracts) = query_as!(
-                ContractRecord,
-                r#"
-                SELECT
-                    deposit_txid,
-                    deposit_idx,
-                    deposit_tx,
-                    operator_table,
-                    state
-                FROM contracts
-                "#,
-            )
-            .fetch_all(db.pool())
+            let contracts = match execute_with_retries(&db_config, || async {
+                let result: Result<Vec<ContractRecord>, _> = query_as!(
+                    ContractRecord,
+                    r#"
+                    SELECT
+                        deposit_txid,
+                        deposit_idx,
+                        deposit_tx,
+                        operator_table,
+                        state
+                    FROM contracts
+                    "#,
+                )
+                .fetch_all(db.pool())
+                .await;
+
+                result.map_err(|e| DbError::Storage(StorageError::Driver(e)))
+            })
             .await
             {
+                Ok(contracts) => contracts,
+                Err(err) => {
+                    error!(?err, "Failed to initialize contracts cache");
+                    Vec::new() // Return empty vector on error
+                }
+            };
+
+            let before_num_contracts = contracts.len();
+            info!(%before_num_contracts, "initializing the RPC server initial contract cache fill");
+
+            // Convert raw records to typed records
+            let refreshed_contracts: Vec<_> = contracts
+                .into_iter()
+                .filter_map(|record| record.into_typed().ok())
+                .map(|record| {
+                    let config = ContractCfg {
+                        network,
+                        operator_table: record.operator_table.clone(),
+                        connector_params: connectors,
+                        peg_out_graph_params: tx_graph.clone(),
+                        sidesystem_params: sidesystem.clone(),
+                        stake_chain_params: stake_chain,
+                        deposit_idx: record.deposit_idx,
+                        deposit_tx: record.deposit_tx.clone(),
+                    };
+                    (record, config)
+                })
+                .collect();
+            let after_num_contracts = refreshed_contracts.len();
+
+            let mut cache_lock = cached_contracts.write().await;
+            *cache_lock = refreshed_contracts;
+            // Strive to always drop the lock as soon as possible to avoid blocking other
+            // tasks.
+            drop(cache_lock);
+
+            info!(%after_num_contracts, "RPC server Contracts cache initialized");
+
+            // Periodic refresh in a separate loop outside the closure
+            let mut refresh_interval = interval(period);
+            loop {
+                refresh_interval.tick().await;
+
+                // Each refresh uses execute_with_retries only for the DB operation
+                let contracts = match execute_with_retries(&db_config, || async {
+                    let result: Result<Vec<ContractRecord>, _> = query_as!(
+                        ContractRecord,
+                        r#"
+                                SELECT
+                                    deposit_txid,
+                                    deposit_idx,
+                                    deposit_tx,
+                                    operator_table,
+                                    state
+                                FROM contracts
+                                "#,
+                    )
+                    .fetch_all(db.pool())
+                    .await;
+
+                    result.map_err(|e| DbError::Storage(StorageError::Driver(e)))
+                })
+                .await
+                {
+                    Ok(contracts) => contracts,
+                    Err(err) => {
+                        error!(?err, "Failed to refresh contracts cache");
+                        Vec::new() // Return empty vector on error
+                    }
+                };
+
                 let before_num_contracts = contracts.len();
-                info!(%before_num_contracts, "initializing the RPC server initial contract cache fill");
+                debug!(%before_num_contracts, "refreshing RPC server contract cache");
 
                 // Convert raw records to typed records
                 let refreshed_contracts: Vec<_> = contracts
@@ -275,69 +357,11 @@ impl BridgeRpc {
 
                 let mut cache_lock = cached_contracts.write().await;
                 *cache_lock = refreshed_contracts;
-                // Strive to always drop the lock as soon as possible to avoid blocking other tasks.
+                // Strive to always drop the lock as soon as possible to avoid blocking
+                // other tasks.
                 drop(cache_lock);
 
-                info!(%after_num_contracts, "RPC server Contracts cache initialized");
-            } else {
-                error!("Failed to initialize contracts cache");
-            }
-
-            // Periodic refresh
-            loop {
-                interval.tick().await;
-
-                match query_as!(
-                    ContractRecord,
-                    r#"
-                    SELECT
-                        deposit_txid,
-                        deposit_idx,
-                        deposit_tx,
-                        operator_table,
-                        state
-                    FROM contracts
-                    "#,
-                )
-                .fetch_all(db.pool())
-                .await
-                {
-                    Ok(contracts) => {
-                        let before_num_contracts = contracts.len();
-                        info!(%before_num_contracts, "initializing the RPC server initial contract cache fill");
-
-                        // Convert raw records to typed records
-                        let refreshed_contracts: Vec<_> = contracts
-                            .into_iter()
-                            .filter_map(|record| record.into_typed().ok())
-                            .map(|record| {
-                                let config = ContractCfg {
-                                    network,
-                                    operator_table: record.operator_table.clone(),
-                                    connector_params: connectors,
-                                    peg_out_graph_params: tx_graph.clone(),
-                                    sidesystem_params: sidesystem.clone(),
-                                    stake_chain_params: stake_chain,
-                                    deposit_idx: record.deposit_idx,
-                                    deposit_tx: record.deposit_tx.clone(),
-                                };
-                                (record, config)
-                            })
-                            .collect();
-                        let after_num_contracts = refreshed_contracts.len();
-
-                        let mut cache_lock = cached_contracts.write().await;
-                        *cache_lock = refreshed_contracts;
-                        // Strive to always drop the lock as soon as possible to avoid blocking
-                        // other tasks.
-                        drop(cache_lock);
-
-                        debug!(%after_num_contracts, "Contracts cache refreshed");
-                    }
-                    Err(e) => {
-                        error!(?e, "Failed to refresh contracts cache");
-                    }
-                }
+                debug!(%after_num_contracts, "Contracts cache refreshed");
             }
         });
     }

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -99,7 +99,7 @@ pub(crate) struct ContractRecord {
 
     /// The latest state of the contract.
     #[sqlx(rename = "state")]
-    pub(crate) state: Vec<u8>,
+    pub(crate) state: String,
 }
 
 impl ContractRecord {
@@ -118,7 +118,7 @@ impl ContractRecord {
             error!(?e, "Failed to deserialize operator_table");
             anyhow::anyhow!("Failed to deserialize operator_table: {e}")
         })?;
-        let state = bincode::deserialize(&self.state).map_err(|e| {
+        let state = serde_json::from_str(&self.state).map_err(|e| {
             error!(?e, "Failed to deserialize state");
             anyhow::anyhow!("Failed to deserialize state: {e}")
         })?;

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -275,7 +275,7 @@ impl BridgeRpc {
 
                 let mut cache_lock = cached_contracts.write().await;
                 *cache_lock = refreshed_contracts;
-                // drop the lock!
+                // Strive to always drop the lock as soon as possible to avoid blocking other tasks.
                 drop(cache_lock);
 
                 info!(%after_num_contracts, "RPC server Contracts cache initialized");
@@ -328,7 +328,8 @@ impl BridgeRpc {
 
                         let mut cache_lock = cached_contracts.write().await;
                         *cache_lock = refreshed_contracts;
-                        // drop the lock!
+                        // Strive to always drop the lock as soon as possible to avoid blocking
+                        // other tasks.
                         drop(cache_lock);
 
                         debug!(%after_num_contracts, "Contracts cache refreshed");

--- a/crates/db/src/errors.rs
+++ b/crates/db/src/errors.rs
@@ -5,9 +5,13 @@ use crate::persistent::errors::StorageError;
 /// Error type for the database.
 #[derive(Debug, Error)]
 pub enum DbError {
-    #[error("sqlite: {0}")]
     /// Error originating from the persistence layer.
+    #[error("sqlite: {0}")]
     Storage(#[from] StorageError),
+
+    /// Unexpected catch-all errors.
+    #[error("unexpected: {0}")]
+    Unexpected(String),
 }
 
 /// Wrapper type for database results.

--- a/crates/db/src/persistent/sqlite.rs
+++ b/crates/db/src/persistent/sqlite.rs
@@ -1421,7 +1421,7 @@ impl BitcoinBlockTrackerDb for SqliteDb {
 /// Executes an operation for a given number of retries with a backoff period before erroring out.
 ///
 /// This is useful for retrying transactions that may fail when another thread is holding the lock.
-async fn execute_with_retries<F, Fut, Res>(
+pub async fn execute_with_retries<F, Fut, Res>(
     config: &DbConfig,
     mut operation: F,
 ) -> Result<Res, DbError>

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -113,6 +113,7 @@ impl ContractManager {
                     .collect::<BTreeMap<Txid, ContractSM>>(),
                 Err(e) => crash(e.into()),
             };
+            info!(num_contracts=%active_contracts.len(), "loaded all active contracts");
 
             let operator_pubkey = s2_client
                 .general_wallet_signer()

--- a/crates/duty-tracker/src/contract_persister.rs
+++ b/crates/duty-tracker/src/contract_persister.rs
@@ -155,7 +155,7 @@ impl ContractPersister {
         execute_with_retries(&self.config, || async {
             let _: SqliteQueryResult = sqlx::query(
                 r#"
-            UPDATE contracts SET state = ? WHERE deposit_txid = ?
+            INSERT OR REPLACE INTO contracts (state, deposit_txid) VALUES (?, ?)
             "#,
             )
             .bind(&state_bytes)

--- a/migrations/20241113060253_init_schema.sql
+++ b/migrations/20241113060253_init_schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS contracts (
     deposit_idx INTEGER NOT NULL UNIQUE,    -- Index of the deposit in the stake chain
     deposit_tx BLOB NOT NULL,               -- Serialized with bincode
     operator_table BLOB NOT NULL,           -- Serialized with bincode
-    state BLOB NOT NULL                     -- Serialized with bincode
+    state TEXT NOT NULL                     -- JSON
 );
 
 -- Table for wots_public_keys with a compound index on (operator_id, deposit_txid)


### PR DESCRIPTION
## Description

- Makes all `ContractPersister` and RPC server DB operations robust by using `execute_with_retries` from `strata-bridge-db` crate.
- Commits all columns of the `contracts` table when serializing active contracts with the `ContractPersister`.
- Could not get `bincode`, `ciborium`, `postcard` or `rkyv` to play nice with the huge `MachineState` struct (that has a huge enum `ContractState` inside). So we're JSONing the 🖕🏻 thing as a quick fix.
- Adds the remaining RPC trait instantiations that were missing somehow.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Tested with multiple deposits, stopping restart nodes, and wait long enough to have the deposit confirmed.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1342
