### PR TITLE
Fix/update contract indexing to handle actor shutdown

### DIFF
--- a/crates/duty-tracker/src/contract_actor.rs
+++ b/crates/duty-tracker/src/contract_actor.rs
@@ -69,8 +69,8 @@ pub enum ContractActorMessage {
     /// Clears the [`PegOutGraph`] cache.
     ClearPogCache,
 
-    /// Gracefully shutdowns the actor.
-    Shutdown,
+    /// Gracefully terminates the actor.
+    Terminate,
 }
 
 /// Handles required by the contract actor for state persistence.
@@ -197,8 +197,8 @@ impl ContractActor {
                         csm.clear_pog_cache();
                         debug!(%deposit_txid, "cleared peg-out-graph cache");
                     }
-                    ContractActorMessage::Shutdown => {
-                        info!(%deposit_txid, "contract actor shutting down");
+                    ContractActorMessage::Terminate => {
+                        info!(%deposit_txid, "terminating contract actor");
                         break;
                     }
                 }
@@ -226,7 +226,7 @@ impl ContractActor {
                 duty_response_sender: None,
                 event: None,
             })
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver
             .await
@@ -245,7 +245,7 @@ impl ContractActor {
                 duty_response_sender: Some(duty_response_sender),
                 event: Some(event),
             })
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         Ok(())
     }
