### PR TITLE
fix: change all taproot sighashes to `Default` and better parsing

### DIFF
--- a/crates/duty-tracker/src/executors/deposit.rs
+++ b/crates/duty-tracker/src/executors/deposit.rs
@@ -272,7 +272,7 @@ async fn finalize_claim_funding_tx(
         })
         .collect::<Vec<_>>();
     let mut sighasher = SighashCache::new(&mut tx);
-    let sighash_type = TapSighashType::All;
+    let sighash_type = TapSighashType::Default;
     let prevouts = Prevouts::All(&txins_as_outs);
     for input_index in 0..txins_as_outs.len() {
         let sighash = sighasher

--- a/crates/tx-graph/src/transactions/deposit.rs
+++ b/crates/tx-graph/src/transactions/deposit.rs
@@ -222,7 +222,7 @@ impl DepositTx {
 
         for (i, input) in psbt.inputs.iter_mut().enumerate() {
             input.witness_utxo = Some(prevouts[i].clone());
-            input.sighash_type = Some(TapSighashType::All.into());
+            input.sighash_type = Some(TapSighashType::Default.into());
         }
 
         let witnesses = [TaprootWitness::Tweaked {


### PR DESCRIPTION
## Description

Normalize all `TapSighashesType`s to `Default` since we can save 1 byte in all transactions.


### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Merge together with https://github.com/alpenlabs/alpen/pull/934.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1581