### PR TITLE
just: don't forcely install stuff

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -22,29 +22,28 @@ build:
 
 # Run unit tests
 [group('test')]
-test-unit:
-    -cargo install cargo-nextest --locked
+test-unit: ensure-cargo-nextest
     ZKVM_MOCK=1 cargo nextest run {{unit_test_args}}
 
 # Run unit tests with coverage
 [group('test')]
-cov-unit:
+cov-unit: ensure-cargo-llvm-cov ensure-cargo-nextest
     rm -f {{cov_file}}
     cargo llvm-cov nextest --lcov --output-path {{cov_file}} {{unit_test_args}}
 
 # Generate an HTML coverage report and open it in the browser
 [group('test')]
-cov-report-html:
+cov-report-html: ensure-cargo-llvm-cov ensure-cargo-nextest
     cargo llvm-cov --open nextest {{unit_test_args}}
 
 # Runs `nextest` under `cargo-mutants`. Caution: This can take *really* long to run
 [group('test')]
-mutants-test:
+mutants-test: ensure-cargo-mutants
     cargo mutants --workspace -j2
 
 # Check for security advisories on any dependencies
 [group('test')]
-sec:
+sec: ensure-cargo-audit
     cargo audit
 
 # cargo clean
@@ -116,6 +115,46 @@ fmt-check-ws:
 [group('code-quality')]
 fmt-ws:
     cargo fmt --all
+
+# Check if cargo-audit is installed
+[group('prerequisites')]
+ensure-cargo-audit:
+    #!/usr/bin/env bash
+    if ! command -v cargo-audit &> /dev/null;
+    then
+        echo "cargo-audit not found. Please install it by running the command 'cargo install cargo-audit'"
+        exit 1
+    fi
+
+# Check if cargo-llvm-cov is installed
+[group('prerequisites')]
+ensure-cargo-llvm-cov:
+    #!/usr/bin/env bash
+    if ! command -v cargo-llvm-cov &> /dev/null;
+    then
+        echo "cargo-llvm-cov not found. Please install it by running the command 'cargo install cargo-llvm-cov --locked'"
+        exit 1
+    fi
+
+# Check if cargo-mutants is installed
+[group('prerequisites')]
+ensure-cargo-mutants:
+    #!/usr/bin/env bash
+    if ! command -v cargo-mutants &> /dev/null;
+    then
+        echo "cargo-mutants not found. Please install it by running the command 'cargo install cargo-mutants'"
+        exit 1
+    fi
+
+# Check if cargo-nextest is installed
+[group('prerequisites')]
+ensure-cargo-nextest:
+    #!/usr/bin/env bash
+    if ! command -v cargo-nextest &> /dev/null;
+    then
+        echo "cargo-nextest not found. Please install it by running the command 'cargo install cargo-nextest --locked'"
+        exit 1
+    fi
 
 # Check if taplo is installed
 [group('prerequisites')]


### PR DESCRIPTION
## Description

Right now we're forcefully installing stuff in the user's environment with `cargo install` this is bad practice. We should gracefully exit if we don't detect required tools/binaries and warn the user to install it by whatever means he/she wants.

This was done partially with the aid of `gemini-cli` but verified by me.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.

## Related Issues