### PR TITLE
feat!: RPC rich claims information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9805,6 +9805,7 @@ name = "strata-bridge-rpc"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "btc-notify",
  "jsonrpsee",
  "serde",
  "strata-bridge-primitives",

--- a/bin/alpen-bridge/src/config.rs
+++ b/bin/alpen-bridge/src/config.rs
@@ -72,6 +72,7 @@ pub(crate) struct SecretServiceConfig {
 
     /// Path to the bridge's TLS cert used for client authentication.
     pub cert: PathBuf,
+
     /// Path to the bridge's TLS key used for client authentication.
     pub key: PathBuf,
 
@@ -144,6 +145,14 @@ pub(crate) struct RpcConfig {
     /// Default is
     /// [`DEFAULT_RPC_CACHE_REFRESH_INTERVAL`](crate::constants::DEFAULT_RPC_CACHE_REFRESH_INTERVAL).
     pub refresh_interval: Option<Duration>,
+
+    /// Default bury depth for transactions when not specified in RPC calls.
+    ///
+    /// This is the number of blocks that must be built on top of a given block before that
+    /// block is considered buried. A bury depth of 6 will mean that the most recent "buried"
+    /// block will be the 7th newest block. A bury depth of 0 would mean that the block is
+    /// considered buried the moment it is mined.
+    pub bury_depth: u32,
 }
 
 #[cfg(test)]
@@ -195,6 +204,7 @@ mod tests {
             [rpc]
             rpc_addr = "localhost:5678"
             refresh_interval = {secs = 600, nanos = 0 }
+            bury_depth = 6
 
             [btc_zmq]
             bury_depth = 6

--- a/bin/alpen-bridge/src/mode/operator.rs
+++ b/bin/alpen-bridge/src/mode/operator.rs
@@ -196,7 +196,14 @@ pub(crate) async fn bootstrap(params: Params, config: Config) -> anyhow::Result<
     info!("starting rpc server");
     let rpc_config = config.rpc.clone();
     let rpc_params = params.clone();
-    let rpc_task = start_rpc_server(db_rpc, p2p_handle_rpc, rpc_params, rpc_config).await?;
+    let rpc_task = start_rpc_server(
+        db_rpc,
+        p2p_handle_rpc,
+        rpc_params,
+        rpc_config,
+        bitcoin_rpc_client.clone(),
+    )
+    .await?;
     debug!("rpc server started");
 
     // Wait for all tasks to run
@@ -440,9 +447,10 @@ async fn start_rpc_server(
     p2p_handle: P2PHandle,
     params: Params,
     config: RpcConfig,
+    bitcoin_client: BitcoinClient,
 ) -> anyhow::Result<JoinHandle<()>> {
     let rpc_addr = config.rpc_addr.clone();
-    let rpc_client = BridgeRpc::new(db, p2p_handle, params, config);
+    let rpc_client = BridgeRpc::new(db, p2p_handle, params, config, bitcoin_client);
     let handle = spawn(async move {
         start_rpc(&rpc_client, rpc_addr.as_str())
             .await

--- a/crates/btc-notify/src/event.rs
+++ b/crates/btc-notify/src/event.rs
@@ -1,7 +1,8 @@
 use bitcoin::{Block, BlockHash, Transaction};
+use serde::{Deserialize, Serialize};
 
 /// TxStatus is the primary output of this API via the subscription.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum TxStatus {
     /// Indicates that the transaction is not staged for inclusion in the blockchain.
     ///

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 workspace = true
 
 [dependencies]
+btc-notify.workspace = true
 strata-bridge-primitives.workspace = true
 strata-primitives.workspace = true
 

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -5,8 +5,8 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use strata_primitives::buf::Buf32;
 
 use crate::types::{
-    RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositInfo, RpcDisproveData, RpcOperatorStatus,
-    RpcWithdrawalInfo,
+    RpcBridgeDutyStatus, RpcClaimInfo, RpcClaimTxInfo, RpcDepositInfo, RpcDisproveData,
+    RpcOperatorStatus, RpcWithdrawalInfo,
 };
 
 /// RPCs related to information about the client itself.
@@ -75,9 +75,9 @@ pub trait StrataBridgeMonitoringApi {
         withdrawal_request_txid: Buf32,
     ) -> RpcResult<Option<RpcWithdrawalInfo>>;
 
-    /// Get all claim transaction IDs.
+    /// Get all claim transaction IDs with their Bitcoin network status.
     #[method(name = "claims")]
-    async fn get_claims(&self) -> RpcResult<Vec<Txid>>;
+    async fn get_claims(&self, bury_depth: Option<u32>) -> RpcResult<Vec<RpcClaimTxInfo>>;
 
     /// Get claim details for a given claim transaction ID.
     #[method(name = "claimInfo")]

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -1,6 +1,7 @@
 //! Types for the RPC server.
 
 use bitcoin::{hashes::sha256, secp256k1::XOnlyPublicKey, taproot, OutPoint, Txid};
+use btc_notify::client::TxStatus;
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::{types::OperatorIdx, wots};
 use strata_primitives::buf::Buf32;
@@ -179,4 +180,14 @@ pub struct RpcDisproveData {
 
     /// The N-of-N signature used to finalize the first input in the disprove transaction.
     pub n_of_n_sig: taproot::Signature,
+}
+
+/// Claim transaction information with Bitcoin network status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcClaimTxInfo {
+    /// Transaction ID of the claim transaction
+    pub txid: Txid,
+
+    /// Bitcoin network status of the transaction
+    pub tx_status: TxStatus,
 }


### PR DESCRIPTION
## Description

- Adds `TxInfo` from the `bc-notify` crate to the `claims` RPC method.
- Filters for claims transactions that are either in the mempool or in a block before returning them in the `claims` RPC method.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The commits are linear and self-contained.

Should preferably be merged after #209 for easy of rebase.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1556
