### PR TITLE
Backport fix (rpc): ContractState::Aborted to RpcDepositStatus::Failed

### DIFF
--- a/bin/alpen-bridge/src/rpc_server.rs
+++ b/bin/alpen-bridge/src/rpc_server.rs
@@ -453,6 +453,9 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
             if deposit_request_txid == entry_deposit_request_txid {
                 let status = match &entry.0.state.state {
                     ContractState::Requested { .. } => RpcDepositStatus::InProgress,
+                    ContractState::Aborted => RpcDepositStatus::Failed {
+                        reason: "Deadline to convert to deposit passed".to_string(),
+                    },
                     _ => RpcDepositStatus::Complete {
                         deposit_txid: entry.0.deposit_txid,
                     },

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -27,7 +27,7 @@ pub enum RpcDepositStatus {
     /// Deposit exists, but was never completed (can be reclaimed).
     Failed {
         /// Reason for the failure.
-        failure_reason: String,
+        reason: String,
     },
 
     /// Deposit has been fully processed and minted.


### PR DESCRIPTION
## Description

Backport of #268 to `releases/0.2.0`.

Fixes the RPC get_deposit_request_info by translating ContractState::Aborted to RpcDepositStatus::Failed.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
