### PR TITLE
STR-1529: Completed contracts should also account for Disproven contracts

### DIFF
--- a/crates/duty-tracker/src/contract_actor.rs
+++ b/crates/duty-tracker/src/contract_actor.rs
@@ -481,7 +481,11 @@ impl ContractActorManager {
         info!("all contract actors shutdown complete");
     }
 
-    /// Removes [`ContractActor`]s for completed contracts (resolved or disproved).
+    /// Removes [`ContractActor`]s for completed contracts.
+    ///
+    /// NOTE: Only [`ContractState::Resolved`] is accounted as completed contracts.
+    /// [`ContractState::Disproved`] can still be assigned and fulfilled by another operator,
+    /// apart from the disproved operator(s).
     pub async fn cleanup_completed_contracts(&mut self) {
         let mut to_remove = Vec::new();
 


### PR DESCRIPTION
## Description

Clarifies why we should only cleanup `ContractState::Resolved` and not `ContractState::Disproved` in `ContractActor`'s cleanups and also we can skip resolved contracts in the sync cursor calculation.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

- Clarify `ContractActor`s cleanup: 2733c6ed14654bc867ea185d675fc2212570340b
- Skip resolved contracts in sync cursor calculation: 30d20b53d8d55db03822e7c0032f0a322c6ba257

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1529
