### PR TITLE
STR-1561 execute withdrawal fulfillments in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,6 +287,7 @@ provers/sp1/proofs/
 # binary dumps
 *.bin
 *.borsh
+*.pb.gz
 
 # test data
 !test-data/*.bin

--- a/.justfile
+++ b/.justfile
@@ -245,7 +245,8 @@ checkpoint:
         --btc-user user \
         --btc-pass password \
         --checkpoint-tag strata-ckpt \
-        --sequencer-xpriv tprv8ezKDhpQHojBcUwXVZHBHBMg3QJQieAneQt9kkSMBoxdWdfBi1oBTiDev4J1ebeWH9hVV64fDeddyaLjMe7tjuS16QKPwykFAAiM66RcZams # keep this in sync with `docker/vol/alpen-bridge-{1,2,3}/params.toml`
+        --deposit-entries deposit-entries.json \
+        --sequencer-xpriv tprv8ezKDhpQHojBcUwXVZHBHBMg3QJQieAneQt9kkSMBoxdWdfBi1oBTiDev4J1ebeWH9hVV64fDeddyaLjMe7tjuS16QKPwykFAAiM66RcZWi # keep this in sync with `docker/vol/alpen-bridge-{1,2,3}/params.toml`
 
 # Run bridge-in
 [group('bridge')]

--- a/bin/alpen-bridge/src/main.rs
+++ b/bin/alpen-bridge/src/main.rs
@@ -5,7 +5,7 @@
 )]
 #![feature(generic_const_exprs)] //strata-p2p
 
-use std::{fs, path::Path, thread::sleep, time::Duration};
+use std::{fs, path::Path, thread::sleep};
 
 use args::OperationMode;
 use clap::Parser;
@@ -59,6 +59,7 @@ fn main() {
 
     let params = parse_toml::<Params>(cli.params);
     let config = parse_toml::<Config>(cli.config);
+    let shutdown_timeout = config.shutdown_timeout;
 
     let runtime = runtime::Builder::new_multi_thread()
         .worker_threads(config.num_threads.unwrap_or(DEFAULT_THREAD_COUNT).into())
@@ -97,7 +98,6 @@ fn main() {
         }
     }
 
-    let shutdown_timeout = Duration::from_secs(30);
     if let Err(e) = task_manager.monitor(Some(shutdown_timeout)) {
         panic!("bridge node crashed: {e:?}");
     }

--- a/bin/mock-checkpoint/README.md
+++ b/bin/mock-checkpoint/README.md
@@ -27,5 +27,5 @@ mock-checkpoint --sequencer-xpriv <MASTER_XPRIV> [OPTIONS]
 
 ```bash
 export SEQUENCER_XPRIV=tprv8ezKDhpQHojBcUwXVZHBHBMg3QJQieAneQt9kkSMBoxdWdfBi1oBTiDev4J1ebeWH9hVV64fDeddyaLjMe7tjuS16QKPwykFAAiM66RcZWi
-mock-checkpoint
+mock-checkpoint --deposit-entries deposit-entries.json
 ```

--- a/docker/bitcoin/entrypoint.sh
+++ b/docker/bitcoin/entrypoint.sh
@@ -46,14 +46,14 @@ STAKE_CHAIN_WALLET_3=${STAKE_CHAIN_WALLET_3}
 
 bcli="bitcoin-cli -rpcuser=${BTC_USER} -rpcpassword=${BTC_PASS} -regtest -rpcconnect=127.0.0.1 -rpcport=18443"
 
-# Generate a block to the address of the operator's general wallet
-$bcli generatetoaddress 1 ${GENERAL_WALLET_1}
+# Fund the general wallets with enough funds.
+$bcli generatetoaddress 10 ${GENERAL_WALLET_1}
 sleep 0.1
 
-$bcli generatetoaddress 1 ${GENERAL_WALLET_2}
+$bcli generatetoaddress 10 ${GENERAL_WALLET_2}
 sleep 0.1
 
-$bcli generatetoaddress 1 ${GENERAL_WALLET_3}
+$bcli generatetoaddress 10 ${GENERAL_WALLET_3}
 sleep 0.1
 
 # mine enough blocks to the default wallet address to mature coinbase funds

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -3,6 +3,7 @@ is_faulty = false
 nag_interval = { secs = 300, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 stake_funding_pool_size = 32
+shutdown_timeout = { secs = 30, nanos = 0 }
 
 [secret_service_client]
 server_addr = "172.28.1.5:69"

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -3,6 +3,7 @@ is_faulty = false
 nag_interval = { secs = 300, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 stake_funding_pool_size = 32
+shutdown_timeout = { secs = 30, nanos = 0 }
 
 [secret_service_client]
 server_addr = "172.28.1.6:69"

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -3,6 +3,7 @@ is_faulty = false
 nag_interval = { secs = 300, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 stake_funding_pool_size = 32
+shutdown_timeout = { secs = 30, nanos = 0 }
 
 [secret_service_client]
 server_addr = "172.28.1.7:69"


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR fixes an issue with withdrawal execution where if two withdrawal fufillment duties were created together, the second one would not be executed until the first withdrawal fulfillment transaction had been buried. This can also cause delays in publishing the deposit setup message. The cause of this issue is that in both cases, we first try to sync the operator wallet which requires that we obtain a `WriteLock` on the operator wallet. This lock is held until the transaction is buried. This PR fixes this by releasing the lock on the wallet as soon as possible and tracking the used funding utxos in memory so that two withdrawal fulfillment execution threads running in parallel do not end up using the same funding utxo.

**Auxiliary Fixes**

- Fixes the bridge binary to actually use the `shutdown_timeout` configuration option instead of using the hardcoded value of 30 seconds.
- Updates the `config.toml` file to include the `shutdown_timeout` configuration option when running docker locally.
- Updates the sequencer xpriv value in the `.justfile` to use the one corresponding to the `SchnorrKey` in the `params.toml` files.
- Updates the `README.md` in `mock-checkpoint` to specify `deposit-entries`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->

Closes STR-1561