### PR TITLE
refactor: Use Functor in SSM States

### DIFF
--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -9,6 +9,7 @@ mod utils;
 use std::sync::Arc;
 
 use strata_bridge_sm::stake::duties::StakeDuty;
+use strata_bridge_tx_graph::musig_functor::StakeFunctor;
 
 use crate::{config::ExecutionConfig, errors::ExecutorError, output_handles::OutputHandles};
 
@@ -51,7 +52,7 @@ pub async fn execute_stake_duty(
                 **graph_inpoints,
                 **graph_tweaks,
                 **sighashes,
-                agg_nonces,
+                StakeFunctor::clone(agg_nonces),
                 ordered_pubkeys.clone(),
             )
             .await

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -21,7 +21,7 @@ use strata_bridge_primitives::{
     scripts::taproot::{TaprootTweak, create_key_spend_hash, finalize_input},
     types::OperatorIdx,
 };
-use strata_bridge_tx_graph::stake_graph::StakeGraph;
+use strata_bridge_tx_graph::musig_functor::StakeFunctor;
 use tracing::{info, warn};
 
 use crate::{
@@ -186,22 +186,20 @@ async fn sign_with_general_wallet(
 pub(crate) async fn publish_unstaking_nonces(
     output_handles: &OutputHandles,
     operator_idx: OperatorIdx,
-    graph_inpoints: [bitcoin::OutPoint; StakeGraph::N_MUSIG_INPUTS],
-    graph_tweaks: [TaprootTweak; StakeGraph::N_MUSIG_INPUTS],
+    graph_inpoints: StakeFunctor<OutPoint>,
+    graph_tweaks: StakeFunctor<TaprootTweak>,
     ordered_pubkeys: Vec<XOnlyPublicKey>,
 ) -> Result<(), ExecutorError> {
     info!(%operator_idx, "generating and publishing unstaking nonces for the stake graph");
 
     let musig_signer = output_handles.s2_client.musig2_signer();
 
-    let nonce_futures = graph_inpoints
-        .iter()
-        .zip(graph_tweaks.iter())
+    let nonce_futures = graph_inpoints.zip(graph_tweaks).into_iter()
         .map(|(inpoint, tweak)| {
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
-                tweak: *tweak,
-                input: *inpoint,
+                tweak,
+                input: inpoint,
             };
 
             musig_signer.get_pub_nonce(params).map(move |res| match res {
@@ -232,29 +230,26 @@ pub(crate) async fn publish_unstaking_nonces(
 pub(crate) async fn publish_unstaking_partials(
     output_handles: &OutputHandles,
     operator_idx: OperatorIdx,
-    graph_inpoints: [bitcoin::OutPoint; StakeGraph::N_MUSIG_INPUTS],
-    graph_tweaks: [TaprootTweak; StakeGraph::N_MUSIG_INPUTS],
-    sighashes: [Message; StakeGraph::N_MUSIG_INPUTS],
-    agg_nonces: &[AggNonce; StakeGraph::N_MUSIG_INPUTS],
+    graph_inpoints: StakeFunctor<OutPoint>,
+    graph_tweaks: StakeFunctor<TaprootTweak>,
+    sighashes: StakeFunctor<Message>,
+    agg_nonces: StakeFunctor<AggNonce>,
     ordered_pubkeys: Vec<XOnlyPublicKey>,
 ) -> Result<(), ExecutorError> {
     info!(%operator_idx, "generating and publishing unstaking partial signatures for the stake graph");
 
     let musig_signer = output_handles.s2_client.musig2_signer();
-    let partial_futures = graph_inpoints
-        .iter()
-        .zip(graph_tweaks.iter())
-        .zip(sighashes.iter())
-        .zip(agg_nonces.iter())
-        .map(|(((inpoint, tweak), sighash), agg_nonce)| {
+
+    let partial_futures = StakeFunctor::zip4(graph_inpoints, graph_tweaks, sighashes, agg_nonces)
+        .map(|(inpoint, tweak, sighash, agg_nonce)| {
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
-                tweak: *tweak,
-                input: *inpoint,
+                tweak,
+                input: inpoint,
             };
 
             musig_signer
-                .get_our_partial_sig(params, agg_nonce.clone(), *sighash.as_ref())
+                .get_our_partial_sig(params, agg_nonce, *sighash.as_ref())
                 .map(move |res| match res {
                     Ok(inner) => inner.map_err(|e| match e.to_enum() {
                         terrors::E2::A(_) => {

--- a/crates/bridge-sm/src/stake/duties.rs
+++ b/crates/bridge-sm/src/stake/duties.rs
@@ -9,7 +9,9 @@ use strata_bridge_primitives::{
     scripts::taproot::TaprootTweak,
     types::{OperatorIdx, P2POperatorPubKey},
 };
-use strata_bridge_tx_graph::{stake_graph::StakeGraph, transactions::prelude::UnstakingIntentTx};
+use strata_bridge_tx_graph::{
+    musig_functor::StakeFunctor, transactions::prelude::UnstakingIntentTx,
+};
 
 /// A duty of a Stake State Machine.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,10 +33,10 @@ pub enum StakeDuty {
 
         /// The inpoints of the unstaking transaction graph used to retrieve the musig2 session
         /// from the secret-service.
-        graph_inpoints: Box<[OutPoint; StakeGraph::N_MUSIG_INPUTS]>,
+        graph_inpoints: Box<StakeFunctor<OutPoint>>,
 
         /// The tweak required for taproot spend per input being signed.
-        graph_tweaks: Box<[TaprootTweak; StakeGraph::N_MUSIG_INPUTS]>,
+        graph_tweaks: Box<StakeFunctor<TaprootTweak>>,
 
         /// The ordered public keys of all operators for MuSig2 aggregation.
         ordered_pubkeys: Vec<XOnlyPublicKey>,
@@ -46,19 +48,19 @@ pub enum StakeDuty {
 
         /// The inpoints of the unstaking transaction graph used to retrieve the musig2 session
         /// from the secret-service.
-        graph_inpoints: Box<[OutPoint; StakeGraph::N_MUSIG_INPUTS]>,
+        graph_inpoints: Box<StakeFunctor<OutPoint>>,
 
         /// The tweak required for taproot spend per input being signed.
-        graph_tweaks: Box<[TaprootTweak; StakeGraph::N_MUSIG_INPUTS]>,
+        graph_tweaks: Box<StakeFunctor<TaprootTweak>>,
 
         /// Sighashes that need to signed.
-        sighashes: Box<[Message; StakeGraph::N_MUSIG_INPUTS]>,
+        sighashes: Box<StakeFunctor<Message>>,
 
         /// The ordered public keys of all operators for MuSig2 aggregation.
         ordered_pubkeys: Vec<XOnlyPublicKey>,
 
         /// 1 aggregated per musig transaction input.
-        agg_nonces: Box<[AggNonce; StakeGraph::N_MUSIG_INPUTS]>,
+        agg_nonces: Box<StakeFunctor<AggNonce>>,
     },
     /// Publish the unstaking intent transaction.
     PublishUnstakingIntent {

--- a/crates/bridge-sm/src/stake/events.rs
+++ b/crates/bridge-sm/src/stake/events.rs
@@ -4,7 +4,7 @@ use bitcoin::{OutPoint, Transaction, hashes::sha256};
 use bitcoin_bosd::Descriptor;
 use musig2::{PartialSignature, PubNonce};
 use strata_bridge_primitives::types::{BitcoinBlockHeight, OperatorIdx};
-use strata_bridge_tx_graph::stake_graph::StakeGraph;
+use strata_bridge_tx_graph::musig_functor::StakeFunctor;
 
 /// Event notifying that stake data has been received.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,7 +25,7 @@ pub struct UnstakingNoncesReceivedEvent {
     /// The operator who submitted the nonces.
     pub operator_idx: OperatorIdx,
     /// 1 public nonce per musig transaction input.
-    pub pub_nonces: Box<[PubNonce; StakeGraph::N_MUSIG_INPUTS]>,
+    pub pub_nonces: Box<StakeFunctor<PubNonce>>,
 }
 
 /// Event notifying that partial signatures were received from an operator.
@@ -34,7 +34,7 @@ pub struct UnstakingPartialsReceivedEvent {
     /// The operator who submitted the partial signatures.
     pub operator_idx: OperatorIdx,
     /// 1 partial signature per musig transaction input.
-    pub partial_signatures: [PartialSignature; StakeGraph::N_MUSIG_INPUTS],
+    pub partial_signatures: StakeFunctor<PartialSignature>,
 }
 
 /// Event notifying that the stake transaction has been confirmed on the bitcoin blockchain.

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -9,7 +9,10 @@ use bitcoin::{Txid, secp256k1::schnorr::Signature};
 use musig2::{AggNonce, PartialSignature, PubNonce};
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::types::{BitcoinBlockHeight, OperatorIdx};
-use strata_bridge_tx_graph::stake_graph::{StakeData, StakeGraph, StakeGraphSummary};
+use strata_bridge_tx_graph::{
+    musig_functor::StakeFunctor,
+    stake_graph::{StakeData, StakeGraphSummary},
+};
 
 /// The state of a Stake State Machine.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,7 +31,7 @@ pub enum StakeState {
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// Maps each operator to their public nonces.
-        pub_nonces: BTreeMap<OperatorIdx, [PubNonce; StakeGraph::N_MUSIG_INPUTS]>,
+        pub_nonces: BTreeMap<OperatorIdx, StakeFunctor<PubNonce>>,
     },
     /// All nonces for the stake graph have been collected.
     UnstakingNoncesCollected {
@@ -39,11 +42,11 @@ pub enum StakeState {
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// Maps each operator to their public nonces.
-        pub_nonces: BTreeMap<OperatorIdx, [PubNonce; StakeGraph::N_MUSIG_INPUTS]>,
+        pub_nonces: BTreeMap<OperatorIdx, StakeFunctor<PubNonce>>,
         /// 1 aggregated nonce per musig transaction input.
-        agg_nonces: Box<[AggNonce; StakeGraph::N_MUSIG_INPUTS]>,
+        agg_nonces: Box<StakeFunctor<AggNonce>>,
         /// Maps each operator to their partial signatures.
-        partial_signatures: BTreeMap<OperatorIdx, [PartialSignature; StakeGraph::N_MUSIG_INPUTS]>,
+        partial_signatures: BTreeMap<OperatorIdx, StakeFunctor<PartialSignature>>,
     },
     /// All presignatures for the stake graph have been collected.
     ///
@@ -56,7 +59,7 @@ pub enum StakeState {
         /// Collection of all TXIDs in the stake graph.
         summary: StakeGraphSummary,
         /// 1 signature per musig transaction input.
-        signatures: Box<[Signature; StakeGraph::N_MUSIG_INPUTS]>,
+        signatures: Box<StakeFunctor<Signature>>,
     },
     /// The stake transaction has been confirmed on the bitcoin blockchain.
     Confirmed {
@@ -70,7 +73,7 @@ pub enum StakeState {
         ///
         /// The signatures may be absent if an operator chooses to withhold their partial signature
         /// or broadcasts is too late.
-        signatures: Box<Option<[Signature; StakeGraph::N_MUSIG_INPUTS]>>,
+        signatures: Box<Option<StakeFunctor<Signature>>>,
     },
     /// The unstaking preimage has been revealed on-chain.
     PreimageRevealed {
@@ -88,7 +91,7 @@ pub enum StakeState {
         ///
         /// The signatures may be absent if an operator chose to withhold their partial signature
         /// or broadcasted it too late.
-        signatures: Box<Option<[Signature; StakeGraph::N_MUSIG_INPUTS]>>,
+        signatures: Box<Option<StakeFunctor<Signature>>>,
     },
     /// The unstaking transaction has been confirmed on the bitcoin blockchain.
     Unstaked {

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -7,11 +7,12 @@ use std::{
 
 use bitcoin::{Txid, secp256k1::schnorr::Signature};
 use musig2::{AggNonce, PartialSignature, PubNonce};
+use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::types::{BitcoinBlockHeight, OperatorIdx};
 use strata_bridge_tx_graph::stake_graph::{StakeData, StakeGraph, StakeGraphSummary};
 
 /// The state of a Stake State Machine.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StakeState {
     /// Initial state.
     Created {

--- a/crates/bridge-sm/src/stake/tests/mod.rs
+++ b/crates/bridge-sm/src/stake/tests/mod.rs
@@ -33,8 +33,9 @@ use strata_bridge_test_utils::{
     bridge_fixtures::{TEST_MAGIC_BYTES, TEST_POV_IDX, random_p2tr_desc},
     prelude::generate_keypair,
 };
-use strata_bridge_tx_graph::stake_graph::{
-    ProtocolParams, SetupParams, StakeData, StakeGraph, StakeGraphSummary,
+use strata_bridge_tx_graph::{
+    musig_functor::StakeFunctor,
+    stake_graph::{ProtocolParams, SetupParams, StakeData, StakeGraph, StakeGraphSummary},
 };
 
 use crate::{
@@ -226,84 +227,65 @@ static TEST_MUSIG_SIGNERS: LazyLock<[TestMusigSigner; TEST_N_OPERATORS]> = LazyL
     })
 });
 /// 1 signing info for each Musig transaction input in the stake graph.
-static TEST_SIGNING_INFOS: LazyLock<[SigningInfo; StakeGraph::N_MUSIG_INPUTS]> =
-    LazyLock::new(|| {
-        TEST_GRAPH
-            .musig_signing_info()
-            .pack()
-            .try_into()
-            .expect("correct number of transaction inputs")
-    });
+static TEST_SIGNING_INFOS: LazyLock<StakeFunctor<SigningInfo>> =
+    LazyLock::new(|| TEST_GRAPH.musig_signing_info());
 /// 1 key aggregation context for each Musig transaction input in the stake graph.
-static TEST_KEY_AGG_CTXS: LazyLock<[KeyAggContext; StakeGraph::N_MUSIG_INPUTS]> =
-    LazyLock::new(|| {
-        array::from_fn(|txin_idx| {
-            create_agg_ctx(
-                TEST_CTX.operator_table().btc_keys(),
-                &TEST_SIGNING_INFOS[txin_idx].tweak,
-            )
+static TEST_KEY_AGG_CTXS: LazyLock<StakeFunctor<KeyAggContext>> = LazyLock::new(|| {
+    TEST_SIGNING_INFOS.map(|info| {
+        create_agg_ctx(TEST_CTX.operator_table().btc_keys(), &info.tweak)
             .expect("must be able to build key aggregation contexts for tests")
-        })
-    });
+    })
+});
 /// Maps each operator to their public nonces.
 /// There is 1 public nonce for each Musig transaction input in the stake graph.
-static TEST_PUB_NONCES_MAP: LazyLock<BTreeMap<u32, [PubNonce; StakeGraph::N_MUSIG_INPUTS]>> =
+static TEST_PUB_NONCES_MAP: LazyLock<BTreeMap<u32, StakeFunctor<PubNonce>>> = LazyLock::new(|| {
+    TEST_MUSIG_SIGNERS
+        .iter()
+        .map(|signer| {
+            let nonces = TEST_KEY_AGG_CTXS
+                .clone()
+                .enumerate()
+                .map(|(txin_idx, ctx)| signer.pubnonce(ctx.aggregated_pubkey(), txin_idx as u64));
+            (signer.operator_idx(), nonces)
+        })
+        .collect()
+});
+/// 1 aggregated nonce for each Musig transaction input in the stake graph.
+static TEST_AGG_NONCES: LazyLock<StakeFunctor<AggNonce>> = LazyLock::new(|| {
+    StakeFunctor::sequence_functor(TEST_PUB_NONCES_MAP.values().map(StakeFunctor::as_ref))
+        .map(AggNonce::sum)
+});
+/// Maps each operator to their partial signatures.
+/// There is 1 partial signature for each Musig transaction input in the stake graph.
+static TEST_PARTIAL_SIGS_MAP: LazyLock<BTreeMap<u32, StakeFunctor<PartialSignature>>> =
     LazyLock::new(|| {
         TEST_MUSIG_SIGNERS
             .iter()
             .map(|signer| {
-                let nonces = array::from_fn(|txin_idx| {
-                    signer.pubnonce(
-                        TEST_KEY_AGG_CTXS[txin_idx].aggregated_pubkey(),
-                        txin_idx as u64,
-                    )
+                let partials = StakeFunctor::zip3(
+                    TEST_KEY_AGG_CTXS.as_ref(),
+                    TEST_AGG_NONCES.as_ref(),
+                    TEST_SIGNING_INFOS.as_ref(),
+                )
+                .enumerate()
+                .map(|(txin_idx, (ctx, agg_nonce, info))| {
+                    signer.sign(ctx, txin_idx as u64, agg_nonce, info.sighash)
                 });
-                (signer.operator_idx(), nonces)
+                (signer.operator_idx(), partials)
             })
             .collect()
     });
-/// 1 aggregated nonce for each Musig transaction input in the stake graph.
-static TEST_AGG_NONCES: LazyLock<Box<[AggNonce; StakeGraph::N_MUSIG_INPUTS]>> =
-    LazyLock::new(|| {
-        Box::new(array::from_fn(|txin_idx| {
-            AggNonce::sum(
-                TEST_PUB_NONCES_MAP
-                    .values()
-                    .map(|nonces| nonces[txin_idx].clone()),
-            )
-        }))
-    });
-/// Maps each operator to their partial signatures.
-/// There is 1 partial signature for each Musig transaction input in the stake graph.
-static TEST_PARTIAL_SIGS_MAP: LazyLock<
-    BTreeMap<u32, [PartialSignature; StakeGraph::N_MUSIG_INPUTS]>,
-> = LazyLock::new(|| {
-    TEST_MUSIG_SIGNERS
-        .iter()
-        .map(|signer| {
-            let partials = array::from_fn(|txin_idx| {
-                signer.sign(
-                    &TEST_KEY_AGG_CTXS[txin_idx],
-                    txin_idx as u64,
-                    &TEST_AGG_NONCES[txin_idx],
-                    TEST_SIGNING_INFOS[txin_idx].sighash,
-                )
-            });
-            (signer.operator_idx(), partials)
-        })
-        .collect()
-});
 /// 1 final signature for each Musig transaction input in the stake graph.
-static TEST_FINAL_SIGS: LazyLock<[Signature; StakeGraph::N_MUSIG_INPUTS]> = LazyLock::new(|| {
-    array::from_fn(|txin_idx| {
-        aggregate_partial_signatures(
-            &TEST_KEY_AGG_CTXS[txin_idx],
-            &TEST_AGG_NONCES[txin_idx],
-            TEST_PARTIAL_SIGS_MAP
-                .values()
-                .map(|operator_partial_sigs| operator_partial_sigs[txin_idx]),
-            TEST_SIGNING_INFOS[txin_idx].sighash.as_ref(),
-        )
-        .expect("test partial signatures must aggregate")
-    })
+static TEST_FINAL_SIGS: LazyLock<StakeFunctor<Signature>> = LazyLock::new(|| {
+    let partials = StakeFunctor::sequence_functor(TEST_PARTIAL_SIGS_MAP.values().cloned());
+    StakeFunctor::zip_with_4(
+        |ctx, agg_nonce, partials, info| {
+            aggregate_partial_signatures(ctx, agg_nonce, partials, info.sighash.as_ref())
+                .expect("test partial signatures must aggregate")
+        },
+        TEST_KEY_AGG_CTXS.as_ref(),
+        TEST_AGG_NONCES.as_ref(),
+        partials,
+        TEST_SIGNING_INFOS.as_ref(),
+    )
 });

--- a/crates/bridge-sm/src/stake/tests/nag_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/nag_tick.rs
@@ -91,7 +91,7 @@ fn nag_unstaking_partials() {
         stake_data: TEST_STAKE_DATA.clone(),
         summary: *TEST_GRAPH_SUMMARY,
         pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-        agg_nonces: TEST_AGG_NONCES.clone(),
+        agg_nonces: TEST_AGG_NONCES.clone().boxed(),
         partial_signatures,
     };
     let expected_state = from_state.clone();

--- a/crates/bridge-sm/src/stake/tests/new_block.rs
+++ b/crates/bridge-sm/src/stake/tests/new_block.rs
@@ -1,7 +1,5 @@
 //! Unit tests for [`StakeSM::process_new_block`].
 
-use strata_bridge_tx_graph::musig_functor::StakeFunctor;
-
 use super::*;
 use crate::stake::{duties::StakeDuty, errors::SSMError, events::NewBlockEvent, state::StakeState};
 
@@ -19,7 +17,7 @@ fn states_with_last_block_height(last_block_height: u64) -> [StakeState; 6] {
             stake_data: TEST_STAKE_DATA.clone(),
             summary: *TEST_GRAPH_SUMMARY,
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-            agg_nonces: TEST_AGG_NONCES.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
             partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
         },
         StakeState::UnstakingSigned {
@@ -135,8 +133,7 @@ fn preimage_revealed_timelock_mature() {
     let from_state = preimage_revealed_state(STAKE_HEIGHT, UNSTAKING_INTENT_HEIGHT);
     let expected_state = preimage_revealed_state(new_height, UNSTAKING_INTENT_HEIGHT);
     let stake_graph = StakeGraph::new(TEST_STAKE_DATA.clone());
-    let stake_sig_functor = StakeFunctor::unpack(TEST_FINAL_SIGS.to_vec()).unwrap();
-    let unstaking_tx = stake_graph.unstaking.finalize(stake_sig_functor.unstaking);
+    let unstaking_tx = stake_graph.unstaking.finalize(TEST_FINAL_SIGS.unstaking);
     test_stake_transition(StakeTransition {
         from_state,
         event: NewBlockEvent {

--- a/crates/bridge-sm/src/stake/tests/preimage_revealed.rs
+++ b/crates/bridge-sm/src/stake/tests/preimage_revealed.rs
@@ -53,7 +53,7 @@ fn invalid_states() -> [StakeState; 4] {
             stake_data: TEST_STAKE_DATA.clone(),
             summary: *TEST_GRAPH_SUMMARY,
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-            agg_nonces: TEST_AGG_NONCES.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
             partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
         },
         StakeState::UnstakingSigned {
@@ -77,7 +77,7 @@ fn unstaking_intent_tx() -> Transaction {
         .unstaking_intent
         .clone()
         .finalize(&UnstakingIntentWitness {
-            n_of_n_signature: TEST_FINAL_SIGS[0],
+            n_of_n_signature: TEST_FINAL_SIGS.unstaking_intent[0],
             unstaking_preimage: TEST_UNSTAKING_PREIMAGE,
         })
 }

--- a/crates/bridge-sm/src/stake/tests/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/retry_tick.rs
@@ -42,7 +42,7 @@ fn retry_nothing() {
             stake_data: TEST_STAKE_DATA.clone(),
             summary: *TEST_GRAPH_SUMMARY,
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-            agg_nonces: TEST_AGG_NONCES.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
             partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
         },
         StakeState::Confirmed {

--- a/crates/bridge-sm/src/stake/tests/stake_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/stake_confirmed.rs
@@ -18,7 +18,7 @@ fn nonces_collected_state() -> StakeState {
         stake_data: TEST_STAKE_DATA.clone(),
         summary: *TEST_GRAPH_SUMMARY,
         pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-        agg_nonces: TEST_AGG_NONCES.clone(),
+        agg_nonces: TEST_AGG_NONCES.clone().boxed(),
         partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
     }
 }

--- a/crates/bridge-sm/src/stake/tests/stake_data_received.rs
+++ b/crates/bridge-sm/src/stake/tests/stake_data_received.rs
@@ -15,7 +15,7 @@ fn invalid_states() -> [StakeState; 5] {
             stake_data: TEST_STAKE_DATA.clone(),
             summary: *TEST_GRAPH_SUMMARY,
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-            agg_nonces: TEST_AGG_NONCES.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
             partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
         },
         StakeState::UnstakingSigned {

--- a/crates/bridge-sm/src/stake/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/stake/tests/tx_classifier.rs
@@ -23,7 +23,7 @@ fn unstaking_nonces_collected_state() -> StakeState {
         stake_data: TEST_STAKE_DATA.clone(),
         summary: *TEST_GRAPH_SUMMARY,
         pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-        agg_nonces: TEST_AGG_NONCES.clone(),
+        agg_nonces: TEST_AGG_NONCES.clone().boxed(),
         partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
     }
 }

--- a/crates/bridge-sm/src/stake/tests/unstaking_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_confirmed.rs
@@ -32,7 +32,7 @@ fn invalid_states() -> [StakeState; 5] {
             stake_data: TEST_STAKE_DATA.clone(),
             summary: *TEST_GRAPH_SUMMARY,
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-            agg_nonces: TEST_AGG_NONCES.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
             partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
         },
         StakeState::UnstakingSigned {
@@ -54,7 +54,7 @@ fn unstaking_tx() -> Transaction {
     TEST_GRAPH
         .unstaking
         .clone()
-        .finalize([TEST_FINAL_SIGS[1], TEST_FINAL_SIGS[2]])
+        .finalize(TEST_FINAL_SIGS.unstaking)
 }
 
 #[test]

--- a/crates/bridge-sm/src/stake/tests/unstaking_nonces_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_nonces_received.rs
@@ -9,9 +9,7 @@ use crate::{
     testing::EventSequence,
 };
 
-fn stake_graph_generated_state(
-    pub_nonces: BTreeMap<u32, [PubNonce; StakeGraph::N_MUSIG_INPUTS]>,
-) -> StakeState {
+fn stake_graph_generated_state(pub_nonces: BTreeMap<u32, StakeFunctor<PubNonce>>) -> StakeState {
     StakeState::StakeGraphGenerated {
         last_block_height: STAKE_HEIGHT,
         stake_data: TEST_STAKE_DATA.clone(),
@@ -20,7 +18,7 @@ fn stake_graph_generated_state(
     }
 }
 
-fn operator_pub_nonces(operator_idx: u32) -> [PubNonce; StakeGraph::N_MUSIG_INPUTS] {
+fn operator_pub_nonces(operator_idx: u32) -> StakeFunctor<PubNonce> {
     TEST_PUB_NONCES_MAP[&operator_idx].clone()
 }
 
@@ -104,17 +102,17 @@ fn accept_nonces_all_collected() {
             partial_signatures,
         } if (
         *last_block_height == STAKE_HEIGHT
-        && *stake_data == TEST_STAKE_DATA.clone()
+        && *stake_data == *TEST_STAKE_DATA
         && *summary == *TEST_GRAPH_SUMMARY
-        && *pub_nonces ==  TEST_PUB_NONCES_MAP.clone()
-        && *agg_nonces == TEST_AGG_NONCES.clone()
+        && *pub_nonces ==  *TEST_PUB_NONCES_MAP
+        && **agg_nonces == *TEST_AGG_NONCES
         && partial_signatures.is_empty()
     )));
 
     let duties = seq.all_duties();
     assert!(
         matches!(duties.as_slice(), [StakeDuty::PublishUnstakingPartials { operator_idx, agg_nonces, .. }] if {
-            *operator_idx == TEST_CTX.operator_idx() && *agg_nonces == TEST_AGG_NONCES.clone()
+            *operator_idx == TEST_CTX.operator_idx() && **agg_nonces == *TEST_AGG_NONCES
         })
     );
 }
@@ -152,7 +150,7 @@ fn reject_duplicate_in_collected_nonces() {
             last_block_height: STAKE_HEIGHT,
             stake_data: TEST_STAKE_DATA.clone(),
             pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-            agg_nonces: TEST_AGG_NONCES.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
             summary: *TEST_GRAPH_SUMMARY,
             partial_signatures: BTreeMap::new(),
         },

--- a/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
@@ -3,18 +3,18 @@
 use super::*;
 use crate::stake::{errors::SSMError, events::UnstakingPartialsReceivedEvent, state::StakeState};
 
-fn operator_partial_sigs(operator_idx: u32) -> [PartialSignature; StakeGraph::N_MUSIG_INPUTS] {
+fn operator_partial_sigs(operator_idx: u32) -> StakeFunctor<PartialSignature> {
     TEST_PARTIAL_SIGS_MAP[&operator_idx]
 }
 
 fn nonces_collected_state(
-    partial_signatures: BTreeMap<u32, [PartialSignature; StakeGraph::N_MUSIG_INPUTS]>,
+    partial_signatures: BTreeMap<u32, StakeFunctor<PartialSignature>>,
 ) -> StakeState {
     StakeState::UnstakingNoncesCollected {
         last_block_height: STAKE_HEIGHT,
         stake_data: TEST_STAKE_DATA.clone(),
         pub_nonces: TEST_PUB_NONCES_MAP.clone(),
-        agg_nonces: TEST_AGG_NONCES.clone(),
+        agg_nonces: TEST_AGG_NONCES.clone().boxed(),
         summary: *TEST_GRAPH_SUMMARY,
         partial_signatures,
     }

--- a/crates/bridge-sm/src/stake/transitions/new_block.rs
+++ b/crates/bridge-sm/src/stake/transitions/new_block.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use strata_bridge_tx_graph::{musig_functor::StakeFunctor, stake_graph::StakeGraph};
+use strata_bridge_tx_graph::stake_graph::StakeGraph;
 
 use crate::{
     stake::{
@@ -60,12 +60,8 @@ impl StakeSM {
                     + u64::from(cfg.protocol_params.game_timelock.value())
         {
             let stake_graph = StakeGraph::new(stake_data.clone());
-            let unstaking_sig_functor = StakeFunctor::unpack(
-                signatures
-                    .expect("own signatures must be present in state")
-                    .to_vec(),
-            )
-            .expect("signatures already in state must be valid");
+            let unstaking_sig_functor =
+                signatures.expect("own signatures must be present in state");
             let unstaking_tx = stake_graph
                 .unstaking
                 .finalize(unstaking_sig_functor.unstaking);

--- a/crates/bridge-sm/src/stake/transitions/stake_data_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/stake_data_received.rs
@@ -52,20 +52,11 @@ impl StakeSM {
                     pub_nonces: BTreeMap::new(),
                 };
 
-                let graph_inpoints = stake_graph
-                    .musig_inpoints()
-                    .pack()
-                    .try_into()
-                    .expect("number of musig inputs is correct by construction");
-
+                let graph_inpoints = stake_graph.musig_inpoints().boxed();
                 let graph_tweaks = stake_graph
                     .musig_signing_info()
-                    .pack()
-                    .iter()
-                    .map(|m| m.tweak)
-                    .collect::<Vec<_>>()
-                    .try_into()
-                    .expect("number of musig inputs is correct by construction");
+                    .map(|info| info.tweak)
+                    .boxed();
 
                 let ordered_pubkeys = self
                     .context()

--- a/crates/bridge-sm/src/stake/transitions/unstaking_nonces_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_nonces_received.rs
@@ -1,9 +1,7 @@
-use std::{array, collections::BTreeMap};
+use std::collections::BTreeMap;
 
-use bitcoin::secp256k1::Message;
 use musig2::AggNonce;
-use strata_bridge_primitives::scripts::taproot::TaprootTweak;
-use strata_bridge_tx_graph::stake_graph::StakeGraph;
+use strata_bridge_tx_graph::{musig_functor::StakeFunctor, stake_graph::StakeGraph};
 
 use crate::{
     stake::{
@@ -45,9 +43,12 @@ impl StakeSM {
                 pub_nonces.insert(event.operator_idx, *event.pub_nonces);
 
                 if pub_nonces.len() == n_operators {
-                    let agg_nonces = Box::new(array::from_fn(|txin_idx| {
-                        AggNonce::sum(pub_nonces.values().map(|nonces| nonces[txin_idx].clone()))
-                    }));
+                    let agg_nonces = StakeFunctor::sequence_functor(
+                        pub_nonces.values().map(StakeFunctor::as_ref),
+                    )
+                    .map(AggNonce::sum)
+                    .boxed();
+
                     let stake_data = stake_data.clone();
                     let stake_graph = StakeGraph::new(stake_data.clone());
 
@@ -60,24 +61,13 @@ impl StakeSM {
                         partial_signatures: BTreeMap::new(),
                     };
 
-                    let graph_inpoints = stake_graph
-                        .musig_inpoints()
-                        .pack()
-                        .try_into()
-                        .expect("number of musig inputs is correct by construction");
-
-                    let (graph_tweaks, sighashes): (Vec<TaprootTweak>, Vec<Message>) = stake_graph
+                    let graph_inpoints = stake_graph.musig_inpoints().boxed();
+                    let (graph_tweaks, sighashes) = stake_graph
                         .musig_signing_info()
-                        .pack()
-                        .iter()
                         .map(|m| (m.tweak, m.sighash))
                         .unzip();
-                    let graph_tweaks = graph_tweaks
-                        .try_into()
-                        .expect("number of musig inputs is correct by construction");
-                    let sighashes = sighashes
-                        .try_into()
-                        .expect("number of musig inputs is correct by construction");
+                    let graph_tweaks = graph_tweaks.boxed();
+                    let sighashes = sighashes.boxed();
 
                     let ordered_pubkeys = self
                         .context()

--- a/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
@@ -62,13 +62,15 @@ impl StakeSM {
                 let signing_infos = stake_graph.musig_signing_info();
                 let agg_nonces_functor = agg_nonces.as_ref().clone();
 
-                for (txin_idx, (((signing_info, partial_sig), agg_nonce), pub_nonce)) in
-                    signing_infos
-                        .zip(event.partial_signatures)
-                        .zip(agg_nonces_functor)
-                        .zip(operator_pub_nonces)
-                        .into_iter()
-                        .enumerate()
+                for (txin_idx, (signing_info, partial_sig, agg_nonce, pub_nonce)) in
+                    StakeFunctor::zip4(
+                        signing_infos,
+                        event.partial_signatures,
+                        agg_nonces_functor,
+                        operator_pub_nonces,
+                    )
+                    .into_iter()
+                    .enumerate()
                 {
                     let key_agg_ctx =
                         create_agg_ctx(operator_pubkeys.iter().copied(), &signing_info.tweak)

--- a/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
@@ -1,8 +1,6 @@
-use std::array;
-
 use musig2::{aggregate_partial_signatures, verify_partial};
 use strata_bridge_primitives::key_agg::create_agg_ctx;
-use strata_bridge_tx_graph::stake_graph::StakeGraph;
+use strata_bridge_tx_graph::{musig_functor::StakeFunctor, stake_graph::StakeGraph};
 
 use crate::{
     stake::{
@@ -58,16 +56,18 @@ impl StakeSM {
 
                 let operator_pub_nonces = pub_nonces
                     .get(&event.operator_idx)
-                    .expect("operator index has been validated above");
+                    .expect("operator index has been validated above")
+                    .clone();
                 let stake_graph = StakeGraph::new(stake_data.clone());
-                let signing_infos = stake_graph.musig_signing_info().pack();
+                let signing_infos = stake_graph.musig_signing_info();
+                let agg_nonces_functor = agg_nonces.as_ref().clone();
 
                 for (txin_idx, (((signing_info, partial_sig), agg_nonce), pub_nonce)) in
                     signing_infos
-                        .iter()
-                        .zip(event.partial_signatures.iter().copied())
-                        .zip(agg_nonces.iter())
-                        .zip(operator_pub_nonces.iter())
+                        .zip(event.partial_signatures)
+                        .zip(agg_nonces_functor)
+                        .zip(operator_pub_nonces)
+                        .into_iter()
                         .enumerate()
                 {
                     let key_agg_ctx =
@@ -77,9 +77,9 @@ impl StakeSM {
                     if verify_partial(
                         &key_agg_ctx,
                         partial_sig,
-                        agg_nonce,
+                        &agg_nonce,
                         current_operator_pubkey,
-                        pub_nonce,
+                        &pub_nonce,
                         signing_info.sighash.as_ref(),
                     )
                     .is_err()
@@ -98,24 +98,35 @@ impl StakeSM {
                 partial_signatures.insert(event.operator_idx, event.partial_signatures);
 
                 if partial_signatures.len() == n_operators {
-                    let signatures = Box::new(array::from_fn(|txin_idx| {
-                        let signing_info = &signing_infos[txin_idx];
-                        let key_agg_ctx =
-                            create_agg_ctx(operator_pubkeys.iter().copied(), &signing_info.tweak)
+                    let (contexts, sighashes) = stake_graph
+                        .musig_signing_info()
+                        .map(|info| {
+                            let ctx = create_agg_ctx(operator_pubkeys.iter().copied(), &info.tweak)
                                 .expect("must be able to create key aggregation context");
 
-                        aggregate_partial_signatures(
-                            &key_agg_ctx,
-                            &agg_nonces[txin_idx],
-                            partial_signatures
-                                .values()
-                                .map(|partial_sigs_single_operator| {
-                                    partial_sigs_single_operator[txin_idx]
-                                }),
-                            signing_info.sighash.as_ref(),
-                        )
-                        .expect("partial signatures have been checked to be valid")
-                    }));
+                            (ctx, info.sighash)
+                        })
+                        .unzip();
+                    let agg_nonces_functor = StakeFunctor::as_ref(agg_nonces);
+                    let partials =
+                        StakeFunctor::sequence_functor(partial_signatures.values().copied());
+
+                    let signatures = StakeFunctor::zip_with_4(
+                        |ctx, agg_nonce, partial_sigs_single_op, sighash| {
+                            aggregate_partial_signatures(
+                                &ctx,
+                                agg_nonce,
+                                partial_sigs_single_op,
+                                sighash.as_ref(),
+                            )
+                            .expect("partial signatures have been checked to be valid")
+                        },
+                        contexts,
+                        agg_nonces_functor,
+                        partials,
+                        sighashes,
+                    )
+                    .boxed();
 
                     self.state = StakeState::UnstakingSigned {
                         last_block_height: *last_block_height,

--- a/crates/tx-graph/src/musig_functor.rs
+++ b/crates/tx-graph/src/musig_functor.rs
@@ -553,7 +553,7 @@ impl<A> StakeFunctor<A> {
     }
 
     /// Attempts to create a new functor from a vector.
-    pub fn unpack(packed: Vec<A>) -> Option<Self> {
+    pub fn unpack<I: IntoIterator<Item = A>>(packed: I) -> Option<Self> {
         let mut cursor = packed.into_iter();
         let inner = FunctorInner::<STAKE_SINGLE_LEN, 0, A> {
             fields: take_array(&mut cursor)?,
@@ -561,6 +561,11 @@ impl<A> StakeFunctor<A> {
         };
 
         Some(Self::from_inner(inner))
+    }
+
+    /// Moves the functor into a [`Box`].
+    pub fn boxed(self) -> Box<Self> {
+        Box::new(self)
     }
 
     /// Converts a reference to a functor into a functor of references.
@@ -678,9 +683,20 @@ impl<A> StakeFunctor<A> {
     }
 
     /// Converts a vector of functors into a functor of vectors.
-    pub fn sequence_functor(vec_self: Vec<StakeFunctor<A>>) -> StakeFunctor<Vec<A>> {
-        let inners = vec_self.into_iter().map(StakeFunctor::into_inner).collect();
+    pub fn sequence_functor<I: IntoIterator<Item = Self>>(functors: I) -> StakeFunctor<Vec<A>> {
+        let inners = functors.into_iter().map(StakeFunctor::into_inner).collect();
         StakeFunctor::from_inner(StakeFunctorInner::sequence_functor(inners))
+    }
+
+    /// Returns a functor where each value knows its index.
+    pub fn enumerate(self) -> StakeFunctor<(usize, A)> {
+        let [a] = self.unstaking_intent;
+        let [b, c] = self.unstaking;
+
+        StakeFunctor {
+            unstaking_intent: [(0, a)],
+            unstaking: [(1, b), (2, c)],
+        }
     }
 }
 
@@ -702,6 +718,18 @@ impl<A: Clone> StakeFunctor<&A> {
 impl<A: Semigroup> Semigroup for StakeFunctor<A> {
     fn merge(self, other: Self) -> Self {
         StakeFunctor::zip_with(A::merge, self, other)
+    }
+}
+
+impl<A> IntoIterator for StakeFunctor<A> {
+    type Item = A;
+    type IntoIter = std::iter::Chain<
+        <[A; UnstakingIntentTx::N_INPUTS] as IntoIterator>::IntoIter,
+        <[A; UnstakingTx::N_INPUTS] as IntoIterator>::IntoIter,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.unstaking_intent.into_iter().chain(self.unstaking)
     }
 }
 

--- a/crates/tx-graph/src/musig_functor.rs
+++ b/crates/tx-graph/src/musig_functor.rs
@@ -542,14 +542,9 @@ impl<A> StakeFunctor<A> {
         }
     }
 
-    /// Consumes the functor and returns its data as a vector.
-    pub fn pack(self) -> Vec<A> {
-        let mut packed = Vec::with_capacity(STAKE_SINGLE_LEN);
-        let inner = self.into_inner();
-        packed.extend(inner.fields);
-
-        debug_assert_eq!(packed.len(), STAKE_SINGLE_LEN);
-        packed
+    /// Consumes the functor and returns its data as an array.
+    pub fn pack(self) -> [A; STAKE_SINGLE_LEN] {
+        self.into_inner().fields
     }
 
     /// Attempts to create a new functor from a vector.
@@ -690,13 +685,10 @@ impl<A> StakeFunctor<A> {
 
     /// Returns a functor where each value knows its index.
     pub fn enumerate(self) -> StakeFunctor<(usize, A)> {
-        let [a] = self.unstaking_intent;
-        let [b, c] = self.unstaking;
-
-        StakeFunctor {
-            unstaking_intent: [(0, a)],
-            unstaking: [(1, b), (2, c)],
-        }
+        let mut fields = self.pack().into_iter().enumerate();
+        let enumerated_fields: [(usize, A); STAKE_SINGLE_LEN] =
+            array::from_fn(|_| fields.next().unwrap());
+        StakeFunctor::unpack(enumerated_fields).expect("correct number of elements")
     }
 }
 

--- a/crates/tx-graph/src/stake_graph.rs
+++ b/crates/tx-graph/src/stake_graph.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// Data that is needed to construct a [`StakeGraph`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StakeData {
     /// Parameters that are inherent from the protocol.
     pub protocol: ProtocolParams,
@@ -30,7 +30,7 @@ pub struct StakeData {
 }
 
 /// Parameters that are known at setup time.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SetupParams {
     /// Operator index.
     pub operator_index: u32,
@@ -69,7 +69,7 @@ pub struct StakeGraph {
 }
 
 /// Collection of the IDs of all transactions of a [`StakeGraph`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StakeGraphSummary {
     /// ID of the stake transaction.
     pub stake: Txid,


### PR DESCRIPTION
## Description

This PR replaces `[T; StakeGraph::N_MUSIG_INPUTS]` with `StakeFunctor<T>` in the SSM implementation. This change gives us stronger compile-time guarantees and it prevents unnecessary conversions between `Vec<T>`, `[T; N]` and `StakeFunctor<T>`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

AI was used for some autocompletion. I wrote most of the code myself.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues
