### PR TITLE
Fix/unknown session after restart

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -119,8 +119,7 @@ services:
       - STAKE_CHAIN_WALLET_3=$STAKE_CHAIN_WALLET_3
       - AUTOMINE=5 # every 5 seconds, set to 0 to disable auto generating blocks, keep in alignment with `block_time` in sidesystem params
     networks:
-      bridge:
-        ipv4_address: 172.28.1.8
+      - bridge
 
 networks:
   bridge:

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,7 @@ x-base-bridge-node: &base-bridge-node
     - RUST_BACKTRACE=full
     - MULTI_THREAD_GRAPH_GEN=0 # 1 in order to use an OS thread per graph generation
     - SP1_PROVER=$SP1_PROVER
+    - SP1_PROOF_STRATEGY=$SP1_PROOF_STRATEGY
     - NETWORK_RPC_URL=$NETWORK_RPC_URL
     - NETWORK_PRIVATE_KEY=$NETWORK_PRIVATE_KEY
   depends_on:

--- a/crates/db/src/inmemory/public.rs
+++ b/crates/db/src/inmemory/public.rs
@@ -217,6 +217,23 @@ impl PublicDb for PublicDbInMemory {
             .copied())
     }
 
+    async fn add_all_stake_data(&self, data: Vec<(OperatorIdx, u32, StakeTxData)>) -> DbResult<()> {
+        let mut operator_stake_data = self.stake_data.write().await;
+
+        for (operator_idx, stake_index, stake_data) in data {
+            if let Some(data) = operator_stake_data.get_mut(&operator_idx) {
+                data.insert(stake_index, stake_data);
+            } else {
+                let mut data = HashMap::new();
+                data.insert(stake_index, stake_data);
+
+                operator_stake_data.insert(operator_idx, data);
+            }
+        }
+
+        Ok(())
+    }
+
     async fn set_pre_stake(&self, operator_idx: OperatorIdx, pre_stake: OutPoint) -> DbResult<()> {
         let mut pre_stake_table = self.pre_stake_table.write().await;
         pre_stake_table.insert(operator_idx, pre_stake);

--- a/crates/db/src/persistent/models.rs
+++ b/crates/db/src/persistent/models.rs
@@ -11,7 +11,7 @@ use strata_bridge_stake_chain::transactions::stake::StakeTxData;
 use super::types::{
     DbAggNonce, DbAmount, DbHash, DbInputIndex, DbOperatorIdx, DbPartialSig, DbPubNonce,
     DbScriptBuf, DbSecNonce, DbSignature, DbTaprootWitness, DbTxid, DbWots256PublicKey,
-    DbWotsPublicKeys, DbWotsSignatures,
+    DbWotsPublicKeys, DbWotsSignatures, DbXOnlyPublicKey,
 };
 
 /// The model for WOTS public keys stored in the database.
@@ -76,6 +76,9 @@ pub(super) struct DbStakeTxData {
 
     /// The WOTS public key used to commit to the withdrawal fulfillment transaction.
     pub(super) withdrawal_fulfillment_pk: DbWots256PublicKey,
+
+    /// The public key of the operator that is used to lock the stake.
+    pub(super) operator_pubkey: DbXOnlyPublicKey,
 }
 
 impl From<StakeTxData> for DbStakeTxData {
@@ -85,6 +88,7 @@ impl From<StakeTxData> for DbStakeTxData {
             funding_vout: stake_tx_data.operator_funds.vout.into(),
             hash: stake_tx_data.hash.into(),
             withdrawal_fulfillment_pk: stake_tx_data.withdrawal_fulfillment_pk.into(),
+            operator_pubkey: stake_tx_data.operator_pubkey.into(),
         }
     }
 }
@@ -98,6 +102,7 @@ impl From<DbStakeTxData> for StakeTxData {
             },
             hash: *db_stake_tx_data.hash,
             withdrawal_fulfillment_pk: db_stake_tx_data.withdrawal_fulfillment_pk.deref().clone(),
+            operator_pubkey: *db_stake_tx_data.operator_pubkey,
         }
     }
 }

--- a/crates/db/src/persistent/types.rs
+++ b/crates/db/src/persistent/types.rs
@@ -5,7 +5,13 @@
 
 use std::{ops::Deref, str::FromStr};
 
-use bitcoin::{consensus, hashes::sha256, hex::DisplayHex, Amount, ScriptBuf, Transaction, Txid};
+use bitcoin::{
+    consensus,
+    hashes::sha256,
+    hex::{DisplayHex, FromHex},
+    secp256k1::XOnlyPublicKey,
+    Amount, ScriptBuf, Transaction, Txid,
+};
 use musig2::{BinaryEncoding, PartialSignature, PubNonce, SecNonce};
 use rkyv::rancor::Error as RkyvError;
 use secp256k1::schnorr::Signature;