@@ -255,7 +255,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetState(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver
             .await
@@ -267,7 +267,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetConfig(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver
             .await
@@ -279,7 +279,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetPogCache(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver.await.map_err(|_| {
             TransitionErr("failed to receive peg-out-graph cache from CSM actor".to_string())
@@ -294,7 +294,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(tx.clone());
         self.event_sender
             .send(ContractActorMessage::TransactionFilter(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver.await.map_err(|_| {
             TransitionErr("failed to receive filter result from CSM actor".to_string())
@@ -306,7 +306,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetClaimTxids(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver
             .await
@@ -318,7 +318,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetDepositRequestTxid(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver.await.map_err(|_| {
             TransitionErr("failed to receive deposit request txid from CSM actor".to_string())
@@ -330,7 +330,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetWithdrawalRequestTxid(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver.await.map_err(|_| {
             TransitionErr("failed to receive withdrawal request txid from CSM actor".to_string())
@@ -342,7 +342,7 @@ impl ContractActor {
         let (req, receiver) = Req::new(());
         self.event_sender
             .send(ContractActorMessage::GetWithdrawalFulfillmentTxid(req))
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
 
         receiver.await.map_err(|_| {
             TransitionErr(
@@ -355,13 +355,13 @@ impl ContractActor {
     pub async fn clear_pog_cache(&self) -> Result<(), TransitionErr> {
         self.event_sender
             .send(ContractActorMessage::ClearPogCache)
-            .map_err(|_| TransitionErr("CSM actor has shut down".to_string()))?;
+            .map_err(|_| TransitionErr("CSM actor has terminated".to_string()))?;
         Ok(())
     }
 
-    /// Gracefully shutdowns the actor.
-    pub async fn shutdown(self) -> Result<(), TransitionErr> {
-        let _ = self.event_sender.send(ContractActorMessage::Shutdown);
+    /// Gracefully terminates the actor.
+    pub async fn terminate(self) -> Result<(), TransitionErr> {
+        let _ = self.event_sender.send(ContractActorMessage::Terminate);
 
         // Wait for the actor to finish with a timeout
         let handle = self.handle;
@@ -371,10 +371,10 @@ impl ContractActor {
                 Ok(())
             }
             Err(_) => {
-                warn!(deposit_txid=%self.deposit_txid, "Actor shutdown timed out, aborting");
+                warn!(deposit_txid=%self.deposit_txid, "actor termination timed out, aborting");
                 // Handle was moved into timeout, so we need to create a new abort mechanism
                 // In this case, the timeout already happened, so the task should be dropped
-                Err(TransitionErr("actor shutdown timed out".to_string()))
+                Err(TransitionErr("actor termination timed out".to_string()))
             }
         }
     }
@@ -480,22 +480,22 @@ impl ContractActorManager {
         self.actors.is_empty()
     }
 
-    /// Gracefully shutdowns all [`ContractActor`]s.
-    pub async fn shutdown_all(self) {
-        info!(num_actors=%self.actors.len(), "shutting down all contract actors");
+    /// Gracefully terminates all [`ContractActor`]s.
+    pub async fn terminate_all(self) {
+        info!(num_actors=%self.actors.len(), "terminating down all contract actors");
 
-        let shutdown_futures: Vec<_> = self
+        let terminate_futures: Vec<_> = self
             .actors
             .into_iter()
             .map(|(deposit_txid, actor)| async move {
-                if let Err(e) = actor.shutdown().await {
-                    error!(%deposit_txid, %e, "failed to shutdown contract actor");
+                if let Err(e) = actor.terminate().await {
+                    error!(%deposit_txid, %e, "failed to terminate contract actor");
                 }
             })
             .collect();
 
-        join_all(shutdown_futures).await;
-        info!("all contract actors shutdown complete");
+        join_all(terminate_futures).await;
+        info!("all contract actors terminated");
     }
 
     /// Removes [`ContractActor`]s for completed contracts.
@@ -517,8 +517,8 @@ impl ContractActorManager {
         for deposit_txid in to_remove {
             if let Some(actor) = self.remove_actor(&deposit_txid).await {
                 info!(%deposit_txid, "cleaning up completed contract");
-                if let Err(e) = actor.shutdown().await {
-                    error!(%deposit_txid, %e, "failed to shutdown completed contract actor");
+                if let Err(e) = actor.terminate().await {
+                    error!(%deposit_txid, %e, "failed to terminate completed contract actor");
                 }
             }
         }

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -439,8 +439,8 @@ impl ContractManager {
                 });
             }
 
-            info!("event loop ended, shutting down contract actors");
-            ctx.state.active_contracts.shutdown_all().await;
+            info!("event loop ended, terminating contract actors");
+            ctx.state.active_contracts.terminate_all().await;
         })
     }
 }

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -549,13 +549,8 @@ impl ContractManagerCtx {
         let mut new_contracts: Vec<(ContractActor, Txid)> = Vec::new();
 
         let pov_key = self.cfg.operator_table.pov_op_key().clone();
-        // TODO(proofofkeags): prune the active contract set and still preserve the ability
-        // to recover this value.
-        //
-        // Since new contracts are added after all the transactions are processed, we can
-        // assume that the stake/deposit index is the same as the number of active contracts
-        // throughout the processing of this block.
-        let stake_index = self.state.active_contracts.len() as u32;
+        // The next contract will have its index at the tip of the current stake chain.
+        let deposit_idx_offset = self.state.stake_chains.height();
 
         for tx in block.txdata {
             // could be an assignment
@@ -566,13 +561,14 @@ impl ContractManagerCtx {
             }
 
             let txid = tx.compute_txid();
+            let deposit_idx = deposit_idx_offset + new_contracts.len() as u32;
             // or a deposit request
             if let Some(deposit_request_data) = deposit_request_info(
                 &tx,
                 &self.cfg.sidesystem_params,
                 &self.cfg.pegout_graph_params,
                 &self.cfg.operator_table.tx_build_context(self.cfg.network),
-                stake_index,
+                deposit_idx,
             ) {
                 let deposit_request_txid = txid;
                 let deposit_tx = match DepositTx::new(
@@ -610,7 +606,7 @@ impl ContractManagerCtx {
                     .expect("this operator's p2p key must exist in the operator table")
                     .clone();
 
-                debug!(%stake_index, %deposit_request_txid, "creating a new contract");
+                debug!(%deposit_idx, %deposit_request_txid, "creating a new contract");
                 let cfg = ContractCfg {
                     network: self.cfg.network,
                     operator_table: self.cfg.operator_table.clone(),
@@ -618,7 +614,7 @@ impl ContractManagerCtx {
                     peg_out_graph_params: self.cfg.pegout_graph_params,
                     sidesystem_params: self.cfg.sidesystem_params.clone(),
                     stake_chain_params: self.cfg.stake_chain_params,
-                    deposit_idx: stake_index + new_contracts.len() as u32,
+                    deposit_idx,
                     deposit_tx,
                 };
 

--- a/crates/duty-tracker/src/stake_chain_state_machine.rs
+++ b/crates/duty-tracker/src/stake_chain_state_machine.rs
@@ -179,6 +179,19 @@ impl StakeChainSM {
         &self.stake_chains
     }
 
+    /// Returns the height of the current stake chain.
+    ///
+    /// This corresponds to the number of contracts in the
+    /// [`crate::contract_state_machine::ContractSM`] that have been processed since genesis.
+    pub fn height(&self) -> u32 {
+        let my_key = self.operator_table.pov_op_key();
+
+        self.stake_chains
+            .get(my_key)
+            .map(|inputs| inputs.stake_inputs.len() as u32)
+            .unwrap_or(0)
+    }
+
     /// Gets the stake transaction for the operator at the stake index of the argument.
     pub fn stake_tx(
         &self,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR uses the height of the current operator's stake chain to compute the next deposit index offset when processing a block. In the current implementation, this value is computed using the number of active contract actors. This is problematic since the deposit index should always increase monotonically but the number of contract actors can decrease when the associated contract is resolved and the actor is terminated.

This also renames `shutdown` to `terminate` to soften the phrasing. CC: @barakshani 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
+1 in the "we need a proper test-suite" jar.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
