### PR TITLE
feat!(rpc): proper RPC traits and types for the monitoring API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9933,6 +9933,7 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "strata-bridge-primitives",
+ "strata-primitives",
 ]
 
 [[package]]

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -691,16 +691,19 @@ const fn contract_state_to_reimbursement_status(state: &ContractState) -> RpcRei
         | ContractState::Assigned { .. }
         | ContractState::StakeTxReady { .. }
         | ContractState::Fulfilled { .. } => RpcReimbursementStatus::NotStarted,
-        ContractState::Claimed { .. } => RpcReimbursementStatus::InProgress {
+        ContractState::Claimed { active_graph, .. } => RpcReimbursementStatus::InProgress {
             challenge_step: ChallengeStep::Claim,
+            claim_txid: active_graph.1.claim_txid,
         },
-        ContractState::Challenged { .. } => RpcReimbursementStatus::Challenged {
+        ContractState::Challenged { active_graph, .. } => RpcReimbursementStatus::Challenged {
             challenge_step: ChallengeStep::Challenge,
+            claim_txid: active_graph.1.claim_txid,
         },
-        ContractState::PreAssertConfirmed { .. }
-        | ContractState::AssertDataConfirmed { .. }
-        | ContractState::Asserted { .. } => RpcReimbursementStatus::Challenged {
+        ContractState::PreAssertConfirmed { active_graph, .. }
+        | ContractState::AssertDataConfirmed { active_graph, .. }
+        | ContractState::Asserted { active_graph, .. } => RpcReimbursementStatus::Challenged {
             challenge_step: ChallengeStep::Assert,
+            claim_txid: active_graph.1.claim_txid,
         },
         ContractState::Resolved { payout_txid, .. } => RpcReimbursementStatus::Complete {
             payout_txid: *payout_txid,

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -496,7 +496,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                         fulfiller,
                         ..
                     } => Some(RpcBridgeDutyStatus::Withdrawal {
-                        withdrawal_request_txid: Buf32::from(withdrawal_request_txid),
+                        withdrawal_request_txid,
                         assigned_operator_idx: fulfiller,
                     }),
                     ContractState::StakeTxReady {
@@ -504,7 +504,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                         fulfiller,
                         ..
                     } => Some(RpcBridgeDutyStatus::Withdrawal {
-                        withdrawal_request_txid: Buf32::from(withdrawal_request_txid),
+                        withdrawal_request_txid,
                         assigned_operator_idx: fulfiller,
                     }),
                     // Anything else is not a duty for the bridge operator
@@ -546,7 +546,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                         ..
                     } if claim_txids.contains_key(operator_p2p_pk) => {
                         Some(RpcBridgeDutyStatus::Withdrawal {
-                            withdrawal_request_txid: Buf32::from(*withdrawal_request_txid),
+                            withdrawal_request_txid: *withdrawal_request_txid,
                             assigned_operator_idx: *fulfiller,
                         })
                     }
@@ -558,7 +558,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                         ..
                     } if claim_txids.contains_key(operator_p2p_pk) => {
                         Some(RpcBridgeDutyStatus::Withdrawal {
-                            withdrawal_request_txid: Buf32::from(*withdrawal_request_txid),
+                            withdrawal_request_txid: *withdrawal_request_txid,
                             assigned_operator_idx: *fulfiller,
                         })
                     }
@@ -580,13 +580,13 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                     withdrawal_request_txid,
                     ..
                 } => {
-                    withdrawals.push(Buf32::from(*withdrawal_request_txid));
+                    withdrawals.push(*withdrawal_request_txid);
                 }
                 ContractState::StakeTxReady {
                     withdrawal_request_txid,
                     ..
                 } => {
-                    withdrawals.push(Buf32::from(*withdrawal_request_txid));
+                    withdrawals.push(*withdrawal_request_txid);
                 }
                 _ => {}
             }
