### PR TITLE
fix/publish partials for all graphs concurrently

### DIFF
--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -1901,7 +1901,11 @@ impl ContractSM {
                             "could not process graph nonces. claim_txid ({claim_txid}) not found in peg out graph map"
                         )));
                     };
-                    let nonce_per_operator = graph_nonces.get(claim_txid).unwrap().clone();
+                    let nonce_per_operator = graph_nonces.get(claim_txid).ok_or(
+                        TransitionErr(format!(
+                            "could not process graph nonces. claim_txid ({claim_txid}) not found in nonce map",
+                        )),
+                    )?.clone();
 
                     // NOTE: (@Rajil1213) we cannot use `self.retrieve_graph` here because it needs
                     // `&mut self` and the borrow checker does not allow us to reborrow it mutably

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -1888,7 +1888,7 @@ impl ContractSM {
                     .map(|(op, claim_txid)| (claim_txid, op))
                     .collect::<BTreeMap<_, _>>();
 
-                for claim_txid in graph_nonces.keys() {
+                for (claim_txid, nonce_per_operator) in graph_nonces {
                     let graph_owner =
                         claim_txid_to_operator_map
                             .get(claim_txid)
@@ -1901,11 +1901,6 @@ impl ContractSM {
                             "could not process graph nonces. claim_txid ({claim_txid}) not found in peg out graph map"
                         )));
                     };
-                    let nonce_per_operator = graph_nonces.get(claim_txid).ok_or(
-                        TransitionErr(format!(
-                            "could not process graph nonces. claim_txid ({claim_txid}) not found in nonce map",
-                        )),
-                    )?.clone();
 
                     // NOTE: (@Rajil1213) we cannot use `self.retrieve_graph` here because it needs
                     // `&mut self` and the borrow checker does not allow us to reborrow it mutably
@@ -1926,7 +1921,7 @@ impl ContractSM {
                     let pubnonces = self
                         .cfg
                         .operator_table
-                        .convert_map_op_to_btc(nonce_per_operator)
+                        .convert_map_op_to_btc(nonce_per_operator.clone())
                         .map_err(|e| {
                             TransitionErr(format!(
                                 "could not convert nonce map keys: {e} not in operator table",

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -1,6 +1,6 @@
 datadir = "/app/data"
 is_faulty = false
-nag_interval = { secs = 60, nanos = 0 }
+nag_interval = { secs = 300, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 
 [secret_service_client]

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -1,6 +1,6 @@
 datadir = "/app/data"
 is_faulty = false
-nag_interval = { secs = 60, nanos = 0 }
+nag_interval = { secs = 300, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 
 [secret_service_client]

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -1,6 +1,6 @@
 datadir = "/app/data"
 is_faulty = false
-nag_interval = { secs = 60, nanos = 0 }
+nag_interval = { secs = 300, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 
 [secret_service_client]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR fixes a bug in the current implementation of the `process_graph_sigs` stf where only the duty to generate the partials for the graph that received the latest set of nonces was created (even though all graphs had all the required nonces). It does so by creating one duty per graph once all the nonces have been collected for all graphs. It also fixes an issue with the `process_aggregate_sigs` stf where the `PublishRootNonce` duty was not created and so a node had to be nagged after all the aggregate sigs have been added to state.

This reduces the time required to process a deposit to 30 seconds even with the nag interval set to 5 mins.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Relates to STR-1314