### PR TITLE
fix(operator-wallet): move all transactions to V3

### DIFF
--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -160,8 +160,13 @@ impl OperatorWallet {
     /// Creates a PSBT that outfronts a withdrawal from the general wallet to a user owned P2TR
     /// address. (excluding anchor outputs). Needs signing by the general wallet.
     ///
+    /// # Notes
+    ///
     /// The caller is responsible of assuring that the `OP_RETURN` data is within standard limits,
     /// i.e. `<= 80` bytes.
+    ///
+    /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
+    /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
     pub fn front_withdrawal(
         &mut self,
         fee_rate: FeeRate,
@@ -176,6 +181,8 @@ impl OperatorWallet {
         let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint).collect();
 
         let mut tx_builder = self.general_wallet.build_tx();
+        // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
+        tx_builder.version(3);
         // DON'T spend any of the anchor outputs
         tx_builder.unspendable(anchor_outpoints);
         tx_builder.unspendable(self.fronting_outpoints.iter().copied().collect());
@@ -196,6 +203,11 @@ impl OperatorWallet {
 
     /// Creates a PSBT that refills the pool of claim funding UTXOs from the general wallet
     /// (excluding anchor outputs). Needs signing by the general wallet.
+    ///
+    /// # Notes
+    ///
+    /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
+    /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
     pub fn refill_claim_funding_utxos(
         &mut self,
         fee_rate: FeeRate,
@@ -220,6 +232,8 @@ impl OperatorWallet {
             .collect();
 
         let mut tx_builder = self.general_wallet.build_tx();
+        // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
+        tx_builder.version(3);
         tx_builder.unspendable(excluded);
 
         let current_size = current_claim_funding_outpoints.len();
@@ -268,9 +282,16 @@ impl OperatorWallet {
 
     /// Creates a new prestake transaction by paying funds from the general wallet into the
     /// stakechain wallet (excludes anchor outputs). This will create a [Self::s_utxo].
+    ///
+    /// # Notes
+    ///
+    /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
+    /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
     pub fn create_prestake_tx(&mut self, fee_rate: FeeRate) -> Result<Psbt, CreateTxError> {
         let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint).collect();
         let mut tx_builder = self.general_wallet.build_tx();
+        // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
+        tx_builder.version(3);
         // DON'T spend any of the anchor outputs
         tx_builder.unspendable(anchor_outpoints);
         tx_builder.fee_rate(fee_rate);


### PR DESCRIPTION
## Description

Changes all transactions to V3 which facilitates the CPFP handles and package relay TRUC combo transactions.
A version-2 transaction cannot spend from a version-3 transaction that has not been confirmed yet.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Added documentation information for version 3, including the maximum size of 10,000 vbytes.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1587