### PR TITLE
chore: add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@
 /bridge-guest-builder/ @Rajil1213 @prajwolrg
 
 # Other components
+/crates/agent/ @Rajil1213 @prajwolrg
 /crates/db/ @Rajil1213 @storopoli
 /crates/p2p-service/ @storopoli
 /crates/rpc/ @storopoli
@@ -58,6 +59,7 @@
 # Test utilities
 /crates/test-utils/ @storopoli
 /bin/dev-cli/ @Rajil1213 @storopoli
+/bin/dev-bridge/ @Rajil1213
 /bin/assert-splitter/ @Rajil1213
 /test-data/ @Rajil1213
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /rust-toolchain.toml @Rajil1213 @storopoli @ProofOfKeags @Zk2u
 **/Cargo.toml @Rajil1213 @storopoli @ProofOfKeags @Zk2u
 **/Cargo.lock @Rajil1213 @storopoli @ProofOfKeags @Zk2u
-**/Makefile @Rajil1213 @storopoli
+**/Makefile @Rajil1213 @storopoli @Zk2u 
 **/LICENSE* @Rajil1213 @storopoli @ProofOfKeags @Zk2u
 **/README.md @Rajil1213 @storopoli @ProofOfKeags @Zk2u
 **/.gitignore @storopoli
@@ -69,7 +69,7 @@
 /.config/ @Rajil1213
 /.vscode/ @Rajil1213
 /docker/ @Rajil1213 @Zk2u
-/compose.yml @Rajil1213
+/compose.yml @Rajil1213 @Zk2u 
 /.dockerignore @Rajil1213
 /.editorconfig @Rajil1213
 /.sample_env @Rajil1213

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,78 @@
+# CODEOWNERS file for strata-bridge
+# Based on git blame analysis of contributor patterns
+# and initial implementation contributions
+
+# Global fallback: core bridge team
+* @Rajil1213 @storopoli @ProofOfKeags @Zk2u
+
+# Bookkeeping
+*.toml @storopoli
+*.md @storopoli
+/rust-toolchain.toml @Rajil1213 @storopoli @ProofOfKeags @Zk2u
+**/Cargo.toml @Rajil1213 @storopoli @ProofOfKeags @Zk2u
+**/Cargo.lock @Rajil1213 @storopoli @ProofOfKeags @Zk2u
+**/Makefile @Rajil1213 @storopoli
+**/LICENSE* @Rajil1213 @storopoli @ProofOfKeags @Zk2u
+**/README.md @Rajil1213 @storopoli @ProofOfKeags @Zk2u
+**/.gitignore @storopoli
+/migrations/ @Rajil1213
+/scripts/ @storopoli
+/zizmor.yml @storopoli
+/assets/ @Rajil1213
+
+# Primitives and common components
+/crates/primitives/ @Rajil1213 @ProofOfKeags @storopoli
+/crates/common/ @Rajil1213 @ProofOfKeags @storopoli
+/crates/wots/ @storopoli @ProofOfKeags
+/crates/params/ @Rajil1213 @storopoli
+
+# Secret service components
+/crates/secret-service-client/ @Zk2u
+/crates/secret-service-proto/ @Zk2u
+/crates/secret-service-server/ @Zk2u
+/bin/secret-service/ @Zk2u
+/**/secret-service/ @Zk2u
+
+# Duty tracker components
+/crates/btc-notify/ @ProofOfKeags
+/crates/duty-tracker/ @ProofOfKeags
+
+# Transaction graph components
+/crates/tx-graph/ @Rajil1213
+/crates/stake-chain/ @storopoli
+/crates/connectors/ @Rajil1213
+
+# Main binary
+/bin/alpen-bridge/ @storopoli @Rajil1213 @ProofOfKeags
+
+# Prover things
+/crates/bridge-proof/ @Rajil1213 @prajwolrg
+/bridge-guest-builder/ @Rajil1213 @prajwolrg
+
+# Other components
+/crates/db/ @Rajil1213 @storopoli
+/crates/p2p-service/ @storopoli
+/crates/rpc/ @storopoli
+/crates/operator-wallet/ @Zk2u @storopoli
+
+# Test utilities
+/crates/test-utils/ @storopoli
+/bin/dev-cli/ @Rajil1213 @storopoli
+/bin/assert-splitter/ @Rajil1213
+/test-data/ @Rajil1213
+
+# Configuration and infrastructure
+/rustfmt.toml @Rajil1213
+/.cargo/ @Rajil1213
+/.config/ @Rajil1213
+/.vscode/ @Rajil1213
+/docker/ @Rajil1213
+/compose.yml @Rajil1213
+/.dockerignore @Rajil1213
+/.editorconfig @Rajil1213
+/.sample_env @Rajil1213
+/.codespellrc @Rajil1213
+
+# CI/CD
+/.github/ @storopoli
+/.codecov.yml @storopoli

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,7 @@
 /.cargo/ @Rajil1213
 /.config/ @Rajil1213
 /.vscode/ @Rajil1213
-/docker/ @Rajil1213
+/docker/ @Rajil1213 @Zk2u
 /compose.yml @Rajil1213
 /.dockerignore @Rajil1213
 /.editorconfig @Rajil1213


### PR DESCRIPTION
## Description

This adds a `CODEOWNERS` file to the repo.
I used my judgement to assign usernames here using three criteria:

1. Who was the first implementer of the component
2. `git blame` analyses for frequency of contribution
3. Who was comfortable working on certain things and also is well known to have notorious knowledge about it

I also tried to balance things out between us.

Finally, I left two crates out since they are deprecated and we need to remove them: `dev-bridge` and `agent`. Let me know if you want me to include them and who should own them.

Let's f**** bikeshed this properly. I am in no rush to merge this and let's get it right. I don't want to see people get hurt by this, but empowered.
I want this to "spark joy".

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] Meta: stuff about stuff

## Notes to Reviewers



## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues


