### PR TITLE
STR-1318: Service `PubNonce`s, `AggNonce`s and `PartialSignature`s

### DIFF
--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -991,6 +991,7 @@ impl ContractManagerCtx {
                             claim_txid,
                             pog_prevouts,
                             pog_witnesses,
+                            nonces: None,
                         })
                     } else {
                         warn!("nagged for nonces on a ContractSM that is not in a Requested state");
@@ -1011,6 +1012,7 @@ impl ContractManagerCtx {
                         Some(OperatorDuty::PublishRootNonce {
                             deposit_request_txid,
                             witness,
+                            nonce: None,
                         })
                     } else {
                         warn!("nagged for nonces on a ContractSM that is not in a Requested state");
@@ -1357,12 +1359,14 @@ async fn execute_duty(
         OperatorDuty::PublishRootNonce {
             deposit_request_txid,
             witness,
+            nonce,
         } => {
             handle_publish_root_nonce(
                 &output_handles.s2_session_manager,
                 &output_handles.msg_handler,
                 OutPoint::new(deposit_request_txid, 0),
                 witness,
+                nonce,
             )
             .await
         }
@@ -1371,6 +1375,7 @@ async fn execute_duty(
             claim_txid,
             pog_prevouts: pog_inputs,
             pog_witnesses,
+            nonces,
         } => {
             handle_publish_graph_nonces(
                 s2_session_manager,
@@ -1378,6 +1383,7 @@ async fn execute_duty(
                 claim_txid,
                 pog_inputs,
                 pog_witnesses,
+                nonces,
             )
             .await
         }

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -672,8 +672,7 @@ pub enum OperatorDuty {
 
         /// Pre-generated nonces to publish.
         ///
-        /// If [`None`], will generate new nonces via secret service, and then add them here as
-        /// [`Some`].
+        /// The duty executor will generate new nonces if [`None`] is passed.
         nonces: Option<PogMusigF<PubNonce>>,
     },
 
@@ -694,8 +693,7 @@ pub enum OperatorDuty {
 
         /// Pre-generated partial signatures to publish.
         ///
-        /// If [`None`], will generate new partial signatures via secret service, and then add them
-        /// here as [`Some`].
+        /// The duty executor will generate new partial signatures if [`None`] is passed.
         partial_signatures: Option<PogMusigF<PartialSignature>>,
     },
 
@@ -724,8 +722,7 @@ pub enum OperatorDuty {
 
         /// Pre-generated nonce to publish.
         ///
-        /// If [`None`], will generate new nonce via secret service, and then add it here as
-        /// [`Some`].
+        /// The duty executor will generate new nonce if [`None`] is passed.
         nonce: Option<PubNonce>,
     },
 
@@ -742,9 +739,7 @@ pub enum OperatorDuty {
 
         /// Pre-generated partial signature to publish.
         ///
-        /// If [`None`], will generate new partial signature via secret service, and then add it
-        /// here as
-        /// [`Some`].
+        /// The duty executor will generate new partial signature if [`None`] is passed.
         partial_signature: Option<PartialSignature>,
     },
 

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -669,6 +669,12 @@ pub enum OperatorDuty {
         /// The set of taproot witnesses required to reconstruct the taproot control blocks for the
         /// outpoints.
         pog_witnesses: PogMusigF<TaprootWitness>,
+
+        /// Pre-generated nonces to publish.
+        ///
+        /// If [`None`], will generate new nonces via secret service, and then add them here as
+        /// [`Some`].
+        nonces: Option<PogMusigF<PubNonce>>,
     },
 
     /// Instructs us to send out signatures for the peg out graph.
@@ -709,6 +715,12 @@ pub enum OperatorDuty {
 
         /// The taproot witness required to reconstruct the taproot control block for the outpoint.
         witness: TaprootWitness,
+
+        /// Pre-generated nonce to publish.
+        ///
+        /// If [`None`], will generate new nonce via secret service, and then add it here as
+        /// [`Some`].
+        nonce: Option<PubNonce>,
     },
 
     /// Instructs us to send out signatures for the deposit transaction.
@@ -1431,6 +1443,7 @@ impl ContractSM {
                         claim_txid: graph.claim_tx.compute_txid(),
                         pog_prevouts: graph.musig_inpoints(),
                         pog_witnesses: graph.musig_witnesses(),
+                        nonces: None,
                     })
                     .collect::<Vec<_>>();
 

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -691,6 +691,12 @@ pub enum OperatorDuty {
 
         /// The set of sighashes that need to be signed.
         pog_sighashes: PogMusigF<Message>,
+
+        /// Pre-generated partial signatures to publish.
+        ///
+        /// If [`None`], will generate new partial signatures via secret service, and then add them
+        /// here as [`Some`].
+        partial_signatures: Option<PogMusigF<PartialSignature>>,
     },
 
     /// Instructs us to commit the aggregated signatures to state.
@@ -733,6 +739,13 @@ pub enum OperatorDuty {
 
         /// The sighash that needs to be signed.
         sighash: Message,
+
+        /// Pre-generated partial signature to publish.
+        ///
+        /// If [`None`], will generate new partial signature via secret service, and then add it
+        /// here as
+        /// [`Some`].
+        partial_signature: Option<PartialSignature>,
     },
 
     /// Instructs us to submit the deposit transaction to the network.
@@ -1573,6 +1586,7 @@ impl ContractSM {
                     pubnonces,
                     pog_prevouts: pog.musig_inpoints(),
                     pog_sighashes: pog.musig_sighashes(),
+                    partial_signatures: None,
                 }))
             }
             _ => Err(TransitionErr(format!(
@@ -1793,6 +1807,7 @@ impl ContractSM {
                                 .expect("received nonces from nonexistent operator"),
                             deposit_request_txid: self.deposit_request_txid(),
                             sighash,
+                            partial_signature: None,
                         })
                     } else {
                         None

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -1484,8 +1484,7 @@ impl ContractSM {
                 // session nonces must be present for this claim_txid at this point
                 let Some(session_nonces) = graph_nonces.get_mut(&claim_txid) else {
                     return Err(TransitionErr(format!(
-                        "could not process graph nonces. claim_txid ({}) not found in nonce map",
-                        claim_txid
+                        "could not process graph nonces. claim_txid ({claim_txid}) not found in nonce map"
                     )));
                 };
 
@@ -1493,8 +1492,7 @@ impl ContractSM {
                     warn!(%claim_txid, %signer, "already received nonces for graph");
                     debug_assert_eq!(
                         &unpacked, existing,
-                        "conflicting graph nonces received from {} for claim {}",
-                        signer, claim_txid
+                        "conflicting graph nonces received from {signer} for claim {claim_txid}"
                     );
 
                     // FIXME: (@Rajil1213) this should return an error
@@ -1526,8 +1524,7 @@ impl ContractSM {
 
                 let Some(pog_input) = peg_out_graph_inputs.get(&graph_owner) else {
                     return Err(TransitionErr(format!(
-                        "could not process graph nonces. claim_txid ({}) not found in peg out graph map" ,
-                        claim_txid
+                        "could not process graph nonces. claim_txid ({claim_txid}) not found in peg out graph map"
                     )));
                 };
                 let graph_nonces = graph_nonces.get(&claim_txid).unwrap().clone();

--- a/crates/duty-tracker/src/executors/deposit.rs
+++ b/crates/duty-tracker/src/executors/deposit.rs
@@ -32,7 +32,7 @@ use strata_p2p_types::{
     WotsPublicKeys,
 };
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     contract_manager::{ExecutionConfig, OutputHandles},
@@ -413,7 +413,7 @@ pub(crate) async fn handle_publish_graph_sigs(
 
             // Add all nonces to the musig session manager context.
             for (pk, graph_nonces) in pubnonces {
-                info!(%pk, "loading nonces");
+                trace!(%pk, "loading nonces");
 
                 PogMusigF::<()>::transpose_result::<MusigSessionErr>(
                     pog_outpoints
@@ -617,7 +617,7 @@ pub(crate) async fn handle_publish_root_signature(
 
         let our_pubkey = cfg.operator_table.pov_btc_key();
         for (musig2_pubkey, nonce) in nonces.into_iter().filter(|(pk, _)| *pk != our_pubkey) {
-            info!(%musig2_pubkey, %deposit_request_txid, "loading nonce");
+            trace!(%musig2_pubkey, %deposit_request_txid, "loading nonce");
             s2_client
                 .put_nonce(prevout, musig2_pubkey.to_x_only_pubkey(), nonce)
                 .await

--- a/crates/duty-tracker/src/executors/deposit.rs
+++ b/crates/duty-tracker/src/executors/deposit.rs
@@ -306,8 +306,7 @@ async fn finalize_claim_funding_tx(
 
 /// Handles the duty to publish the graph nonces for the given peg out graph identified by the
 /// transaction ID of its claim transaction.
-///
-/// TODO: This also commits the graph nonces to the database in the `pub_nonces` table.
+// TODO: This also commits the graph nonces to the database in the `pub_nonces` table.
 pub(crate) async fn handle_publish_graph_nonces(
     musig: &MusigSessionManager,
     message_handler: &MessageHandler,
@@ -392,9 +391,8 @@ pub(crate) async fn handle_publish_graph_nonces(
 
 /// Handles the duty to publish the graph partial signatures for the given peg out graph identified
 /// by the transaction ID of its claim transaction.
-///
-/// TODO: This also commits the graph partial signatures to the database in the `partial_signatures`
-/// table.
+// TODO: This also commits the graph partial signatures to the database in the `partial_signatures`
+// table.
 pub(crate) async fn handle_publish_graph_sigs(
     musig: &MusigSessionManager,
     message_handler: &MessageHandler,
@@ -557,8 +555,7 @@ pub(crate) async fn handle_commit_sig(
 
 /// Handles the duty to publish the root nonce for the given deposit request identified by the
 /// its prevout i.e., the outpoint of the Deposit Request Transaction.
-///
-/// TODO: This also commits the root nonce to the database in the `pub_nonces` table.
+// TODO: This also commits the root nonce to the database in the `pub_nonces` table.
 pub(crate) async fn handle_publish_root_nonce(
     s2_client: &MusigSessionManager,
     msg_handler: &MessageHandler,
@@ -597,8 +594,7 @@ pub(crate) async fn handle_publish_root_nonce(
 
 /// Handles the duty to publish the root signature for the given deposit request identified by the
 /// its prevout i.e., the outpoint of the Deposit Request Transaction.
-///
-/// TODO: This also commits the root signature to the database in the `partial_signatures` table.
+// TODO: This also commits the root signature to the database in the `partial_signatures` table.
 pub(crate) async fn handle_publish_root_signature(
     cfg: &ExecutionConfig,
     s2_client: &MusigSessionManager,

--- a/crates/duty-tracker/src/executors/deposit.rs
+++ b/crates/duty-tracker/src/executors/deposit.rs
@@ -306,7 +306,7 @@ async fn finalize_claim_funding_tx(
 
 /// Handles the duty to publish the graph nonces for the given peg out graph identified by the
 /// transaction ID of its claim transaction.
-// TODO: This also commits the graph nonces to the database in the `pub_nonces` table.
+// TODO(@storopoli): This also commits the graph nonces to the database in the `pub_nonces` table.
 pub(crate) async fn handle_publish_graph_nonces(
     musig: &MusigSessionManager,
     message_handler: &MessageHandler,
@@ -391,8 +391,8 @@ pub(crate) async fn handle_publish_graph_nonces(
 
 /// Handles the duty to publish the graph partial signatures for the given peg out graph identified
 /// by the transaction ID of its claim transaction.
-// TODO: This also commits the graph partial signatures to the database in the `partial_signatures`
-// table.
+// TODO(@storopoli): This also commits the graph partial signatures to the database in the
+// `partial_signatures` table.
 pub(crate) async fn handle_publish_graph_sigs(
     musig: &MusigSessionManager,
     message_handler: &MessageHandler,
@@ -555,7 +555,7 @@ pub(crate) async fn handle_commit_sig(
 
 /// Handles the duty to publish the root nonce for the given deposit request identified by the
 /// its prevout i.e., the outpoint of the Deposit Request Transaction.
-// TODO: This also commits the root nonce to the database in the `pub_nonces` table.
+// TODO(@storopoli): This also commits the root nonce to the database in the `pub_nonces` table.
 pub(crate) async fn handle_publish_root_nonce(
     s2_client: &MusigSessionManager,
     msg_handler: &MessageHandler,
@@ -594,7 +594,8 @@ pub(crate) async fn handle_publish_root_nonce(
 
 /// Handles the duty to publish the root signature for the given deposit request identified by the
 /// its prevout i.e., the outpoint of the Deposit Request Transaction.
-// TODO: This also commits the root signature to the database in the `partial_signatures` table.
+// TODO(@storopoli): This also commits the root signature to the database in the
+// `partial_signatures` table.
 pub(crate) async fn handle_publish_root_signature(
     cfg: &ExecutionConfig,
     s2_client: &MusigSessionManager,


### PR DESCRIPTION
## Description

Whenever we get nagged for a nonce or partial sig that we have already, we don't go through the secret service to get it again, instead we just publish the already known/generated one.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This PR:

1. Adds an `Option<PogMusigF<{PubNonce,PartialSignature}>>` field to `OperatorDuty::PublishGraph{Nonces,Signatures}` and an `Option<{PubNonce,PartialSignature}>` field to `OperatorDuty::PublishRoot{Nonce,Signature}`.
2. If we get nagged and we have our nonce or partial sig already in the `ContractState::Requested` enum variant, we fetch it and add as `Some` in the optional field in the duty.
3. When fulfilling the duty if the optional pre-existing field for nonce(s)/partial signature(s) is `Some`, then we bypass secret service client and just publish that thing again.

This avoids messing up with the semantics and logic of duty generating from processing nags in the `process_p2p_requests` function.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1318
