### PR TITLE
chore(deps): update vuln deps and ignore those with pending upsteam fixes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,11 @@ ignore = [
 
   # lru 0.12.5 pulled by sp1-prover. Blocked on sp1 upstream.
   "RUSTSEC-2026-0002",
+
+  # rustls-webpki 0.101.7 pulled by bitreq (via bitcoind-async-client).
+  # bitreq still depends on rustls 0.21 which requires 0.101.x; fix needs >=0.103.12.
+  # Low risk: only used for bitcoind RPC connections to known/trusted endpoints.
+  # Upstream fix: https://github.com/rust-bitcoin/corepc/pull/536
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,9 +1790,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf88316bfce42d7db313826acfa4325857c085e26f163c3e8c1cfb38fef4007"
+checksum = "08221cf31c5f00fb6fc8fa697cea54176b06801a518bd9d3482aa27099827a3a"
 dependencies = [
  "rustls 0.21.12",
  "rustls-webpki 0.101.7",
@@ -2178,7 +2178,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4479,7 +4479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.1",
- "windows-targets 0.53.5",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4865,7 +4865,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.28",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "thiserror 2.0.18",
  "x509-parser",
  "yasna",
@@ -6155,7 +6155,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.28",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6713,7 +6713,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -6763,7 +6763,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -6784,7 +6784,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
@@ -6809,9 +6809,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9602,7 +9602,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR updates some of the new external deps vulnerabilities flagged by `cargo-audit`. The `rustls` vulnerability has been whitelisted as the [upstream fix](https://github.com/rust-bitcoin/corepc/pull/536) is pending.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
This blocks the rest of the PRs since the `supply-chain` CI is failing.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->