### PR TITLE
fix(docker): chmod +x binaries in runtime stage to fix Permission denied on macOS buildx

### DIFF
--- a/docker/asm-runner/Dockerfile
+++ b/docker/asm-runner/Dockerfile
@@ -26,5 +26,6 @@ COPY functional-tests/factory/common/asm_params.py /usr/local/bin/asm_params.py
 COPY functional-tests/constants.py /usr/local/bin/constants.py
 COPY docker/asm-runner/gen_asm_params.py /usr/local/bin/gen_asm_params.py
 COPY docker/asm-runner/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/strata-asm-runner /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["sh", "/usr/local/bin/entrypoint.sh"]

--- a/docker/strata-bridge/Dockerfile
+++ b/docker/strata-bridge/Dockerfile
@@ -10,12 +10,12 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/app/target \
     cargo b -r -p strata-bridge
 
-RUN --mount=type=cache,target=/app/target cp /app/target/release/strata-bridge /app/strata-bridge
+RUN --mount=type=cache,target=/app/target cp /app/target/release/strata-bridge /tmp/strata-bridge
 
 FROM --platform=linux/amd64 bridge-rt:latest AS runtime
 
 # Copy the built binaries from the builder stage
-COPY --from=builder /app/strata-bridge /usr/local/bin/strata-bridge
+COPY --from=builder /tmp/strata-bridge /usr/local/bin/strata-bridge
 COPY docker/strata-bridge/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/strata-bridge /usr/local/bin/entrypoint.sh
 

--- a/docker/strata-bridge/Dockerfile
+++ b/docker/strata-bridge/Dockerfile
@@ -17,5 +17,6 @@ FROM --platform=linux/amd64 bridge-rt:latest AS runtime
 # Copy the built binaries from the builder stage
 COPY --from=builder /app/strata-bridge /usr/local/bin/strata-bridge
 COPY docker/strata-bridge/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/strata-bridge /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["sh", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary

When building on macOS (arm64) with `docker buildx` targeting `linux/amd64`, `COPY --from=builder` does not reliably preserve the executable bit. This causes a `Permission denied` crash at container startup on EKS:

```
/usr/local/bin/entrypoint.sh: 7: /usr/local/bin/strata-bridge: Permission denied
```

Fix: explicit `chmod +x` in the runtime stage of both Dockerfiles.

## Changes

**`docker/strata-bridge/Dockerfile`**
```dockerfile
RUN chmod +x /usr/local/bin/strata-bridge /usr/local/bin/entrypoint.sh
```

**`docker/asm-runner/Dockerfile`**
```dockerfile
RUN chmod +x /usr/local/bin/strata-asm-runner /usr/local/bin/entrypoint.sh
```

## Test plan

- [ ] Build both images on macOS with `docker buildx --platform linux/amd64`
- [ ] Verify containers start without `Permission denied`
- [ ] Confirm on Linux native builds still work (chmod is a no-op there)