### PR TITLE
fix: handle node going down before persisting stake data and missing deposit requests

### DIFF
--- a/crates/db/src/inmemory/public.rs
+++ b/crates/db/src/inmemory/public.rs
@@ -1,6 +1,9 @@
 //! In-memory database traits and implementations for the public.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use bitcoin::{OutPoint, Txid};
@@ -284,14 +287,21 @@ impl PublicDb for PublicDbInMemory {
             .cloned())
     }
 
-    async fn get_all_stake_data(&self, operator_idx: OperatorIdx) -> DbResult<Vec<StakeTxData>> {
+    async fn get_all_stake_data(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> DbResult<BTreeMap<u32, StakeTxData>> {
         Ok(self
             .stake_data
             .read()
             .await
             .get(&operator_idx)
-            .map(|map| map.values().cloned().collect())
-            .unwrap_or(vec![]))
+            .map(|map| {
+                map.iter()
+                    .map(|(deposit_idx, stake_data)| (*deposit_idx, stake_data.clone()))
+                    .collect()
+            })
+            .unwrap_or_default())
     }
 
     async fn register_claim_txid(

--- a/crates/db/src/persistent/models.rs
+++ b/crates/db/src/persistent/models.rs
@@ -65,6 +65,9 @@ pub(super) struct Signature {
 
 /// The model for tracking the stake information.
 pub(super) struct DbStakeTxData {
+    /// The index of the deposit.
+    pub(super) deposit_idx: u32,
+
     /// The txid of the transaction used to fund the dust outputs.
     pub(super) funding_txid: DbTxid,
 
@@ -81,9 +84,10 @@ pub(super) struct DbStakeTxData {
     pub(super) operator_pubkey: DbXOnlyPublicKey,
 }
 
-impl From<StakeTxData> for DbStakeTxData {
-    fn from(stake_tx_data: StakeTxData) -> Self {
+impl DbStakeTxData {
+    pub(crate) fn new(deposit_idx: u32, stake_tx_data: StakeTxData) -> Self {
         Self {
+            deposit_idx,
             funding_txid: stake_tx_data.operator_funds.txid.into(),
             funding_vout: stake_tx_data.operator_funds.vout.into(),
             hash: stake_tx_data.hash.into(),

--- a/crates/db/src/public.rs
+++ b/crates/db/src/public.rs
@@ -1,5 +1,7 @@
 //! Public database interface for the Strata Bridge.
 
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use bitcoin::{OutPoint, Txid};
 use secp256k1::schnorr::Signature;
@@ -91,7 +93,10 @@ pub trait PublicDb {
     async fn add_all_stake_data(&self, data: Vec<(OperatorIdx, u32, StakeTxData)>) -> DbResult<()>;
 
     /// Gets all [`StakeTxData`] for a given [`OperatorIdx`].
-    async fn get_all_stake_data(&self, operator_idx: OperatorIdx) -> DbResult<Vec<StakeTxData>>;
+    async fn get_all_stake_data(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> DbResult<BTreeMap<u32, StakeTxData>>;
 
     /// Sets the pre-stake [`OutPoint`] for a given [`OperatorIdx`]. This is typically the output
     /// point of the transaction that will be used as an input to the first stake transaction.

--- a/crates/duty-tracker/src/contract_manager.rs
+++ b/crates/duty-tracker/src/contract_manager.rs
@@ -933,7 +933,6 @@ impl ContractManagerCtx {
                         wots_pks: wots_pks.clone(),
                     };
 
-                    debug!(%deposit_txid, %sender_id, %index, "processing stake tx setup");
                     let Some(_stake_txid) =
                         self.state.stake_chains.process_setup(key.clone(), &setup)?
                     else {
@@ -1306,7 +1305,7 @@ impl ContractManagerCtx {
                 nonces: existing_nonces,
             })
         } else {
-            warn!("nagged for nonces on a ContractSM that is not in a Requested state");
+            warn!(deposit_idx=%csm.cfg().deposit_idx, "nagged for nonces on a ContractSM that is not in a Requested state");
             None
         }
     }
@@ -1341,7 +1340,7 @@ impl ContractManagerCtx {
                 nonce: existing_nonce,
             })
         } else {
-            warn!("nagged for nonces on a ContractSM that is not in a Requested state");
+            warn!(deposit_idx=%csm.cfg().deposit_idx, "nagged for nonces on a ContractSM that is not in a Requested state");
             None
         }
     }

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -1834,11 +1834,11 @@ impl ContractSM {
                 session_nonces.insert(signer.clone(), unpacked);
 
                 let num_operators = self.cfg.operator_table.cardinality();
-                let have_all_graphs = graph_nonces.values().count() == num_operators;
-                let have_all_nonces_in_each_graph = graph_nonces
-                    .values()
-                    .all(|session_nonces| session_nonces.len() == num_operators);
-                let have_all_nonces = have_all_graphs && have_all_nonces_in_each_graph;
+                let have_all_nonces = claim_txids.values().all(|claim_txid| {
+                    graph_nonces.get(claim_txid).is_some_and(|session_nonces| {
+                        session_nonces.keys().count() == num_operators
+                    })
+                });
 
                 if !have_all_nonces {
                     let received_nonces = graph_nonces
@@ -1860,7 +1860,7 @@ impl ContractSM {
                     .map(|(op, claim_txid)| (claim_txid, op))
                     .collect::<BTreeMap<_, _>>();
 
-                for claim_txid in graph_nonces.keys() {
+                for claim_txid in claim_txids.values() {
                     let graph_owner =
                         claim_txid_to_operator_map
                             .get(claim_txid)
@@ -2013,11 +2013,13 @@ impl ContractSM {
                 session_partials.insert(signer, unpacked);
 
                 let num_operators = self.cfg.operator_table.cardinality();
-                let have_all_graphs = graph_partials.values().count() == num_operators;
-                let have_all_partials_for_all_graphs = graph_partials
-                    .values()
-                    .all(|session_partials| session_partials.len() == num_operators);
-                let have_all_partials = have_all_graphs && have_all_partials_for_all_graphs;
+                let have_all_partials = claim_txids.values().all(|claim_txid| {
+                    graph_partials
+                        .get(claim_txid)
+                        .is_some_and(|session_partials| {
+                            session_partials.keys().count() == num_operators
+                        })
+                });
 
                 if !have_all_partials {
                     let received_partials = graph_partials

--- a/crates/duty-tracker/src/contract_state_machine.rs
+++ b/crates/duty-tracker/src/contract_state_machine.rs
@@ -1778,6 +1778,12 @@ impl ContractSM {
 
                 Ok(duties)
             }
+            ContractState::Aborted => {
+                // this can happen if some of the contracts are in `Aborted` state after a prolonged
+                // downtime.
+                debug!("received deposit setup in Aborted state, doing nothing");
+                Ok(vec![])
+            }
             _ => Err(TransitionErr(format!(
                 "unexpected state in process_deposit_setup ({})",
                 self.state.state

--- a/crates/duty-tracker/src/errors.rs
+++ b/crates/duty-tracker/src/errors.rs
@@ -88,6 +88,12 @@ pub enum StakeChainErr {
     #[error("stake inputs missing for operators: {0:?}")]
     IncompleteState(Vec<P2POperatorPubKey>),
 
+    /// Error indicating an inconsistent state in the
+    /// [`StakeChainSM`](crate::stake_chain_state_machine::StakeChainSM) such that an expected
+    /// stake txid is not present.
+    #[error("stake txid missing for operator: {0}, index: {1}")]
+    MissingStakeTxid(P2POperatorPubKey, u32),
+
     /// Error indicating that some stake chain data is missing.
     #[error("stake chain inputs incomplete for operator: {0}, index: {1}")]
     IncompleteStakeChainInput(P2POperatorPubKey, u32),

--- a/crates/duty-tracker/src/stake_chain_persister.rs
+++ b/crates/duty-tracker/src/stake_chain_persister.rs
@@ -74,7 +74,7 @@ impl StakeChainPersister {
         let operator_ids = cfg.operator_idxs();
 
         for operator_id in operator_ids {
-            let stake_data = self.db.get_all_stake_data(operator_id).await?;
+            let stake_inputs = self.db.get_all_stake_data(operator_id).await?;
             let pre_stake_outpoint = self.db.get_pre_stake(operator_id).await?;
             let p2p_key = cfg.idx_to_p2p_key(&operator_id);
 
@@ -84,17 +84,13 @@ impl StakeChainPersister {
                         p2p_key.clone(),
                         StakeChainInputs {
                             pre_stake_outpoint,
-                            stake_inputs: stake_data
-                                .into_iter()
-                                .enumerate()
-                                .map(|(index, stake_data)| (index as u32, stake_data))
-                                .collect(),
+                            stake_inputs,
                         },
                     );
                 }
                 _ => {
                     warn!(
-                        ?stake_data,
+                        ?stake_inputs,
                         ?pre_stake_outpoint,
                         p2p_key = ?p2p_key.map(|k| Vec::<u8>::from(k.clone()).to_lower_hex_string()),
                         "ignoring incomplete data"

--- a/crates/duty-tracker/src/stake_chain_state_machine.rs
+++ b/crates/duty-tracker/src/stake_chain_state_machine.rs
@@ -171,6 +171,13 @@ impl StakeChainSM {
         &self.stake_chains
     }
 
+    /// Returns the stake txid for an operator for a given deposit index.
+    pub fn stake_txid(&self, op: &P2POperatorPubKey, deposit_idx: u32) -> Option<&Txid> {
+        self.stake_txids
+            .get(op)
+            .and_then(|stake_txids| stake_txids.get(&deposit_idx))
+    }
+
     /// Returns the height of the current stake chain.
     ///
     /// This corresponds to the number of contracts in the

--- a/crates/duty-tracker/src/stake_chain_state_machine.rs
+++ b/crates/duty-tracker/src/stake_chain_state_machine.rs
@@ -178,9 +178,9 @@ impl StakeChainSM {
     pub fn height(&self) -> u32 {
         let my_key = self.operator_table.pov_p2p_key();
 
-        self.stake_chains
+        self.stake_txids
             .get(my_key)
-            .map(|inputs| inputs.stake_inputs.len() as u32)
+            .map(|txids| txids.len() as u32)
             .unwrap_or(0)
     }
 

--- a/crates/duty-tracker/src/stake_chain_state_machine.rs
+++ b/crates/duty-tracker/src/stake_chain_state_machine.rs
@@ -233,13 +233,10 @@ impl StakeChainSM {
                     .get(op)
                     .ok_or(StakeChainErr::StakeTxNotFound(op.clone(), nth))?;
 
-                let prev_stake_txid =
-                    stake_txids
-                        .get(&(nth - 1))
-                        .ok_or(StakeChainErr::IncompleteStakeChainInput(
-                            op.clone(),
-                            nth - 1,
-                        ))?;
+                let prev_stake_txid = stake_txids
+                    .get(&(nth - 1))
+                    .ok_or(StakeChainErr::MissingStakeTxid(op.clone(), nth - 1))?;
+
                 let prev_input = stake_chain_inputs.stake_inputs.get(&(nth - 1)).ok_or(
                     StakeChainErr::IncompleteStakeChainInput(op.clone(), nth - 1),
                 )?;

--- a/crates/stake-chain/Cargo.toml
+++ b/crates/stake-chain/Cargo.toml
@@ -14,6 +14,7 @@ strata-bridge-primitives.workspace = true
 bitcoin = { workspace = true, features = ["rand-std"] }
 serde.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 strata-bridge-common.workspace = true

--- a/crates/stake-chain/src/stake_chain.rs
+++ b/crates/stake-chain/src/stake_chain.rs
@@ -50,6 +50,9 @@ impl StakeChain {
     ///
     /// This can be used to recreate a stake chain if the initial set of inputs are known.
     ///
+    /// NOTE: if there are discontinuities in the [`StakeChainInputs`], then only the chain fragment
+    /// till the first discontinuity is created.
+    ///
     /// # Parameters
     ///
     /// - `context`: The context to use for building the transactions.
@@ -61,21 +64,14 @@ impl StakeChain {
         stake_chain_inputs: &StakeChainInputs,
         stake_chain_params: &StakeChainParams,
     ) -> Self {
-        // Instantiate a vector with the length `M`.
         let stake_inputs = &stake_chain_inputs.stake_inputs;
-        let num_inputs = stake_inputs.len();
 
-        if num_inputs == 0 {
+        let Some(first_stake_inputs) = stake_inputs.get(&0) else {
             return Self {
                 head: None,
                 tail: vec![],
             };
-        }
-
-        let first_stake_inputs = stake_chain_inputs
-            .stake_inputs
-            .get(&0)
-            .expect("must have at least one stake input");
+        };
 
         let first_stake_tx = StakeTx::<Head>::new(
             context,
@@ -87,21 +83,15 @@ impl StakeChain {
             first_stake_inputs.operator_pubkey,
         );
 
-        if num_inputs == 1 {
+        let Some(next_stake_input) = stake_inputs.get(&1) else {
             return Self {
                 head: Some(first_stake_tx),
                 tail: vec![],
             };
-        }
+        };
 
-        let next_stake_tx = first_stake_tx.advance(
-            context,
-            stake_chain_params,
-            stake_inputs
-                .get(&1)
-                .cloned()
-                .expect("must have at least two stake inputs"),
-        );
+        let next_stake_tx =
+            first_stake_tx.advance(context, stake_chain_params, next_stake_input.clone());
 
         let num_inputs = stake_inputs.len();
         let mut tail: Vec<StakeTx<Tail>> = Vec::with_capacity(num_inputs - 1);

--- a/docker/vol/alpen-bridge-1/config.toml
+++ b/docker/vol/alpen-bridge-1/config.toml
@@ -1,6 +1,6 @@
 datadir = "/app/data"
 is_faulty = false
-nag_interval = { secs = 300, nanos = 0 }
+nag_interval = { secs = 30, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 stake_funding_pool_size = 32
 shutdown_timeout = { secs = 30, nanos = 0 }

--- a/docker/vol/alpen-bridge-2/config.toml
+++ b/docker/vol/alpen-bridge-2/config.toml
@@ -1,6 +1,6 @@
 datadir = "/app/data"
 is_faulty = false
-nag_interval = { secs = 300, nanos = 0 }
+nag_interval = { secs = 30, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 stake_funding_pool_size = 32
 shutdown_timeout = { secs = 30, nanos = 0 }

--- a/docker/vol/alpen-bridge-3/config.toml
+++ b/docker/vol/alpen-bridge-3/config.toml
@@ -1,6 +1,6 @@
 datadir = "/app/data"
 is_faulty = false
-nag_interval = { secs = 300, nanos = 0 }
+nag_interval = { secs = 30, nanos = 0 }
 min_withdrawal_fulfillment_window = 144
 stake_funding_pool_size = 32
 shutdown_timeout = { secs = 30, nanos = 0 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR fixes an issue where a node would not be able to make progress under the following circumstances:

1. The node goes down _after_ persisting a new contract but _before_ persisting the corresponding stake data.
2. While down, one or more deposit requests are made.
3. When the node comes back up, the node crashes as the lagged blocks are processed first and without the stake data (that couldn't be persisted before the crash), the deposit requests cannot be processed as the stake chain has a discontinuity.

This fix involves the following changes:

1. We now don't crash when we fail to process an ouroboros message so that we let things run their course and reach eventual consistency.
2. We also nag if the stake data is missing for a contract that has been persisted since this data is persisted separately from the contract state and may be missing.
3. We allow replacement of the stake txid in the `PegOutGraphInput` for the same reason as (2) and additionally because it is safe to do so.

Additionally, it also accounts for the case where the node remains down for entirety of the `refund_delay` such that the contract it was processing before going down is Aborted when it comes back. Handling this case is more complex and involves the following changes:

1. We now allow nagging for stake data even if the contract is in `Aborted` state. This is necessary because as reasoned above, the stake data and contract state are persisted separately and may not be in sync. Losing stake data disrupts the entire working of the bridge as it blocks future deposit processing. Similarly, we also allow receiving the `DepositSetup` message in the `Aborted` state.
2. When a stake chain is constructed from persistence, we now read the `deposit_idx` as well. If it is not contiguous, we break the construction of the stake chain. Furthermore, we now use the `stake_txids` cache to determine whether a particular stake data is available.
3. In case, the contract state is persisted before the stake data is and the `claim_txids` table in the contract state has been populated before the crash, we'll need to generate new stake data when the node comes back up. This results in a completely new graph with a different `claim_txid`. To account for this case, we now allow replacing the `claim_txid` in the `claim_txids` map. As a result, we now need to check the `claim_txid` against the `claim_txids` map instead of individual maps (`graph_nonces`, `graph_partials`).

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
See the `erase-deposit-setup` and `leak-deposit-setup` recipes to run local tests.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes STR-1588

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->