### PR TITLE
feat: graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "strata-p2p",
  "strata-p2p-types",
  "strata-primitives",
+ "strata-tasks",
  "tikv-jemallocator",
  "tokio",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,6 +3355,7 @@ dependencies = [
  "strata-p2p-wire",
  "strata-primitives",
  "strata-state",
+ "strata-tasks",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ strata-proofimpl-btc-blockspace = { git = "https://github.com/alpenlabs/alpen.gi
 strata-rpc-api = { git = "https://github.com/alpenlabs/alpen.git" }
 strata-rpc-types = { git = "https://github.com/alpenlabs/alpen.git" }
 strata-state = { git = "https://github.com/alpenlabs/alpen.git" }
+strata-tasks = { git = "https://github.com/alpenlabs/alpen.git" }
 
 strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git" }
 strata-p2p-types = { git = "https://github.com/alpenlabs/strata-p2p.git" }

--- a/bin/alpen-bridge/Cargo.toml
+++ b/bin/alpen-bridge/Cargo.toml
@@ -28,6 +28,7 @@ strata-p2p-types.workspace = true
 strata-primitives.workspace = true
 
 strata-bridge-common.workspace = true
+strata-tasks.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/bin/alpen-bridge/src/config.rs
+++ b/bin/alpen-bridge/src/config.rs
@@ -40,6 +40,9 @@ pub(crate) struct Config {
     /// The target pool size for claim funding transactions.
     pub stake_funding_pool_size: usize,
 
+    /// Timeout for shutdown operations.
+    pub shutdown_timeout: Duration,
+
     /// Configuration required to connector to a _local_ instance of the secret service server.
     pub secret_service_client: SecretServiceConfig,
 
@@ -160,6 +163,7 @@ mod tests {
             nag_interval = { secs = 60, nanos = 0 }
             min_withdrawal_fulfillment_window = 144
             stake_funding_pool_size = 32
+            shutdown_timeout = { secs = 15, nanos = 0 }
 
             [secret_service_client]
             server_addr = "localhost:1234"
@@ -203,6 +207,8 @@ mod tests {
             rawblock_connection_string = "tcp://127.0.0.1:28334"
             rawtx_connection_string = "tcp://127.0.0.1:28335"
             sequence_connection_string = "tcp://127.0.0.1:28336"
+
+            shutdown_timeout = { secs = 15, nanos = 0 }
         "#;
 
         let config = toml::from_str::<Config>(config);

--- a/bin/alpen-bridge/src/mode/verifier.rs
+++ b/bin/alpen-bridge/src/mode/verifier.rs
@@ -1,11 +1,16 @@
 //! Defines the main loop for the bridge-client in verifier mode.
+use strata_tasks::TaskExecutor;
 use tracing::info;
 
 use crate::{config::Config, params::Params};
 
 /// Bootstraps the bridge client in Verifier mode by hooking up all the required auxiliary services
-/// including database, p2p client, etc.
-pub(crate) async fn bootstrap(_params: Params, _config: Config) -> anyhow::Result<()> {
+/// including database, rpc server, graceful shutdown handler, etc.
+pub(crate) async fn bootstrap(
+    _params: Params,
+    _config: Config,
+    _executor: TaskExecutor,
+) -> anyhow::Result<()> {
     info!("bootstrapping verifier node");
 
     unimplemented!()

--- a/crates/duty-tracker/Cargo.toml
+++ b/crates/duty-tracker/Cargo.toml
@@ -25,6 +25,7 @@ strata-p2p-types = { workspace = true, features = ["proptest"] }
 strata-p2p-wire.workspace = true
 strata-primitives.workspace = true
 strata-state.workspace = true
+strata-tasks.workspace = true
 
 ark-bn254.workspace = true
 ark-groth16.workspace = true

--- a/crates/duty-tracker/src/errors.rs
+++ b/crates/duty-tracker/src/errors.rs
@@ -105,3 +105,23 @@ pub enum StakeChainErr {
     #[error("unexpected problem with stake chain state machine: {0}")]
     Unexpected(String),
 }
+
+/// Error type for shutdown operations.
+#[derive(Debug, Error)]
+pub enum ShutdownErr {
+    /// Error during contract state persistence.
+    #[error("failed to persist contract state: {0}")]
+    ContractPersistErr(#[from] ContractPersistErr),
+
+    /// Error during stake chain state persistence.
+    #[error("failed to persist stake chain state: {0}")]
+    StakeChainPersistErr(#[from] DbError),
+
+    /// Timeout during shutdown operations
+    #[error("timeout during shutdown operation: {0}")]
+    ShutdownTimeout(String),
+
+    /// Error indicatiing unexpected behavior during shutdown.
+    #[error("unexpected problem with the shutdown operation: {0}")]
+    Unexpected(String),
+}

--- a/crates/duty-tracker/src/lib.rs
+++ b/crates/duty-tracker/src/lib.rs
@@ -15,6 +15,7 @@ pub mod contract_state_machine;
 pub mod errors;
 pub mod executors;
 pub mod predicates;
+pub mod shutdown;
 pub mod stake_chain_persister;
 pub mod stake_chain_state_machine;
 pub mod tx_driver;

--- a/crates/duty-tracker/src/shutdown.rs
+++ b/crates/duty-tracker/src/shutdown.rs
@@ -1,0 +1,170 @@
+//! Shutdown handler for the duty tracker.
+//!
+//! This module implements persistence of critical in-memory state before shutdown.
+
+use std::{collections::BTreeMap, time::Duration};
+
+use bitcoin::Txid;
+use strata_bridge_primitives::operator_table::OperatorTable;
+use strata_tasks::ShutdownGuard;
+use tokio::time::timeout;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    contract_persister::ContractPersister, contract_state_machine::ContractSM, errors::ShutdownErr,
+    stake_chain_persister::StakeChainPersister, stake_chain_state_machine::StakeChainSM,
+};
+
+/// Execution state that needs to be persisted before shutdown.
+#[derive(Debug)]
+pub struct ExecutionState {
+    /// Active contracts state.
+    pub active_contracts: BTreeMap<Txid, ContractSM>,
+
+    /// Claim transaction IDs state map.
+    pub claim_txids: BTreeMap<Txid, Txid>,
+
+    /// Stake chain state.
+    pub stake_chains: StakeChainSM,
+
+    /// Operator table for stake chain persistence.
+    pub operator_table: OperatorTable,
+}
+
+/// Shutdown handler for the duty tracker.
+#[derive(Debug)]
+pub struct ShutdownHandler {
+    /// [`ContractPersister`] handle for persisting contract state.
+    contract_persister: ContractPersister,
+
+    /// [`StakeChainPersister`] handle for persisting stake chain state.
+    stake_chain_persister: StakeChainPersister,
+}
+
+impl ShutdownHandler {
+    /// Creates a new [`ShutdownHandler`] with the given persisters.
+    pub const fn new(
+        contract_persister: ContractPersister,
+        stake_chain_persister: StakeChainPersister,
+    ) -> Self {
+        Self {
+            contract_persister,
+            stake_chain_persister,
+        }
+    }
+
+    /// Persists all critical state before shutdown.
+    pub async fn persist_state_before_shutdown(
+        &self,
+        execution_state: &ExecutionState,
+        shutdown_guard: &ShutdownGuard,
+        shutdown_timeout: Duration,
+    ) -> Result<(), ShutdownErr> {
+        info!("initiating shutdown - persisting critical state");
+
+        // Check if we should shutdown before starting.
+        if shutdown_guard.should_shutdown() {
+            warn!("shutdown requested before state persistence started");
+            return Ok(());
+        }
+
+        // Persist contract state with timeout.
+        let contract_result = timeout(
+            shutdown_timeout,
+            self.persist_contract_state(execution_state, shutdown_guard),
+        )
+        .await;
+
+        match contract_result {
+            Ok(Ok(())) => {
+                info!("contract state persisted successfully");
+            }
+            Ok(Err(e)) => {
+                error!("failed to persist contract state: {e:?}");
+                return Err(e);
+            }
+            Err(_) => {
+                error!("timeout persisting contract state");
+                return Err(ShutdownErr::ShutdownTimeout(
+                    "timeout persisting contract state".to_string(),
+                ));
+            }
+        }
+
+        // Check shutdown again.
+        if shutdown_guard.should_shutdown() {
+            warn!("shutdown requested during state persistence");
+            return Ok(());
+        }
+
+        // Persist stake chain state with timeout.
+        let stake_result = timeout(
+            shutdown_timeout,
+            self.persist_stake_chain_state(execution_state, shutdown_guard),
+        )
+        .await;
+
+        match stake_result {
+            Ok(Ok(())) => {
+                info!("stake chain state persisted successfully");
+            }
+            Ok(Err(e)) => {
+                error!("failed to persist stake chain state: {e:?}");
+                return Err(e);
+            }
+            Err(_) => {
+                error!("timeout persisting stake chain state");
+                return Err(ShutdownErr::ShutdownTimeout(
+                    "timeout persisting stake chain state".to_string(),
+                ));
+            }
+        }
+
+        info!("shutdown - all critical state persisted successfully");
+        Ok(())
+    }
+
+    /// Persists contract state.
+    async fn persist_contract_state(
+        &self,
+        execution_state: &ExecutionState,
+        shutdown_guard: &ShutdownGuard,
+    ) -> Result<(), ShutdownErr> {
+        debug!("persisting contract state");
+
+        if shutdown_guard.should_shutdown() {
+            warn!("shutdown requested before contract persistence");
+            return Ok(());
+        }
+
+        self.contract_persister
+            .commit_all(execution_state.active_contracts.iter())
+            .await?;
+
+        debug!("contract state persistence completed");
+        Ok(())
+    }
+
+    /// Persists stake chain state.
+    async fn persist_stake_chain_state(
+        &self,
+        execution_state: &ExecutionState,
+        shutdown_guard: &ShutdownGuard,
+    ) -> Result<(), ShutdownErr> {
+        debug!("persisting stake chain state");
+
+        if shutdown_guard.should_shutdown() {
+            warn!("shutdown requested before stake chain persistence");
+            return Ok(());
+        }
+
+        let stake_chain_state = execution_state.stake_chains.state().clone();
+
+        self.stake_chain_persister
+            .commit_stake_data(&execution_state.operator_table, stake_chain_state)
+            .await?;
+
+        debug!("stake chain state persistence completed");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

Implements graceful shutdown for the bridge node that persists critical state before termination. When shutdown signals are received, the system extracts active contracts, claim txids, and stake chain data, then persists them to disk before shutting down.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The key changes:

- Adds a new `shutdown` module that uses `strata-tasks` to handle persistence critical in-memory state before shutdown.
- Replaces the `contract_manager` module `ExecutionState` for the new `shutdown` module `ExecutionState`.
- Modifies `alpen-bridge` to use the new shutdown system.

The shutdown flow: Signal → Extract state → Persist to disk → Exit

As always, the commits are linear and somewhat atomic. So this PR is commit-review-friendly.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1497