### PR TITLE
Fix/Do not regenerate graphs when nagged

### DIFF
--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -3143,7 +3143,8 @@ impl ContractSM {
         &self.state
     }
 
-    /// Returns an immutable copy of the peg out graph.
+    /// Returns an immutable copy of the [`PegOutGraph`] cache indexed by the corresponding stake
+    /// [`Txid`].
     pub const fn pog(&self) -> &BTreeMap<Txid, PegOutGraph> {
         &self.pog
     }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR exposes the `pog_cache` in the `ContractSM` to the `ContractActor` and uses this cache to retrieve graphs when a node is nagged for nonces and partials instead of regenerating the graph each time.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
