### PR TITLE
docker: bump bitcoind image to v29

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -84,7 +84,7 @@ services:
         ipv4_address: 172.28.0.7
 
   bitcoind:
-    image: bitcoin/bitcoin:28.1
+    image: bitcoin/bitcoin:29
     volumes:
       - ./docker/bitcoin/entrypoint.sh:/entrypoint.sh
     ports:


### PR DESCRIPTION
## Description

I realized that we're using `bitcoin` v28.1 in our docker environment and we should be testing against the latest v29.

I ran couple deposits to see if we wouldn't have any issues and so far so good.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
