### PR TITLE
github: fix links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -63,7 +63,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#code-of-conduct)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#code-of-conduct)
       options:
         - label: I agree to follow the Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: GitHub Discussions
-    url: https://github.com/alpenlabs/alpen/discussions
+    url: https://github.com/alpenlabs/strata-bridge/discussions
     about: Please ask and answer questions here to keep the issue tracker clean.


### PR DESCRIPTION
## Description

Ensures the issue templates are in line with the alpen repo and additionally fixes the links to not direct people to the alpen repo for things that can be addressed in this repo.

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

This change doesn't need to be backported since issue templates should be opened up against main anyway.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

NONE
