### PR TITLE
STR-1502: Abort Contracts

### DIFF
--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -586,7 +586,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 // NOTE: Resolved contracts have no *current* withdrawals and will pollute the return array.
                 | ContractState::Resolved { .. }
                 | ContractState::Disproved { .. }
-                | ContractState::Aborted {  } => {
+                | ContractState::Aborted => {
                     continue;
                 }
             }
@@ -612,7 +612,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 ContractState::Requested { .. }
                 | ContractState::Deposited { .. }
                 | ContractState::Disproved { .. }
-                | ContractState::Aborted {} => {
+                | ContractState::Aborted => {
                     // These states do not have withdrawals, so we skip them
                     None
                 }
@@ -706,7 +706,7 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 // States that are terminal and do not have an active graph.
                 ContractState::Resolved { .. }
                 | ContractState::Disproved { .. }
-                | ContractState::Aborted {} => None,
+                | ContractState::Aborted => None,
             })
             .collect();
 
@@ -738,7 +738,7 @@ const fn contract_state_to_reimbursement_status(state: &ContractState) -> RpcRei
         | ContractState::Deposited { .. }
         | ContractState::Assigned { .. }
         | ContractState::Fulfilled { .. }
-        | ContractState::Aborted {} => RpcReimbursementStatus::NotStarted,
+        | ContractState::Aborted => RpcReimbursementStatus::NotStarted,
         ContractState::Claimed { active_graph, .. } => RpcReimbursementStatus::InProgress {
             challenge_step: ChallengeStep::Claim,
             claim_txid: active_graph.1.claim_txid,

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -585,7 +585,8 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 | ContractState::Deposited { .. }
                 // NOTE: Resolved contracts have no *current* withdrawals and will pollute the return array.
                 | ContractState::Resolved { .. }
-                | ContractState::Disproved { .. } => {
+                | ContractState::Disproved { .. }
+                | ContractState::Aborted {  } => {
                     continue;
                 }
             }
@@ -610,7 +611,8 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 // No withdraw information.
                 ContractState::Requested { .. }
                 | ContractState::Deposited { .. }
-                | ContractState::Disproved { .. } => {
+                | ContractState::Disproved { .. }
+                | ContractState::Aborted {} => {
                     // These states do not have withdrawals, so we skip them
                     None
                 }
@@ -702,7 +704,9 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 | ContractState::Assigned { .. } => None,
 
                 // States that are terminal and do not have an active graph.
-                ContractState::Resolved { .. } | ContractState::Disproved { .. } => None,
+                ContractState::Resolved { .. }
+                | ContractState::Disproved { .. }
+                | ContractState::Aborted {} => None,
             })
             .collect();
 
@@ -733,7 +737,8 @@ const fn contract_state_to_reimbursement_status(state: &ContractState) -> RpcRei
         ContractState::Requested { .. }
         | ContractState::Deposited { .. }
         | ContractState::Assigned { .. }
