### PR TITLE
fix(operator_wallet) add retry mechanism to op wallet sync

### DIFF
--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -18,9 +18,9 @@ use tracing::{error, info};
 
 /// How many times we should reattempt after an error during a wallet sync
 const SYNC_RETRIES: u32 = 5;
-/// The wallet will delay a retry by SYNC_BASE_DELAY*2^current_retry,
+/// The wallet will delay a retry by SYNC_BASE_DELAY*SYNC_BACKOFF^current_retry,
 /// exponential backoff
-const SYNC_BACKOFF: u32 = 2;
+const SYNC_BACKOFF: u32 = 3;
 const SYNC_BASE_DELAY: Duration = Duration::from_millis(100);
 
 /// Config for [`OperatorWallet`]
@@ -311,7 +311,7 @@ impl OperatorWallet {
 
     /// Syncs the wallet using the backend provided on construction.
     pub async fn sync(&mut self) -> Result<(), SyncError> {
-        let mut retries_left = SYNC_RETRIES;
+        let mut attempt = 0;
         loop {
             let mut err = None;
             if let Err(e) = self
@@ -332,11 +332,11 @@ impl OperatorWallet {
             match err {
                 Some(e) => {
                     error!(?e, "error syncing wallet");
-                    if retries_left == 0 {
+                    if attempt >= SYNC_RETRIES {
                         break Err(e);
                     }
-                    sleep(SYNC_BASE_DELAY * SYNC_BACKOFF.pow(SYNC_RETRIES - retries_left)).await;
-                    retries_left -= 1;
+                    sleep(SYNC_BASE_DELAY * SYNC_BACKOFF.pow(attempt)).await;
+                    attempt += 1;
                 }
                 None => break Ok(()),
             }


### PR DESCRIPTION
## Description

Adds a simple exponential backoff to the operator wallet sync process

This current configuration does:
100ms, 300ms, 900ms, 2.7s, 8.1sec, error

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

STR-1585