@@ -621,7 +621,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 };
 
                 if let Some(entry_withdrawal_request_txid) = entry_withdrawal_request_txid {
-                    if withdrawal_request_txid == Buf32::from(entry_withdrawal_request_txid) {
+                    if withdrawal_request_txid == entry_withdrawal_request_txid {
                         // Determine the status based on the current state
                         let status = match &entry.0.state.state {
                             ContractState::Fulfilled {

--- a/crates/duty-tracker/src/contract_actor.rs
+++ b/crates/duty-tracker/src/contract_actor.rs
@@ -7,6 +7,7 @@ use algebra::req::Req;
 use bitcoin::{Transaction, Txid};
 use futures::future::join_all;
 use strata_bridge_tx_graph::{peg_out_graph::PegOutGraph, transactions::covenant_tx::CovenantTx};
+use strata_primitives::buf::Buf32;
 use tokio::{sync::mpsc, task::JoinHandle, time::timeout};
 use tracing::{debug, error, info, trace, warn};
 
@@ -58,7 +59,10 @@ pub enum ContractActorMessage {
     GetDepositRequestTxid(Req<(), Txid>),
 
     /// Gets the withdrawal request transaction ID (if any).
-    GetWithdrawalRequestTxid(Req<(), Option<Txid>>),
+    ///
+    /// NOTE: These are not Bitcoin [`Txid`]s but [`Buf32`] representing the transaction IDs of the
+    /// withdrawal transactions in the sidesystem's execution environment.
+    GetWithdrawalRequestTxid(Req<(), Option<Buf32>>),
 
     /// Gets the withdrawal fulfillment transaction ID (if any).
     GetWithdrawalFulfillmentTxid(Req<(), Option<Txid>>),

--- a/crates/duty-tracker/src/contract_actor.rs
+++ b/crates/duty-tracker/src/contract_actor.rs
@@ -330,7 +330,7 @@ impl ContractActor {
     }
 
     /// Gets the withdrawal request transaction ID (if any).
-    pub async fn withdrawal_request_txid(&self) -> Result<Option<Txid>, TransitionErr> {
+    pub async fn withdrawal_request_txid(&self) -> Result<Option<Buf32>, TransitionErr> {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetWithdrawalRequestTxid(req))

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -48,7 +48,7 @@ use strata_bridge_tx_graph::{
     },
 };
 use strata_p2p_types::{P2POperatorPubKey, WotsPublicKeys};
-use strata_primitives::params::RollupParams;
+use strata_primitives::{buf::Buf32, params::RollupParams};
 use strata_state::bridge_state::{DepositEntry, DepositState};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
@@ -2443,7 +2443,7 @@ impl ContractSM {
                             deadline,
                             active_graph,
                             recipient: recipient.clone(),
-                            withdrawal_request_txid: withdrawal_request_txid.into(),
+                            withdrawal_request_txid,
                             l1_start_height: height,
                         };
 
@@ -3199,9 +3199,9 @@ impl ContractSM {
         .collect()
     }
 
-    /// The txid of the assignment transaction for this contract.
+    /// The transaction ID of the assignment transaction for this contract.
     ///
-    /// Note that this is only available if the contract is in the [`ContractState::Assigned`] or
+    /// NOTE: that this is only available if the contract is in the [`ContractState::Assigned`] or
     /// [`ContractState::StakeTxReady`] state.
     ///
     /// This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of the

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -324,7 +324,10 @@ pub enum ContractState {
         active_graph: (PegOutGraphInput, PegOutGraphSummary),
 
         /// The transaction ID of the withdrawal request transaction in the execution environment.
-        withdrawal_request_txid: Txid,
+        ///
+        /// NOTE: This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of
+        /// the withdrawal transaction in the sidesystem's execution environment.
+        withdrawal_request_txid: Buf32,
 
         /// The height of the last block in bitcoin covered by the sidesystem checkpoint containing
         /// the assignment.
@@ -361,7 +364,10 @@ pub enum ContractState {
         active_graph: (PegOutGraphInput, PegOutGraphSummary),
 
         /// The transaction ID of the withdrawal request transaction in the execution environment.
-        withdrawal_request_txid: Txid,
+        ///
+        /// NOTE: This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of
+        /// the withdrawal transaction in the sidesystem's execution environment.
+        withdrawal_request_txid: Buf32,
 
         /// The height of the last block in bitcoin covered by the sidesystem checkpoint containing
         /// the assignment.
@@ -3197,7 +3203,10 @@ impl ContractSM {
     ///
     /// Note that this is only available if the contract is in the [`ContractState::Assigned`] or
     /// [`ContractState::StakeTxReady`] state.
-    pub const fn withdrawal_request_txid(&self) -> Option<Txid> {
+    ///
+    /// This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of the
+    /// withdrawal transaction in the sidesystem's execution environment.
+    pub const fn withdrawal_request_txid(&self) -> Option<Buf32> {
         match &self.state().state {
             ContractState::Assigned {
                 withdrawal_request_txid,

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -390,6 +390,12 @@ pub enum ContractState {
         /// The graph that belongs to the assigned operator.
         active_graph: (PegOutGraphInput, PegOutGraphSummary),
 
+        /// The transaction ID of the withdrawal request transaction in the execution environment.
+        ///
+        /// NOTE: This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of
+        /// the withdrawal transaction in the sidesystem's execution environment.
+        withdrawal_request_txid: Buf32,
+
         /// The withdrawal fulfillment transaction ID.
         withdrawal_fulfillment_txid: Txid,
 
@@ -2609,6 +2615,7 @@ impl ContractSM {
                 graph_sigs,
                 fulfiller,
                 active_graph,
+                withdrawal_request_txid,
                 recipient,
                 l1_start_height,
                 ..
@@ -2649,6 +2656,7 @@ impl ContractSM {
                     graph_sigs: graph_sigs.clone(),
                     fulfiller: *fulfiller,
                     active_graph: active_graph.clone(),
+                    withdrawal_request_txid: *withdrawal_request_txid,
                     withdrawal_fulfillment_txid,
                     withdrawal_fulfillment_height: height,
                     l1_start_height: *l1_start_height,

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 strata-bridge-primitives.workspace = true
+strata-primitives.workspace = true
 
 bitcoin.workspace = true
 jsonrpsee = { workspace = true, features = ["server", "macros"] }

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -2,6 +2,7 @@
 
 use bitcoin::{taproot::Signature, PublicKey, Transaction, Txid};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use strata_primitives::buf::Buf32;
 
 use crate::types::{
     RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositInfo, RpcDisproveData, RpcOperatorStatus,
@@ -57,21 +58,21 @@ pub trait StrataBridgeMonitoringApi {
         operator_pk: PublicKey,
     ) -> RpcResult<Vec<RpcBridgeDutyStatus>>;
 
-    /// Get all withdrawal request outpoints.
+    /// Get all withdrawal request txids.
     ///
-    /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
-    /// withdraw.
+    /// NOTE: These are not Bitcoin txids but [`Buf32`] representing the transaction IDs of the
+    /// withdrawal transactions in the sidesystem's execution environment.
     #[method(name = "withdrawals")]
-    async fn get_withdrawals(&self) -> RpcResult<Vec<Txid>>;
+    async fn get_withdrawals(&self) -> RpcResult<Vec<Buf32>>;
 
-    /// Get withdrawal details using withdrawal request outpoint.
+    /// Get withdrawal details using withdrawal request txid.
     ///
-    /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
-    /// withdraw.
+    /// NOTE: This is not a Bitcoin txid but a [`Buf32`] representing the transaction ID of the
+    /// withdrawal transaction in the sidesystem's execution environment.
     #[method(name = "withdrawalInfo")]
     async fn get_withdrawal_info(
         &self,
-        withdrawal_request_txid: Txid,
+        withdrawal_request_txid: Buf32,
     ) -> RpcResult<RpcWithdrawalInfo>;
 
     /// Get all claim transaction IDs.

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -4,7 +4,7 @@ use bitcoin::{taproot::Signature, OutPoint, PublicKey, Transaction, Txid};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use crate::types::{
-    RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositStatus, RpcDisproveData, RpcOperatorStatus,
+    RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositInfo, RpcDisproveData, RpcOperatorStatus,
     RpcWithdrawalInfo,
 };
 
@@ -31,25 +31,43 @@ pub trait StrataBridgeMonitoringApi {
     #[method(name = "operatorStatus")]
     async fn get_operator_status(&self, operator_pk: PublicKey) -> RpcResult<RpcOperatorStatus>;
 
+    /// Get all deposit request outpoints.
+    #[method(name = "depositRequests")]
+    async fn get_deposit_requests(&self) -> RpcResult<Vec<OutPoint>>;
+
     /// Get deposit details using the deposit request outpoint.
     #[method(name = "depositInfo")]
     async fn get_deposit_request_info(
         &self,
         deposit_request_outpoint: OutPoint,
-    ) -> RpcResult<RpcDepositStatus>;
+    ) -> RpcResult<RpcDepositInfo>;
 
     /// Get bridge duties.
+    // TODO: refactor this to a new trait since the monitoring API does not use it
+    //       but we'll use it internally for debugging and introspection.
     #[method(name = "bridgeDuties")]
     async fn get_bridge_duties(&self) -> RpcResult<Vec<RpcBridgeDutyStatus>>;
 
     /// Get bridge duties assigned to an operator by its [`PublicKey`].
+    // TODO: refactor this to a new trait since the monitoring API does not use it
+    //       but we'll use it internally for debugging and introspection.
     #[method(name = "bridgeDutiesByPk")]
     async fn get_bridge_duties_by_operator_pk(
         &self,
         operator_pk: PublicKey,
     ) -> RpcResult<Vec<RpcBridgeDutyStatus>>;
 
-    /// Get withdrawal details using withdrawal outpoint.
+    /// Get all withdrawal request outpoints.
+    ///
+    /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
+    /// withdraw.
+    #[method(name = "withdrawals")]
+    async fn get_withdrawals(&self) -> RpcResult<Vec<OutPoint>>;
+
+    /// Get withdrawal details using withdrawal request outpoint.
+    ///
+    /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
+    /// withdraw.
     #[method(name = "withdrawalInfo")]
     async fn get_withdrawal_info(
         &self,

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -1,6 +1,6 @@
 //! Traits for the RPC server.
 
-use bitcoin::{taproot::Signature, OutPoint, PublicKey, Transaction, Txid};
+use bitcoin::{taproot::Signature, PublicKey, Transaction, Txid};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use crate::types::{
@@ -33,13 +33,13 @@ pub trait StrataBridgeMonitoringApi {
 
     /// Get all deposit request outpoints.
     #[method(name = "depositRequests")]
-    async fn get_deposit_requests(&self) -> RpcResult<Vec<OutPoint>>;
+    async fn get_deposit_requests(&self) -> RpcResult<Vec<Txid>>;
 
     /// Get deposit details using the deposit request outpoint.
     #[method(name = "depositInfo")]
     async fn get_deposit_request_info(
         &self,
-        deposit_request_outpoint: OutPoint,
+        deposit_request_txid: Txid,
     ) -> RpcResult<RpcDepositInfo>;
 
     /// Get bridge duties.
@@ -62,7 +62,7 @@ pub trait StrataBridgeMonitoringApi {
     /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
     /// withdraw.
     #[method(name = "withdrawals")]
-    async fn get_withdrawals(&self) -> RpcResult<Vec<OutPoint>>;
+    async fn get_withdrawals(&self) -> RpcResult<Vec<Txid>>;
 
     /// Get withdrawal details using withdrawal request outpoint.
     ///
@@ -71,7 +71,7 @@ pub trait StrataBridgeMonitoringApi {
     #[method(name = "withdrawalInfo")]
     async fn get_withdrawal_info(
         &self,
-        withdrawal_outpoint: OutPoint,
+        withdrawal_request_txid: Txid,
     ) -> RpcResult<RpcWithdrawalInfo>;
 
     /// Get all claim transaction IDs.

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -32,11 +32,11 @@ pub trait StrataBridgeMonitoringApi {
     #[method(name = "operatorStatus")]
     async fn get_operator_status(&self, operator_pk: PublicKey) -> RpcResult<RpcOperatorStatus>;
 
-    /// Get all deposit request outpoints.
+    /// Get all deposit request [`Txid`]s.
     #[method(name = "depositRequests")]
     async fn get_deposit_requests(&self) -> RpcResult<Vec<Txid>>;
 
-    /// Get deposit details using the deposit request outpoint.
+    /// Get deposit details using the deposit request [`Txid`].
     #[method(name = "depositInfo")]
     async fn get_deposit_request_info(
         &self,

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -73,7 +73,7 @@ pub trait StrataBridgeMonitoringApi {
     async fn get_withdrawal_info(
         &self,
         withdrawal_request_txid: Buf32,
-    ) -> RpcResult<RpcWithdrawalInfo>;
+    ) -> RpcResult<Option<RpcWithdrawalInfo>>;
 
     /// Get all claim transaction IDs.
     #[method(name = "claims")]

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -3,6 +3,7 @@
 use bitcoin::{hashes::sha256, secp256k1::XOnlyPublicKey, taproot, OutPoint, Txid};
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::{types::OperatorIdx, wots};
+use strata_primitives::buf::Buf32;
 
 /// Enum representing the status of a bridge operator
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,9 +118,9 @@ pub struct RpcWithdrawalInfo {
 
     /// Transaction ID of the withdrawal request transaction (WRT).
     ///
-    /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
-    /// withdraw.
-    pub withdrawal_request_txid: Txid,
+    /// NOTE: This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of the
+    /// withdrawal transaction in the sidesystem's execution environment.
+    pub withdrawal_request_txid: Buf32,
 }
 
 /// Represents reimbursement transaction details
@@ -144,7 +145,10 @@ pub enum RpcBridgeDutyStatus {
     /// Withdrawal duty
     Withdrawal {
         /// Transaction ID of the withdrawal request transaction (WRT).
-        withdrawal_request_txid: Txid,
+        ///
+        /// NOTE: This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of
+        /// the withdrawal transaction in the sidesystem's execution environment.
+        withdrawal_request_txid: Buf32,
 
         /// Assigned operator index.
         assigned_operator_idx: OperatorIdx,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -21,25 +21,16 @@ pub enum RpcOperatorStatus {
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum RpcDepositStatus {
     /// Deposit exists, but minting hasn't happened yet.
-    InProgress {
-        /// Transaction ID of the deposit request transaction (DRT).
-        deposit_request_txid: Txid,
-    },
+    InProgress,
 
     /// Deposit exists, but was never completed (can be reclaimed).
     Failed {
-        /// Transaction ID of the deposit request transaction (DRT).
-        deposit_request_txid: Txid,
-
         /// Reason for the failure.
         failure_reason: String,
     },
 
     /// Deposit has been fully processed and minted.
     Complete {
-        /// Transaction ID of the deposit request transaction (DRT).
-        deposit_request_txid: Txid,
-
         /// Transaction ID of the deposit transaction (DT).
         deposit_txid: Txid,
     },
@@ -81,16 +72,25 @@ pub enum RpcReimbursementStatus {
     NotStarted,
 
     /// Claim exists, challenge step is "Claim", no payout.
-    InProgress,
+    InProgress {
+        /// Challenge step.
+        challenge_step: ChallengeStep,
+    },
 
     /// Claim exists, challenge step is "Challenge" or "Assert", no payout.
-    Challenged,
+    Challenged {
+        /// Challenge step.
+        challenge_step: ChallengeStep,
+    },
 
     /// Operator was slashed, claim is no longer valid.
     Cancelled,
 
     /// Claim has been successfully reimbursed.
-    Complete,
+    Complete {
+        /// Payout transaction ID.
+        payout_txid: Txid,
+    },
 }
 
 /// Represents deposit transaction details
@@ -98,6 +98,9 @@ pub enum RpcReimbursementStatus {
 pub struct RpcDepositInfo {
     /// Status of the deposit.
     pub status: RpcDepositStatus,
+
+    /// Transaction ID of the deposit request transaction (DRT).
+    pub deposit_request_txid: Txid,
 }
 
 /// Represents withdrawal transaction details
@@ -105,6 +108,12 @@ pub struct RpcDepositInfo {
 pub struct RpcWithdrawalInfo {
     /// Status of the withdrawal.
     pub status: RpcWithdrawalStatus,
+
+    /// Outpoint of the withdrawal request transaction (WRT).
+    ///
+    /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
+    /// withdraw.
+    pub withdrawal_request_outpoint: OutPoint,
 }
 
 /// Represents reimbursement transaction details

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -75,12 +75,18 @@ pub enum RpcReimbursementStatus {
     InProgress {
         /// Challenge step.
         challenge_step: ChallengeStep,
+
+        /// Transaction ID of the claim transaction.
+        claim_txid: Txid,
     },
 
     /// Claim exists, challenge step is "Challenge" or "Assert", no payout.
     Challenged {
         /// Challenge step.
         challenge_step: ChallengeStep,
+
+        /// Transaction ID of the claim transaction.
+        claim_txid: Txid,
     },
 
     /// Operator was slashed, claim is no longer valid.

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -115,11 +115,11 @@ pub struct RpcWithdrawalInfo {
     /// Status of the withdrawal.
     pub status: RpcWithdrawalStatus,
 
-    /// Outpoint of the withdrawal request transaction (WRT).
+    /// Transaction ID of the withdrawal request transaction (WRT).
     ///
     /// NOTE: This outpoint is the on-chain strata checkpoint that assigned operators to fulfill a
     /// withdraw.
-    pub withdrawal_request_outpoint: OutPoint,
+    pub withdrawal_request_txid: Txid,
 }
 
 /// Represents reimbursement transaction details


### PR DESCRIPTION
## Description

On draft until #157 is merged.
This is what we need for the monitoring bridge API as pair coded with @krsnapaudel.

The twin PR in the `alpen-dashboards` is https://github.com/alpenlabs/alpen-dashboards/pull/25.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This PR also corrects the field `withdrawal_request_txid` in the `duty-tracker` to be a `Buf32` since it represents the transaction ID from the sidesystem (Reth) and NOT a Bitcoin transaction ID.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-919