### PR TITLE
fix(docker): use `network` value from params file in asm-runner

### DIFF
--- a/docker/asm-runner/gen_asm_params.py
+++ b/docker/asm-runner/gen_asm_params.py
@@ -128,6 +128,7 @@ def validate_params(asm_params: dict, bridge_params: dict) -> None:
 
     checks = [
         ("magic", asm_params["magic"], bridge["magic_bytes"]),
+        ("network", asm_params["anchor"]["network"], bridge_params["network"]),
         (
             "genesis_height",
             asm_params["anchor"]["block"]["height"],

--- a/docker/asm-runner/gen_asm_params.py
+++ b/docker/asm-runner/gen_asm_params.py
@@ -178,8 +178,9 @@ def main() -> None:
     logging.info("Fetching chain context for genesis height")
     block_hash, header = fetch_chain_context(config["bitcoin"], genesis_height)
 
-    logging.info("Updating ASM params with chain context")
-    params["anchor"] = asdict(build_l1_anchor(genesis_height, block_hash, header))
+    network = params["anchor"]["network"]
+    logging.info(f"Updating ASM params with chain context for {network} network")
+    params["anchor"] = asdict(build_l1_anchor(genesis_height, block_hash, header, network))
 
     logging.info(f"Writing updated ASM params to {params_path}")
     params_path.write_text(json.dumps(params, indent=4) + "\n")

--- a/functional-tests/factory/common/asm_params.py
+++ b/functional-tests/factory/common/asm_params.py
@@ -73,12 +73,16 @@ def parse_bits_to_target(bits: int | str) -> int:
     return int(bits)
 
 
+# NOTE: (@Rajil1213) This function is also used by the `gen_asm_params.py` script
+# in the `docker/asm-runner` directory, so it should be kept generic
+# and not rely on any test-specific logic.
 def build_l1_anchor(
     genesis_height: int,
     block_hash: str,
     header: dict[str, Any],
     network: str = "regtest",
 ) -> L1Anchor:
+    """Constructs the L1 anchor for the ASM parameters based on the provided block information."""
     header_time = int(header["time"])
     next_target = parse_bits_to_target(header["bits"])
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR updates the params generator script for the `asm-runner` container to use the same bitcoin network value as specified in the supplied sample `asm-params.json` file.

AI was not used.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->