### PR TITLE
fix(rpc-server): remove todos macros for no-ops

### DIFF
--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -588,10 +588,10 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
         // Iterate over all contract states to find the matching withdrawal
         for entry in all_entries {
             match &entry.0.state.state {
-                ContractState::Requested { .. } => todo!(),
-                ContractState::Deposited { .. } => todo!(),
-                ContractState::Assigned { .. } => todo!(),
-                ContractState::StakeTxReady { .. } => todo!(),
+                ContractState::Requested { .. } => (),
+                ContractState::Deposited { .. } => (),
+                ContractState::Assigned { .. } => (),
+                ContractState::StakeTxReady { .. } => (),
                 ContractState::Fulfilled {
                     withdrawal_fulfillment_txid,
                     ..
@@ -604,11 +604,12 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                         });
                     }
                 }
-                ContractState::Claimed { .. } => todo!(),
-                ContractState::Challenged { .. } => todo!(),
-                ContractState::Asserted { .. } => todo!(),
-                ContractState::Disproved { .. } => todo!(),
-                ContractState::Resolved { .. } => todo!(),
+                // TODO(@storopoli): We cannot get the withdrawal_outpoint for these states
+                ContractState::Claimed { .. } => (),
+                ContractState::Challenged { .. } => (),
+                ContractState::Asserted { .. } => (),
+                ContractState::Disproved { .. } => (),
+                ContractState::Resolved { .. } => (),
             }
         }
 


### PR DESCRIPTION
## Description

This was leftover from the RPC server PR.
There's no way to get from the `ContractState` the `withdrawal_outpoint` for all others states apart from `Fulfilled`.
This avoids a run-time crash if we hit the `todo!()`s that we had previously in all of the remaining `ContractState`s in the `match` statement.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I don't know how to further introspect other `ContractState`s given an `withdrawal_outpoint`.
Do we need to include it in these `ContractState`s somehow?

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues


