### PR TITLE
Hack/support delta zero in stake chain

### DIFF
--- a/crates/connectors/src/connector_s.rs
+++ b/crates/connectors/src/connector_s.rs
@@ -4,9 +4,12 @@ use std::slice;
 
 use bitcoin::{
     hashes::{sha256, Hash},
-    opcodes::all::{OP_CHECKSIGVERIFY, OP_CSV, OP_EQUALVERIFY, OP_SHA256, OP_SIZE},
+    opcodes::{
+        all::{OP_CHECKSIGVERIFY, OP_CSV, OP_EQUALVERIFY, OP_SHA256, OP_SIZE},
+        OP_TRUE,
+    },
     psbt::Input,
-    relative,
+    relative::{self, LockTime},
     taproot::{ControlBlock, LeafVersion},
     Address, Network, ScriptBuf, TapNodeHash,
 };
@@ -106,7 +109,7 @@ impl ConnectorStake {
     /// <stake_preimage> OP_EQUALVERIFY <ΔS> OP_CHECKSEQUENCEVERIFY
     /// ```
     pub fn generate_script(&self) -> ScriptBuf {
-        ScriptBuf::builder()
+        let mut locking_script = ScriptBuf::builder()
             .push_slice(self.operator_pubkey.serialize())
             .push_opcode(OP_CHECKSIGVERIFY)
             .push_opcode(OP_SIZE)
@@ -114,10 +117,19 @@ impl ConnectorStake {
             .push_opcode(OP_EQUALVERIFY)
             .push_opcode(OP_SHA256)
             .push_slice(self.stake_hash.to_byte_array())
-            .push_opcode(OP_EQUALVERIFY)
-            .push_sequence(self.delta.into())
-            .push_opcode(OP_CSV)
-            .into_script()
+            .push_opcode(OP_EQUALVERIFY);
+
+        // handle `0`-locktime differently as pushing `0` sequence means no element is pushed which
+        // results in the stack being empty when it is executed when spending.
+        if self.delta != LockTime::ZERO {
+            locking_script = locking_script
+                .push_sequence(self.delta.into())
+                .push_opcode(OP_CSV)
+        } else {
+            locking_script = locking_script.push_opcode(OP_TRUE);
+        }
+
+        locking_script.into_script()
     }
 
     /// Creates a P2TR address with key spend path for the given operator set and a single script

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -2373,6 +2373,7 @@ impl ContractSM {
             )));
         }
 
