### PR TITLE
Fix memory issue in Wots256PublicKey and Groth16PublicKeys Arbitrary implementations

### DIFF
--- a/crates/primitives/src/wots.rs
+++ b/crates/primitives/src/wots.rs
@@ -151,9 +151,14 @@ impl Arbitrary for Wots256PublicKey {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        any::<[u8; std::mem::size_of::<Wots256PublicKey>()]>()
+        any::<[u8; std::mem::size_of::<<wots256 as Wots>::PublicKey>()]>()
             .no_shrink()
-            .prop_map(|arr| unsafe { std::mem::transmute(arr) })
+            .prop_map(|arr| {
+                #[allow(clippy::missing_transmute_annotations)]
+                Wots256PublicKey(Arc::new(unsafe {
+                    std::mem::transmute::<_, <wots256 as Wots>::PublicKey>(arr)
+                }))
+            })
             .boxed()
     }
 
@@ -370,9 +375,14 @@ impl Arbitrary for Groth16PublicKeys {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        any::<[u8; std::mem::size_of::<Groth16PublicKeys>()]>()
+        any::<[u8; std::mem::size_of::<BitVmG16PublicKeys>()]>()
             .no_shrink()
-            .prop_map(|arr| unsafe { std::mem::transmute(arr) })
+            .prop_map(|arr| {
+                Groth16PublicKeys(Arc::new(unsafe {
+                    #[allow(clippy::missing_transmute_annotations)]
+                    std::mem::transmute::<_, BitVmG16PublicKeys>(arr)
+                }))
+            })
             .boxed()
     }
 


### PR DESCRIPTION
  Arbitrary implementations

## Description
* It seems there was bug in current Arbitrary implementation of `Wots256PublicKey` and  `Groth16PublicKeys`

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
