### PR TITLE
fix!(alpen-bridge): missing RPC claim information for `Resolved` contracts

### DIFF
--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -704,9 +704,10 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
                 | ContractState::Assigned { .. } => None,
 
                 // States that are terminal and do not have an active graph.
-                ContractState::Resolved { .. }
-                | ContractState::Disproved { .. }
-                | ContractState::Aborted => None,
+                ContractState::Disproved { .. } | ContractState::Aborted => None,
+
+                // However resolved contracts have a definite `claim_txid`.
+                ContractState::Resolved { claim_txid, .. } => Some(claim_txid),
             })
             .collect();
 

--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -740,19 +740,16 @@ const fn contract_state_to_reimbursement_status(state: &ContractState) -> RpcRei
         | ContractState::Assigned { .. }
         | ContractState::Fulfilled { .. }
         | ContractState::Aborted => RpcReimbursementStatus::NotStarted,
-        ContractState::Claimed { active_graph, .. } => RpcReimbursementStatus::InProgress {
+        ContractState::Claimed { .. } => RpcReimbursementStatus::InProgress {
             challenge_step: ChallengeStep::Claim,
-            claim_txid: active_graph.1.claim_txid,
         },
-        ContractState::Challenged { active_graph, .. } => RpcReimbursementStatus::Challenged {
+        ContractState::Challenged { .. } => RpcReimbursementStatus::Challenged {
             challenge_step: ChallengeStep::Challenge,
-            claim_txid: active_graph.1.claim_txid,
         },
-        ContractState::PreAssertConfirmed { active_graph, .. }
-        | ContractState::AssertDataConfirmed { active_graph, .. }
-        | ContractState::Asserted { active_graph, .. } => RpcReimbursementStatus::Challenged {
+        ContractState::PreAssertConfirmed { .. }
+        | ContractState::AssertDataConfirmed { .. }
+        | ContractState::Asserted { .. } => RpcReimbursementStatus::Challenged {
             challenge_step: ChallengeStep::Assert,
-            claim_txid: active_graph.1.claim_txid,
         },
         ContractState::Resolved { payout_txid, .. } => RpcReimbursementStatus::Complete {
             payout_txid: *payout_txid,

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -76,18 +76,12 @@ pub enum RpcReimbursementStatus {
     InProgress {
         /// Challenge step.
         challenge_step: ChallengeStep,
-
-        /// Transaction ID of the claim transaction.
-        claim_txid: Txid,
     },
 
     /// Claim exists, challenge step is "Challenge" or "Assert", no payout.
     Challenged {
         /// Challenge step.
         challenge_step: ChallengeStep,
-
-        /// Transaction ID of the claim transaction.
-        claim_txid: Txid,
     },
 
     /// Operator was slashed, claim is no longer valid.


### PR DESCRIPTION
## Description

adds `claim_txid` for `Resolved` contracts in the `claims` RPC method.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Slightly breaking because removing `claim_txid` from `RpcReimbursementStatus` since that information is already available in the `RpcClaimInfo`. Heads-up @krsnapaudel!

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1625
