### PR TITLE
docker: remove `memory_profiling` build

### DIFF
--- a/docker/alpen-bridge/Dockerfile
+++ b/docker/alpen-bridge/Dockerfile
@@ -8,7 +8,7 @@ COPY bin/alpen-bridge bin/alpen-bridge
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/app/target \
-    cargo b -r -p alpen-bridge --features memory_profiling
+    cargo b -r -p alpen-bridge
 
 RUN --mount=type=cache,target=/app/target cp /app/target/release/alpen-bridge /app/alpen-bridge
 

--- a/docker/secret-service/Dockerfile
+++ b/docker/secret-service/Dockerfile
@@ -7,7 +7,7 @@ COPY bin/secret-service bin/secret-service
 RUN --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/app/target \
-    cargo b -r -p secret-service --features memory_profiling
+    cargo b -r -p secret-service
 
 RUN --mount=type=cache,target=/app/target cp /app/target/release/secret-service /app/secret-service
 


### PR DESCRIPTION
## Description

Removes hard-coded `memory_profiling` feature from bridge and secret service binaries' Dockerfiles.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Tested locally

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
