### PR TITLE
refactor: only store setup in ssm state

### DIFF
--- a/crates/bridge-sm/src/stake/context.rs
+++ b/crates/bridge-sm/src/stake/context.rs
@@ -4,7 +4,9 @@ use bitcoin::{OutPoint, hashes::sha256};
 use bitcoin_bosd::Descriptor;
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::{operator_table::OperatorTable, types::OperatorIdx};
-use strata_bridge_tx_graph::stake_graph::SetupParams;
+use strata_bridge_tx_graph::stake_graph::{SetupParams, StakeData};
+
+use crate::stake::config::StakeSMCfg;
 
 /// Execution context for a single instance of a Stake State Machine.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -70,6 +72,42 @@ impl StakeSMCtx {
             unstaking_image,
             unstaking_operator_descriptor: unstaking_output_desc,
             stake_funds,
+        }
+    }
+}
+
+/// Smaller version of [`StakeData`].
+///
+/// The original [`StakeData`] is obtained by adding  [`StakeSMCfg`] and [`StakeSMCtx`].
+// NOTE: (@uncomputable) This struct is almost identical to `UnstakingInput`,
+// but here the unstaking operator descriptor is of type `Descriptor`, which is validated.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MinimumStakeData {
+    /// The UTXO that funds the stake transaction.
+    pub stake_funds: OutPoint,
+    /// The unstaking hash image.
+    pub unstaking_image: sha256::Hash,
+    /// The descriptor where the operator wants to receive the unstaked funds.
+    pub unstaking_operator_desc: Descriptor,
+}
+
+impl MinimumStakeData {
+    /// Combines the [`MinimumStakeData`] with [`StakeSMCfg`] and [`StakeSMCtx`]
+    /// to obtain the original [`StakeData`].
+    pub fn expand(&self, cfg: StakeSMCfg, ctx: &StakeSMCtx) -> StakeData {
+        StakeData {
+            protocol: cfg.protocol_params,
+            setup: SetupParams {
+                operator_index: ctx.operator_idx(),
+                n_of_n_pubkey: ctx
+                    .operator_table()
+                    .aggregated_btc_key()
+                    .x_only_public_key()
+                    .0,
+                unstaking_image: self.unstaking_image,
+                unstaking_operator_descriptor: self.unstaking_operator_desc.clone(),
+                stake_funds: self.stake_funds,
+            },
         }
     }
 }

