### PR TITLE
(mock-checkpoint): Fix deposit entries populating in chainstate

### DIFF
--- a/bin/mock-checkpoint/src/chainstate.rs
+++ b/bin/mock-checkpoint/src/chainstate.rs
@@ -1,5 +1,7 @@
 use arbitrary::{Arbitrary, Unstructured};
+use bitcoin::OutPoint;
 use strata_bridge_common::tracing::info;
+use strata_primitives::l1::{BitcoinAmount, OutputRef};
 use strata_state::{bridge_state::DepositEntry, chain_state::Chainstate};
 
 /// Chainstate wrapper which ensures the chainstate always has empty deposit table.
@@ -33,7 +35,22 @@ pub(crate) fn update_deposit_entries(
     let dep_table = chs.deposits_table_mut();
 
     info!("updating deposit entries in chainstate");
+    // It is important to have deposit entry of idx n to be at the nth index because the only way
+    // deposit table can be populated is by using `create_next_deposit` as done below.
+    // For this we put dummy deposit entries at other places and put corresponding deposit entries
+    // at the required index.
+    let maxidx = dep_entries
+        .iter()
+        .map(|e| e.idx())
+        .max()
+        .unwrap_or_default() as usize;
+    let mut new_entries = vec![dummy_entry(); maxidx + 1];
+
     for entry in dep_entries {
+        new_entries[entry.idx() as usize] = entry.clone();
+    }
+
+    for entry in new_entries {
         // Can only create Accepted deposit entry.
         let idx = dep_table.create_next_deposit(
             *entry.output(),
@@ -46,4 +63,11 @@ pub(crate) fn update_deposit_entries(
         dep_entry.set_withdrawal_request_txid(entry.withdrawal_request_txid());
     }
     chs
+}
+
+fn dummy_entry() -> DepositEntry {
+    let txref = OutputRef(OutPoint::null());
+    let operators = vec![0, 1, 2];
+    let amt = BitcoinAmount::from_int_btc(10);
+    DepositEntry::new(0, txref, operators, amt, None)
 }


### PR DESCRIPTION
## Description

There was a wrong assumption about how the mock deposit entries can be populated in the mock chainstate. This PR fixes that.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