+        let operator_table = self.cfg().operator_table.clone();
         match assignment.deposit_state() {
             DepositState::Dispatched(dispatched_state) => {
                 let assignee = dispatched_state.assignee();
@@ -2446,6 +2447,9 @@ impl ContractSM {
                     ContractState::Assigned {
                         fulfiller,
                         deadline,
+                        claim_txids,
+                        active_graph,
+                        peg_out_graphs,
                         ..
                     } => {
                         if *fulfiller != assignee {
@@ -2453,6 +2457,23 @@ impl ContractSM {
 
                             *fulfiller = assignee;
                             *deadline = dispatched_state.exec_deadline();
+                            let p2p_key =
+                                operator_table
+                                    .idx_to_op_key(&assignee)
+                                    .ok_or(TransitionErr(format!(
+                                    "could not convert operator index {assignee} to operator key"
+                                )))?;
+
+                            let claim_txid = claim_txids.get(p2p_key).ok_or(TransitionErr(format!(
+                                "could not find claim_txid for operator {p2p_key} in csm {deposit_txid}",
+                            )))?;
+
+                            *active_graph = peg_out_graphs
+                                .get(claim_txid)
+                                .ok_or(TransitionErr(format!(
+                                    "could not find peg out graph for claim txid {claim_txid} in csm {deposit_txid}",
+                                )))?
+                                .to_owned();
                         }
 
                         Ok(Some(OperatorDuty::FulfillerDuty(
@@ -2466,6 +2487,9 @@ impl ContractSM {
                     ContractState::StakeTxReady {
                         fulfiller,
                         deadline,
+                        claim_txids,
+                        active_graph,
+                        peg_out_graphs,
                         ..
                     } => {
                         if *fulfiller != assignee {
@@ -2473,6 +2497,24 @@ impl ContractSM {
 
                             *fulfiller = assignee;
                             *deadline = dispatched_state.exec_deadline();
+
+                            let p2p_key =
+                                operator_table
+                                    .idx_to_op_key(&assignee)
+                                    .ok_or(TransitionErr(format!(
+                                    "could not convert operator index {assignee} to operator key"
+                                )))?;
+
+                            let claim_txid = claim_txids.get(p2p_key).ok_or(TransitionErr(format!(
+                                "could not find claim_txid for operator {p2p_key} in csm {deposit_txid}",
+                            )))?;
+
+                            *active_graph = peg_out_graphs
+                                .get(claim_txid)
+                                .ok_or(TransitionErr(format!(
+                                    "could not find peg out graph for claim txid {claim_txid} in csm {deposit_txid}",
+                                )))?
+                                .to_owned();
                         }
 
                         let is_assigned_to_me = *fulfiller == pov_idx;
@@ -2613,6 +2655,7 @@ impl ContractSM {
                 l1_start_height,
                 ..
             } => {
+                let txid = tx.compute_txid();
                 if !is_fulfillment_tx(
                     network,
                     &peg_out_graph_params,
@@ -2625,6 +2668,7 @@ impl ContractSM {
                     // might get somebody else's stake transaction here.
                     // this can happen if this node's stake transaction is settled before other
                     // nodes'.
+                    warn!(%txid, "received a non-fulfillment tx in process_fulfillment_confirmation");
 
                     // FIXME: (@Rajil1213) this should be an error case.
                     return Ok(None);
@@ -2635,7 +2679,7 @@ impl ContractSM {
                     let stake_txid = active_graph.1.stake_txid;
 
                     Some(OperatorDuty::FulfillerDuty(FulfillerDuty::PublishClaim {
-                        withdrawal_fulfillment_txid: tx.compute_txid(),
+                        withdrawal_fulfillment_txid: txid,
                         stake_txid,
                         deposit_txid,
                     }))

--- a/crates/duty-tracker/src/executors/optimistic_withdrawal.rs
+++ b/crates/duty-tracker/src/executors/optimistic_withdrawal.rs
@@ -1,7 +1,7 @@
 //! Handles the withdrawal duty as it pertains to the optimistic case i.e., when no challenges
 //! occur.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use bitcoin::{
     hashes::{sha256, Hash},
@@ -32,7 +32,7 @@ use strata_bridge_tx_graph::transactions::{
         NUM_PAYOUT_OPTIMISTIC_INPUTS,
     },
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     contract_manager::{ExecutionConfig, OutputHandles},
@@ -42,6 +42,7 @@ use crate::{
         wots_handler::get_withdrawal_fulfillment_wots_pk,
     },
     s2_session_manager::MusigSessionManager,
+    tx_driver::TxDriver,
 };
 
 pub(crate) async fn handle_publish_first_stake(
@@ -75,12 +76,8 @@ pub(crate) async fn handle_publish_first_stake(
     let signed_stake_tx = stake_tx.finalize_unchecked(funds_signature, stake_signature);
 
     info!(txid=%signed_stake_tx.compute_txid(), "broadcasting first stake transaction");
-    output_handles
-        .tx_driver
-        .drive(signed_stake_tx, TxStatus::is_buried)
-        .await?;
 
-    Ok(())
+    try_publish_stake_tx(&output_handles.tx_driver, signed_stake_tx, 0).await
 }
 
 /// Advances the stake chain by submitting the given transaction to the tx driver.
@@ -158,12 +155,71 @@ pub(crate) async fn handle_advance_stake_chain(
     );
 
     info!(txid=%signed_stake_tx.compute_txid(), %stake_index, "broadcasting stake transaction");
-    output_handles
-        .tx_driver
-        .drive(signed_stake_tx, TxStatus::is_buried)
-        .await?;
+    try_publish_stake_tx(&output_handles.tx_driver, signed_stake_tx, stake_index).await
+}
 
-    Ok(())
+/// Tries to publish the stake transaction using the provided `TxDriver` for a maximum of
+/// `max_retries`.
+///
+/// # Errors
+///
+/// If the transaction fails to be broadcasted after `max_retries`.
+// HACK: (@Rajil1213) this function is a workaround for the fact that the stake chain must be
+// broadcasted sequentially with a certain timelock between consecutive links.
+// If there are multiple withdrawal requests, it may be the case that the transactions cannot be
+// broadcasted concurrently, so we retry until the parent transaction is confirmed or the maximum
+// number of retries is reached.
+async fn try_publish_stake_tx(
+    tx_driver: &TxDriver,
+    signed_stake_tx: bitcoin::Transaction,
+    stake_index: u32,
+) -> Result<(), ContractManagerErr> {
+    // NOTE: (@Rajil1213) The following constants are not made configurable as this is supposed to
+    // be a temporary workaround.
+
+    /// The maximum number of retries to publish a stake transaction.
+    ///
+    /// The value 30 is chosen to allow enough time for the first stake transaction to be confirmed
+    /// in a batch of 25 transactions -- 25 being the number of dependent transactions that are
+    /// allowed to exist in the mempool.
+    const MAX_RETRIES: usize = 30;
+
+    /// The delay between consecutive retries when trying to publish a stake transaction.
+    const RETRY_DELAY: Duration = Duration::from_secs(60);
+
+    let mut num_retries = 0;
+    let stake_txid = signed_stake_tx.compute_txid();
+
+    loop {
+        match tx_driver
+            .drive(signed_stake_tx.clone(), TxStatus::is_buried)
+            .await
+        {
+            Ok(_) => {
+                debug!(%stake_txid, %stake_index, "successfully broadcasted stake transaction");
+                return Ok(());
+            }
+            Err(e) => {
+                if num_retries >= MAX_RETRIES {
+                    error!(?e, %stake_txid, %stake_index, %num_retries, "failed to broadcast stake transaction after max retries");
+                    return Err(ContractManagerErr::TxDriverErr(e));
+                }
+
+                warn!(
+                    ?e,
+                    %stake_txid,
+                    %stake_index,
+                    %num_retries,
+                    "failed to broadcast first stake transaction, retrying..."
+                );
+
+                num_retries += 1;
+            }
+        }
+
+        debug!(%stake_txid, %stake_index, %num_retries, "waiting for {} seconds before retrying", RETRY_DELAY.as_secs());
+        tokio::time::sleep(RETRY_DELAY).await;
+    }
 }
 
 /// Constructs, finalizes and broadcasts the Withdrawal Fulfillment Transaction.


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR supports setting a 0-block timelock between consecutive stake transactions in the stake chain. To enable this, it adds the following features:

 - Adds a mechanism for the `tx-driver` to provide immediate feedback if the transaction could not be published.
 - Adds a retry mechanism when publishing stake transactions to account for the case where the parent stake may not have been broadcasted.
 
This also fixes a bug in reassignments where the active graph was not updated upon reassignment.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
The retry logic for broadcasting stake transactions is a temporary hack but supporting of `0-blocks` timelock is not as that is something the `stake-chain` crate must support.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
