### PR TITLE
Fix: aggregated_nonces keyed by (txid, input_index), not operator_id

### DIFF
--- a/crates/db/src/inmemory/operator.rs
+++ b/crates/db/src/inmemory/operator.rs
@@ -38,7 +38,7 @@ pub struct OperatorDbInMemory {
     /// operator_id -> txid, input_index -> PubNonce
     pub_nonces: Arc<RwLock<OperatorIdxToTxInputNonceMap>>,
 
-    /// operator_id -> txid, input_index -> AggNonce
+    /// txid, input_index -> AggNonce
     aggregated_nonces: Arc<RwLock<TxInputToAggNonceMap>>,
 
     /// operator_id -> txid, input_index -> PartialSignature (secp256k1::schnorr::Signature)


### PR DESCRIPTION
Aligns OperatorDbInMemory field doc with trait and persistent implementation.
No logic changes; only documentation correction for clarity.