### PR TITLE
STR-1509 Make retry logic for publishing stake txs configurable

### DIFF
--- a/bin/alpen-bridge/src/config.rs
+++ b/bin/alpen-bridge/src/config.rs
@@ -212,7 +212,6 @@ mod tests {
             rawtx_connection_string = "tcp://127.0.0.1:28335"
             sequence_connection_string = "tcp://127.0.0.1:28336"
 
-            shutdown_timeout = { secs = 15, nanos = 0 }
             [stake_tx]
             max_retries = 5
             retry_delay = { secs = 1, nanos = 0 }

--- a/bin/alpen-bridge/src/config.rs
+++ b/bin/alpen-bridge/src/config.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, time::Duration};
 
 use btc_notify::client::BtcZmqConfig;
+use duty_tracker::executors::config::StakeTxRetryConfig;
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 use strata_bridge_db::persistent::config::DbConfig;
@@ -60,6 +61,9 @@ pub(crate) struct Config {
 
     /// Configuration for the Bitcoin ZMQ client.
     pub btc_zmq: BtcZmqConfig,
+
+    /// Configuration for retrying the publishing of stake chain transactions.
+    pub stake_tx: StakeTxRetryConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -209,6 +213,9 @@ mod tests {
             sequence_connection_string = "tcp://127.0.0.1:28336"
 
             shutdown_timeout = { secs = 15, nanos = 0 }
+            [stake_tx]
+            max_retries = 5
+            retry_delay = { secs = 1, nanos = 0 }
         "#;
 
         let config = toml::from_str::<Config>(config);

--- a/bin/alpen-bridge/src/mode/operator.rs
+++ b/bin/alpen-bridge/src/mode/operator.rs
@@ -54,7 +54,7 @@ use strata_bridge_stake_chain::prelude::OPERATOR_FUNDS;
 use strata_p2p::swarm::handle::P2PHandle;
 use strata_p2p_types::{P2POperatorPubKey, StakeChainId};
 use strata_tasks::TaskExecutor;
-use tokio::{net::lookup_host, select, sync::broadcast, task::JoinHandle};
+use tokio::{net::lookup_host, select, sync::mpsc, task::JoinHandle};
 use tracing::{debug, error, info};
 
 use crate::{
@@ -569,8 +569,8 @@ async fn handle_stakechain_genesis(
 ) {
     // the ouroboros sender is part of the message handler interface but is unused when sending
     // stakechain genesis information.
-    let (ouroboros_msg_sender, _ouroboros_msg_receiver) = broadcast::channel(1);
-    let (ouroboros_req_sender, _ouroboros_req_receiver) = broadcast::channel(1);
+    let (ouroboros_msg_sender, _ouroboros_msg_receiver) = mpsc::unbounded_channel();
+    let (ouroboros_req_sender, _ouroboros_req_receiver) = mpsc::unbounded_channel();
     let message_handler = MessageHandler::new(ouroboros_msg_sender, ouroboros_req_sender);
     let general_key = s2_client
         .general_wallet_signer()

--- a/bin/alpen-bridge/src/mode/operator.rs
+++ b/bin/alpen-bridge/src/mode/operator.rs
@@ -490,6 +490,7 @@ async fn init_duty_tracker(
         config.is_faulty,
         config.min_withdrawal_fulfillment_window,
         config.stake_funding_pool_size,
+        config.stake_tx,
         pre_stake_pubkey,
         zmq_client,
         rpc_client,

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -45,7 +45,7 @@ use crate::{
         OperatorDuty, TransitionErr,
     },
     errors::{ContractManagerErr, StakeChainErr},
-    executors::prelude::*,
+    executors::{config::StakeTxRetryConfig, prelude::*},
     predicates::{deposit_request_info, parse_strata_checkpoint},
     shutdown::ExecutionState,
     stake_chain_persister::StakeChainPersister,
@@ -81,6 +81,7 @@ impl ContractManager {
         is_faulty: bool,
         min_withdrawal_fulfillment_window: u64,
         stake_funding_pool_size: usize,
+        stake_tx_retry_config: StakeTxRetryConfig,
         // Genesis information
         pre_stake_pubkey: ScriptBuf,
         // Subsystem Handles
@@ -182,6 +183,7 @@ impl ContractManager {
                 stake_chain_params,
                 sidesystem_params,
                 operator_table,
+                stake_tx_retry_config,
                 pre_stake_pubkey: pre_stake_pubkey.clone(),
                 funding_address: funding_address.clone(),
                 is_faulty,
@@ -545,6 +547,7 @@ pub(super) struct ExecutionConfig {
     pub(super) stake_chain_params: StakeChainParams,
     pub(super) sidesystem_params: RollupParams,
     pub(super) operator_table: OperatorTable,
+    pub(super) stake_tx_retry_config: StakeTxRetryConfig,
     pub(super) pre_stake_pubkey: ScriptBuf,
     pub(super) funding_address: Address,
     pub(super) is_faulty: bool,

--- a/crates/duty-tracker/src/executors/config.rs
+++ b/crates/duty-tracker/src/executors/config.rs
@@ -1,0 +1,23 @@
+//! This mdoule contains the configuration for the duty executors.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// The configuration for retrying the publishing of stake chain transactions.
+///
+/// As there may be a non-zero timelock between consecutive transactions in the stake chain, it is
+/// not possible to execute withdrawal duties in parallel. This configuration tells the executor how
+/// soon to retry publishing a stake chain transaction in case of failure and how many times to do
+/// it.
+// NOTE: (@Rajil1213) this is a temporary solution to handle parallel execution of withdrawal
+// fulfillment until we fundamentally reshape the current model of the contract manager as it
+// pertains to the stake chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StakeTxRetryConfig {
+    /// The maximum number of retries for a stake transaction.
+    pub max_retries: u32,
+
+    /// The delay between retries.
+    pub retry_delay: Duration,
+}

--- a/crates/duty-tracker/src/executors/mod.rs
+++ b/crates/duty-tracker/src/executors/mod.rs
@@ -1,5 +1,6 @@
 //! Contains execution logic for various duties emitted by the contract manager event loop.
 
+pub mod config;
 pub(crate) mod constants;
 pub(crate) mod contested_withdrawal;
 pub(crate) mod deposit;

--- a/crates/p2p-service/src/message_handler.rs
+++ b/crates/p2p-service/src/message_handler.rs
@@ -5,7 +5,7 @@ use musig2::{PartialSignature, PubNonce};
 use strata_p2p::commands::UnsignedPublishMessage;
 use strata_p2p_types::{P2POperatorPubKey, Scope, SessionId, StakeChainId, WotsPublicKeys};
 use strata_p2p_wire::p2p::v1::GetMessageRequest;
-use tokio::sync::broadcast;
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace};
 
 /// Message handler for the bridge node for relaying p2p messages.
@@ -17,21 +17,21 @@ use tracing::{debug, error, info, trace};
 pub struct MessageHandler {
     /// The outbound channel used to self-publish gossipsub messages i.e., to send messages to
     /// itself rather than the network.
-    ouroboros_msg_sender: broadcast::Sender<UnsignedPublishMessage>,
+    ouroboros_msg_sender: mpsc::UnboundedSender<UnsignedPublishMessage>,
 
     /// The outbound channel used to self-publish message requests.
     ///
     /// It is used when a node needs to nag itself. This mimics a duty retry mechanism and is
     /// useful if the node broadcasts a message to its peers that it then loses or fails to
     /// persist before an inopportune restart.
-    ouroboros_req_sender: broadcast::Sender<GetMessageRequest>,
+    ouroboros_req_sender: mpsc::UnboundedSender<GetMessageRequest>,
 }
 
 impl MessageHandler {
     /// Creates a new message handler.
     pub const fn new(
-        ouroboros_msg_sender: broadcast::Sender<UnsignedPublishMessage>,
-        ouroboros_req_sender: broadcast::Sender<GetMessageRequest>,
+        ouroboros_msg_sender: mpsc::UnboundedSender<UnsignedPublishMessage>,
+        ouroboros_req_sender: mpsc::UnboundedSender<GetMessageRequest>,
     ) -> Self {
         Self {
             ouroboros_msg_sender,

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -44,3 +44,7 @@ hashtx_connection_string = "tcp://host.docker.internal:28333"
 rawblock_connection_string = "tcp://host.docker.internal:28334"
 rawtx_connection_string = "tcp://host.docker.internal:28335"
 sequence_connection_string = "tcp://host.docker.internal:28336"
+
+[stake_tx]
+max_retries = 10
+retry_delay = { secs = 5, nanos = 0 }

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -44,3 +44,7 @@ hashtx_connection_string = "tcp://host.docker.internal:28333"
 rawblock_connection_string = "tcp://host.docker.internal:28334"
 rawtx_connection_string = "tcp://host.docker.internal:28335"
 sequence_connection_string = "tcp://host.docker.internal:28336"
+
+[stake_tx]
+max_retries = 10
+retry_delay = { secs = 5, nanos = 0 }

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -44,3 +44,7 @@ hashtx_connection_string = "tcp://host.docker.internal:28333"
 rawblock_connection_string = "tcp://host.docker.internal:28334"
 rawtx_connection_string = "tcp://host.docker.internal:28335"
 sequence_connection_string = "tcp://host.docker.internal:28336"
+
+[stake_tx]
+max_retries = 10
+retry_delay = { secs = 5, nanos = 0 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR makes the retry logic for publishing stake transactions configurable. Previously, this logic was hardcoded to retry 25 times with a 1-minute delay. This is not suitable for all environments where the signet block times may be different. Furthermore, the value 25 was chosen because it is the descendant limit for version-2 transactions but for version-3 transactions, the limit is just 2, which means that retrying is futile until a new block is created. Making the retry logic configurable is the most straightforward way to address this issue.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-1589