-        | ContractState::Fulfilled { .. } => RpcReimbursementStatus::NotStarted,
+        | ContractState::Fulfilled { .. }
+        | ContractState::Aborted {} => RpcReimbursementStatus::NotStarted,
         ContractState::Claimed { active_graph, .. } => RpcReimbursementStatus::InProgress {
             challenge_step: ChallengeStep::Claim,
             claim_txid: active_graph.1.claim_txid,

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -1936,7 +1936,11 @@ async fn execute_duty(
         OperatorDuty::Abort => {
             warn!("received an Abort duty, this should not happen in normal operation");
 
-            unimplemented!("abort duty is not implemented yet");
+            // TODO(proofofkeags): right now we don't actively attempt to prune Aborted contracts.
+            // We need to hold onto them in our active state for now because of its implications on
+            // advancing the stake chain. In the future we need to prune them after their stake
+            // transaction is published since their state is no longer relevant.
+            Ok(())
         }
         OperatorDuty::VerifierDuty(verifier_duty) => {
             warn!(%verifier_duty, "ignoring verifier duty");

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -616,7 +616,7 @@ pub enum ContractState {
 
     /// This state describes the state where the refund delay has been exceeded before a DRT could
     /// be converted to a DT.
-    Aborted {},
+    Aborted,
 }
 
 impl Display for ContractState {
@@ -695,7 +695,7 @@ impl Display for ContractState {
             } => {
                 format!("Resolved via {path} path with withdrawal fulfillment ({withdrawal_fulfillment_txid}) and payout ({payout_txid})")
             }
-            ContractState::Aborted {} => "Aborted".to_string(),
+            ContractState::Aborted => "Aborted".to_string(),
         };
 
         write!(f, "ContractState: {display_str}")
@@ -746,7 +746,7 @@ impl ContractState {
             | ContractState::Asserted { peg_out_graphs, .. } => get_summaries(peg_out_graphs),
             ContractState::Disproved { .. }
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => Vec::new(),
+            | ContractState::Aborted => Vec::new(),
         }
     }
 
@@ -768,7 +768,7 @@ impl ContractState {
                 return HashSet::from([*claim_txid]);
             }
 
-            ContractState::Disproved { .. } | ContractState::Aborted {} => &dummy,
+            ContractState::Disproved { .. } | ContractState::Aborted => &dummy,
         };
 
         claim_txids.values().copied().collect()
@@ -788,7 +788,7 @@ impl ContractState {
             | ContractState::Asserted { graph_sigs, .. } => graph_sigs,
             ContractState::Disproved { .. }
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => &BTreeMap::new(),
+            | ContractState::Aborted => &BTreeMap::new(),
         };
 
         graph_sigs.clone()
@@ -808,7 +808,7 @@ impl ContractState {
             ContractState::Asserted { claim_txids, .. } => claim_txids,
             ContractState::Disproved {}
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => &BTreeMap::new(),
+            | ContractState::Aborted => &BTreeMap::new(),
         };
 
         claim_txids.iter().find_map(|(op_key, claim)| {
@@ -841,7 +841,7 @@ impl ContractState {
             }
             ContractState::Disproved {}
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => None,
+            | ContractState::Aborted => None,
         }
     }
 
@@ -864,7 +864,7 @@ impl ContractState {
             }
             ContractState::Disproved {}
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => None,
+            | ContractState::Aborted => None,
         }
     }
 }
@@ -1607,7 +1607,7 @@ impl ContractSM {
                 tx.compute_txid(),
                 self.state.state
             ))),
-            ContractState::Aborted {} => Err(TransitionErr(format!(
+            ContractState::Aborted => Err(TransitionErr(format!(
                 "peg out graph confirmation ({}) delivered to CSM in Aborted state ({})",
                 tx.compute_txid(),
                 self.state.state
@@ -2298,13 +2298,13 @@ impl ContractSM {
             | ContractState::AssertDataConfirmed { .. }
             | ContractState::Disproved {}
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => None,
+            | ContractState::Aborted => None,
 
             // the next states for the following states depend on a timelock
             // and therefore care about a new block event.
             ContractState::Requested { abort_deadline, .. } => {
                 if self.state.block_height >= *abort_deadline {
-                    self.state.state = ContractState::Aborted {};
+                    self.state.state = ContractState::Aborted;
                     Some(OperatorDuty::Abort)
                 } else {
                     None
@@ -3163,7 +3163,7 @@ impl ContractSM {
                 return vec![*claim_txid];
             }
 
-            ContractState::Disproved {} | ContractState::Aborted {} => &dummy,
+            ContractState::Disproved {} | ContractState::Aborted => &dummy,
         }
         .values()
         .copied()
@@ -3194,7 +3194,7 @@ impl ContractSM {
             | ContractState::Asserted { .. }
             | ContractState::Disproved {}
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => None,
+            | ContractState::Aborted => None,
         }
     }
     /// The txid of the withdrawal fulfillment for this contract.
@@ -3208,7 +3208,7 @@ impl ContractSM {
             | ContractState::Assigned { .. }
             | ContractState::Disproved {}
             | ContractState::Resolved { .. }
-            | ContractState::Aborted {} => None,
+            | ContractState::Aborted => None,
 
             ContractState::Fulfilled {
                 withdrawal_fulfillment_txid,


### PR DESCRIPTION
Implements non-crashing abort behavior if deposit transaction isn't issued before the abort deadline.

## Description

This is a super simple change just to make sure we don't crash if we ever abort a contract. Right now we do nothing and we keep these contracts around indefinitely. This technically constitutes a resource leak but it will not be an issue to begin with. The change needed to get rid of the resource leak is pruning "active" Aborted contracts once their deposit index has been surpassed by the stake chain height.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Make sure I didn't forget anything in the state transition rules that would prevent the stake transaction from being published. CC @Rajil1213.

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