--- a/crates/bridge-sm/src/stake/handlers/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/handlers/retry_tick.rs
@@ -2,6 +2,7 @@ use strata_bridge_tx_graph::stake_graph::StakeGraph;
 
 use crate::{
     stake::{
+        config::StakeSMCfg,
         duties::StakeDuty,
         errors::SSMResult,
         machine::{SSMOutput, StakeSM},
@@ -14,10 +15,10 @@ impl StakeSM {
     /// Processes the [`RetryTickEvent`].
     ///
     /// Emits retriable duties for the current state.
-    pub(crate) fn process_retry_tick(&self) -> SSMResult<SSMOutput> {
+    pub(crate) fn process_retry_tick(&self, cfg: &StakeSMCfg) -> SSMResult<SSMOutput> {
         let duties = match self.state() {
             StakeState::UnstakingSigned { stake_data, .. } => {
-                let stake_graph = StakeGraph::new(stake_data.clone());
+                let stake_graph = StakeGraph::new(stake_data.expand(*cfg, self.context()));
                 vec![StakeDuty::PublishStake {
                     tx: stake_graph.stake.as_ref().clone(),
                 }]

--- a/crates/bridge-sm/src/stake/machine.rs
+++ b/crates/bridge-sm/src/stake/machine.rs
@@ -39,17 +39,17 @@ impl StateMachine for StakeSM {
         match event {
             StakeEvent::StakeDataReceived(event) => self.process_stake_data(&cfg, event),
             StakeEvent::UnstakingNoncesReceived(event) => {
-                self.process_unstaking_nonces_received(event)
+                self.process_unstaking_nonces_received(&cfg, event)
             }
             StakeEvent::UnstakingPartialsReceived(event) => {
-                self.process_unstaking_partials_received(event)
+                self.process_unstaking_partials_received(&cfg, event)
             }
             StakeEvent::StakeConfirmed(event) => self.process_stake_confirmed(event),
             StakeEvent::PreimageRevealed(event) => self.process_preimage_revealed(event),
             StakeEvent::UnstakingConfirmed(event) => self.process_unstaking_confirmed(event),
             StakeEvent::NewBlock(event) => self.process_new_block(cfg, event),
             StakeEvent::NagTick(NagTickEvent) => self.process_nag_tick(),
-            StakeEvent::RetryTick(RetryTickEvent) => self.process_retry_tick(),
+            StakeEvent::RetryTick(RetryTickEvent) => self.process_retry_tick(&cfg),
         }
     }
 }

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -8,7 +8,9 @@ use std::{
 use bitcoin::{Txid, secp256k1::schnorr::Signature};
 use musig2::{AggNonce, PartialSignature, PubNonce};
 use strata_bridge_primitives::types::{BitcoinBlockHeight, OperatorIdx};
-use strata_bridge_tx_graph::stake_graph::{StakeData, StakeGraph, StakeGraphSummary};
+use strata_bridge_tx_graph::stake_graph::{StakeGraph, StakeGraphSummary};
+
+use crate::stake::context::MinimumStakeData;
 
 /// The state of a Stake State Machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,7 +25,7 @@ pub enum StakeState {
         /// Latest bitcoin block height observed by the state machine.
         last_block_height: BitcoinBlockHeight,
         /// Data that is required to construct the stake graph.
-        stake_data: StakeData,
+        stake_data: MinimumStakeData,
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// Maps each operator to their public nonces.
@@ -34,7 +36,7 @@ pub enum StakeState {
         /// Latest bitcoin block height observed by the state machine.
         last_block_height: BitcoinBlockHeight,
         /// Data that is required to construct the stake graph.
-        stake_data: StakeData,
+        stake_data: MinimumStakeData,
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// Maps each operator to their public nonces.
@@ -51,7 +53,7 @@ pub enum StakeState {
         /// Latest bitcoin block height observed by the state machine.
         last_block_height: BitcoinBlockHeight,
         /// Data that is required to construct the stake graph.
-        stake_data: StakeData,
+        stake_data: MinimumStakeData,
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// 1 signature per musig transaction input.
@@ -62,7 +64,7 @@ pub enum StakeState {
         /// Latest bitcoin block height observed by the state machine.
         last_block_height: BitcoinBlockHeight,
         /// Data that is required to construct the stake graph.
-        stake_data: StakeData,
+        stake_data: MinimumStakeData,
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// 1 signature per musig transaction input.
@@ -76,7 +78,7 @@ pub enum StakeState {
         /// Latest bitcoin block height observed by the state machine.
         last_block_height: BitcoinBlockHeight,
         /// Data that is required to construct the stake graph.
-        stake_data: StakeData,
+        stake_data: MinimumStakeData,
         /// The revealed unstaking preimage.
         preimage: [u8; 32],
         /// Block height where the unstaking intent transaction was confirmed.

--- a/crates/bridge-sm/src/stake/tests/mod.rs
+++ b/crates/bridge-sm/src/stake/tests/mod.rs
@@ -33,15 +33,18 @@ use strata_bridge_test_utils::{
     bridge_fixtures::{TEST_MAGIC_BYTES, TEST_POV_IDX, random_p2tr_desc},
     prelude::generate_keypair,
 };
-use strata_bridge_tx_graph::stake_graph::{
-    ProtocolParams, SetupParams, StakeData, StakeGraph, StakeGraphSummary,
-};
+use strata_bridge_tx_graph::stake_graph::{ProtocolParams, StakeGraph, StakeGraphSummary};
 
 use crate::{
     signals::Signal,
     stake::{
-        config::StakeSMCfg, context::StakeSMCtx, duties::StakeDuty, errors::SSMError,
-        events::StakeEvent, machine::StakeSM, state::StakeState,
+        config::StakeSMCfg,
+        context::{MinimumStakeData, StakeSMCtx},
+        duties::StakeDuty,
+        errors::SSMError,
+        events::StakeEvent,
+        machine::StakeSM,
+        state::StakeState,
     },
     testing::{
         signer::TestMusigSigner,
@@ -187,24 +190,15 @@ const TEST_UNSTAKING_PREIMAGE: [u8; 32] = [0; 32];
 static TEST_UNSTAKING_OPERATOR_DESCRIPTOR: LazyLock<Descriptor> = LazyLock::new(random_p2tr_desc);
 /// UTXO that funds the stake transaction.
 static TEST_STAKE_FUNDS: LazyLock<OutPoint> = LazyLock::new(OutPoint::null);
-/// Data for the stake transaction graph.
-static TEST_STAKE_DATA: LazyLock<StakeData> = LazyLock::new(|| StakeData {
-    protocol: TEST_CFG.protocol_params,
-    setup: SetupParams {
-        operator_index: TEST_POV_IDX,
-        n_of_n_pubkey: TEST_CTX
-            .operator_table()
-            .aggregated_btc_key()
-            .x_only_public_key()
-            .0,
-        unstaking_image: sha256::Hash::hash(&TEST_UNSTAKING_PREIMAGE),
-        unstaking_operator_descriptor: TEST_UNSTAKING_OPERATOR_DESCRIPTOR.clone(),
-        stake_funds: *TEST_STAKE_FUNDS,
-    },
+/// Minimum data for the stake transaction graph.
+static TEST_STAKE_DATA: LazyLock<MinimumStakeData> = LazyLock::new(|| MinimumStakeData {
+    stake_funds: *TEST_STAKE_FUNDS,
+    unstaking_image: sha256::Hash::hash(&TEST_UNSTAKING_PREIMAGE),
+    unstaking_operator_desc: TEST_UNSTAKING_OPERATOR_DESCRIPTOR.clone(),
 });
 /// Stake transaction graph.
 static TEST_GRAPH: LazyLock<StakeGraph> =
-    LazyLock::new(|| StakeGraph::new(TEST_STAKE_DATA.clone()));
+    LazyLock::new(|| StakeGraph::new(TEST_STAKE_DATA.expand(**TEST_CFG, &TEST_CTX)));
 /// Stake transaction graph summary.
 static TEST_GRAPH_SUMMARY: LazyLock<StakeGraphSummary> = LazyLock::new(|| TEST_GRAPH.summarize());
 /// Block height of the stake transaction.

--- a/crates/bridge-sm/src/stake/tests/new_block.rs
+++ b/crates/bridge-sm/src/stake/tests/new_block.rs
@@ -134,7 +134,7 @@ fn preimage_revealed_timelock_mature() {
     let new_height = UNSTAKING_INTENT_HEIGHT + TEST_UNSTAKING_TIMELOCK + 1;
     let from_state = preimage_revealed_state(STAKE_HEIGHT, UNSTAKING_INTENT_HEIGHT);
     let expected_state = preimage_revealed_state(new_height, UNSTAKING_INTENT_HEIGHT);
-    let stake_graph = StakeGraph::new(TEST_STAKE_DATA.clone());
+    let stake_graph = TEST_GRAPH.clone();
     let stake_sig_functor = StakeFunctor::unpack(TEST_FINAL_SIGS.to_vec()).unwrap();
     let unstaking_tx = stake_graph.unstaking.finalize(stake_sig_functor.unstaking);
     test_stake_transition(StakeTransition {

--- a/crates/bridge-sm/src/stake/tests/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/retry_tick.rs
@@ -5,7 +5,7 @@ use crate::stake::{duties::StakeDuty, events::RetryTickEvent, state::StakeState}
 
 #[test]
 fn retry_publish_stake() {
-    let stake_graph = StakeGraph::new(TEST_STAKE_DATA.clone());
+    let stake_graph = TEST_GRAPH.clone();
     let from_state = StakeState::UnstakingSigned {
         last_block_height: STAKE_HEIGHT,
         stake_data: TEST_STAKE_DATA.clone(),

--- a/crates/bridge-sm/src/stake/tests/stake_data_received.rs
+++ b/crates/bridge-sm/src/stake/tests/stake_data_received.rs
@@ -58,9 +58,9 @@ fn accept_stake_data() {
     seq.process(
         TEST_CFG.clone(),
         StakeDataReceivedEvent {
-            stake_funds: TEST_STAKE_DATA.setup.stake_funds,
-            unstaking_image: TEST_STAKE_DATA.setup.unstaking_image,
-            unstaking_output_desc: TEST_STAKE_DATA.setup.unstaking_operator_descriptor.clone(),
+            stake_funds: TEST_STAKE_DATA.stake_funds,
+            unstaking_image: TEST_STAKE_DATA.unstaking_image,
+            unstaking_output_desc: TEST_STAKE_DATA.unstaking_operator_desc.clone(),
         }
         .into(),
     );
@@ -86,7 +86,6 @@ fn accept_stake_data() {
 
 #[test]
 fn reject_duplicate_data() {
-    let setup_params = TEST_STAKE_DATA.setup.clone();
     test_stake_invalid_transition(StakeInvalidTransition {
         from_state: StakeState::StakeGraphGenerated {
             last_block_height: STAKE_HEIGHT,
@@ -95,9 +94,9 @@ fn reject_duplicate_data() {
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
         },
         event: StakeDataReceivedEvent {
-            stake_funds: setup_params.stake_funds,
-            unstaking_image: setup_params.unstaking_image,
-            unstaking_output_desc: setup_params.unstaking_operator_descriptor,
+            stake_funds: TEST_STAKE_DATA.stake_funds,
+            unstaking_image: TEST_STAKE_DATA.unstaking_image,
+            unstaking_output_desc: TEST_STAKE_DATA.unstaking_operator_desc.clone(),
         }
         .into(),
         expected_error: |e| matches!(e, SSMError::Duplicate { .. }),
@@ -106,14 +105,13 @@ fn reject_duplicate_data() {
 
 #[test]
 fn reject_invalid_states() {
-    let setup_params = TEST_STAKE_DATA.setup.clone();
     for from_state in invalid_states() {
         test_stake_invalid_transition(StakeInvalidTransition {
             from_state,
             event: StakeDataReceivedEvent {
-                stake_funds: setup_params.stake_funds,
-                unstaking_image: setup_params.unstaking_image,
-                unstaking_output_desc: setup_params.unstaking_operator_descriptor.clone(),
+                stake_funds: TEST_STAKE_DATA.stake_funds,
+                unstaking_image: TEST_STAKE_DATA.unstaking_image,
+                unstaking_output_desc: TEST_STAKE_DATA.unstaking_operator_desc.clone(),
             }
             .into(),
             expected_error: |e| matches!(e, SSMError::Rejected { .. }),

--- a/crates/bridge-sm/src/stake/tests/unstaking_nonces_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_nonces_received.rs
@@ -104,7 +104,7 @@ fn accept_nonces_all_collected() {
             partial_signatures,
         } if (
         *last_block_height == STAKE_HEIGHT
-        && *stake_data == TEST_STAKE_DATA.clone()
+        && *stake_data == *TEST_STAKE_DATA
         && *summary == *TEST_GRAPH_SUMMARY
         && *pub_nonces ==  TEST_PUB_NONCES_MAP.clone()
         && *agg_nonces == TEST_AGG_NONCES.clone()

--- a/crates/bridge-sm/src/stake/transitions/new_block.rs
+++ b/crates/bridge-sm/src/stake/transitions/new_block.rs
@@ -59,7 +59,7 @@ impl StakeSM {
                 > *unstaking_intent_block_height
                     + u64::from(cfg.protocol_params.game_timelock.value())
         {
-            let stake_graph = StakeGraph::new(stake_data.clone());
+            let stake_graph = StakeGraph::new(stake_data.expand(*cfg, self.context()));
             let unstaking_sig_functor = StakeFunctor::unpack(
                 signatures
                     .expect("own signatures must be present in state")

--- a/crates/bridge-sm/src/stake/transitions/stake_data_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/stake_data_received.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
 
-use strata_bridge_tx_graph::stake_graph::{StakeData, StakeGraph};
+use strata_bridge_tx_graph::stake_graph::StakeGraph;
 
 use crate::{
     stake::{
         config::StakeSMCfg,
+        context::MinimumStakeData,
         duties::StakeDuty,
         errors::{SSMError, SSMResult},
         events::StakeDataReceivedEvent,
@@ -34,20 +35,16 @@ impl StakeSM {
                     unstaking_image,
                     unstaking_output_desc,
                 } = event;
-                let setup = self.context().generate_setup_params(
+                let stake_data = MinimumStakeData {
                     stake_funds,
                     unstaking_image,
-                    unstaking_output_desc,
-                );
-                let stake_data = StakeData {
-                    setup,
-                    protocol: cfg.protocol_params,
+                    unstaking_operator_desc: unstaking_output_desc,
                 };
-                let stake_graph = StakeGraph::new(stake_data.clone());
+                let stake_graph = StakeGraph::new(stake_data.expand(*cfg, self.context()));
 
                 self.state = StakeState::StakeGraphGenerated {
                     last_block_height: *last_block_height,
-                    stake_data: stake_data.clone(),
+                    stake_data,
                     summary: stake_graph.summarize(),
                     pub_nonces: BTreeMap::new(),
                 };

--- a/crates/bridge-sm/src/stake/transitions/unstaking_nonces_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_nonces_received.rs
@@ -7,6 +7,7 @@ use strata_bridge_tx_graph::stake_graph::StakeGraph;
 
 use crate::{
     stake::{
+        config::StakeSMCfg,
         duties::StakeDuty,
         errors::{SSMError, SSMResult},
         events::UnstakingNoncesReceivedEvent,
@@ -25,9 +26,11 @@ impl StakeSM {
     /// [`StakeDuty::PublishUnstakingPartials`].
     pub(crate) fn process_unstaking_nonces_received(
         &mut self,
+        cfg: &StakeSMCfg,
         event: UnstakingNoncesReceivedEvent,
     ) -> SSMResult<SSMOutput> {
         self.check_operator_idx(event.operator_idx, &event)?;
+        let context = self.context().clone();
 
         let n_operators = self.context().operator_table().cardinality();
 
@@ -48,12 +51,11 @@ impl StakeSM {
                     let agg_nonces = Box::new(array::from_fn(|txin_idx| {
                         AggNonce::sum(pub_nonces.values().map(|nonces| nonces[txin_idx].clone()))
                     }));
-                    let stake_data = stake_data.clone();
-                    let stake_graph = StakeGraph::new(stake_data.clone());
+                    let stake_graph = StakeGraph::new(stake_data.expand(*cfg, &context));
 
                     self.state = StakeState::UnstakingNoncesCollected {
                         last_block_height: *last_block_height,
-                        stake_data,
+                        stake_data: stake_data.clone(),
                         summary: *summary,
                         pub_nonces: pub_nonces.clone(),
                         agg_nonces: agg_nonces.clone(),

--- a/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
@@ -6,6 +6,7 @@ use strata_bridge_tx_graph::stake_graph::StakeGraph;
 
 use crate::{
     stake::{
+        config::StakeSMCfg,
         errors::{SSMError, SSMResult},
         events::UnstakingPartialsReceivedEvent,
         machine::{SSMOutput, StakeSM},
@@ -22,9 +23,11 @@ impl StakeSM {
     /// partial signatures, the machine transitions to [`StakeState::UnstakingSigned`].
     pub(crate) fn process_unstaking_partials_received(
         &mut self,
+        cfg: &StakeSMCfg,
         event: UnstakingPartialsReceivedEvent,
     ) -> SSMResult<SSMOutput> {
         self.check_operator_idx(event.operator_idx, &event)?;
+        let context = self.context().clone();
 
         let n_operators = self.context().operator_table().cardinality();
         let operator_pubkeys: Vec<_> = self
@@ -59,7 +62,7 @@ impl StakeSM {
                 let operator_pub_nonces = pub_nonces
                     .get(&event.operator_idx)
                     .expect("operator index has been validated above");
-                let stake_graph = StakeGraph::new(stake_data.clone());
+                let stake_graph = StakeGraph::new(stake_data.expand(*cfg, &context));
                 let signing_infos = stake_graph.musig_signing_info().pack();
 
                 for (txin_idx, (((signing_info, partial_sig), agg_nonce), pub_nonce)) in


### PR DESCRIPTION
## Description

This PR replaces `StakeData` in fields of `StakeState` with `SetupParams`. This reduces the size of each state.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

AI wrote most of the code, which I reviewed.

I may need to update this PR based on the discussions on Jira.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

Closes https://alpenlabs.atlassian.net/browse/STR-2935
