### PR TITLE
ci: sync rust toolchain with `rust-toolchain.toml` file

### DIFF
--- a/.github/actions/extract-rust-version/action.yml
+++ b/.github/actions/extract-rust-version/action.yml
@@ -1,0 +1,17 @@
+name: Extract Rust toolchain version
+description: "Extracts the Rust nightly version from rust-toolchain.toml file."
+inputs: {}
+outputs:
+  nightly-version:
+    description: "The extracted nightly version from rust-toolchain.toml"
+    value: ${{ steps.extract.outputs.nightly-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract nightly version
+      id: extract
+      shell: bash
+      run: |
+        VERSION="$(grep '^channel = ' rust-toolchain.toml | sed 's/channel = "\(.*\)"/\1/')"
+        echo "nightly-version=$VERSION" >> "$GITHUB_OUTPUT" 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,27 +13,47 @@ env:
 permissions: {}
 
 jobs:
-  crate-checks:
-    name: Check that crates compile on their own
+  extract-rust-version:
+    name: Extract toolchain version
     runs-on: ubuntu-latest
-    timeout-minutes: 90 # cold run takes a lot of time as each crate is compiled separately
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
+
+  crate-checks:
+    name: Check that crates compile on their own
+    runs-on: ubuntu-latest
+    needs: extract-rust-version
+    timeout-minutes: 90 # cold run takes a lot of time as each crate is compiled separately
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          toolchain: nightly-2024-11-01
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
+        with:
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: taiki-e/install-action@27d86b8f455f5faba378fdd55a1c18e1998b3633 # cargo-hack
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@27d86b8f455f5faba378fdd55a1c18e1998b3633 # cargo-hack
 
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 
@@ -59,7 +79,8 @@ jobs:
       - name: Run db migrations
         run: make migrate
 
-      - run: cargo hack check
+      - name: Check crates compile
+        run: cargo hack check
         env:
           DATABASE_URL: sqlite://./operator.db
           SKIP_GUEST_BUILD: 1

--- a/.github/workflows/cron-nightly-rust.yml
+++ b/.github/workflows/cron-nightly-rust.yml
@@ -18,10 +18,14 @@ jobs:
       contents: write # Needed to create commits
       pull-requests: write # Needed to create a PR
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
+
       - name: Update rust-toolchain.toml to use latest nightly
         run: |
           set -xe
@@ -50,6 +54,7 @@ jobs:
               echo "Attempted to update nightly but the latest-nightly date did not change. Not opening any PR."
               echo "changes_made=false" >> "$GITHUB_ENV"
           fi
+
       - name: Create Pull Request
         if: env.changes_made == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -28,19 +28,38 @@ env:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
+
   update:
     name: Update
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     permissions:
       contents: write # Needed to create commits
       pull-requests: write # Needed to create a PR
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
         with:
-          toolchain: nightly-2024-11-01
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
 
       - name: cargo update
         # Remove first line that always just says "Updating crates.io index"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,20 +12,39 @@ env:
 permissions: {}
 
 jobs:
-  docs:
-    name: Generate docs
+  extract-rust-version:
+    name: Extract toolchain version
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
-        with:
-          toolchain: nightly-2024-11-01
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
 
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+  docs:
+    name: Generate docs
+    runs-on: ubuntu-latest
+    needs: extract-rust-version
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
+        with:
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,12 +1,13 @@
-name: Lint GitHub Actions workflows
+name: Lint Actions
+
 on:
   pull_request:
-    paths:
-      - ".github/**"
   merge_group:
   push:
-    paths:
-      - ".github/**"
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
 
 permissions: {}
 
@@ -14,9 +15,12 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - uses: reviewdog/action-actionlint@534eb894142bcf31616e5436cbe4214641c58101 # v1.61
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65
         with:
           fail_level: "any"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,26 +8,43 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY: nightly-2024-10-31
 
 permissions: {}
 
 jobs:
-  clippy:
-    name: Run clippy on crates
+  extract-rust-version:
+    name: Extract toolchain version
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - name: Install ${{ env.NIGHTLY }}
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
+
+  clippy:
+    name: Run clippy on crates
+    runs-on: ubuntu-latest
+    needs: extract-rust-version
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
         with:
-          toolchain: ${{ env.NIGHTLY }}
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
 
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 
@@ -56,6 +73,7 @@ jobs:
 
   miri:
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 60
     strategy:
       matrix:
@@ -63,18 +81,20 @@ jobs:
           - secret-service-server
           # - strata-bridge-tx-graph # broken given sp1 does not like miri.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
           submodules: true
 
-      - name: Install ${{ env.NIGHTLY }}
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
         with:
-          toolchain: ${{ env.NIGHTLY }}
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
           components: miri
 
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 
@@ -98,17 +118,20 @@ jobs:
   fmt:
     name: Check code formatting
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - name: Install ${{ env.NIGHTLY }}
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
         with:
-          toolchain: ${{ env.NIGHTLY }}
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
           components: rustfmt
+
       - name: cargo fmt check
         run: cargo fmt --all --check
 
@@ -117,18 +140,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
 
   taplo:
     name: Lint and check formatting of TOML files
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -136,9 +162,11 @@ jobs:
         run: |
           curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \
             | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+
       - name: Run taplo lint
         run: |
           taplo lint
+
       - name: Run taplo format check
         run: |
           taplo fmt --check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,11 +15,13 @@ jobs:
   supply-chain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 # v1.4.1
+      - name: Run security audit
+        uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,9 +25,25 @@ concurrency:
 permissions: {}
 
 jobs:
+  extract-rust-version:
+    name: Extract toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
+
   test:
     name: Run unit tests and generate report
     runs-on: ubuntu-latest
+    needs: extract-rust-version
     timeout-minutes: 60 # better fail-safe than the default 360 in github actions
     steps:
       - name: Checkout repository
@@ -51,11 +67,11 @@ jobs:
           bitcoind --version
           rm -rf "bitcoin-${{ env.BITCOIND_VERSION }}" "bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
 
-      - name: Install llvm-tools-preview
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@b95584d8105b9ab200e15821fa671848cf2b7017 # nightly
         with:
           components: llvm-tools-preview
-          toolchain: nightly-2024-11-01
+          toolchain: ${{ needs.extract-rust-version.outputs.nightly-version }}
 
       - name: Install latest nextest release
         uses: taiki-e/install-action@ba0a04e0afd83836a25f30f6f33e6ebdd81a8ff1 # v2
@@ -78,7 +94,8 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
         with:
           cache-on-failure: true
 


### PR DESCRIPTION
## Description

CI jobs needs to specify a `toolchain` since `dtolnay/rust-toolchain` does not support `rust-toolchain.toml` (see https://github.com/dtolnay/rust-toolchain/issues/133).
This is annoying since we have manually sync the rust nightly version across multiple files, and also the damn thing is automatically updated every day 1.

This PR adds the feature for CI jobs to extract the nightly version from the `rust-toolchain.toml` using regex magic 🧙🏻 and saves the output in a ENV variable that can be used in further steps by the CI job to know which nightly version to use.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] CI improvements

## Notes to Reviewers



## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
