### PR TITLE
refactor(orchestrator): update block-processing granularity to be tx level

### DIFF
--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -159,3 +159,177 @@ impl<'a> Applicator<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use strata_bridge_primitives::types::GraphIdx;
+    use strata_bridge_sm::{
+        deposit::events::{DepositEvent, NewBlockEvent as DepositNewBlock},
+        graph::events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+    };
+
+    use super::*;
+    use crate::testing::{
+        INITIAL_BLOCK_HEIGHT, N_TEST_OPERATORS, test_empty_registry, test_populated_registry,
+    };
+
+    // ===== apply_batch basic tests =====
+
+    #[test]
+    fn empty_batch_yields_no_duties_and_no_touched_sms() {
+        let mut registry = test_populated_registry(1);
+        let mut applicator = Applicator::new(&mut registry);
+
+        applicator.apply_batch(vec![]).unwrap();
+
+        let (duties, tracker) = applicator.finish();
+        assert!(duties.is_empty());
+        assert!(tracker.into_batches().is_empty());
+    }
+
+    #[test]
+    fn applied_event_marks_sm_as_touched() {
+        let mut registry = test_populated_registry(1);
+        let height = INITIAL_BLOCK_HEIGHT + 1;
+
+        let mut applicator = Applicator::new(&mut registry);
+
+        let seed_events = vec![(
+            SMId::Deposit(0),
+            SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                block_height: height,
+            }))),
+        )];
+
+        applicator.apply_batch(seed_events).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        assert!(!batches.is_empty(), "applied event must mark SM as touched");
+    }
+
+    #[test]
+    fn applied_graph_event_marks_sm_as_touched() {
+        let mut registry = test_populated_registry(1);
+        let height = INITIAL_BLOCK_HEIGHT + 1;
+
+        let graph_idx = GraphIdx {
+            deposit: 0,
+            operator: 0,
+        };
+
+        let mut applicator = Applicator::new(&mut registry);
+
+        let seed_events = vec![(
+            SMId::Graph(graph_idx),
+            SMEvent::Graph(Box::new(GraphEvent::NewBlock(GraphNewBlock {
+                block_height: height,
+            }))),
+        )];
+
+        applicator.apply_batch(seed_events).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        assert!(!batches.is_empty());
+    }
+
+    #[test]
+    fn successive_batches_accumulate_touched_sms() {
+        let mut registry = test_populated_registry(2);
+        let height = INITIAL_BLOCK_HEIGHT + 1;
+
+        let mut applicator = Applicator::new(&mut registry);
+
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(0),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: height,
+                }))),
+            )])
+            .unwrap();
+
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(1),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: height,
+                }))),
+            )])
+            .unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let all_ids: BTreeSet<_> = tracker.into_batches().into_iter().flatten().collect();
+        assert!(all_ids.contains(&SMId::Deposit(0)));
+        assert!(all_ids.contains(&SMId::Deposit(1)));
+    }
+
+    // ===== Error handling tests =====
+
+    #[test]
+    fn unknown_sm_id_is_fatal() {
+        let mut registry = test_empty_registry();
+        let mut applicator = Applicator::new(&mut registry);
+
+        let seed_events = vec![(
+            SMId::Deposit(99),
+            SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                block_height: 200,
+            }))),
+        )];
+
+        let result = applicator.apply_batch(seed_events);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_event_is_ignored_non_fatally() {
+        let mut registry = test_populated_registry(1);
+        let mut applicator = Applicator::new(&mut registry);
+
+        let event = || {
+            (
+                SMId::Deposit(0),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: INITIAL_BLOCK_HEIGHT + 1,
+                }))),
+            )
+        };
+
+        applicator.apply_batch(vec![event()]).unwrap();
+        // Same height again — duplicate, should not fail
+        applicator.apply_batch(vec![event()]).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        assert!(!tracker.into_batches().is_empty());
+    }
+
+    // ===== Registry access between batches =====
+
+    #[test]
+    fn registry_reflects_settled_state_between_batches() {
+        let mut registry = test_populated_registry(1);
+        let mut applicator = Applicator::new(&mut registry);
+
+        assert_eq!(applicator.registry().num_deposits(), 1);
+        assert_eq!(
+            applicator.registry().get_graph_ids().len(),
+            N_TEST_OPERATORS
+        );
+
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(0),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: INITIAL_BLOCK_HEIGHT + 1,
+                }))),
+            )])
+            .unwrap();
+
+        // Registry still accessible and consistent after batch
+        assert_eq!(applicator.registry().num_deposits(), 1);
+    }
+}

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -78,14 +78,19 @@ impl<'a> Applicator<'a> {
         &mut self,
         seed_events: impl IntoIterator<Item = (SMId, SMEvent)>,
     ) -> Result<(), PipelineError> {
+        // Snapshot the duty count before this batch so we only fabricate follow-up events for
+        // duties produced by *this* batch, not duties accumulated from earlier batches.
+        let duties_before = self.duties.len();
+
         // Process initial seed events
         for (sm_id, sm_event) in seed_events {
             self.apply_one(sm_id, sm_event)?;
         }
 
-        // Fabricate follow-up events for any VerifyAdaptors duties produced by this batch
-        let fabricated: Vec<_> = self
-            .duties
+        // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2669>
+        // Remove this fabrication once adaptor verification is handled properly by the GSM.
+        // Fabricate follow-up events only for VerifyAdaptors duties produced by this batch.
+        let fabricated: Vec<_> = self.duties[duties_before..]
             .iter()
             .filter_map(|duty| {
                 if let UnifiedDuty::Graph(GraphDuty::VerifyAdaptors { graph_idx, .. }) = duty {

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -1,0 +1,161 @@
+//! The fixed-point batch processor for state machine events.
+//!
+//! The [`Applicator`] owns the STF execution, signal cascade, duty accumulation, and persistence
+//! tracking logic. It provides a single entry point ([`apply_batch`](Applicator::apply_batch)) that
+//! processes a set of seed events to a fixed point — all signals are drained and no intermediate
+//! state is externally visible until the batch settles.
+//!
+//! Both on-chain (per-transaction) and off-chain (per-event) paths use the same `Applicator`,
+//! ensuring uniform batch semantics across the pipeline.
+
+use std::collections::VecDeque;
+
+use strata_bridge_sm::graph::{
+    duties::GraphDuty,
+    events::{AdaptorsVerifiedEvent, GraphEvent},
+};
+use tracing::{info, warn};
+
+use crate::{
+    errors::PipelineError,
+    persister::PersistenceTracker,
+    signals_router,
+    sm_registry::{IgnoredEventReason, ProcessOutcome, SMRegistry},
+    sm_types::{SMEvent, SMId, UnifiedDuty},
+};
+
+/// A fixed-point batch processor that drives state machine transitions and signal cascades.
+///
+/// Created once per top-level event (off-chain) or once per block (on-chain), the `Applicator`
+/// accumulates duties and tracks persistence across one or more [`apply_batch`](Self::apply_batch)
+/// calls, then yields its results via [`finish`](Self::finish).
+#[expect(missing_debug_implementations)]
+pub struct Applicator<'a> {
+    registry: &'a mut SMRegistry,
+    tracker: PersistenceTracker,
+    duties: Vec<UnifiedDuty>,
+    signal_queue: VecDeque<(SMId, SMEvent)>,
+}
+
+impl<'a> Applicator<'a> {
+    /// Creates a new `Applicator` bound to the given registry.
+    pub fn new(registry: &'a mut SMRegistry) -> Self {
+        Self {
+            registry,
+            tracker: PersistenceTracker::new(),
+            duties: Vec::new(),
+            signal_queue: VecDeque::new(),
+        }
+    }
+
+    /// Returns a shared reference to the underlying registry.
+    ///
+    /// This is safe to call between `apply_batch` calls to inspect settled state (e.g., to derive
+    /// the active operator snapshot before classifying the next transaction in a block).
+    pub const fn registry(&self) -> &SMRegistry {
+        self.registry
+    }
+
+    /// Returns a mutable reference to the underlying registry.
+    ///
+    /// Needed by callers that must mutate the registry between batches (e.g., registering new SMs
+    /// discovered during block classification).
+    pub const fn registry_mut(&mut self) -> &mut SMRegistry {
+        self.registry
+    }
+
+    /// Processes a batch of seed events to a fixed point.
+    ///
+    /// This method:
+    /// 1. Processes each seed event through the state transition function.
+    /// 2. Fabricates any follow-up events (e.g., `AdaptorsVerified` after `VerifyAdaptors`).
+    /// 3. Drains the signal queue until no more signals remain.
+    /// 4. Accumulates all duties produced.
+    /// 5. Updates the persistence tracker for every touched state machine.
+    ///
+    /// No intermediate state is externally visible until this method returns.
+    pub fn apply_batch(
+        &mut self,
+        seed_events: impl IntoIterator<Item = (SMId, SMEvent)>,
+    ) -> Result<(), PipelineError> {
+        // Process initial seed events
+        for (sm_id, sm_event) in seed_events {
+            self.apply_one(sm_id, sm_event)?;
+        }
+
+        // Fabricate follow-up events for any VerifyAdaptors duties produced by this batch
+        let fabricated: Vec<_> = self
+            .duties
+            .iter()
+            .filter_map(|duty| {
+                if let UnifiedDuty::Graph(GraphDuty::VerifyAdaptors { graph_idx, .. }) = duty {
+                    Some((
+                        (*graph_idx).into(),
+                        SMEvent::from(GraphEvent::AdaptorsVerified(AdaptorsVerifiedEvent {})),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for (sm_id, event) in fabricated {
+            info!(?sm_id, "enqueuing fabricated AdaptorsVerified event");
+            self.signal_queue.push_back((sm_id, event));
+        }
+
+        // Drain signal cascade to fixed point
+        while let Some((sm_id, sm_event)) = self.signal_queue.pop_front() {
+            self.apply_one(sm_id, sm_event)?;
+        }
+
+        Ok(())
+    }
+
+    /// Adds duties directly (e.g., initial duties from newly created SMs that are not produced by
+    /// the STF but by SM constructors).
+    pub fn add_duties(&mut self, duties: impl IntoIterator<Item = UnifiedDuty>) {
+        self.duties.extend(duties);
+    }
+
+    /// Consumes the applicator and returns the accumulated duties and persistence tracker.
+    pub fn finish(self) -> (Vec<UnifiedDuty>, PersistenceTracker) {
+        (self.duties, self.tracker)
+    }
+
+    /// Processes a single event through the registry's STF.
+    ///
+    /// On success, accumulates duties and enqueues any signal-derived events. Ignored outcomes
+    /// (duplicates, rejections) are non-fatal and logged. Fatal errors are propagated.
+    fn apply_one(&mut self, sm_id: SMId, sm_event: SMEvent) -> Result<(), PipelineError> {
+        match self.registry.process_event(&sm_id, sm_event) {
+            Ok(ProcessOutcome::Applied(output)) => {
+                self.duties.extend(output.duties);
+                self.tracker.record(sm_id);
+
+                for signal in output.signals {
+                    for (target_id, target_event) in
+                        signals_router::route_signal(self.registry, signal)
+                    {
+                        self.tracker.link(sm_id, target_id);
+                        self.signal_queue.push_back((target_id, target_event));
+                    }
+                }
+
+                Ok(())
+            }
+            Ok(ProcessOutcome::Ignored { id, event, reason }) => {
+                match reason {
+                    IgnoredEventReason::Duplicate => {
+                        warn!(?id, %event, "duplicate event, skipping");
+                    }
+                    IgnoredEventReason::Rejected(rejected_reason) => {
+                        warn!(?id, %event, %rejected_reason, "event rejected by state machine, skipping");
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -40,26 +40,29 @@ use strata_bridge_tx_graph::transactions::prelude::DepositData;
 use tracing::{Level, error, info};
 
 use crate::{
-    errors::ProcessError,
+    applicator::Applicator,
+    errors::{PipelineError, ProcessError},
     sm_registry::SMRegistry,
     sm_types::{SMEvent, SMId, UnifiedDuty},
 };
 
-type EventsMap = Vec<(SMId, SMEvent)>;
-type InitialDuties = Vec<UnifiedDuty>;
-type ClassifiedBlock = (EventsMap, InitialDuties);
-
-/// Classifies a buried block into a list of ([`SMId`], [`SMEvent`]) targets and a list of new
-/// [`UnifiedDuty`]'s.
-pub(crate) fn classify_block(
+/// Processes a buried block by iterating its transactions in chain order.
+///
+/// For each transaction, seed events are classified and applied as a fixed-point batch via the
+/// [`Applicator`]. This ensures that state changes from earlier transactions (e.g., stake
+/// confirmations) are visible when classifying later transactions (e.g., DRTs) in the same block.
+///
+/// After all transactions are processed, `NewBlock` cursor events are emitted for all SMs that
+/// existed before the block was processed.
+pub(crate) fn process_block(
+    applicator: &mut Applicator<'_>,
     initial_operator_table: &OperatorTable,
-    registry: &mut SMRegistry,
     block_event: &BlockEvent,
-) -> Result<ClassifiedBlock, ProcessError> {
+) -> Result<(), PipelineError> {
     let (cur_stakes, cur_unstaking_images) = get_mocked_stake_data(initial_operator_table);
 
-    let deposit_cfg = registry.cfg().deposit.clone();
-    let graph_cfg = registry.cfg().graph.clone();
+    let deposit_cfg = applicator.registry().cfg().deposit.clone();
+    let graph_cfg = applicator.registry().cfg().graph.clone();
     let height = block_event
         .block
         .bip34_block_height()
@@ -67,49 +70,44 @@ pub(crate) fn classify_block(
 
     // Snapshot pre-existing SM IDs: newly created SMs already know the current block height,
     // so only pre-existing ones need a NewBlock cursor event.
-    let existing_deposits = registry.get_deposit_ids();
-    let existing_graphs = registry.get_graph_ids();
-
-    let mut targets = Vec::new();
-    let mut initial_duties = Vec::new();
+    let existing_deposits = applicator.registry().get_deposit_ids();
+    let existing_graphs = applicator.registry().get_graph_ids();
 
     for tx in &block_event.block.txdata {
         // If this tx is a DRT, register new DepositSM + per-operator GraphSMs
-        initial_duties.extend(try_register_deposit(
+        let initial_duties = try_register_deposit(
             &deposit_cfg,
             initial_operator_table,
             &cur_stakes,
             &cur_unstaking_images,
-            registry,
+            applicator.registry_mut(),
             tx,
             height,
-        )?);
+        )?;
 
         // Classify this tx against every active SM via TxClassifier
-        // PERF: (Rajil1213) this needs benchmarking to make sure that classifying every tx against
-        // every SM is not too expensive. If it is, we can optimize by maintaining a cache
-        // of all relevant txids/outpoints per SM and only running TxClassifier if the tx contains a
-        // relevant txid/outpoint and do it only on the relevant SM. It is too expensive if for a
-        // saturated bitcoin block (~3000 txs) and ~1000*15 SMs (45M lookups), we are unable to
-        // classify the block within ~5 minutes (half the average block time) on a
-        // reasonably powerful machine.
-        targets.extend(classify_tx_for_all_sms(
-            &deposit_cfg,
-            &graph_cfg,
-            registry,
-            tx,
-            height,
-        ));
+        // PERF: (Rajil1213) this needs benchmarking to make sure that classifying every tx
+        // against every SM is not too expensive. If it is, we can optimize by maintaining a
+        // cache of all relevant txids/outpoints per SM and only running TxClassifier if the tx
+        // contains a relevant txid/outpoint and do it only on the relevant SM. It is too
+        // expensive if for a saturated bitcoin block (~3000 txs) and ~1000*15 SMs (45M
+        // lookups), we are unable to classify the block within ~5 minutes (half the average
+        // block time) on a reasonably powerful machine.
+        let seed_events =
+            classify_tx_for_all_sms(&deposit_cfg, &graph_cfg, applicator.registry(), tx, height);
+
+        // Apply seed events as one fixed-point batch per transaction
+        applicator.apply_batch(seed_events)?;
+
+        // Add initial duties from newly created SMs (produced by SM constructors, not the STF)
+        applicator.add_duties(initial_duties);
     }
 
-    // Append NewBlock cursor events only for pre-existing SMs
-    targets.extend(new_block_events(
-        &existing_deposits,
-        &existing_graphs,
-        height,
-    ));
+    // Append NewBlock cursor events for pre-existing SMs as the final batch
+    let new_block = new_block_events(&existing_deposits, &existing_graphs, height);
+    applicator.apply_batch(new_block)?;
 
-    Ok((targets, initial_duties))
+    Ok(())
 }
 
 /// Generates mocked stake data for the given operator table.

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -9,6 +9,7 @@
 //! - Driving state machines that implement the core business-logic of the bridge.
 //! - Providing a channel of communication between the various state machines in the bridge.
 
+pub mod applicator;
 pub mod duty_dispatcher;
 pub mod errors;
 pub mod events_classifier;

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -1,32 +1,25 @@
 //! The main event loop that wires all pipeline stages together:
-//! `EventsMux` → classify → process → signal cascade → persist → dispatch.
-
-use std::collections::VecDeque;
+//! `EventsMux` → classify → `Applicator::apply_batch` → persist → dispatch.
 
 use strata_bridge_primitives::operator_table::OperatorTable;
-use strata_bridge_sm::graph::{
-    duties::GraphDuty,
-    events::{AdaptorsVerifiedEvent, GraphEvent},
-};
-use tracing::{info, trace, warn};
+use tracing::{info, trace};
 
 use crate::{
+    applicator::Applicator,
     duty_dispatcher::DutyDispatcher,
     errors::PipelineError,
     events_classifier::{offchain, onchain},
     events_mux::{EventsMux, UnifiedEvent},
     events_router,
-    persister::{PersistenceTracker, Persister},
-    signals_router,
-    sm_registry::{IgnoredEventReason, ProcessOutcome, SMRegistry},
-    sm_types::{SMEvent, SMId, UnifiedDuty},
+    persister::Persister,
+    sm_registry::SMRegistry,
 };
 
 /// The main pipeline that drives the orchestrator.
 ///
 /// Continuously pulls events from the multiplexer, classifies and routes them to state machines,
-/// processes them through the STF, cascades any resulting signals, persists state changes, and
-/// dispatches duties to executors.
+/// processes them through the [`Applicator`], persists state changes, and dispatches duties to
+/// executors.
 #[expect(missing_debug_implementations)]
 pub struct Pipeline {
     event_mux: EventsMux,
@@ -75,148 +68,46 @@ impl Pipeline {
                 routable => routable,
             };
 
-            // Stage 2: Classification
-            trace!(
-                ?event,
-                "classifying event and determining target state machines"
-            );
-            let (targets, new_duties): (Vec<(SMId, SMEvent)>, Vec<UnifiedDuty>) = match &event {
-                UnifiedEvent::Block(block_event) => onchain::classify_block(
-                    &initial_operator_table,
-                    &mut self.registry,
-                    block_event,
-                )?,
+            // Stage 2+3: Classify and process through Applicator
+            let mut applicator = Applicator::new(&mut self.registry);
+
+            match &event {
+                UnifiedEvent::Block(block_event) => {
+                    onchain::process_block(&mut applicator, &initial_operator_table, block_event)?;
+                }
 
                 _ => {
                     // P2P / assignment / ticks: route to SM ids, then classify each
-                    let sm_ids = events_router::route(&event, &self.registry);
-                    (
-                        sm_ids
-                            .into_iter()
-                            .filter_map(|sm_id| {
-                                offchain::classify(&sm_id, &event, &self.registry)
-                                    .map(|sm_event| (sm_id, sm_event))
-                            })
-                            .collect(),
-                        Vec::new(),
-                    )
+                    trace!(
+                        ?event,
+                        "classifying event and determining target state machines"
+                    );
+                    let sm_ids = events_router::route(&event, applicator.registry());
+                    let seed_events: Vec<_> = sm_ids
+                        .into_iter()
+                        .filter_map(|sm_id| {
+                            offchain::classify(&sm_id, &event, applicator.registry())
+                                .map(|sm_event| (sm_id, sm_event))
+                        })
+                        .collect();
+
+                    applicator.apply_batch(seed_events)?;
                 }
-            };
+            }
 
-            // Stages 3+4: Process targets + signal cascade
-            let (mut all_duties, tracker) = self.process_and_cascade(targets)?;
-            all_duties.extend(new_duties);
+            let (all_duties, tracker) = applicator.finish();
 
-            // Stage 5: Batch persistence
-
+            // Stage 4: Batch persistence
             let batches = tracker.into_batches();
             info!(count=%batches.len(), "persisting updated state machines batches");
             for batch in batches {
                 self.persister.persist_batch(batch, &self.registry).await?;
             }
 
-            // Stage 6: Dispatch duties
+            // Stage 5: Dispatch duties
             for duty in all_duties {
                 self.dispatcher.dispatch(duty);
             }
-        }
-    }
-
-    /// Processes all targets through the STF and cascades any resulting signals until the signal
-    /// queue is drained.
-    ///
-    /// Returns the accumulated duties and the persistence tracker recording which SMs were touched.
-    fn process_and_cascade(
-        &mut self,
-        targets: Vec<(SMId, SMEvent)>,
-    ) -> Result<(Vec<crate::sm_types::UnifiedDuty>, PersistenceTracker), PipelineError> {
-        let mut all_duties = Vec::new();
-        let mut signal_queue: VecDeque<(SMId, SMEvent)> = VecDeque::new();
-        let mut tracker = PersistenceTracker::new();
-
-        // Process initial targets
-        for (sm_id, sm_event) in targets {
-            self.process_event(
-                sm_id,
-                sm_event,
-                &mut all_duties,
-                &mut signal_queue,
-                &mut tracker,
-            )?;
-        }
-
-        all_duties
-            .iter()
-            .filter_map(|duty| {
-                if let UnifiedDuty::Graph(GraphDuty::VerifyAdaptors { graph_idx, .. }) = duty {
-                    Some((
-                        *graph_idx,
-                        GraphEvent::AdaptorsVerified(AdaptorsVerifiedEvent {}),
-                    ))
-                } else {
-                    None
-                }
-            })
-            .for_each(|(graph_idx, event)| {
-                info!(%graph_idx, "enqueuing fabricated AdaptorsVerified event");
-
-                signal_queue.push_back((graph_idx.into(), event.into()));
-            });
-
-        // Signal cascade: process signals until the queue is drained
-        while let Some((sm_id, sm_event)) = signal_queue.pop_front() {
-            self.process_event(
-                sm_id,
-                sm_event,
-                &mut all_duties,
-                &mut signal_queue,
-                &mut tracker,
-            )?;
-        }
-
-        Ok((all_duties, tracker))
-    }
-
-    /// Processes a single (SMId, SMEvent) pair through the registry's STF.
-    ///
-    /// On success, accumulates duties and enqueues any signal-derived events.
-    /// Ignored outcomes are non-fatal (logged and skipped). Fatal errors are propagated.
-    fn process_event(
-        &mut self,
-        sm_id: SMId,
-        sm_event: SMEvent,
-        all_duties: &mut Vec<crate::sm_types::UnifiedDuty>,
-        signal_queue: &mut VecDeque<(SMId, SMEvent)>,
-        tracker: &mut PersistenceTracker,
-    ) -> Result<(), PipelineError> {
-        match self.registry.process_event(&sm_id, sm_event) {
-            Ok(ProcessOutcome::Applied(output)) => {
-                all_duties.extend(output.duties);
-                tracker.record(sm_id);
-
-                for signal in output.signals {
-                    for (target_id, target_event) in
-                        signals_router::route_signal(&self.registry, signal)
-                    {
-                        tracker.link(sm_id, target_id);
-                        signal_queue.push_back((target_id, target_event));
-                    }
-                }
-
-                Ok(())
-            }
-            Ok(ProcessOutcome::Ignored { id, event, reason }) => {
-                match reason {
-                    IgnoredEventReason::Duplicate => {
-                        warn!(?id, %event, "duplicate event, skipping");
-                    }
-                    IgnoredEventReason::Rejected(rejected_reason) => {
-                        warn!(?id, %event, %rejected_reason, "event rejected by state machine, skipping");
-                    }
-                }
-                Ok(())
-            }
-            Err(e) => Err(e.into()),
         }
     }
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
In the current orchestrator pipeline, each block is processed in a single batch -- each relevant tx is mapped to an event (as per the classifier logic), enqueued and then, applied sequentially. This means that the event-processing semantics is already at the granularity of the transactions in the block _but_ the classification logic isn't. The overall effect is that if the classification logic itself is mutated by an event in the queue, it is not reflected in the overall state of the system since it used to operate on a pre-block state snapshot. A more concrete example for when this becomes an issue is that if a contest and a counterproof transaction are in the same block (unlikely but possible), then the state machine will miss the counterproof transaction since the classifier only cares about the `contest` tx in the `Claimed` state.

This is fixed by introducing a new Applicator API that processes events on a per-transaction basis.

This change is also needed for the SSM integration where the presence of the Unstaking Intent transaction in a block mutates the operator table and affects any DRTs in the same block following the Unstaking Intent transaction.

Both Codex and Claude were used to brainstorm ideas for the architectural refactor. Claude was used to apply the changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
[Design doc](https://www.notion.so/Bridge-Orchestrator-2af901ba000f80dfab3afe8b669ec41a?source=copy_link) has already been updated and explains some of the design choices.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3094