@@ -152,6 +158,50 @@ impl<'q> sqlx::Encode<'q, Sqlite> for DbHash {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DbXOnlyPublicKey(XOnlyPublicKey);
+
+impl Deref for DbXOnlyPublicKey {
+    type Target = XOnlyPublicKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<XOnlyPublicKey> for DbXOnlyPublicKey {
+    fn from(value: XOnlyPublicKey) -> Self {
+        Self(value)
+    }
+}
+
+impl sqlx::Type<Sqlite> for DbXOnlyPublicKey {
+    fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
+        <String as sqlx::Type<Sqlite>>::type_info()
+    }
+}
+
+impl<'r> sqlx::Decode<'r, Sqlite> for DbXOnlyPublicKey {
+    fn decode(value: SqliteValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+        let pubkey_str: String = sqlx::decode::Decode::<'r, Sqlite>::decode(value)?;
+        let pubkey = XOnlyPublicKey::from_str(&pubkey_str)
+            .map_err(|_| sqlx::Error::Decode("Failed to decode XOnlyPublicKey".into()))?;
+
+        Ok(DbXOnlyPublicKey(pubkey))
+    }
+}
+
+impl<'q> sqlx::Encode<'q, Sqlite> for DbXOnlyPublicKey {
+    fn encode_by_ref(
+        &self,
+        buf: &mut Vec<sqlx::sqlite::SqliteArgumentValue<'q>>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        let pubkey_str = self.0.to_string();
+
+        sqlx::Encode::<'q, Sqlite>::encode_by_ref(&pubkey_str, buf)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct DbWotsPublicKeys(wots::PublicKeys);
 
 impl Deref for DbWotsPublicKeys {
@@ -216,13 +266,15 @@ impl From<Wots256PublicKey> for DbWots256PublicKey {
 
 impl sqlx::Type<Sqlite> for DbWots256PublicKey {
     fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
-        <Vec<u8> as sqlx::Type<Sqlite>>::type_info()
+        <String as sqlx::Type<Sqlite>>::type_info()
     }
 }
 
 impl<'r> sqlx::Decode<'r, Sqlite> for DbWots256PublicKey {
     fn decode(value: SqliteValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
-        let bytes: Vec<u8> = sqlx::decode::Decode::<'r, Sqlite>::decode(value)?;
+        let encoded_bytes: String = sqlx::decode::Decode::<'r, Sqlite>::decode(value)?;
+        let bytes = Vec::<u8>::from_hex(&encoded_bytes)
+            .map_err(|_| sqlx::Error::Decode("Failed to decode hex string".into()))?;
         let keys = rkyv::from_bytes::<Wots256PublicKey, RkyvError>(&bytes)
             .map_err(|_| sqlx::Error::Decode("Failed to decode Wots256PublicKey".into()))?;
 
@@ -238,8 +290,9 @@ impl<'q> sqlx::Encode<'q, Sqlite> for DbWots256PublicKey {
         let bytes = rkyv::to_bytes::<RkyvError>(&self.0)
             .map_err(|_| sqlx::Error::Decode("Failed to serialize Wots256PublicKey".into()))?
             .to_vec();
+        let encoded_bytes = bytes.to_lower_hex_string();
 
-        sqlx::Encode::<'q, Sqlite>::encode_by_ref(&bytes, buf)
+        sqlx::Encode::<'q, Sqlite>::encode_by_ref(&encoded_bytes, buf)
     }
 }
 

--- a/crates/db/src/public.rs
+++ b/crates/db/src/public.rs
@@ -85,6 +85,11 @@ pub trait PublicDb {
         stake_id: u32,
     ) -> DbResult<Option<Txid>>;
 
+    /// Adds all [`StakeTxData`] for a given [`OperatorIdx`] and stake index (`u32`).
+    ///
+    /// This is used to dump all stake-chain related data at once.
+    async fn add_all_stake_data(&self, data: Vec<(OperatorIdx, u32, StakeTxData)>) -> DbResult<()>;
+
     /// Gets all [`StakeTxData`] for a given [`OperatorIdx`].
     async fn get_all_stake_data(&self, operator_idx: OperatorIdx) -> DbResult<Vec<StakeTxData>>;
 

--- a/crates/duty-tracker/src/contract_persister.rs
+++ b/crates/duty-tracker/src/contract_persister.rs
@@ -177,7 +177,7 @@ impl ContractPersister {
 
             let _: SqliteQueryResult = sqlx::query(
                 r#"
-                INSERT OR REPLACE INTO contracts (deposit_txid, deposit_idx, deposit_tx, operator_table, state) 
+                INSERT OR REPLACE INTO contracts (deposit_txid, deposit_idx, deposit_tx, operator_table, state)
                 VALUES (?, ?, ?, ?, ?)
                 "#,
             )
@@ -252,7 +252,7 @@ impl ContractPersister {
             for (deposit_txid, deposit_idx, deposit_tx_bytes, operator_table_bytes, state_json) in &contracts_data {
                 let _: SqliteQueryResult = sqlx::query(
                     r#"
-                    INSERT OR REPLACE INTO contracts (deposit_txid, deposit_idx, deposit_tx, operator_table, state) 
+                    INSERT OR REPLACE INTO contracts (deposit_txid, deposit_idx, deposit_tx, operator_table, state)
                     VALUES (?, ?, ?, ?, ?)
                     "#,
                 )

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -86,6 +86,7 @@ impl DepositSetup {
             withdrawal_fulfillment_pk: strata_bridge_primitives::wots::Wots256PublicKey(Arc::new(
                 self.wots_pks.withdrawal_fulfillment.0,
             )),
+            operator_pubkey: self.operator_pk,
         }
     }
 }

--- a/crates/duty-tracker/src/stake_chain_persister.rs
+++ b/crates/duty-tracker/src/stake_chain_persister.rs
@@ -36,28 +36,31 @@ impl StakeChainPersister {
         cfg: &OperatorTable,
         state: BTreeMap<P2POperatorPubKey, StakeChainInputs>,
     ) -> Result<(), DbError> {
-        let op_id_and_chain_inputs = state.iter().filter_map(|(p2p_key, chain_inputs)| {
+        let op_id_and_chain_inputs = state.into_iter().filter_map(|(p2p_key, chain_inputs)| {
             // extract only those with valid operator ids
-            cfg.op_key_to_idx(p2p_key)
+            cfg.op_key_to_idx(&p2p_key)
                 .map(|op_id| (op_id, chain_inputs))
         });
 
         info!("committing all stake chain data to disk");
+        let mut stake_chain_data = Vec::new();
         for (operator_id, chain_inputs) in op_id_and_chain_inputs {
-            for (stake_index, stake_input) in chain_inputs.stake_inputs.iter() {
+            for (stake_index, stake_input) in chain_inputs.stake_inputs.into_iter() {
                 trace!(
                     %operator_id,
                     %stake_index,
                     ?stake_input,
-                    "committing stake data to disk"
+                    "constructing stake data to commit to disk"
                 );
-                debug!(%operator_id, %stake_index, hash=%stake_input.hash, "committing stake data to disk");
+                debug!(%operator_id, %stake_index, hash=%stake_input.hash, "contructing stake data to commit to disk");
 
-                self.db
-                    .add_stake_data(operator_id, *stake_index, stake_input.to_owned())
-                    .await?;
+                stake_chain_data.push((operator_id, stake_index, stake_input));
             }
         }
+
+        info!("committing all stake chain data to disk");
+        self.db.add_all_stake_data(stake_chain_data).await?;
+
         Ok(())
     }
 

--- a/crates/duty-tracker/src/stake_chain_persister.rs
+++ b/crates/duty-tracker/src/stake_chain_persister.rs
@@ -52,7 +52,7 @@ impl StakeChainPersister {
                     ?stake_input,
                     "constructing stake data to commit to disk"
                 );
-                debug!(%operator_id, %stake_index, hash=%stake_input.hash, "contructing stake data to commit to disk");
+                debug!(%operator_id, %stake_index, hash=%stake_input.hash, "constructing stake data to commit to disk");
 
                 stake_chain_data.push((operator_id, stake_index, stake_input));
             }

--- a/crates/duty-tracker/src/stake_chain_persister.rs
+++ b/crates/duty-tracker/src/stake_chain_persister.rs
@@ -80,7 +80,6 @@ impl StakeChainPersister {
                     stake_chain_inputs.insert(
                         p2p_key.clone(),
                         StakeChainInputs {
-                            operator_pubkey,
                             pre_stake_outpoint,
                             stake_inputs: stake_data
                                 .into_iter()

--- a/crates/tx-graph/src/peg_out_graph.rs
+++ b/crates/tx-graph/src/peg_out_graph.rs
@@ -1291,7 +1291,6 @@ mod tests {
             pre_stake,
             operator_funds,
             operator_pubkey,
-            connector_cpfp,
         );
 
         info!("signing and broadcasting the first stake tx");
@@ -1860,15 +1859,10 @@ mod tests {
             operator_funds: funding_outpoint,
             hash: new_hash,
             withdrawal_fulfillment_pk: new_withdrawal_fulfillment_pk,
+            operator_pubkey,
         };
 
-        let new_stake_tx = first_stake_tx.advance(
-            &context,
-            &stake_chain_params,
-            stake_data,
-            operator_pubkey,
-            connector_cpfp,
-        );
+        let new_stake_tx = first_stake_tx.advance(&context, &stake_chain_params, stake_data);
 
         let new_stake_txid = new_stake_tx.compute_txid();
         let input = PegOutGraphInput {

--- a/docker/bitcoin/entrypoint.sh
+++ b/docker/bitcoin/entrypoint.sh
@@ -12,7 +12,7 @@ regtest=1
 [regtest]
 rpcuser=${BTC_USER}
 rpcpassword=${BTC_PASS}
-rpcbind=172.28.1.8:18443
+rpcbind=0.0.0.0:18443
 rpcallowip=0.0.0.0/0
 fallbackfee=0.00001
 server=1
@@ -24,11 +24,11 @@ blockmintxfee=0.0
 dustRelayFee=0.0
 debug=zmq
 debuglogfile=/home/bitcoin/daemon.log
-zmqpubhashblock=tcp://172.28.1.8:28332
-zmqpubhashtx=tcp://172.28.1.8:28333
-zmqpubrawblock=tcp://172.28.1.8:28334
-zmqpubrawtx=tcp://172.28.1.8:28335
-zmqpubsequence=tcp://172.28.1.8:28336
+zmqpubhashblock=tcp://0.0.0.0:28332
+zmqpubhashtx=tcp://0.0.0.0:28333
+zmqpubrawblock=tcp://0.0.0.0:28334
+zmqpubrawtx=tcp://0.0.0.0:28335
+zmqpubsequence=tcp://0.0.0.0:28336
 EOF
 
 bitcoind -daemon -conf=${BITCOIND_CONF_FILE}
@@ -44,7 +44,7 @@ STAKE_CHAIN_WALLET_2=${STAKE_CHAIN_WALLET_2}
 GENERAL_WALLET_3=${GENERAL_WALLET_3}
 STAKE_CHAIN_WALLET_3=${STAKE_CHAIN_WALLET_3}
 
-bcli="bitcoin-cli -rpcuser=${BTC_USER} -rpcpassword=${BTC_PASS} -regtest -rpcconnect=172.28.1.8 -rpcport=18443"
+bcli="bitcoin-cli -rpcuser=${BTC_USER} -rpcpassword=${BTC_PASS} -regtest -rpcconnect=127.0.0.1 -rpcport=18443"
 
 # Generate a block to the address of the operator's general wallet
 $bcli generatetoaddress 1 ${GENERAL_WALLET_1}

--- a/migrations/20241113060253_init_schema.sql
+++ b/migrations/20241113060253_init_schema.sql
@@ -68,13 +68,14 @@ CREATE TABLE IF NOT EXISTS operator_pre_stake_data (
 -- Table to store the stake chain txids for each operator id and deposit index in deposits table
 CREATE TABLE IF NOT EXISTS operator_stake_data (
     operator_idx INTEGER NOT NULL,
-    deposit_id INTEGER NOT NULL,               -- Foreign key to deposits table
+    deposit_idx INTEGER NOT NULL,               -- Foreign key to deposits table
     funding_txid TEXT NOT NULL,                -- Store as hex string
     funding_vout INTEGER NOT NULL,
     hash TEXT NOT NULL,                        -- Store as hex string
+    operator_pubkey TEXT NOT NULL,             -- Store as hex string
     withdrawal_fulfillment_pk BLOB NOT NULL,   -- Serialized with rkyv
 
-    PRIMARY KEY (operator_idx, deposit_id)      -- Compound primary key
+    PRIMARY KEY (operator_idx, deposit_idx)     -- Compound primary key
 );
 
 -- Table to store the index of the last published stake transaction.


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR primarily fixes the issue where upon restart nodes do not reach a consensus on the graph for the restarted node. This is due to a bug in how the data is loaded from disk into memory after restart. Specifically, the operator key (used to lock the stake for a particular operator) was not being set properly.

It also includes a bunch of enhancements related to stability including:

- wrapping all commitments to stake data in database transactions.
- committing to stake data as early as possible.
- handling the case where a node may lag behind its peers when exchanging nonces due to restart.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
