### PR TITLE
feat(orchestrator): integrate Stake SM

### DIFF
--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -53,12 +53,8 @@ pub(in crate::mode) async fn init_operator_wallet(
     let stakechain_key = s2_client.stakechain_wallet_signer().pubkey().await?;
     info!(%stakechain_key, "operator wallet stakechain key");
     let operator_funds = compute_funding_amount(params);
-    let operator_wallet_config = OperatorWalletConfig::new(
-        operator_funds,
-        SEGWIT_MIN_AMOUNT,
-        params.protocol.stake_amount,
-        params.network,
-    );
+    let operator_wallet_config =
+        OperatorWalletConfig::new(operator_funds, SEGWIT_MIN_AMOUNT, params.network);
     debug!(?operator_wallet_config, "operator wallet config");
 
     let sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -243,6 +243,7 @@ fn build_exec_config(params: &Params, config: &Config) -> ExecutionConfig {
         magic_bytes: params.protocol.magic_bytes,
         maximum_fee_rate: FeeRate::from_sat_per_vb(config.max_fee_rate).unwrap(),
         operator_fee: params.protocol.operator_fee,
+        stake_amount: params.protocol.stake_amount,
         funding_uxto_pool_size: config.operator_wallet.claim_funding_pool_size,
     }
 }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -136,7 +136,7 @@ pub(crate) async fn init_orchestrator(
 
             // Handle pipeline completion (this should indicate an error as this is supposed to run indefinitely)
             pipeline_complete = tokio::task::spawn(async move {
-                pipeline.run(operator_table).await
+                pipeline.run(operator_table, start_height).await
             }) => {
                 match pipeline_complete {
                     Ok(Ok(())) => {

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -19,8 +19,13 @@ use strata_bridge_orchestrator::{
 };
 use strata_bridge_p2p_service::MessageHandler;
 use strata_bridge_primitives::operator_table::OperatorTable;
-use strata_bridge_sm::{self, deposit::config::DepositSMCfg, graph::config::GraphSMCfg};
-use strata_bridge_tx_graph::game_graph::ProtocolParams as TxGraphProtocolParams;
+use strata_bridge_sm::{
+    self, deposit::config::DepositSMCfg, graph::config::GraphSMCfg, stake::config::StakeSMCfg,
+};
+use strata_bridge_tx_graph::{
+    game_graph::ProtocolParams as TxGraphProtocolParams,
+    stake_graph::ProtocolParams as StakeGraphProtocolParams,
+};
 use strata_mosaic_client_api::MosaicClientApi;
 use strata_p2p::swarm::handle::{GossipHandle, ReqRespHandle};
 use strata_tasks::TaskExecutor;
@@ -211,9 +216,23 @@ pub(super) fn build_sm_config(config: &Config, params: &Params) -> SMConfig {
         bridge_proof_predicate: params.protocol.bridge_proof_predicate.clone(),
     };
 
+    // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2924>
+    // Promote `unstaking_timelock` to a protocol parameter on `ProtocolParams` once the
+    // params schema is updated. For now, use a sensible default (approximately 21 days).
+    const DEFAULT_UNSTAKING_TIMELOCK_BLOCKS: u16 = 3024;
+    let stake_config = StakeSMCfg {
+        protocol_params: StakeGraphProtocolParams {
+            network,
+            magic_bytes,
+            unstaking_timelock: relative::Height::from_height(DEFAULT_UNSTAKING_TIMELOCK_BLOCKS),
+            stake_amount: params.protocol.stake_amount,
+        },
+    };
+
     SMConfig {
         deposit: Arc::new(deposit_config),
         graph: Arc::new(graph_config),
+        stake: Arc::new(stake_config),
     }
 }
 

--- a/bin/strata-bridge/src/mode/services/rpc_server.rs
+++ b/bin/strata-bridge/src/mode/services/rpc_server.rs
@@ -25,13 +25,14 @@ use strata_bridge_rpc::{
     },
     types::{
         RpcActiveClaim, RpcAggregateSignatures, RpcBridgeDutyStatus, RpcClaimInfo, RpcClaimPhase,
-        RpcDepositInfo, RpcDepositStatus, RpcGraphData, RpcOperatorStatus,
-        RpcPendingWithdrawalInfo, RpcWithdrawalInfo,
+        RpcDepositInfo, RpcDepositStatus, RpcGraphData, RpcOperatorStakeInfo, RpcOperatorStatus,
+        RpcPendingWithdrawalInfo, RpcStakeState, RpcWithdrawalInfo,
     },
 };
 use strata_bridge_sm::{
     deposit::state::DepositState,
     graph::{config::GraphSMCfg, context::GraphSMCtx, state::GraphState},
+    stake::state::StakeState,
 };
 use strata_identifiers::Buf32;
 use strata_p2p::swarm::handle::CommandHandle;
@@ -415,6 +416,33 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
         };
 
         Ok(Some(info))
+    }
+
+    async fn get_stake_status(&self) -> RpcResult<Vec<RpcOperatorStakeInfo>> {
+        let cached_registry = self.cached_registry.read().await;
+        Ok(cached_registry
+            .stakes()
+            .map(|(&operator_idx, sm)| RpcOperatorStakeInfo {
+                operator_idx,
+                state: stake_state_to_rpc(sm.state()),
+            })
+            .collect())
+    }
+}
+
+const fn stake_state_to_rpc(state: &StakeState) -> RpcStakeState {
+    match state {
+        StakeState::Created { .. } => RpcStakeState::Created,
+        StakeState::StakeGraphGenerated { .. } => RpcStakeState::StakeGraphGenerated,
+        StakeState::UnstakingNoncesCollected { .. } => RpcStakeState::UnstakingNoncesCollected,
+        StakeState::UnstakingSigned { .. } => RpcStakeState::UnstakingSigned,
+        StakeState::Confirmed { summary, .. } => RpcStakeState::Confirmed {
+            stake_txid: summary.stake,
+        },
+        StakeState::PreimageRevealed { .. } => RpcStakeState::PreimageRevealed,
+        StakeState::Unstaked { unstaking_txid, .. } => RpcStakeState::Unstaked {
+            unstaking_txid: *unstaking_txid,
+        },
     }
 }
 

--- a/crates/bridge-exec/src/config.rs
+++ b/crates/bridge-exec/src/config.rs
@@ -23,6 +23,10 @@ pub struct ExecutionConfig {
     /// The fee charged by an operator for processing a withdrawal.
     pub operator_fee: Amount,
 
+    /// The amount of BTC this operator stakes as collateral. The stake-funding UTXO spent by the
+    /// stake transaction must carry `stake_amount` plus any connector dust the stake tx produces.
+    pub stake_amount: Amount,
+
     /// The number of claim funding utxos to generate at any given time when the pool is exhausted.
     pub funding_uxto_pool_size: usize,
 }

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -57,7 +57,7 @@ pub async fn execute_stake_duty(
             )
             .await
         }
-        StakeDuty::PublishStake { tx } => staking::publish_stake(&output_handles, tx).await,
+        StakeDuty::PublishStake { tx } => staking::publish_stake(&cfg, &output_handles, tx).await,
         StakeDuty::PublishUnstakingIntent {
             unsigned_tx,
             stake_funds,

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use strata_bridge_sm::stake::duties::StakeDuty;
 use strata_bridge_tx_graph::musig_functor::StakeFunctor;
+use tracing::info;
 
 use crate::{config::ExecutionConfig, errors::ExecutorError, output_handles::OutputHandles};
 
@@ -21,6 +22,7 @@ pub async fn execute_stake_duty(
 ) -> Result<(), ExecutorError> {
     match duty {
         StakeDuty::PublishStakeData { operator_idx } => {
+            info!(%operator_idx, "executing StakeDuty::PublishStakeData");
             staking::publish_stake_data(&cfg, &output_handles, *operator_idx).await
         }
         StakeDuty::PublishUnstakingNonces {
@@ -29,6 +31,7 @@ pub async fn execute_stake_duty(
             graph_tweaks,
             ordered_pubkeys,
         } => {
+            info!(%operator_idx, "executing StakeDuty::PublishUnstakingNonces");
             staking::publish_unstaking_nonces(
                 &output_handles,
                 *operator_idx,
@@ -46,6 +49,7 @@ pub async fn execute_stake_duty(
             ordered_pubkeys,
             agg_nonces,
         } => {
+            info!(%operator_idx, "executing StakeDuty::PublishUnstakingPartials");
             staking::publish_unstaking_partials(
                 &output_handles,
                 *operator_idx,
@@ -57,12 +61,16 @@ pub async fn execute_stake_duty(
             )
             .await
         }
-        StakeDuty::PublishStake { tx } => staking::publish_stake(&cfg, &output_handles, tx).await,
+        StakeDuty::PublishStake { tx } => {
+            info!(stake_txid=%tx.compute_txid(), "executing StakeDuty::PublishStake");
+            staking::publish_stake(&cfg, &output_handles, tx).await
+        }
         StakeDuty::PublishUnstakingIntent {
             unsigned_tx,
             stake_funds,
             n_of_n_signature,
         } => {
+            info!(%stake_funds, "executing StakeDuty::PublishUnstakingIntent");
             unstaking::publish_unstaking_intent(
                 &output_handles,
                 *stake_funds,
@@ -72,8 +80,12 @@ pub async fn execute_stake_duty(
             .await
         }
         StakeDuty::PublishUnstakingTx { signed_tx } => {
+            info!(unstaking_txid=%signed_tx.compute_txid(), "executing StakeDuty::PublishUnstakingTx");
             unstaking::publish_unstaking_tx(&output_handles, signed_tx).await
         }
-        StakeDuty::Nag(nag_duty) => nag::execute_nag_duty(&output_handles, nag_duty).await,
+        StakeDuty::Nag(nag_duty) => {
+            info!(?nag_duty, "executing StakeDuty::Nag");
+            nag::execute_nag_duty(&output_handles, nag_duty).await
+        }
     }
 }

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -22,7 +22,7 @@ use strata_bridge_primitives::{
     types::OperatorIdx,
 };
 use strata_bridge_tx_graph::musig_functor::StakeFunctor;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
@@ -103,6 +103,14 @@ async fn create_stake_funding_tx(
     info!(%fee_rate, "creating stake funding transaction");
     let psbt = {
         let mut wallet = output_handles.wallet.write().await;
+
+        match wallet.sync().await {
+            Ok(()) => info!("synced wallet successfully"),
+            Err(e) => error!(
+                ?e,
+                "could not sync wallet before creating stake funding tx; still attempting"
+            ),
+        }
 
         wallet
             .create_stake_funding_tx(fee_rate)

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -335,27 +335,18 @@ pub(crate) async fn publish_stake(
 
     let prevouts = Prevouts::All(&[prevout]);
     let mut sighash_cache = SighashCache::new(tx);
-    let mut signed_tx = tx.clone();
-    for (input_index, _) in tx.input.iter().enumerate() {
-        let sighash = create_key_spend_hash(
-            &mut sighash_cache,
-            prevouts.clone(),
-            TapSighashType::Default,
-            input_index,
-        )
+    let sighash = create_key_spend_hash(&mut sighash_cache, prevouts, TapSighashType::Default, 0)
         .expect("must be able to create key spend sighash");
 
-        let signature = output_handles
-            .s2_client
-            .stakechain_wallet_signer()
-            .sign(sighash.as_ref(), None)
-            .await
-            .map_err(ExecutorError::SecretServiceErr)?;
+    let signature = output_handles
+        .s2_client
+        .stakechain_wallet_signer()
+        .sign(sighash.as_ref(), None)
+        .await
+        .map_err(ExecutorError::SecretServiceErr)?;
 
-        signed_tx.input[input_index]
-            .witness
-            .push(signature.serialize());
-    }
+    let mut signed_tx = tx.clone();
+    signed_tx.input[0].witness.push(signature.serialize());
 
     info!(%stake_txid, "publishing signed stake transaction");
     publish_signed_transaction(

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -4,7 +4,7 @@
 //! the stake transaction.
 
 use bitcoin::{
-    Address, FeeRate, OutPoint, Psbt, TapSighashType, Transaction,
+    Address, Amount, FeeRate, Network, OutPoint, Psbt, TapSighashType, Transaction, TxOut,
     hashes::{Hash, sha256},
     key::TapTweak,
     secp256k1::{Message, XOnlyPublicKey},
@@ -16,6 +16,8 @@ use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PubNonce};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
+use strata_bridge_connectors::{Connector, prelude::UnstakingIntentOutput};
+use strata_bridge_db::traits::BridgeDb;
 use strata_bridge_p2p_types::UnstakingInput;
 use strata_bridge_primitives::{
     scripts::taproot::{TaprootTweak, create_key_spend_hash, finalize_input},
@@ -34,23 +36,28 @@ pub(crate) async fn publish_stake_data(
     output_handles: &OutputHandles,
     operator_idx: OperatorIdx,
 ) -> Result<(), ExecutorError> {
-    // Create stake funding transaction
-    let wallet = output_handles.wallet.read().await;
-
-    info!("checking if there is an existing stake funding transaction");
-    let stake_funds = if let Some(out) = wallet.s_utxo() {
-        drop(wallet); // drop lock
-        info!(outpoint=%out.outpoint, "found existing stake funding transaction");
-        out.outpoint
+    // Check the database first — if we already created a stake funding tx on a prior attempt,
+    // reuse that outpoint so the stake flow is idempotent across retries / restarts.
+    info!(%operator_idx, "checking for a persisted stake funding outpoint");
+    let stake_funds = if let Some(outpoint) = output_handles
+        .db
+        .get_stake_funding_outpoint(operator_idx)
+        .await?
+    {
+        info!(%operator_idx, %outpoint, "reusing persisted stake funding outpoint");
+        outpoint
     } else {
-        drop(wallet); // drop read lock before acquiring write lock in create_stake_funding_tx
-        info!("no existing stake funding transaction found, creating a new one");
-        let stake_funding_tx = create_stake_funding_tx(output_handles).await?;
-
-        OutPoint {
+        info!(%operator_idx, "no persisted stake funding outpoint; creating a new funding tx");
+        let stake_funding_tx = create_stake_funding_tx(cfg, output_handles).await?;
+        let outpoint = OutPoint {
             txid: stake_funding_tx.compute_txid(),
-            vout: 0, // there is only one output in the stake funding transaction.
-        }
+            vout: 0, // there is only one recipient output in the stake funding transaction.
+        };
+        output_handles
+            .db
+            .set_stake_funding_outpoint(operator_idx, outpoint)
+            .await?;
+        outpoint
     };
 
     info!("fetching unstaking intent preimage from secret-service");
@@ -88,6 +95,7 @@ pub(crate) async fn publish_stake_data(
 }
 
 async fn create_stake_funding_tx(
+    cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
 ) -> Result<Transaction, ExecutorError> {
     const DEFAULT_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(5);
@@ -100,7 +108,10 @@ async fn create_stake_funding_tx(
 
     let fee_rate = FeeRate::from_sat_per_vb(fee_rate).unwrap_or(DEFAULT_FEE_RATE);
 
-    info!(%fee_rate, "creating stake funding transaction");
+    let unstaking_intent_dust = unstaking_intent_dust_value(cfg.network);
+    let funding_amount = cfg.stake_amount + unstaking_intent_dust;
+
+    info!(%fee_rate, %funding_amount, "creating stake funding transaction");
     let psbt = {
         let mut wallet = output_handles.wallet.write().await;
 
@@ -113,7 +124,7 @@ async fn create_stake_funding_tx(
         }
 
         wallet
-            .create_stake_funding_tx(fee_rate)
+            .create_stake_funding_tx(fee_rate, funding_amount)
             .expect("must be able to create stake funding transaction")
     };
 
@@ -292,14 +303,83 @@ pub(crate) async fn publish_unstaking_partials(
 }
 
 pub(crate) async fn publish_stake(
+    cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
     tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    let stake_txid = tx.compute_txid();
+    let funding_input = tx.input[0].previous_output;
+
+    let unstaking_intent_dust = unstaking_intent_dust_value(cfg.network);
+
+    // The stake tx spends a single funding UTXO in the stakechain wallet and is not presigned by
+    // the covenant, so key-path sign it with the stakechain wallet signer before broadcasting.
+    // Reconstruct the prevout from known values: the funding UTXO is always at the stakechain
+    // address with value `stake_amount + unstaking_intent_output.value()`.
+    let stakechain_script = {
+        let wallet = output_handles.wallet.read().await;
+        wallet.stakechain_script_buf().clone()
+    };
+    let stake_funding_amount = cfg.stake_amount + unstaking_intent_dust;
+    let prevout = TxOut {
+        script_pubkey: stakechain_script,
+        value: stake_funding_amount,
+    };
+
+    info!(
+        %stake_txid,
+        %funding_input,
+        %stake_funding_amount,
+        "signing stake transaction with stakechain wallet signer"
+    );
+
+    let prevouts = Prevouts::All(&[prevout]);
+    let mut sighash_cache = SighashCache::new(tx);
+    let mut signed_tx = tx.clone();
+    for (input_index, _) in tx.input.iter().enumerate() {
+        let sighash = create_key_spend_hash(
+            &mut sighash_cache,
+            prevouts.clone(),
+            TapSighashType::Default,
+            input_index,
+        )
+        .expect("must be able to create key spend sighash");
+
+        let signature = output_handles
+            .s2_client
+            .stakechain_wallet_signer()
+            .sign(sighash.as_ref(), None)
+            .await
+            .map_err(ExecutorError::SecretServiceErr)?;
+
+        signed_tx.input[input_index]
+            .witness
+            .push(signature.serialize());
+    }
+
+    info!(%stake_txid, "publishing signed stake transaction");
     publish_signed_transaction(
         &output_handles.tx_driver,
-        tx,
+        &signed_tx,
         "stake tx",
         TxStatus::is_buried,
     )
-    .await
+    .await?;
+    info!(%stake_txid, "stake transaction confirmed on-chain");
+
+    Ok(())
+}
+
+/// Returns the dust value of an [`UnstakingIntentOutput`] on the given network.
+///
+/// The stake transaction spends its funding UTXO into the NOfN connector (`stake_amount`), the
+/// unstaking-intent connector, and a zero-value CPFP anchor.
+fn unstaking_intent_dust_value(network: Network) -> Amount {
+    // `UnstakingIntentOutput::value()` is the P2TR script's `minimal_non_dust()` and therefore
+    // depends only on the script kind — not on the particular n-of-n key or unstaking image. We
+    // supply a dummy x-only pubkey (the generator point's x-coordinate) and a zero image so we can
+    // compute the value without a secret-service round trip.
+    let dummy_pubkey = XOnlyPublicKey::from_slice(&bitcoin::key::constants::GENERATOR_X)
+        .expect("valid x-only key");
+    UnstakingIntentOutput::new(network, dummy_pubkey, sha256::Hash::all_zeros()).value()
 }

--- a/crates/bridge-exec/src/stake/unstaking.rs
+++ b/crates/bridge-exec/src/stake/unstaking.rs
@@ -7,6 +7,7 @@ use bitcoin::{OutPoint, Transaction, secp256k1::schnorr};
 use btc_tracker::event::TxStatus;
 use strata_bridge_connectors::prelude::UnstakingIntentWitness;
 use strata_bridge_tx_graph::transactions::prelude::UnstakingIntentTx;
+use tracing::info;
 
 use crate::{
     chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
@@ -19,6 +20,7 @@ pub(crate) async fn publish_unstaking_intent(
     unstaking_intent_tx: UnstakingIntentTx,
     n_of_n_signature: &schnorr::Signature,
 ) -> Result<(), ExecutorError> {
+    info!(%stake_funds, "fetching unstaking preimage from secret-service");
     let preimage = get_preimage(&output_handles.s2_client, stake_funds).await?;
 
     let unstaking_intent_witness = UnstakingIntentWitness {
@@ -27,25 +29,32 @@ pub(crate) async fn publish_unstaking_intent(
     };
 
     let signed_unstaking_intent_tx = unstaking_intent_tx.finalize(&unstaking_intent_witness);
-
+    let unstaking_intent_txid = signed_unstaking_intent_tx.compute_txid();
+    info!(%unstaking_intent_txid, "publishing unstaking intent transaction");
     publish_signed_transaction(
         &output_handles.tx_driver,
         &signed_unstaking_intent_tx,
         "unstaking intent tx",
         TxStatus::is_buried,
     )
-    .await
+    .await?;
+    info!(%unstaking_intent_txid, "unstaking intent transaction confirmed on-chain");
+    Ok(())
 }
 
 pub(crate) async fn publish_unstaking_tx(
     output_handles: &OutputHandles,
     signed_tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    let unstaking_txid = signed_tx.compute_txid();
+    info!(%unstaking_txid, "publishing unstaking transaction");
     publish_signed_transaction(
         &output_handles.tx_driver,
         signed_tx,
         "unstaking tx",
         TxStatus::is_buried,
     )
-    .await
+    .await?;
+    info!(%unstaking_txid, "unstaking transaction confirmed on-chain");
+    Ok(())
 }

--- a/crates/bridge-sm/src/stake/machine.rs
+++ b/crates/bridge-sm/src/stake/machine.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     signals::Signal,
     stake::{
@@ -16,7 +18,7 @@ use crate::{
 };
 
 /// The Stake State Machine tracks the lifecycle of the stake of a given operator.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StakeSM {
     /// The context of the state machine.
     pub context: StakeSMCtx,

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -120,6 +120,25 @@ impl StakeState {
         )
     }
 
+    /// Returns true if this operator is still eligible to participate in new deposits.
+    ///
+    /// This is the admission predicate for creating new per-operator
+    /// [`GraphSM`](crate::graph::machine::GraphSM) instances. It is stricter than
+    /// [`has_staked`](Self::has_staked): an operator whose unstaking preimage has been revealed
+    /// (or who has fully unstaked) is excluded because their stake UTXO will soon be spent.
+    pub const fn is_stake_available(&self) -> bool {
+        matches!(self, Self::Confirmed { .. })
+    }
+
+    /// Returns true if this operator has been removed from the future covenant.
+    ///
+    /// Complement of [`is_stake_available`](Self::is_stake_available) for operators that have
+    /// already staked: `PreimageRevealed` and `Unstaked` states indicate the operator is
+    /// winding down and must not be included in future covenant signing sessions.
+    pub const fn is_removed_from_future_covenant(&self) -> bool {
+        matches!(self, Self::PreimageRevealed { .. } | Self::Unstaked { .. })
+    }
+
     /// Returns true if the stake is fully unstaked.
     pub const fn is_unstaked(&self) -> bool {
         matches!(self, Self::Unstaked { .. })

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -5,6 +5,7 @@
 //! subscription objects can be primarily worked with via their [`futures::Stream`] trait API.
 use std::{collections::VecDeque, error::Error, marker::PhantomData, sync::Arc, time::Duration};
 
+use algebra::retry::{retry_with, Strategy};
 use bitcoin::{Block, Transaction};
 use bitcoincore_zmq::{subscribe_async_wait_handshake, Message, SocketMessage};
 use futures::{future::join_all, StreamExt};
@@ -128,6 +129,11 @@ impl BtcNotifyClient<Disconnected> {
     ///
     /// Consumes the disconnected client and returns a connected client.
     /// The connected client will have an active monitoring thread that processes ZMQ events.
+    ///
+    /// The ZMQ subscription handshake is retried with a short per-attempt timeout and a fixed
+    /// delay between attempts. This tolerates a brief window after a bitcoind restart during
+    /// which the RPC server is reachable but the ZMQ publishers have not yet bound their
+    /// endpoints.
     pub async fn connect<F>(
         self,
         start_height: u64,
@@ -137,29 +143,53 @@ impl BtcNotifyClient<Disconnected> {
         F: BlockFetcher + Send + Sync + 'static,
         <F as BlockFetcher>::Error: std::fmt::Debug + Send,
     {
+        /// Per-attempt timeout for the ZMQ subscription handshake.
+        const HANDSHAKE_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(2);
+        /// Delay between successive ZMQ handshake attempts.
+        const HANDSHAKE_RETRY_BACKOFF: Duration = Duration::from_millis(500);
+        /// Maximum number of retry attempts beyond the initial attempt. Total elapsed time is
+        /// bounded by roughly
+        /// `(HANDSHAKE_ATTEMPT_TIMEOUT + HANDSHAKE_RETRY_BACKOFF) * (1 + HANDSHAKE_MAX_RETRIES)`.
+        const HANDSHAKE_MAX_RETRIES: usize = 11;
+
         trace!(sockets=?self.sockets, "subscribing to bitcoind");
 
-        let mut stream = match tokio::time::timeout(
-            Duration::from_millis(2000),
-            subscribe_async_wait_handshake(
-                &self.sockets.iter().map(String::as_str).collect::<Vec<_>>(),
-            ),
-        )
+        let sockets = self.sockets.clone();
+        let strategy =
+            Strategy::fixed_delay(HANDSHAKE_RETRY_BACKOFF).with_max_retries(HANDSHAKE_MAX_RETRIES);
+        let mut stream = retry_with(strategy, move || {
+            let sockets = sockets.clone();
+            async move {
+                let urls: Vec<&str> = sockets.iter().map(String::as_str).collect();
+                match tokio::time::timeout(
+                    HANDSHAKE_ATTEMPT_TIMEOUT,
+                    subscribe_async_wait_handshake(&urls),
+                )
+                .await
+                {
+                    Ok(Ok(stream)) => Ok(stream),
+                    Ok(Err(err)) => {
+                        warn!(?err, "zmq subscription handshake attempt failed, retrying");
+                        Err(format!("subscribe error: {err}"))
+                    }
+                    Err(_) => {
+                        warn!(
+                            attempt_timeout = ?HANDSHAKE_ATTEMPT_TIMEOUT,
+                            "zmq subscription handshake attempt timed out, retrying"
+                        );
+                        Err(format!("timed out after {HANDSHAKE_ATTEMPT_TIMEOUT:?}"))
+                    }
+                }
+            }
+        })
         .await
-        {
-            Ok(Ok(stream)) => {
-                // Ok(Ok(_)), ok from both functions.
-                stream
-            }
-            Ok(Err(err)) => {
-                // Ok(Err(_)), ok from `timeout` but an error from the subscribe function.
-                panic!("subscribe error: {err}");
-            }
-            Err(_) => {
-                // Err(_), err from `timeout` means that it timed out.
-                panic!("bitcoin-core zmq subscription handshake timed out");
-            }
-        };
+        .map_err(|last_err: String| -> Box<dyn Error> {
+            format!(
+                "bitcoin-core zmq subscription handshake failed after {} attempts: last error: {last_err}",
+                HANDSHAKE_MAX_RETRIES + 1
+            )
+            .into()
+        })?;
 
         // Clone references for the spawned thread
         let block_subs_thread = self.block_subs.clone();

--- a/crates/db/src/fdb/bridge_db.rs
+++ b/crates/db/src/fdb/bridge_db.rs
@@ -4,7 +4,9 @@ use bitcoin::{OutPoint, Txid};
 use foundationdb::{FdbBindingError, options::TransactionOption};
 use secp256k1::schnorr::Signature;
 use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
-use strata_bridge_sm::{deposit::machine::DepositSM, graph::machine::GraphSM};
+use strata_bridge_sm::{
+    deposit::machine::DepositSM, graph::machine::GraphSM, stake::machine::StakeSM,
+};
 use terrors::OneOf;
 
 use crate::{
@@ -19,6 +21,7 @@ use crate::{
             },
             graphs::GraphStateRowSpec,
             signatures::{SignatureKey, SignatureRowSpec},
+            stakes::{StakeStateKey, StakeStateRowSpec},
         },
     },
     traits::BridgeDb,
@@ -116,6 +119,40 @@ impl BridgeDb for FdbClient {
 
     async fn delete_graph_state(&self, graph_idx: GraphIdx) -> Result<(), Self::Error> {
         self.basic_delete::<GraphStateRowSpec>(graph_idx.into())
+            .await
+    }
+
+    // ── Stake States ─────────────────────────────────────────────────
+
+    async fn get_stake_state(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> Result<Option<StakeSM>, Self::Error> {
+        self.basic_get::<StakeStateRowSpec>(StakeStateKey { operator_idx })
+            .await
+    }
+
+    async fn set_stake_state(
+        &self,
+        operator_idx: OperatorIdx,
+        state: StakeSM,
+    ) -> Result<(), Self::Error> {
+        self.basic_set::<StakeStateRowSpec>(StakeStateKey { operator_idx }, state)
+            .await
+    }
+
+    async fn get_all_stake_states(&self) -> Result<Vec<(OperatorIdx, StakeSM)>, Self::Error> {
+        let pairs = self
+            .basic_get_all::<StakeStateRowSpec>(|dirs| &dirs.stakes)
+            .await?;
+        Ok(pairs
+            .into_iter()
+            .map(|(k, v)| (k.operator_idx, v))
+            .collect())
+    }
+
+    async fn delete_stake_state(&self, operator_idx: OperatorIdx) -> Result<(), Self::Error> {
+        self.basic_delete::<StakeStateRowSpec>(StakeStateKey { operator_idx })
             .await
     }
 
@@ -249,6 +286,16 @@ impl BridgeDb for FdbClient {
                 )
                 .map_err(OneOf::new)?;
             }
+            for sm in batch.stakes() {
+                self.basic_set_in::<StakeStateRowSpec>(
+                    &trx,
+                    StakeStateKey {
+                        operator_idx: sm.context.operator_idx(),
+                    },
+                    sm.clone(),
+                )
+                .map_err(OneOf::new)?;
+            }
 
             match trx.commit().await {
                 Ok(_committed) => return Ok(()),
@@ -298,6 +345,7 @@ mod tests {
     use strata_bridge_sm::{
         deposit::{context::DepositSMCtx, state::DepositState},
         graph::{context::GraphSMCtx, state::GraphState},
+        stake::{context::StakeSMCtx, machine::StakeSM, state::StakeState},
     };
     use strata_bridge_test_utils::arbitrary_generator::{arb_outpoint, arb_outpoints, arb_txid};
     use strata_bridge_tx_graph::game_graph::{
@@ -369,6 +417,18 @@ mod tests {
                 deposit_outpoint: outpoint,
                 operator_table,
             },
+            state,
+        }
+    }
+
+    /// Builds a [`StakeSM`] for the given operator from the operator table and state.
+    fn make_stake_sm(
+        operator_idx: OperatorIdx,
+        operator_table: OperatorTable,
+        state: StakeState,
+    ) -> StakeSM {
+        StakeSM {
+            context: StakeSMCtx::new(operator_idx, operator_table),
             state,
         }
     }
@@ -652,6 +712,103 @@ mod tests {
                     .get_graph_state(GraphIdx { deposit: deposit_idx, operator: operator_idx })
                     .await
                     .unwrap();
+                prop_assert_eq!(None, retrieved);
+
+                Ok(())
+            })?;
+        }
+
+        /// Property: any stake SM stored can be retrieved with the same operator index.
+        #[test]
+        fn stake_state_roundtrip(
+            last_block_height in any::<u64>(),
+            operator_table in arb_operator_table(),
+        ) {
+            // StakeSM serialization currently supports only states with no musig2 payloads.
+            // Exercising the `Created` variant keeps this roundtrip independent of the musig2
+            // serde work being landed separately.
+            let operator_idx = operator_table.pov_idx();
+            let stake_sm = make_stake_sm(
+                operator_idx,
+                operator_table,
+                StakeState::Created { last_block_height },
+            );
+
+            block_on(async {
+                let client = get_client();
+
+                client.set_stake_state(operator_idx, stake_sm.clone()).await.unwrap();
+
+                let retrieved = client.get_stake_state(operator_idx).await.unwrap();
+                prop_assert_eq!(Some(stake_sm), retrieved);
+
+                Ok(())
+            })?;
+        }
+
+        /// Property: `get_all_stake_states` returns all previously stored stake states.
+        #[test]
+        fn get_all_stake_states_test(
+            last_block_height_a in any::<u64>(),
+            last_block_height_b in any::<u64>(),
+            operator_table in arb_operator_table(),
+        ) {
+            // Pick two distinct operator indices from the generated table.
+            let op_idxs: Vec<_> = operator_table.operator_idxs().iter().copied().collect();
+            prop_assume!(op_idxs.len() >= 2);
+            let op_a = op_idxs[0];
+            let op_b = op_idxs[1];
+
+            let sm_a = make_stake_sm(
+                op_a,
+                operator_table.clone(),
+                StakeState::Created { last_block_height: last_block_height_a },
+            );
+            let sm_b = make_stake_sm(
+                op_b,
+                operator_table,
+                StakeState::Created { last_block_height: last_block_height_b },
+            );
+
+            block_on(async {
+                let client = get_client();
+
+                client.set_stake_state(op_a, sm_a.clone()).await.unwrap();
+                client.set_stake_state(op_b, sm_b.clone()).await.unwrap();
+
+                let all = client.get_all_stake_states().await.unwrap();
+
+                let found_a = all.iter().any(|(idx, sm)| *idx == op_a && *sm == sm_a);
+                let found_b = all.iter().any(|(idx, sm)| *idx == op_b && *sm == sm_b);
+
+                prop_assert!(found_a, "op_a not found in get_all_stake_states");
+                prop_assert!(found_b, "op_b not found in get_all_stake_states");
+
+                Ok(())
+            })?;
+        }
+
+        /// Property: deleting a stake state makes it unreadable.
+        #[test]
+        fn delete_stake_state_roundtrip(
+            last_block_height in any::<u64>(),
+            operator_table in arb_operator_table(),
+        ) {
+            let operator_idx = operator_table.pov_idx();
+            let stake_sm = make_stake_sm(
+                operator_idx,
+                operator_table,
+                StakeState::Created { last_block_height },
+            );
+
+            block_on(async {
+                let client = get_client();
+
+                client.set_stake_state(operator_idx, stake_sm).await.unwrap();
+
+                client.delete_stake_state(operator_idx).await.unwrap();
+
+                let retrieved = client.get_stake_state(operator_idx).await.unwrap();
                 prop_assert_eq!(None, retrieved);
 
                 Ok(())
@@ -952,8 +1109,8 @@ mod tests {
             })?;
         }
 
-        /// Property: `persist_batch` atomically writes deposit and
-        /// graph SMs that can be read back individually.
+        /// Property: `persist_batch` atomically writes deposit, graph, and stake SMs that can be
+        /// read back individually.
         #[test]
         fn persist_batch_test(
             deposit_idx in any::<DepositIdx>(),
@@ -973,8 +1130,15 @@ mod tests {
                 GraphIdx { deposit: deposit_idx,
                 operator: operator_idx},
                 outpoint,
-                operator_table,
+                operator_table.clone(),
                 GraphState::Created { last_block_height },
+            );
+
+            let stake_op_idx = operator_table.pov_idx();
+            let stake_sm = make_stake_sm(
+                stake_op_idx,
+                operator_table,
+                StakeState::Created { last_block_height },
             );
 
             block_on(async {
@@ -983,6 +1147,7 @@ mod tests {
                 let mut batch = WriteBatch::new();
                 batch.add_deposit(deposit_sm.clone());
                 batch.add_graph(graph_sm.clone());
+                batch.add_stake(stake_sm.clone());
 
                 client.persist_batch(&batch).await.unwrap();
 
@@ -997,6 +1162,9 @@ mod tests {
                     .await
                     .unwrap();
                 prop_assert_eq!(Some(graph_sm), retrieved_graph);
+
+                let retrieved_stake = client.get_stake_state(stake_op_idx).await.unwrap();
+                prop_assert_eq!(Some(stake_sm), retrieved_stake);
 
                 Ok(())
             })?;

--- a/crates/db/src/fdb/bridge_db.rs
+++ b/crates/db/src/fdb/bridge_db.rs
@@ -16,7 +16,8 @@ use crate::{
         row_spec::{
             deposits::{DepositStateKey, DepositStateRowSpec},
             funds::{
-                ClaimFundingKey, ClaimFundingRowSpec, ClaimFundingValue, WithdrawalFundingKey,
+                ClaimFundingKey, ClaimFundingRowSpec, ClaimFundingValue, StakeFundingKey,
+                StakeFundingRowSpec, StakeFundingValue, WithdrawalFundingKey,
                 WithdrawalFundingRowSpec, WithdrawalFundingValue,
             },
             graphs::GraphStateRowSpec,
@@ -212,20 +213,55 @@ impl BridgeDb for FdbClient {
         let claim_pairs = self
             .basic_get_all::<ClaimFundingRowSpec>(|dirs| &dirs.claim_funds)
             .await?;
+        let stake_pairs = self
+            .basic_get_all::<StakeFundingRowSpec>(|dirs| &dirs.stake_funds)
+            .await?;
         let withdrawal_pairs = self
             .basic_get_all::<WithdrawalFundingRowSpec>(|dirs| &dirs.fulfillment_funds)
             .await?;
 
         let mut funds = Vec::with_capacity(
             claim_pairs.len()
+                + stake_pairs.len()
                 + withdrawal_pairs
                     .iter()
                     .map(|(_, v)| v.0.len())
                     .sum::<usize>(),
         );
         funds.extend(claim_pairs.into_iter().map(|(_, v)| v.0));
+        funds.extend(stake_pairs.into_iter().map(|(_, v)| v.0));
         funds.extend(withdrawal_pairs.into_iter().flat_map(|(_, v)| v.0));
         Ok(funds)
+    }
+
+    async fn get_stake_funding_outpoint(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> Result<Option<OutPoint>, Self::Error> {
+        let result = self
+            .basic_get::<StakeFundingRowSpec>(StakeFundingKey { operator_idx })
+            .await?;
+        Ok(result.map(|v| v.0))
+    }
+
+    async fn set_stake_funding_outpoint(
+        &self,
+        operator_idx: OperatorIdx,
+        outpoint: OutPoint,
+    ) -> Result<(), Self::Error> {
+        self.basic_set::<StakeFundingRowSpec>(
+            StakeFundingKey { operator_idx },
+            StakeFundingValue(outpoint),
+        )
+        .await
+    }
+
+    async fn delete_stake_funding_outpoint(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> Result<(), Self::Error> {
+        self.basic_delete::<StakeFundingRowSpec>(StakeFundingKey { operator_idx })
+            .await
     }
 
     async fn delete_claim_funding_outpoint(&self, graph_idx: GraphIdx) -> Result<(), Self::Error> {

--- a/crates/db/src/fdb/dirs.rs
+++ b/crates/db/src/fdb/dirs.rs
@@ -53,6 +53,9 @@ pub struct Directories {
     /// Subspace for storing Graph SM states, keyed by (`DepositIdx`, `OperatorIdx`).
     pub graphs: DirectorySubspace,
 
+    /// Subspace for storing Stake SM states, keyed by `OperatorIdx`.
+    pub stakes: DirectorySubspace,
+
     /// Subspace for storing claim-funding outpoints, keyed by `(DepositIdx, OperatorIdx)`.
     pub claim_funds: DirectorySubspace,
 
@@ -76,6 +79,7 @@ impl Directories {
         let signatures = open_subdir(&root, txn, SubSpaceId::Signatures).await?;
         let deposits = open_subdir(&root, txn, SubSpaceId::Deposits).await?;
         let graphs = open_subdir(&root, txn, SubSpaceId::Graphs).await?;
+        let stakes = open_subdir(&root, txn, SubSpaceId::Stakes).await?;
         let claim_funding_outpoints = open_subdir(&root, txn, SubSpaceId::ClaimFunds).await?;
         let withdrawal_funding_outpoints =
             open_subdir(&root, txn, SubSpaceId::FulfillmentFunds).await?;
@@ -85,6 +89,7 @@ impl Directories {
             signatures,
             deposits,
             graphs,
+            stakes,
             claim_funds: claim_funding_outpoints,
             fulfillment_funds: withdrawal_funding_outpoints,
         })
@@ -123,6 +128,8 @@ pub enum SubSpaceId {
     Deposits,
     /// Subspace for storing Graph SM states, keyed by (`DepositIdx`, `OperatorIdx`).
     Graphs,
+    /// Subspace for storing Stake SM states, keyed by `OperatorIdx`.
+    Stakes,
     /// Subspace for storing claim-funding outpoints.
     ClaimFunds,
     /// Subspace for storing withdrawal-funding outpoints.
@@ -135,6 +142,7 @@ impl From<SubSpaceId> for &'static str {
             SubSpaceId::Signatures => "signatures",
             SubSpaceId::Deposits => "deposits",
             SubSpaceId::Graphs => "graphs",
+            SubSpaceId::Stakes => "stakes",
             SubSpaceId::ClaimFunds => "claim_funds",
             SubSpaceId::FulfillmentFunds => "fulfillment_funds",
         }

--- a/crates/db/src/fdb/dirs.rs
+++ b/crates/db/src/fdb/dirs.rs
@@ -59,6 +59,9 @@ pub struct Directories {
     /// Subspace for storing claim-funding outpoints, keyed by `(DepositIdx, OperatorIdx)`.
     pub claim_funds: DirectorySubspace,
 
+    /// Subspace for storing stake-funding outpoints, keyed by `OperatorIdx`.
+    pub stake_funds: DirectorySubspace,
+
     /// Subspace for storing withdrawal-funding outpoints, keyed by `DepositIdx`.
     pub fulfillment_funds: DirectorySubspace,
 }
@@ -81,6 +84,7 @@ impl Directories {
         let graphs = open_subdir(&root, txn, SubSpaceId::Graphs).await?;
         let stakes = open_subdir(&root, txn, SubSpaceId::Stakes).await?;
         let claim_funding_outpoints = open_subdir(&root, txn, SubSpaceId::ClaimFunds).await?;
+        let stake_funds = open_subdir(&root, txn, SubSpaceId::StakeFunds).await?;
         let withdrawal_funding_outpoints =
             open_subdir(&root, txn, SubSpaceId::FulfillmentFunds).await?;
 
@@ -91,6 +95,7 @@ impl Directories {
             graphs,
             stakes,
             claim_funds: claim_funding_outpoints,
+            stake_funds,
             fulfillment_funds: withdrawal_funding_outpoints,
         })
     }
@@ -132,6 +137,8 @@ pub enum SubSpaceId {
     Stakes,
     /// Subspace for storing claim-funding outpoints.
     ClaimFunds,
+    /// Subspace for storing stake-funding outpoints, keyed by `OperatorIdx`.
+    StakeFunds,
     /// Subspace for storing withdrawal-funding outpoints.
     FulfillmentFunds,
 }
@@ -144,6 +151,7 @@ impl From<SubSpaceId> for &'static str {
             SubSpaceId::Graphs => "graphs",
             SubSpaceId::Stakes => "stakes",
             SubSpaceId::ClaimFunds => "claim_funds",
+            SubSpaceId::StakeFunds => "stake_funds",
             SubSpaceId::FulfillmentFunds => "fulfillment_funds",
         }
     }

--- a/crates/db/src/fdb/row_spec/funds.rs
+++ b/crates/db/src/fdb/row_spec/funds.rs
@@ -124,6 +124,63 @@ impl KVRowSpec for ClaimFundingRowSpec {
     type Value = ClaimFundingValue;
 }
 
+/// Key for stake-funding rows: `OperatorIdx`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StakeFundingKey {
+    /// Operator index.
+    pub operator_idx: OperatorIdx,
+}
+
+impl PackableKey for StakeFundingKey {
+    type PackingError = Infallible;
+    type UnpackingError = PackError;
+    type Packed = Vec<u8>;
+
+    fn pack(&self, dirs: &Directories) -> Result<Self::Packed, Self::PackingError> {
+        Ok(dirs.stake_funds.pack::<(u32,)>(&(self.operator_idx,)))
+    }
+
+    fn unpack(dirs: &Directories, bytes: &[u8]) -> Result<Self, Self::UnpackingError> {
+        let (operator_idx,) = dirs.stake_funds.unpack::<(u32,)>(bytes)?;
+        Ok(Self { operator_idx })
+    }
+}
+
+/// Value for a stake-funding row: a single `OutPoint`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StakeFundingValue(pub OutPoint);
+
+impl SerializableValue for StakeFundingValue {
+    type SerializeError = Infallible;
+    type DeserializeError = InvalidOutPointBytes;
+    type Serialized = [u8; SERIALIZED_OUTPOINT_SIZE];
+
+    fn serialize(&self) -> Result<Self::Serialized, Self::SerializeError> {
+        let outpoint = self.0;
+        let mut out = [0u8; SERIALIZED_OUTPOINT_SIZE];
+        out[..SERIALIZED_TXID_SIZE].copy_from_slice(outpoint.txid.as_raw_hash().as_ref());
+        out[SERIALIZED_TXID_SIZE..].copy_from_slice(&outpoint.vout.to_le_bytes());
+        Ok(out)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<Self, Self::DeserializeError> {
+        let outpoints = deserialize_outpoints(bytes)?;
+        if outpoints.len() != 1 {
+            return Err(InvalidOutPointBytes { len: bytes.len() });
+        }
+        Ok(Self(outpoints[0]))
+    }
+}
+
+/// ZST for stake-funding rows.
+#[derive(Debug)]
+pub struct StakeFundingRowSpec;
+
+impl KVRowSpec for StakeFundingRowSpec {
+    type Key = StakeFundingKey;
+    type Value = StakeFundingValue;
+}
+
 /// Key for withdrawal-funding rows: `DepositIdx`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WithdrawalFundingKey {

--- a/crates/db/src/fdb/row_spec/mod.rs
+++ b/crates/db/src/fdb/row_spec/mod.rs
@@ -5,3 +5,4 @@ pub mod funds;
 pub mod graphs;
 pub mod kv;
 pub mod signatures;
+pub mod stakes;

--- a/crates/db/src/fdb/row_spec/stakes.rs
+++ b/crates/db/src/fdb/row_spec/stakes.rs
@@ -1,0 +1,55 @@
+//! Row spec for Stake SM states.
+
+use std::convert::Infallible;
+
+use foundationdb::tuple::PackError;
+use strata_bridge_primitives::types::OperatorIdx;
+use strata_bridge_sm::stake::machine::StakeSM;
+
+use super::kv::{KVRowSpec, PackableKey, SerializableValue};
+use crate::fdb::dirs::Directories;
+
+/// Key for a stake state row: a single [`OperatorIdx`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StakeStateKey {
+    /// Operator index.
+    pub operator_idx: OperatorIdx,
+}
+
+impl PackableKey for StakeStateKey {
+    type PackingError = Infallible;
+    type UnpackingError = PackError;
+    type Packed = Vec<u8>;
+
+    fn pack(&self, dirs: &Directories) -> Result<Self::Packed, Self::PackingError> {
+        Ok(dirs.stakes.pack::<(u32,)>(&(self.operator_idx,)))
+    }
+
+    fn unpack(dirs: &Directories, bytes: &[u8]) -> Result<Self, Self::UnpackingError> {
+        let (operator_idx,) = dirs.stakes.unpack::<(u32,)>(bytes)?;
+        Ok(Self { operator_idx })
+    }
+}
+
+impl SerializableValue for StakeSM {
+    type SerializeError = postcard::Error;
+    type DeserializeError = postcard::Error;
+    type Serialized = Vec<u8>;
+
+    fn serialize(&self) -> Result<Self::Serialized, Self::SerializeError> {
+        postcard::to_allocvec(self)
+    }
+
+    fn deserialize(bytes: &[u8]) -> Result<Self, Self::DeserializeError> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+/// ZST for the stake state row spec.
+#[derive(Debug)]
+pub struct StakeStateRowSpec;
+
+impl KVRowSpec for StakeStateRowSpec {
+    type Key = StakeStateKey;
+    type Value = StakeSM;
+}

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -5,7 +5,9 @@ use std::fmt::Debug;
 use bitcoin::{OutPoint, Txid};
 use secp256k1::schnorr::Signature;
 use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
-use strata_bridge_sm::{deposit::machine::DepositSM, graph::machine::GraphSM};
+use strata_bridge_sm::{
+    deposit::machine::DepositSM, graph::machine::GraphSM, stake::machine::StakeSM,
+};
 
 use crate::types::WriteBatch;
 
@@ -84,6 +86,32 @@ pub trait BridgeDb {
     fn delete_graph_state(
         &self,
         graph_idx: GraphIdx,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    // ── Stake States ─────────────────────────────────────────────────
+
+    /// Gets, if present, the [`StakeSM`] for the given [`OperatorIdx`].
+    fn get_stake_state(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> impl Future<Output = Result<Option<StakeSM>, Self::Error>> + Send;
+
+    /// Sets the [`StakeSM`] for the given [`OperatorIdx`].
+    fn set_stake_state(
+        &self,
+        operator_idx: OperatorIdx,
+        state: StakeSM,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Returns all stored stake states as `(OperatorIdx, StakeSM)` pairs.
+    fn get_all_stake_states(
+        &self,
+    ) -> impl Future<Output = Result<Vec<(OperatorIdx, StakeSM)>, Self::Error>> + Send;
+
+    /// Deletes the [`StakeSM`] for the given [`OperatorIdx`].
+    fn delete_stake_state(
+        &self,
+        operator_idx: OperatorIdx,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     // ── Funds ─────────────────────────────────────────────────────────

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -131,6 +131,30 @@ pub trait BridgeDb {
         outpoint: OutPoint,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
+    /// Gets, if present, the reserved [`OutPoint`] used to fund the stake transaction for the
+    /// given operator.
+    ///
+    /// Persisting the outpoint lets the stake executor retrieve the existing funding UTXO on
+    /// retry (after a crash, restart, or duty re-dispatch) without creating a new funding tx
+    /// each time, which would consume additional wallet funds.
+    fn get_stake_funding_outpoint(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> impl Future<Output = Result<Option<OutPoint>, Self::Error>> + Send;
+
+    /// Sets the reserved [`OutPoint`] used to fund the stake transaction for the given operator.
+    fn set_stake_funding_outpoint(
+        &self,
+        operator_idx: OperatorIdx,
+        outpoint: OutPoint,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Deletes the reserved stake-funding [`OutPoint`] for the given operator.
+    fn delete_stake_funding_outpoint(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
     /// Gets, if present, the reserved [`OutPoint`]s for fulfilling withdrawals requests.
     fn get_withdrawal_funding_outpoints(
         &self,

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -1,6 +1,8 @@
 //! Database types that are agnostic to the underlying database implementation.
 
-use strata_bridge_sm::{deposit::machine::DepositSM, graph::machine::GraphSM};
+use strata_bridge_sm::{
+    deposit::machine::DepositSM, graph::machine::GraphSM, stake::machine::StakeSM,
+};
 
 /// A batch of state machine writes to persist atomically.
 ///
@@ -13,6 +15,8 @@ pub struct WriteBatch {
     deposits: Vec<DepositSM>,
     /// Graph state machines to persist, keyed by graph index.
     graphs: Vec<GraphSM>,
+    /// Stake state machines to persist, keyed by operator index.
+    stakes: Vec<StakeSM>,
 }
 
 impl WriteBatch {
@@ -21,6 +25,7 @@ impl WriteBatch {
         Self {
             deposits: Vec::new(),
             graphs: Vec::new(),
+            stakes: Vec::new(),
         }
     }
 
@@ -34,6 +39,11 @@ impl WriteBatch {
         &self.graphs
     }
 
+    /// Returns the stake state machines in the batch.
+    pub fn stakes(&self) -> &[StakeSM] {
+        &self.stakes
+    }
+
     /// Adds a deposit state machine to the batch.
     pub fn add_deposit(&mut self, deposit_sm: DepositSM) {
         self.deposits.push(deposit_sm);
@@ -42,5 +52,10 @@ impl WriteBatch {
     /// Adds a graph state machine to the batch.
     pub fn add_graph(&mut self, graph_sm: GraphSM) {
         self.graphs.push(graph_sm);
+    }
+
+    /// Adds a stake state machine to the batch.
+    pub fn add_stake(&mut self, stake_sm: StakeSM) {
+        self.stakes.push(stake_sm);
     }
 }

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -28,32 +28,20 @@ pub struct OperatorWalletConfig {
     stake_funding_utxo_value: Amount,
     /// Value of CPFP UTXOs to identify them
     cpfp_value: Amount,
-    /// Value of the `s` connector, the stake amount, to identify the UTXO
-    s_value: Amount,
     /// Bitcoin network we're on
     network: Network,
 }
 
 impl OperatorWalletConfig {
     /// Creates a new [`OperatorWalletConfig`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `cpfp_value` == `s_value`
-    pub fn new(
+    pub const fn new(
         stake_funding_utxo_value: Amount,
         cpfp_value: Amount,
-        s_value: Amount,
         network: Network,
     ) -> Self {
-        assert_ne!(
-            cpfp_value, s_value,
-            "the value of `s` cannot be the same as the CPFP value"
-        );
         Self {
             stake_funding_utxo_value,
             cpfp_value,
-            s_value,
             network,
         }
     }
@@ -335,23 +323,24 @@ impl OperatorWallet {
         (leased, remaining)
     }
 
-    /// Tries to find the `s` connector UTXO from the prestake transaction
-    pub fn s_utxo(&self) -> Option<LocalOutput> {
-        self.stakechain_wallet
-            .list_unspent()
-            .find(|utxo| utxo.txout.value == self.config.s_value)
-    }
-
     /// Creates a new transaction by paying funds from the general wallet into the
-    /// stakechain wallet (excludes anchor outputs). This will create a [Self::s_utxo].
+    /// stakechain wallet (excludes anchor outputs). The resulting UTXO is the single input to
+    /// the stake transaction.
     ///
-    /// This can be used to fund the stake transaction.
+    /// The `funding_amount` must equal the sum of the stake transaction's outputs — the stake
+    /// amount plus any connector dust the caller is
+    /// responsible for covering (for example, the unstaking-intent connector's minimum non-dust
+    /// value).
     ///
     /// # Notes
     ///
     /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
     /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
-    pub fn create_stake_funding_tx(&mut self, fee_rate: FeeRate) -> Result<Psbt, CreateTxError> {
+    pub fn create_stake_funding_tx(
+        &mut self,
+        fee_rate: FeeRate,
+        funding_amount: Amount,
+    ) -> Result<Psbt, CreateTxError> {
         let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint).collect();
         let mut tx_builder = self.general_wallet.build_tx();
         // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
@@ -359,7 +348,7 @@ impl OperatorWallet {
         // DON'T spend any of the anchor outputs
         tx_builder.unspendable(anchor_outpoints);
         tx_builder.fee_rate(fee_rate);
-        tx_builder.add_recipient(self.stakechain_addr_script_buf.clone(), self.config.s_value);
+        tx_builder.add_recipient(self.stakechain_addr_script_buf.clone(), funding_amount);
         tx_builder.ordering(TxOrdering::Untouched);
         tx_builder.finish()
     }

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -159,3 +159,177 @@ impl<'a> Applicator<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use strata_bridge_primitives::types::GraphIdx;
+    use strata_bridge_sm::{
+        deposit::events::{DepositEvent, NewBlockEvent as DepositNewBlock},
+        graph::events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+    };
+
+    use super::*;
+    use crate::testing::{
+        INITIAL_BLOCK_HEIGHT, N_TEST_OPERATORS, test_empty_registry, test_populated_registry,
+    };
+
+    // ===== apply_batch basic tests =====
+
+    #[test]
+    fn empty_batch_yields_no_duties_and_no_touched_sms() {
+        let mut registry = test_populated_registry(1);
+        let mut applicator = Applicator::new(&mut registry);
+
+        applicator.apply_batch(vec![]).unwrap();
+
+        let (duties, tracker) = applicator.finish();
+        assert!(duties.is_empty());
+        assert!(tracker.into_batches().is_empty());
+    }
+
+    #[test]
+    fn applied_event_marks_sm_as_touched() {
+        let mut registry = test_populated_registry(1);
+        let height = INITIAL_BLOCK_HEIGHT + 1;
+
+        let mut applicator = Applicator::new(&mut registry);
+
+        let seed_events = vec![(
+            SMId::Deposit(0),
+            SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                block_height: height,
+            }))),
+        )];
+
+        applicator.apply_batch(seed_events).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        assert!(!batches.is_empty(), "applied event must mark SM as touched");
+    }
+
+    #[test]
+    fn applied_graph_event_marks_sm_as_touched() {
+        let mut registry = test_populated_registry(1);
+        let height = INITIAL_BLOCK_HEIGHT + 1;
+
+        let graph_idx = GraphIdx {
+            deposit: 0,
+            operator: 0,
+        };
+
+        let mut applicator = Applicator::new(&mut registry);
+
+        let seed_events = vec![(
+            SMId::Graph(graph_idx),
+            SMEvent::Graph(Box::new(GraphEvent::NewBlock(GraphNewBlock {
+                block_height: height,
+            }))),
+        )];
+
+        applicator.apply_batch(seed_events).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        assert!(!batches.is_empty());
+    }
+
+    #[test]
+    fn successive_batches_accumulate_touched_sms() {
+        let mut registry = test_populated_registry(2);
+        let height = INITIAL_BLOCK_HEIGHT + 1;
+
+        let mut applicator = Applicator::new(&mut registry);
+
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(0),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: height,
+                }))),
+            )])
+            .unwrap();
+
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(1),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: height,
+                }))),
+            )])
+            .unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let all_ids: BTreeSet<_> = tracker.into_batches().into_iter().flatten().collect();
+        assert!(all_ids.contains(&SMId::Deposit(0)));
+        assert!(all_ids.contains(&SMId::Deposit(1)));
+    }
+
+    // ===== Error handling tests =====
+
+    #[test]
+    fn unknown_sm_id_is_fatal() {
+        let mut registry = test_empty_registry();
+        let mut applicator = Applicator::new(&mut registry);
+
+        let seed_events = vec![(
+            SMId::Deposit(99),
+            SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                block_height: 200,
+            }))),
+        )];
+
+        let result = applicator.apply_batch(seed_events);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn duplicate_event_is_ignored_non_fatally() {
+        let mut registry = test_populated_registry(1);
+        let mut applicator = Applicator::new(&mut registry);
+
+        let event = || {
+            (
+                SMId::Deposit(0),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: INITIAL_BLOCK_HEIGHT + 1,
+                }))),
+            )
+        };
+
+        applicator.apply_batch(vec![event()]).unwrap();
+        // Same height again — duplicate, should not fail
+        applicator.apply_batch(vec![event()]).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        assert!(!tracker.into_batches().is_empty());
+    }
+
+    // ===== Registry access between batches =====
+
+    #[test]
+    fn registry_reflects_settled_state_between_batches() {
+        let mut registry = test_populated_registry(1);
+        let mut applicator = Applicator::new(&mut registry);
+
+        assert_eq!(applicator.registry().num_deposits(), 1);
+        assert_eq!(
+            applicator.registry().get_graph_ids().len(),
+            N_TEST_OPERATORS
+        );
+
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(0),
+                SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
+                    block_height: INITIAL_BLOCK_HEIGHT + 1,
+                }))),
+            )])
+            .unwrap();
+
+        // Registry still accessible and consistent after batch
+        assert_eq!(applicator.registry().num_deposits(), 1);
+    }
+}

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -78,14 +78,19 @@ impl<'a> Applicator<'a> {
         &mut self,
         seed_events: impl IntoIterator<Item = (SMId, SMEvent)>,
     ) -> Result<(), PipelineError> {
+        // Snapshot the duty count before this batch so we only fabricate follow-up events for
+        // duties produced by *this* batch, not duties accumulated from earlier batches.
+        let duties_before = self.duties.len();
+
         // Process initial seed events
         for (sm_id, sm_event) in seed_events {
             self.apply_one(sm_id, sm_event)?;
         }
 
-        // Fabricate follow-up events for any VerifyAdaptors duties produced by this batch
-        let fabricated: Vec<_> = self
-            .duties
+        // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2669>
+        // Remove this fabrication once adaptor verification is handled properly by the GSM.
+        // Fabricate follow-up events only for VerifyAdaptors duties produced by this batch.
+        let fabricated: Vec<_> = self.duties[duties_before..]
             .iter()
             .filter_map(|duty| {
                 if let UnifiedDuty::Graph(GraphDuty::VerifyAdaptors { graph_idx, .. }) = duty {

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -10,9 +10,14 @@
 
 use std::collections::VecDeque;
 
-use strata_bridge_sm::graph::{
-    duties::GraphDuty,
-    events::{AdaptorsVerifiedEvent, GraphEvent},
+use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
+use strata_bridge_sm::{
+    deposit::machine::DepositSM,
+    graph::{
+        duties::GraphDuty,
+        events::{AdaptorsVerifiedEvent, GraphEvent},
+        machine::GraphSM,
+    },
 };
 use tracing::{info, warn};
 
@@ -20,7 +25,7 @@ use crate::{
     errors::PipelineError,
     persister::PersistenceTracker,
     signals_router,
-    sm_registry::{IgnoredEventReason, ProcessOutcome, SMRegistry},
+    sm_registry::{IgnoredEventReason, ProcessOutcome, RegistryInsertError, SMRegistry},
     sm_types::{SMEvent, SMId, UnifiedDuty},
 };
 
@@ -123,6 +128,36 @@ impl<'a> Applicator<'a> {
         self.duties.extend(duties);
     }
 
+    /// Inserts a new deposit state machine into the registry and records it for persistence.
+    ///
+    /// Newly constructed SMs start in their initial state and typically do not classify the
+    /// current transaction into an event, so they would otherwise never reach any `apply_*` calls
+    /// and never be marked as touched. Routing insertions through the
+    /// applicator makes insertion and persistence-tracking atomic, so callers cannot accidentally
+    /// leave a new SM unrecorded and drop it on crash before its first transition.
+    pub fn insert_deposit(
+        &mut self,
+        deposit_idx: DepositIdx,
+        sm: DepositSM,
+    ) -> Result<(), RegistryInsertError> {
+        self.registry.insert_deposit(deposit_idx, sm)?;
+        self.tracker.record(SMId::Deposit(deposit_idx));
+        Ok(())
+    }
+
+    /// Inserts a new graph state machine into the registry and records it for persistence.
+    ///
+    /// See [`insert_deposit`](Self::insert_deposit) for why the applicator owns this insertion.
+    pub fn insert_graph(
+        &mut self,
+        graph_idx: GraphIdx,
+        sm: GraphSM,
+    ) -> Result<(), RegistryInsertError> {
+        self.registry.insert_graph(graph_idx, sm)?;
+        self.tracker.record(SMId::Graph(graph_idx));
+        Ok(())
+    }
+
     /// Consumes the applicator and returns the accumulated duties and persistence tracker.
     pub fn finish(self) -> (Vec<UnifiedDuty>, PersistenceTracker) {
         (self.duties, self.tracker)
@@ -169,15 +204,21 @@ impl<'a> Applicator<'a> {
 mod tests {
     use std::collections::BTreeSet;
 
+    use bitcoin::{Amount, OutPoint, hashes::sha256};
     use strata_bridge_primitives::types::GraphIdx;
     use strata_bridge_sm::{
         deposit::events::{DepositEvent, NewBlockEvent as DepositNewBlock},
-        graph::events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+        graph::{
+            context::GraphSMCtx,
+            events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+        },
     };
+    use strata_bridge_tx_graph::transactions::prelude::DepositData;
 
     use super::*;
     use crate::testing::{
-        INITIAL_BLOCK_HEIGHT, N_TEST_OPERATORS, test_empty_registry, test_populated_registry,
+        INITIAL_BLOCK_HEIGHT, N_TEST_OPERATORS, TEST_POV_IDX, test_deposit_sm_cfg,
+        test_empty_registry, test_operator_table, test_populated_registry,
     };
 
     // ===== apply_batch basic tests =====
@@ -192,6 +233,112 @@ mod tests {
         let (duties, tracker) = applicator.finish();
         assert!(duties.is_empty());
         assert!(tracker.into_batches().is_empty());
+    }
+
+    #[test]
+    fn insert_deposit_marks_sm_for_persistence_without_any_event() {
+        // Freshly inserted SMs do not classify the current transaction (their initial state
+        // returns `None` from the classifier), so they never reach `apply_one()` and would be
+        // omitted from the persistence batch unless routed through the applicator. This guards
+        // against a durability gap where a new DSM could be lost on crash before its first
+        // transition.
+        let mut registry = test_empty_registry();
+        let mut applicator = Applicator::new(&mut registry);
+
+        let dsm = test_deposit_sm(0);
+        applicator
+            .insert_deposit(0, dsm)
+            .expect("insertion should succeed");
+        applicator.apply_batch(vec![]).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        let flat: BTreeSet<SMId> = batches.into_iter().flatten().collect();
+        assert!(
+            flat.contains(&SMId::Deposit(0)),
+            "insert_deposit must add the SM to the persistence batch even with no STF events"
+        );
+    }
+
+    #[test]
+    fn insert_graph_marks_sm_for_persistence_without_any_event() {
+        // Same invariant as for deposits: a freshly inserted GraphSM does not classify the DRT
+        // transaction, so it must be tracked at insertion time or it will be lost.
+        let mut registry = test_empty_registry();
+        let mut applicator = Applicator::new(&mut registry);
+
+        let graph_idx = GraphIdx {
+            deposit: 0,
+            operator: 0,
+        };
+        let gsm = test_graph_sm(graph_idx);
+        applicator
+            .insert_graph(graph_idx, gsm)
+            .expect("insertion should succeed");
+        applicator.apply_batch(vec![]).unwrap();
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        let flat: BTreeSet<SMId> = batches.into_iter().flatten().collect();
+        assert!(
+            flat.contains(&SMId::Graph(graph_idx)),
+            "insert_graph must add the SM to the persistence batch even with no STF events"
+        );
+    }
+
+    #[test]
+    fn insert_deposit_duplicate_does_not_record_duplicate() {
+        // Propagating the insertion error without recording avoids tracking an SM that was not
+        // actually inserted; the original entry remains the source of truth.
+        let mut registry = test_empty_registry();
+        let mut applicator = Applicator::new(&mut registry);
+
+        applicator.insert_deposit(0, test_deposit_sm(0)).unwrap();
+
+        let err = applicator
+            .insert_deposit(0, test_deposit_sm(0))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::sm_registry::RegistryInsertError::DepositAlreadyExists(0)
+        ));
+
+        let (_, tracker) = applicator.finish();
+        let flat: Vec<SMId> = tracker.into_batches().into_iter().flatten().collect();
+        assert_eq!(flat, vec![SMId::Deposit(0)]);
+    }
+
+    fn test_deposit_sm(deposit_idx: DepositIdx) -> DepositSM {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let depositor_pubkey = operator_table.pov_btc_key().x_only_public_key().0;
+        let data = DepositData {
+            deposit_idx,
+            deposit_request_outpoint: OutPoint::default(),
+            magic_bytes: cfg.magic_bytes(),
+        };
+        let drt_amount = cfg.deposit_amount() + Amount::from_sat(10_000);
+        DepositSM::new(
+            cfg,
+            operator_table,
+            data,
+            depositor_pubkey,
+            drt_amount,
+            INITIAL_BLOCK_HEIGHT,
+        )
+    }
+
+    fn test_graph_sm(graph_idx: GraphIdx) -> GraphSM {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let gsm_ctx = GraphSMCtx {
+            graph_idx,
+            deposit_outpoint: OutPoint::default(),
+            stake_outpoint: OutPoint::default(),
+            unstaking_image: <sha256::Hash as bitcoin::hashes::Hash>::all_zeros(),
+            operator_table,
+        };
+        let (gsm, _duty) = GraphSM::new(gsm_ctx, INITIAL_BLOCK_HEIGHT);
+        gsm
     }
 
     #[test]

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -1,0 +1,161 @@
+//! The fixed-point batch processor for state machine events.
+//!
+//! The [`Applicator`] owns the STF execution, signal cascade, duty accumulation, and persistence
+//! tracking logic. It provides a single entry point ([`apply_batch`](Applicator::apply_batch)) that
+//! processes a set of seed events to a fixed point — all signals are drained and no intermediate
+//! state is externally visible until the batch settles.
+//!
+//! Both on-chain (per-transaction) and off-chain (per-event) paths use the same `Applicator`,
+//! ensuring uniform batch semantics across the pipeline.
+
+use std::collections::VecDeque;
+
+use strata_bridge_sm::graph::{
+    duties::GraphDuty,
+    events::{AdaptorsVerifiedEvent, GraphEvent},
+};
+use tracing::{info, warn};
+
+use crate::{
+    errors::PipelineError,
+    persister::PersistenceTracker,
+    signals_router,
+    sm_registry::{IgnoredEventReason, ProcessOutcome, SMRegistry},
+    sm_types::{SMEvent, SMId, UnifiedDuty},
+};
+
+/// A fixed-point batch processor that drives state machine transitions and signal cascades.
+///
+/// Created once per top-level event (off-chain) or once per block (on-chain), the `Applicator`
+/// accumulates duties and tracks persistence across one or more [`apply_batch`](Self::apply_batch)
+/// calls, then yields its results via [`finish`](Self::finish).
+#[expect(missing_debug_implementations)]
+pub struct Applicator<'a> {
+    registry: &'a mut SMRegistry,
+    tracker: PersistenceTracker,
+    duties: Vec<UnifiedDuty>,
+    signal_queue: VecDeque<(SMId, SMEvent)>,
+}
+
+impl<'a> Applicator<'a> {
+    /// Creates a new `Applicator` bound to the given registry.
+    pub fn new(registry: &'a mut SMRegistry) -> Self {
+        Self {
+            registry,
+            tracker: PersistenceTracker::new(),
+            duties: Vec::new(),
+            signal_queue: VecDeque::new(),
+        }
+    }
+
+    /// Returns a shared reference to the underlying registry.
+    ///
+    /// This is safe to call between `apply_batch` calls to inspect settled state (e.g., to derive
+    /// the active operator snapshot before classifying the next transaction in a block).
+    pub const fn registry(&self) -> &SMRegistry {
+        self.registry
+    }
+
+    /// Returns a mutable reference to the underlying registry.
+    ///
+    /// Needed by callers that must mutate the registry between batches (e.g., registering new SMs
+    /// discovered during block classification).
+    pub const fn registry_mut(&mut self) -> &mut SMRegistry {
+        self.registry
+    }
+
+    /// Processes a batch of seed events to a fixed point.
+    ///
+    /// This method:
+    /// 1. Processes each seed event through the state transition function.
+    /// 2. Fabricates any follow-up events (e.g., `AdaptorsVerified` after `VerifyAdaptors`).
+    /// 3. Drains the signal queue until no more signals remain.
+    /// 4. Accumulates all duties produced.
+    /// 5. Updates the persistence tracker for every touched state machine.
+    ///
+    /// No intermediate state is externally visible until this method returns.
+    pub fn apply_batch(
+        &mut self,
+        seed_events: impl IntoIterator<Item = (SMId, SMEvent)>,
+    ) -> Result<(), PipelineError> {
+        // Process initial seed events
+        for (sm_id, sm_event) in seed_events {
+            self.apply_one(sm_id, sm_event)?;
+        }
+
+        // Fabricate follow-up events for any VerifyAdaptors duties produced by this batch
+        let fabricated: Vec<_> = self
+            .duties
+            .iter()
+            .filter_map(|duty| {
+                if let UnifiedDuty::Graph(GraphDuty::VerifyAdaptors { graph_idx, .. }) = duty {
+                    Some((
+                        (*graph_idx).into(),
+                        SMEvent::from(GraphEvent::AdaptorsVerified(AdaptorsVerifiedEvent {})),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for (sm_id, event) in fabricated {
+            info!(?sm_id, "enqueuing fabricated AdaptorsVerified event");
+            self.signal_queue.push_back((sm_id, event));
+        }
+
+        // Drain signal cascade to fixed point
+        while let Some((sm_id, sm_event)) = self.signal_queue.pop_front() {
+            self.apply_one(sm_id, sm_event)?;
+        }
+
+        Ok(())
+    }
+
+    /// Adds duties directly (e.g., initial duties from newly created SMs that are not produced by
+    /// the STF but by SM constructors).
+    pub fn add_duties(&mut self, duties: impl IntoIterator<Item = UnifiedDuty>) {
+        self.duties.extend(duties);
+    }
+
+    /// Consumes the applicator and returns the accumulated duties and persistence tracker.
+    pub fn finish(self) -> (Vec<UnifiedDuty>, PersistenceTracker) {
+        (self.duties, self.tracker)
+    }
+
+    /// Processes a single event through the registry's STF.
+    ///
+    /// On success, accumulates duties and enqueues any signal-derived events. Ignored outcomes
+    /// (duplicates, rejections) are non-fatal and logged. Fatal errors are propagated.
+    fn apply_one(&mut self, sm_id: SMId, sm_event: SMEvent) -> Result<(), PipelineError> {
+        match self.registry.process_event(&sm_id, sm_event) {
+            Ok(ProcessOutcome::Applied(output)) => {
+                self.duties.extend(output.duties);
+                self.tracker.record(sm_id);
+
+                for signal in output.signals {
+                    for (target_id, target_event) in
+                        signals_router::route_signal(self.registry, signal)
+                    {
+                        self.tracker.link(sm_id, target_id);
+                        self.signal_queue.push_back((target_id, target_event));
+                    }
+                }
+
+                Ok(())
+            }
+            Ok(ProcessOutcome::Ignored { id, event, reason }) => {
+                match reason {
+                    IgnoredEventReason::Duplicate => {
+                        warn!(?id, %event, "duplicate event, skipping");
+                    }
+                    IgnoredEventReason::Rejected(rejected_reason) => {
+                        warn!(?id, %event, %rejected_reason, "event rejected by state machine, skipping");
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/crates/orchestrator/src/duty_dispatcher.rs
+++ b/crates/orchestrator/src/duty_dispatcher.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use strata_bridge_exec::{
     config::ExecutionConfig, deposit::execute_deposit_duty, graph::execute_graph_duty,
-    output_handles::OutputHandles,
+    output_handles::OutputHandles, stake::execute_stake_duty,
 };
-use tracing::{error, warn};
+use tracing::error;
 
 use crate::sm_types::UnifiedDuty;
 
@@ -60,13 +60,14 @@ impl DutyDispatcher {
                         })
                 });
             }
-            // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
-            // Wire stake duty execution through the bridge-exec crate.
             UnifiedDuty::Stake(stake_duty) => {
-                warn!(
-                    ?stake_duty,
-                    "stake duty execution not yet implemented; dropping duty"
-                );
+                tokio::task::spawn(async move {
+                    execute_stake_duty(cfg, handles, &stake_duty)
+                        .await
+                        .inspect_err(|err| {
+                            error!(%err, ?stake_duty, "failed to execute stake duty");
+                        })
+                });
             }
         }
     }

--- a/crates/orchestrator/src/duty_dispatcher.rs
+++ b/crates/orchestrator/src/duty_dispatcher.rs
@@ -6,7 +6,7 @@ use strata_bridge_exec::{
     config::ExecutionConfig, deposit::execute_deposit_duty, graph::execute_graph_duty,
     output_handles::OutputHandles,
 };
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::sm_types::UnifiedDuty;
 
@@ -59,6 +59,14 @@ impl DutyDispatcher {
                             error!(%err, ?graph_duty, "failed to execute graph duty");
                         })
                 });
+            }
+            // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
+            // Wire stake duty execution through the bridge-exec crate.
+            UnifiedDuty::Stake(stake_duty) => {
+                warn!(
+                    ?stake_duty,
+                    "stake duty execution not yet implemented; dropping duty"
+                );
             }
         }
     }

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -171,6 +171,12 @@ pub(crate) fn classify_unsigned_gossip(
                 return vec![];
             };
 
+            info!(
+                %operator_idx,
+                stake_funds = %unstaking_input.stake_funds,
+                unstaking_image = %unstaking_input.unstaking_image,
+                "classified UnstakingDataExchange as StakeEvent::StakeDataReceived"
+            );
             vec![
                 StakeEvent::StakeDataReceived(StakeEvents::StakeDataReceivedEvent {
                     stake_funds: unstaking_input.stake_funds,
@@ -276,6 +282,11 @@ pub(crate) fn classify_unsigned_gossip(
                         );
                         return None;
                     };
+                    info!(
+                        stake_owner = %operator_idx,
+                        sender = %sender_idx,
+                        "classified MuSig2Nonce::Unstake as StakeEvent::UnstakingNoncesReceived"
+                    );
                     Some(
                         StakeEvent::UnstakingNoncesReceived(
                             StakeEvents::UnstakingNoncesReceivedEvent {
@@ -392,6 +403,11 @@ pub(crate) fn classify_unsigned_gossip(
                             );
                             return None;
                         };
+                        info!(
+                            stake_owner = %operator_idx,
+                            sender = %sender_idx,
+                            "classified MuSig2Partial::Unstake as StakeEvent::UnstakingPartialsReceived"
+                        );
                         Some(
                             StakeEvent::UnstakingPartialsReceived(
                                 StakeEvents::UnstakingPartialsReceivedEvent {

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -10,6 +10,7 @@ use strata_bridge_p2p_types::{
 use strata_bridge_sm::{
     deposit::events::{self as DepositEvents, DepositEvent, RetryTickEvent},
     graph::events::{self as GraphEvents, AdaptorsVerifiedEvent, GraphEvent},
+    stake::events::{self as StakeEvents, StakeEvent},
 };
 use strata_mosaic_client_api::MosaicEvent;
 use tracing::{debug, error, info, warn};
@@ -335,6 +336,10 @@ pub(crate) fn classify_unsigned_gossip(
                     .get_graph(&graph_idx)
                     .map(|sm| sm.context().operator_table().pov_p2p_key().clone())
                     .expect("router should route nags only to existing graph SMs"),
+                SMId::Stake(operator_idx) => sm_registry
+                    .get_stake(&operator_idx)
+                    .map(|sm| sm.context().operator_table().pov_p2p_key().clone())
+                    .expect("router should route nags only to existing stake SMs"),
             };
 
             // Check recipient matches POV
@@ -426,6 +431,8 @@ fn classify_assignment(sm_id: &SMId, entries: &[AssignmentEntry]) -> Option<SMEv
                 .into()
             })
         }),
+        // Assignments are deposit-scoped; they do not apply to operator-scoped stake SMs.
+        SMId::Stake(_) => None,
     }
 }
 
@@ -434,9 +441,12 @@ fn classify_nag_tick(sm_id: &SMId, sm_registry: &SMRegistry) -> Option<SMEvent> 
         SMId::Deposit(deposit_idx) => sm_registry
             .get_deposit(deposit_idx)
             .map(|_| DepositEvent::NagTick(DepositEvents::NagTickEvent).into()),
-        SMId::Graph(_graph_idx) => sm_registry
-            .get_graph(_graph_idx)
+        SMId::Graph(graph_idx) => sm_registry
+            .get_graph(graph_idx)
             .map(|_| GraphEvent::NagTick(GraphEvents::NagTickEvent).into()),
+        SMId::Stake(operator_idx) => sm_registry
+            .get_stake(operator_idx)
+            .map(|_| StakeEvent::NagTick(StakeEvents::NagTickEvent).into()),
     }
 }
 
@@ -445,9 +455,12 @@ fn classify_retry_tick(sm_id: &SMId, sm_registry: &SMRegistry) -> Option<SMEvent
         SMId::Deposit(deposit_idx) => sm_registry
             .get_deposit(deposit_idx)
             .map(|_| DepositEvent::RetryTick(RetryTickEvent).into()),
-        SMId::Graph(_graph_idx) => sm_registry
-            .get_graph(_graph_idx)
+        SMId::Graph(graph_idx) => sm_registry
+            .get_graph(graph_idx)
             .map(|_| GraphEvent::RetryTick(GraphEvents::RetryTickEvent).into()),
+        SMId::Stake(operator_idx) => sm_registry
+            .get_stake(operator_idx)
+            .map(|_| StakeEvent::RetryTick(StakeEvents::RetryTickEvent).into()),
     }
 }
 
@@ -460,6 +473,10 @@ fn classify_mosaic_event(sm_id: &SMId, sm_registry: &SMRegistry) -> Option<SMEve
         SMId::Graph(graph_idx) => sm_registry
             .get_graph(graph_idx)
             .map(|_| GraphEvent::AdaptorsVerified(AdaptorsVerifiedEvent {}).into()),
+        SMId::Stake(_) => {
+            error!("got unexpected SMId::Stake for mosaic event");
+            None
+        }
     }
 }
 

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -182,7 +182,7 @@ pub(crate) fn classify_unsigned_gossip(
         }
         UnsignedGossipsubMsg::Musig2NoncesExchange(musig2_nonce) => match musig2_nonce {
             MuSig2Nonce::Deposit { deposit_idx, nonce } => sm_registry
-                .lookup_operator(&(*deposit_idx).into(), key)
+                .lookup_operator(&SMId::Deposit(*deposit_idx), key)
                 .into_iter()
                 .filter_map(|op_idx| {
                     PubNonce::try_from(*nonce)
@@ -204,7 +204,7 @@ pub(crate) fn classify_unsigned_gossip(
                 .collect(),
 
             MuSig2Nonce::Payout { deposit_idx, nonce } => sm_registry
-                .lookup_operator(&(*deposit_idx).into(), key)
+                .lookup_operator(&SMId::Deposit(*deposit_idx), key)
                 .into_iter()
                 .filter_map(|op_idx| {
                     PubNonce::try_from(*nonce)
@@ -294,7 +294,7 @@ pub(crate) fn classify_unsigned_gossip(
                     deposit_idx,
                     partial,
                 } => sm_registry
-                    .lookup_operator(&(*deposit_idx).into(), key)
+                    .lookup_operator(&SMId::Deposit(*deposit_idx), key)
                     .into_iter()
                     .filter_map(|op_idx| {
                         PartialSignature::try_from(*partial)
@@ -319,7 +319,7 @@ pub(crate) fn classify_unsigned_gossip(
                     deposit_idx,
                     partial,
                 } => sm_registry
-                    .lookup_operator(&(*deposit_idx).into(), key)
+                    .lookup_operator(&SMId::Deposit(*deposit_idx), key)
                     .into_iter()
                     .filter_map(|op_idx| {
                         PartialSignature::try_from(*partial)

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -12,6 +12,7 @@ use strata_bridge_sm::{
     graph::events::{self as GraphEvents, AdaptorsVerifiedEvent, GraphEvent},
     stake::events::{self as StakeEvents, StakeEvent},
 };
+use strata_bridge_tx_graph::musig_functor::StakeFunctor;
 use strata_mosaic_client_api::MosaicEvent;
 use tracing::{debug, error, info, warn};
 
@@ -139,8 +140,45 @@ pub(crate) fn classify_unsigned_gossip(
                 vec![]
             }
         }
-        UnsignedGossipsubMsg::UnstakingDataExchange { operator_idx, .. } => {
-            todo!("STR-2924: classify unstaking data exchange for operator {operator_idx}")
+        UnsignedGossipsubMsg::UnstakingDataExchange {
+            operator_idx,
+            unstaking_input,
+        } => {
+            let sm_id = SMId::Stake(*operator_idx);
+            let Some(sender_idx) = sm_registry.lookup_operator(&sm_id, key) else {
+                warn!(
+                    %operator_idx,
+                    "Received unstaking data from unknown sender, ignoring"
+                );
+                return vec![];
+            };
+
+            if sender_idx != *operator_idx {
+                warn!(
+                    claimed_operator_idx=%operator_idx, resolved_operator_idx=%sender_idx,
+                    "Received unstaking data with sender/operator mismatch, ignoring"
+                );
+                return vec![];
+            }
+
+            let Ok(unstaking_output_desc) =
+                Descriptor::try_from(unstaking_input.unstaking_operator_desc.clone())
+            else {
+                warn!(
+                    %operator_idx,
+                    "Received unstaking data with invalid operator descriptor, ignoring"
+                );
+                return vec![];
+            };
+
+            vec![
+                StakeEvent::StakeDataReceived(StakeEvents::StakeDataReceivedEvent {
+                    stake_funds: unstaking_input.stake_funds,
+                    unstaking_image: unstaking_input.unstaking_image,
+                    unstaking_output_desc,
+                })
+                .into(),
+            ]
         }
         UnsignedGossipsubMsg::Musig2NoncesExchange(musig2_nonce) => match musig2_nonce {
             MuSig2Nonce::Deposit { deposit_idx, nonce } => sm_registry
@@ -214,9 +252,41 @@ pub(crate) fn classify_unsigned_gossip(
                 })
                 .collect(),
 
-            MuSig2Nonce::Unstake { operator_idx, .. } => {
-                todo!("STR-2924: classify unstaking nonce for operator {operator_idx}")
-            }
+            MuSig2Nonce::Unstake {
+                operator_idx,
+                nonces,
+            } => sm_registry
+                .lookup_operator(&SMId::Stake(*operator_idx), key)
+                .into_iter()
+                .filter_map(|sender_idx| {
+                    let parsed: Result<Vec<_>, _> =
+                        nonces.iter().map(|n| PubNonce::try_from(*n)).collect();
+                    let Ok(pubnonces) = parsed else {
+                        warn!(
+                            %operator_idx, %sender_idx,
+                            "Received invalid pubnonce for stake, discarding message"
+                        );
+                        return None;
+                    };
+                    let Some(pub_nonces) = StakeFunctor::unpack(pubnonces) else {
+                        warn!(
+                            %operator_idx, %sender_idx,
+                            got = nonces.len(),
+                            "Received wrong number of pubnonces for stake, discarding message"
+                        );
+                        return None;
+                    };
+                    Some(
+                        StakeEvent::UnstakingNoncesReceived(
+                            StakeEvents::UnstakingNoncesReceivedEvent {
+                                operator_idx: sender_idx,
+                                pub_nonces: pub_nonces.boxed(),
+                            },
+                        )
+                        .into(),
+                    )
+                })
+                .collect(),
         },
         UnsignedGossipsubMsg::Musig2SignaturesExchange(musig2_partial) => {
             match musig2_partial {
@@ -296,9 +366,43 @@ pub(crate) fn classify_unsigned_gossip(
                     })
                     .collect(),
 
-                MuSig2Partial::Unstake { operator_idx, .. } => {
-                    todo!("STR-2924: classify unstaking partial for operator {operator_idx}")
-                }
+                MuSig2Partial::Unstake {
+                    operator_idx,
+                    partials,
+                } => sm_registry
+                    .lookup_operator(&SMId::Stake(*operator_idx), key)
+                    .into_iter()
+                    .filter_map(|sender_idx| {
+                        let parsed: Result<Vec<_>, _> = partials
+                            .iter()
+                            .map(|p| PartialSignature::try_from(*p))
+                            .collect();
+                        let Ok(partial_sigs) = parsed else {
+                            warn!(
+                                %operator_idx, %sender_idx,
+                                "Received invalid partial signature for stake, discarding message"
+                            );
+                            return None;
+                        };
+                        let Some(partial_signatures) = StakeFunctor::unpack(partial_sigs) else {
+                            warn!(
+                                %operator_idx, %sender_idx,
+                                got = partials.len(),
+                                "Received wrong number of partial signatures for stake, discarding message"
+                            );
+                            return None;
+                        };
+                        Some(
+                            StakeEvent::UnstakingPartialsReceived(
+                                StakeEvents::UnstakingPartialsReceivedEvent {
+                                    operator_idx: sender_idx,
+                                    partial_signatures,
+                                },
+                            )
+                            .into(),
+                        )
+                    })
+                    .collect(),
             }
         }
 
@@ -395,8 +499,16 @@ pub(crate) fn classify_unsigned_gossip(
                 NagRequestPayload::UnstakingData { .. }
                 | NagRequestPayload::UnstakingNonces { .. }
                 | NagRequestPayload::UnstakingPartials { .. } => {
-                    // unreachable: the sm_id match above already todo!()s for unstaking payloads
-                    todo!("STR-2924: classify unstaking nag into SM event")
+                    // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
+                    // Implement stake nag parity (add StakeEvent::NagReceived) in a follow-up.
+                    // For now, received unstaking nag requests are logged and dropped.
+                    warn!(
+                        target_sm = %sm_id,
+                        sender_operator_idx,
+                        payload = ?nag_request.payload,
+                        "dropping unstaking nag: stake nag parity not yet implemented"
+                    );
+                    return vec![];
                 }
             };
 

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -418,7 +418,7 @@ pub(crate) fn classify_unsigned_gossip(
                 NagRequestPayload::UnstakingData { operator_idx }
                 | NagRequestPayload::UnstakingNonces { operator_idx }
                 | NagRequestPayload::UnstakingPartials { operator_idx } => {
-                    todo!("STR-2924: route unstaking nag for operator {operator_idx}")
+                    SMId::Stake(*operator_idx)
                 }
             };
 

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -148,20 +148,21 @@ fn try_register_deposit(
     // Activation rule: before any DSM / GSM may become active, one stake state machine must exist
     // for every configured operator and all of them must have reached `Confirmed` or higher.
     if !registry.all_operators_have_staked() {
-        warn!(
-            %drt_txid,
-            "skipping DRT: not all operators have completed staking"
-        );
+        warn!("skipping DRT: not all operators have completed staking");
         return Ok(Vec::new());
     }
 
     let snapshot = match registry.active_operator_snapshot(full_operator_table) {
         Ok(snap) => snap,
         Err(err) => {
-            warn!(%drt_txid, %err, "skipping DRT: could not derive active operator snapshot");
+            warn!(%err, "skipping DRT: could not derive active operator snapshot");
             return Ok(Vec::new());
         }
     };
+    info!(
+        active_operator_count = snapshot.operator_table.operator_idxs().len(),
+        "passed stake-readiness gate; registering DSM / GSMs from active operator snapshot"
+    );
 
     let depositor_pubkey = drt_info.header_aux().recovery_pk();
     let Ok(depositor_pubkey) = XOnlyPublicKey::from_slice(depositor_pubkey) else {
@@ -175,10 +176,7 @@ fn try_register_deposit(
 
     // Always second output for now: output 0 is SPS-50 OP_RETURN and output 1 is DRT spend UTXO.
     let Some(deposit_request_output) = tx.output.get(1) else {
-        error!(
-            %drt_txid,
-            "invalid DRT: expected spendable output at index 1, ignoring"
-        );
+        error!("invalid DRT: expected spendable output at index 1, ignoring");
         return Ok(Vec::new());
     };
     let deposit_request_outpoint = bitcoin::OutPoint::new(drt_txid, 1);
@@ -264,8 +262,15 @@ fn classify_tx_for_all_sms(
                 .map(|ev| (graph_idx.into(), ev.into()))
         }))
         .chain(registry.stakes().filter_map(|(&operator_idx, sm)| {
-            sm.classify_tx(stake_cfg, tx, height)
-                .map(|ev| (SMId::Stake(operator_idx), ev.into()))
+            sm.classify_tx(stake_cfg, tx, height).map(|ev| {
+                info!(
+                    %operator_idx,
+                    txid = %tx.compute_txid(),
+                    event = %ev,
+                    "stake SM recognized transaction"
+                );
+                (SMId::Stake(operator_idx), ev.into())
+            })
         }))
         .collect()
 }

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -375,6 +375,10 @@ mod tests {
                     GraphEvent::NewBlock(ref nb) => assert_eq!(nb.block_height, TEST_HEIGHT),
                     other => panic!("expected NewBlock, got {other}"),
                 },
+                // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
+                // Assert the block height on the stake NewBlock event once
+                // `new_block_events()` emits them.
+                SMEvent::Stake(_) => {}
             }
         }
     }

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -40,26 +40,29 @@ use strata_bridge_tx_graph::transactions::prelude::DepositData;
 use tracing::{Level, error, info};
 
 use crate::{
-    errors::ProcessError,
+    applicator::Applicator,
+    errors::{PipelineError, ProcessError},
     sm_registry::SMRegistry,
     sm_types::{SMEvent, SMId, UnifiedDuty},
 };
 
-type EventsMap = Vec<(SMId, SMEvent)>;
-type InitialDuties = Vec<UnifiedDuty>;
-type ClassifiedBlock = (EventsMap, InitialDuties);
-
-/// Classifies a buried block into a list of ([`SMId`], [`SMEvent`]) targets and a list of new
-/// [`UnifiedDuty`]'s.
-pub(crate) fn classify_block(
+/// Processes a buried block by iterating its transactions in chain order.
+///
+/// For each transaction, seed events are classified and applied as a fixed-point batch via the
+/// [`Applicator`]. This ensures that state changes from earlier transactions (e.g., stake
+/// confirmations) are visible when classifying later transactions (e.g., DRTs) in the same block.
+///
+/// After all transactions are processed, `NewBlock` cursor events are emitted for all SMs that
+/// existed before the block was processed.
+pub(crate) fn process_block(
+    applicator: &mut Applicator<'_>,
     initial_operator_table: &OperatorTable,
-    registry: &mut SMRegistry,
     block_event: &BlockEvent,
-) -> Result<ClassifiedBlock, ProcessError> {
+) -> Result<(), PipelineError> {
     let (cur_stakes, cur_unstaking_images) = get_mocked_stake_data(initial_operator_table);
 
-    let deposit_cfg = registry.cfg().deposit.clone();
-    let graph_cfg = registry.cfg().graph.clone();
+    let deposit_cfg = applicator.registry().cfg().deposit.clone();
+    let graph_cfg = applicator.registry().cfg().graph.clone();
     let height = block_event
         .block
         .bip34_block_height()
@@ -67,49 +70,44 @@ pub(crate) fn classify_block(
 
     // Snapshot pre-existing SM IDs: newly created SMs already know the current block height,
     // so only pre-existing ones need a NewBlock cursor event.
-    let existing_deposits = registry.get_deposit_ids();
-    let existing_graphs = registry.get_graph_ids();
-
-    let mut targets = Vec::new();
-    let mut initial_duties = Vec::new();
+    let existing_deposits = applicator.registry().get_deposit_ids();
+    let existing_graphs = applicator.registry().get_graph_ids();
 
     for tx in &block_event.block.txdata {
         // If this tx is a DRT, register new DepositSM + per-operator GraphSMs
-        initial_duties.extend(try_register_deposit(
+        let initial_duties = try_register_deposit(
             &deposit_cfg,
             initial_operator_table,
             &cur_stakes,
             &cur_unstaking_images,
-            registry,
+            applicator.registry_mut(),
             tx,
             height,
-        )?);
+        )?;
 
         // Classify this tx against every active SM via TxClassifier
-        // PERF: (Rajil1213) this needs benchmarking to make sure that classifying every tx against
-        // every SM is not too expensive. If it is, we can optimize by maintaining a cache
-        // of all relevant txids/outpoints per SM and only running TxClassifier if the tx contains a
-        // relevant txid/outpoint and do it only on the relevant SM. It is too expensive if for a
-        // saturated bitcoin block (~3000 txs) and ~1000*15 SMs (45M lookups), we are unable to
-        // classify the block within ~5 minutes (half the average block time) on a
-        // reasonably powerful machine.
-        targets.extend(classify_tx_for_all_sms(
-            &deposit_cfg,
-            &graph_cfg,
-            registry,
-            tx,
-            height,
-        ));
+        // PERF: (Rajil1213) this needs benchmarking to make sure that classifying every tx
+        // against every SM is not too expensive. If it is, we can optimize by maintaining a
+        // cache of all relevant txids/outpoints per SM and only running TxClassifier if the tx
+        // contains a relevant txid/outpoint and do it only on the relevant SM. It is too
+        // expensive if for a saturated bitcoin block (~3000 txs) and ~1000*15 SMs (45M
+        // lookups), we are unable to classify the block within ~5 minutes (half the average
+        // block time) on a reasonably powerful machine.
+        let seed_events =
+            classify_tx_for_all_sms(&deposit_cfg, &graph_cfg, applicator.registry(), tx, height);
+
+        // Apply seed events as one fixed-point batch per transaction
+        applicator.apply_batch(seed_events)?;
+
+        // Add initial duties from newly created SMs (produced by SM constructors, not the STF)
+        applicator.add_duties(initial_duties);
     }
 
-    // Append NewBlock cursor events only for pre-existing SMs
-    targets.extend(new_block_events(
-        &existing_deposits,
-        &existing_graphs,
-        height,
-    ));
+    // Append NewBlock cursor events for pre-existing SMs as the final batch
+    let new_block = new_block_events(&existing_deposits, &existing_graphs, height);
+    applicator.apply_batch(new_block)?;
 
-    Ok((targets, initial_duties))
+    Ok(())
 }
 
 /// Generates mocked stake data for the given operator table.

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -257,7 +257,7 @@ fn classify_tx_for_all_sms(
         .deposits()
         .filter_map(|(&deposit_idx, sm)| {
             sm.classify_tx(deposit_cfg, tx, height)
-                .map(|ev| (deposit_idx.into(), ev.into()))
+                .map(|ev| (SMId::Deposit(deposit_idx), ev.into()))
         })
         .chain(registry.graphs().filter_map(|(&graph_idx, sm)| {
             sm.classify_tx(graph_cfg, tx, height)
@@ -265,7 +265,7 @@ fn classify_tx_for_all_sms(
         }))
         .chain(registry.stakes().filter_map(|(&operator_idx, sm)| {
             sm.classify_tx(stake_cfg, tx, height)
-                .map(|ev| (operator_idx.into(), ev.into()))
+                .map(|ev| (SMId::Stake(operator_idx), ev.into()))
         }))
         .collect()
 }
@@ -291,7 +291,7 @@ fn new_block_events(
 
     deposit_ids
         .iter()
-        .map(|&idx| (idx.into(), deposit_event.clone().into()))
+        .map(|&idx| (SMId::Deposit(idx), deposit_event.clone().into()))
         .chain(
             graph_ids
                 .iter()

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -34,6 +34,10 @@ use strata_bridge_sm::{
         events::{GraphEvent, NewBlockEvent as GraphNewBlockEvent},
         machine::GraphSM,
     },
+    stake::{
+        config::StakeSMCfg,
+        events::{NewBlockEvent as StakeNewBlockEvent, StakeEvent},
+    },
     tx_classifier::TxClassifier,
 };
 use strata_bridge_tx_graph::transactions::prelude::DepositData;
@@ -63,6 +67,7 @@ pub(crate) fn process_block(
 
     let deposit_cfg = applicator.registry().cfg().deposit.clone();
     let graph_cfg = applicator.registry().cfg().graph.clone();
+    let stake_cfg = applicator.registry().cfg().stake.clone();
     let height = block_event
         .block
         .bip34_block_height()
@@ -72,6 +77,7 @@ pub(crate) fn process_block(
     // so only pre-existing ones need a NewBlock cursor event.
     let existing_deposits = applicator.registry().get_deposit_ids();
     let existing_graphs = applicator.registry().get_graph_ids();
+    let existing_stakes = applicator.registry().get_stake_ids();
 
     for tx in &block_event.block.txdata {
         // If this tx is a DRT, register new DepositSM + per-operator GraphSMs
@@ -93,8 +99,14 @@ pub(crate) fn process_block(
         // expensive if for a saturated bitcoin block (~3000 txs) and ~1000*15 SMs (45M
         // lookups), we are unable to classify the block within ~5 minutes (half the average
         // block time) on a reasonably powerful machine.
-        let seed_events =
-            classify_tx_for_all_sms(&deposit_cfg, &graph_cfg, applicator.registry(), tx, height);
+        let seed_events = classify_tx_for_all_sms(
+            &deposit_cfg,
+            &graph_cfg,
+            &stake_cfg,
+            applicator.registry(),
+            tx,
+            height,
+        );
 
         // Apply seed events as one fixed-point batch per transaction
         applicator.apply_batch(seed_events)?;
@@ -104,7 +116,12 @@ pub(crate) fn process_block(
     }
 
     // Append NewBlock cursor events for pre-existing SMs as the final batch
-    let new_block = new_block_events(&existing_deposits, &existing_graphs, height);
+    let new_block = new_block_events(
+        &existing_deposits,
+        &existing_graphs,
+        &existing_stakes,
+        height,
+    );
     applicator.apply_batch(new_block)?;
 
     Ok(())
@@ -238,6 +255,7 @@ fn try_register_deposit(
 fn classify_tx_for_all_sms(
     deposit_cfg: &Arc<DepositSMCfg>,
     graph_cfg: &Arc<GraphSMCfg>,
+    stake_cfg: &Arc<StakeSMCfg>,
     registry: &SMRegistry,
     tx: &Transaction,
     height: BitcoinBlockHeight,
@@ -252,6 +270,10 @@ fn classify_tx_for_all_sms(
             sm.classify_tx(graph_cfg, tx, height)
                 .map(|ev| (graph_idx.into(), ev.into()))
         }))
+        .chain(registry.stakes().filter_map(|(&operator_idx, sm)| {
+            sm.classify_tx(stake_cfg, tx, height)
+                .map(|ev| (operator_idx.into(), ev.into()))
+        }))
         .collect()
 }
 
@@ -261,12 +283,16 @@ fn classify_tx_for_all_sms(
 fn new_block_events(
     deposit_ids: &[DepositIdx],
     graph_ids: &[GraphIdx],
+    stake_ids: &[OperatorIdx],
     height: BitcoinBlockHeight,
 ) -> Vec<(SMId, SMEvent)> {
     let deposit_event = DepositEvent::NewBlock(DepositNewBlockEvent {
         block_height: height,
     });
     let graph_event = GraphEvent::NewBlock(GraphNewBlockEvent {
+        block_height: height,
+    });
+    let stake_event = StakeEvent::NewBlock(StakeNewBlockEvent {
         block_height: height,
     });
 
@@ -277,6 +303,11 @@ fn new_block_events(
             graph_ids
                 .iter()
                 .map(|&idx| (idx.into(), graph_event.clone().into())),
+        )
+        .chain(
+            stake_ids
+                .iter()
+                .map(|&idx| (SMId::Stake(idx), stake_event.clone().into())),
         )
         .collect()
 }
@@ -299,14 +330,14 @@ mod tests {
 
     #[test]
     fn new_block_events_empty_ids() {
-        let events = new_block_events(&[], &[], TEST_HEIGHT);
+        let events = new_block_events(&[], &[], &[], TEST_HEIGHT);
         assert!(events.is_empty());
     }
 
     #[test]
     fn new_block_events_deposits_only() {
         let deposit_ids = vec![0u32, 1, 2];
-        let events = new_block_events(&deposit_ids, &[], TEST_HEIGHT);
+        let events = new_block_events(&deposit_ids, &[], &[], TEST_HEIGHT);
 
         assert_eq!(events.len(), 3);
         for (id, _event) in &events {
@@ -326,11 +357,22 @@ mod tests {
                 operator: 1,
             },
         ];
-        let events = new_block_events(&[], &graph_ids, TEST_HEIGHT);
+        let events = new_block_events(&[], &graph_ids, &[], TEST_HEIGHT);
 
         assert_eq!(events.len(), 2);
         for (id, _event) in &events {
             assert!(matches!(id, SMId::Graph(_)));
+        }
+    }
+
+    #[test]
+    fn new_block_events_stakes_only() {
+        let stake_ids = vec![0u32, 1, 2];
+        let events = new_block_events(&[], &[], &stake_ids, TEST_HEIGHT);
+
+        assert_eq!(events.len(), 3);
+        for (id, _event) in &events {
+            assert!(matches!(id, SMId::Stake(_)));
         }
     }
 
@@ -351,9 +393,10 @@ mod tests {
                 operator: 1,
             },
         ];
-        let events = new_block_events(&deposit_ids, &graph_ids, TEST_HEIGHT);
+        let stake_ids = vec![0u32, 1];
+        let events = new_block_events(&deposit_ids, &graph_ids, &stake_ids, TEST_HEIGHT);
 
-        assert_eq!(events.len(), 5);
+        assert_eq!(events.len(), 7);
     }
 
     #[test]
@@ -363,7 +406,8 @@ mod tests {
             deposit: 0,
             operator: 0,
         }];
-        let events = new_block_events(&deposit_ids, &graph_ids, TEST_HEIGHT);
+        let stake_ids = vec![0u32];
+        let events = new_block_events(&deposit_ids, &graph_ids, &stake_ids, TEST_HEIGHT);
 
         for (_id, event) in events {
             match event {
@@ -375,10 +419,10 @@ mod tests {
                     GraphEvent::NewBlock(ref nb) => assert_eq!(nb.block_height, TEST_HEIGHT),
                     other => panic!("expected NewBlock, got {other}"),
                 },
-                // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
-                // Assert the block height on the stake NewBlock event once
-                // `new_block_events()` emits them.
-                SMEvent::Stake(_) => {}
+                SMEvent::Stake(boxed) => match *boxed {
+                    StakeEvent::NewBlock(ref nb) => assert_eq!(nb.block_height, TEST_HEIGHT),
+                    other => panic!("expected NewBlock, got {other}"),
+                },
             }
         }
     }

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -78,13 +78,8 @@ pub(crate) fn process_block(
         // batches via the Applicator, a stake transition that removes an operator from the active
         // set in an earlier transaction will be reflected here for a DRT appearing later in the
         // same block.
-        let initial_duties = try_register_deposit(
-            &deposit_cfg,
-            initial_operator_table,
-            applicator.registry_mut(),
-            tx,
-            height,
-        )?;
+        let initial_duties =
+            try_register_deposit(&deposit_cfg, initial_operator_table, applicator, tx, height)?;
 
         // Classify this tx against every active SM via TxClassifier
         // PERF: (Rajil1213) this needs benchmarking to make sure that classifying every tx
@@ -132,7 +127,7 @@ pub(crate) fn process_block(
 fn try_register_deposit(
     deposit_cfg: &Arc<DepositSMCfg>,
     full_operator_table: &OperatorTable,
-    registry: &mut SMRegistry,
+    applicator: &mut Applicator<'_>,
     tx: &Transaction,
     height: BitcoinBlockHeight,
 ) -> Result<Vec<UnifiedDuty>, ProcessError> {
@@ -147,12 +142,18 @@ fn try_register_deposit(
 
     // Activation rule: before any DSM / GSM may become active, one stake state machine must exist
     // for every configured operator and all of them must have reached `Confirmed` or higher.
-    if !registry.all_operators_have_staked() {
+    if !applicator
+        .registry()
+        .all_operators_have_staked(full_operator_table)
+    {
         warn!("skipping DRT: not all operators have completed staking");
         return Ok(Vec::new());
     }
 
-    let snapshot = match registry.active_operator_snapshot(full_operator_table) {
+    let snapshot = match applicator
+        .registry()
+        .active_operator_snapshot(full_operator_table)
+    {
         Ok(snap) => snap,
         Err(err) => {
             warn!(%err, "skipping DRT: could not derive active operator snapshot");
@@ -172,7 +173,7 @@ fn try_register_deposit(
 
     let magic_bytes = deposit_cfg.magic_bytes;
 
-    let deposit_idx_offset = registry.next_deposit_idx()?;
+    let deposit_idx_offset = applicator.registry().next_deposit_idx()?;
 
     // Always second output for now: output 0 is SPS-50 OP_RETURN and output 1 is DRT spend UTXO.
     let Some(deposit_request_output) = tx.output.get(1) else {
@@ -203,7 +204,7 @@ fn try_register_deposit(
 
     let deposit_outpoint = dsm.context().deposit_outpoint();
     info!(%deposit_outpoint, deposit_idx=deposit_idx_offset, "registering new DepositSM for detected DRT");
-    registry.insert_deposit(deposit_idx_offset, dsm)?;
+    applicator.insert_deposit(deposit_idx_offset, dsm)?;
 
     // Register one GraphSM per active operator, collecting initial duties.
     let mut duties = Vec::new();
@@ -231,7 +232,7 @@ fn try_register_deposit(
         let (gsm, duty) = GraphSM::new(gsm_ctx, height);
 
         info!(%graph_idx, "registering new GraphSM for detected DRT");
-        registry.insert_graph(gsm.context().graph_idx(), gsm)?;
+        applicator.insert_graph(gsm.context().graph_idx(), gsm)?;
         if let Some(duty) = duty {
             duties.push(duty.into());
         }
@@ -447,16 +448,22 @@ mod tests {
             output: vec![],
         };
 
+        let mut applicator = Applicator::new(&mut registry);
         let duties = try_register_deposit(
             &deposit_cfg,
             &operator_table,
-            &mut registry,
+            &mut applicator,
             &random_tx,
             100,
         )
         .expect("non-DRT path should not fail");
+        let (_, tracker) = applicator.finish();
 
         assert!(duties.is_empty());
         assert_eq!(registry.num_deposits(), 0);
+        assert!(
+            tracker.into_batches().is_empty(),
+            "non-DRT path must not record any SMs in the persistence tracker"
+        );
     }
 }

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -8,14 +8,9 @@
 //!
 //! [`TxClassifier::classify_tx()`]: strata_bridge_sm::tx_classifier::TxClassifier::classify_tx
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
-use bitcoin::{
-    OutPoint, Transaction,
-    hashes::{Hash, sha256},
-    hex::DisplayHex,
-    secp256k1::XOnlyPublicKey,
-};
+use bitcoin::{Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
 use btc_tracker::event::BlockEvent;
 use strata_asm_txs_bridge_v1::deposit_request::parse_drt;
 use strata_bridge_primitives::{
@@ -41,12 +36,12 @@ use strata_bridge_sm::{
     tx_classifier::TxClassifier,
 };
 use strata_bridge_tx_graph::transactions::prelude::DepositData;
-use tracing::{Level, error, info};
+use tracing::{Level, error, info, warn};
 
 use crate::{
     applicator::Applicator,
     errors::{PipelineError, ProcessError},
-    sm_registry::SMRegistry,
+    sm_registry::{ActiveOperatorSnapshot, SMRegistry},
     sm_types::{SMEvent, SMId, UnifiedDuty},
 };
 
@@ -63,8 +58,6 @@ pub(crate) fn process_block(
     initial_operator_table: &OperatorTable,
     block_event: &BlockEvent,
 ) -> Result<(), PipelineError> {
-    let (cur_stakes, cur_unstaking_images) = get_mocked_stake_data(initial_operator_table);
-
     let deposit_cfg = applicator.registry().cfg().deposit.clone();
     let graph_cfg = applicator.registry().cfg().graph.clone();
     let stake_cfg = applicator.registry().cfg().stake.clone();
@@ -80,12 +73,14 @@ pub(crate) fn process_block(
     let existing_stakes = applicator.registry().get_stake_ids();
 
     for tx in &block_event.block.txdata {
-        // If this tx is a DRT, register new DepositSM + per-operator GraphSMs
+        // If this tx is a DRT, register new DepositSM + per-operator GraphSMs using the currently
+        // active operator snapshot. Because stake SM state transitions settle between transaction
+        // batches via the Applicator, a stake transition that removes an operator from the active
+        // set in an earlier transaction will be reflected here for a DRT appearing later in the
+        // same block.
         let initial_duties = try_register_deposit(
             &deposit_cfg,
             initial_operator_table,
-            &cur_stakes,
-            &cur_unstaking_images,
             applicator.registry_mut(),
             tx,
             height,
@@ -127,41 +122,16 @@ pub(crate) fn process_block(
     Ok(())
 }
 
-/// Generates mocked stake data for the given operator table.
-fn get_mocked_stake_data(
-    initial_operator_table: &OperatorTable,
-) -> (BTreeMap<u32, OutPoint>, BTreeMap<u32, sha256::Hash>) {
-    // TODO: <https://alpenlabs.atlassian.net/browse/STR-2699>
-    // Query the Operator and Stake state machines for operator table and stake data instead of
-    // using static values.
-
-    let mock_outpoint = OutPoint::default(); // dummy outpoint
-    let stake_outpoints = initial_operator_table
-        .operator_idxs()
-        .into_iter()
-        .map(|idx| (idx, mock_outpoint))
-        .collect();
-
-    let mock_hash = sha256::Hash::from_slice(&[0u8; 32]).expect("dummy hash must be valid");
-    let unstaking_images = initial_operator_table
-        .operator_idxs()
-        .into_iter()
-        .map(|idx| (idx, mock_hash))
-        .collect();
-    // dummy stake images
-    (stake_outpoints, unstaking_images)
-}
-
 /// If `tx` is a valid deposit request transaction, registers a [`DepositSM`] and per-operator
 /// [`GraphSM`]s into the registry.
 ///
 /// Returns initial duties emitted by [`GraphSM`] constructors (e.g., `GenerateGraphData`).
-/// Returns `Ok(Vec::new())` if the transaction is not a DRT.
+/// Returns `Ok(Vec::new())` if the transaction is not a DRT or if the registry is not yet ready
+/// to accept deposits (either because not all operators have staked, or because this node's own
+/// operator is not active).
 fn try_register_deposit(
     deposit_cfg: &Arc<DepositSMCfg>,
-    cur_operator_table: &OperatorTable,
-    cur_stakes: &BTreeMap<OperatorIdx, OutPoint>,
-    cur_unstaking_images: &BTreeMap<OperatorIdx, sha256::Hash>,
+    full_operator_table: &OperatorTable,
     registry: &mut SMRegistry,
     tx: &Transaction,
     height: BitcoinBlockHeight,
@@ -174,6 +144,24 @@ fn try_register_deposit(
 
     let span = tracing::span!(Level::INFO, "registering new deposit", drt_txid=%drt_txid);
     let _entered = span.entered();
+
+    // Activation rule: before any DSM / GSM may become active, one stake state machine must exist
+    // for every configured operator and all of them must have reached `Confirmed` or higher.
+    if !registry.all_operators_have_staked() {
+        warn!(
+            %drt_txid,
+            "skipping DRT: not all operators have completed staking"
+        );
+        return Ok(Vec::new());
+    }
+
+    let snapshot = match registry.active_operator_snapshot(full_operator_table) {
+        Ok(snap) => snap,
+        Err(err) => {
+            warn!(%drt_txid, %err, "skipping DRT: could not derive active operator snapshot");
+            return Ok(Vec::new());
+        }
+    };
 
     let depositor_pubkey = drt_info.header_aux().recovery_pk();
     let Ok(depositor_pubkey) = XOnlyPublicKey::from_slice(depositor_pubkey) else {
@@ -193,16 +181,22 @@ fn try_register_deposit(
         );
         return Ok(Vec::new());
     };
-    let deposit_request_outpoint = OutPoint::new(drt_txid, 1);
+    let deposit_request_outpoint = bitcoin::OutPoint::new(drt_txid, 1);
     let deposit_data = DepositData {
         deposit_idx: deposit_idx_offset,
         deposit_request_outpoint,
         magic_bytes,
     };
 
+    let ActiveOperatorSnapshot {
+        operator_table: active_operator_table,
+        stake_inputs,
+        unstaking_images,
+    } = snapshot;
+
     let dsm = DepositSM::new(
         deposit_cfg.clone(),
-        cur_operator_table.clone(),
+        active_operator_table.clone(),
         deposit_data,
         depositor_pubkey,
         deposit_request_output.value,
@@ -213,28 +207,27 @@ fn try_register_deposit(
     info!(%deposit_outpoint, deposit_idx=deposit_idx_offset, "registering new DepositSM for detected DRT");
     registry.insert_deposit(deposit_idx_offset, dsm)?;
 
-    // Register one GraphSM per operator, collecting initial duties
+    // Register one GraphSM per active operator, collecting initial duties.
     let mut duties = Vec::new();
-    for &op_idx in cur_operator_table.operator_idxs().iter() {
+    for &op_idx in active_operator_table.operator_idxs().iter() {
         let graph_idx = GraphIdx {
             deposit: deposit_idx_offset,
             operator: op_idx,
         };
 
-        let stake_outpoint = *cur_stakes
+        let stake_outpoint = *stake_inputs
             .get(&op_idx)
-            .expect("must have stake for operator idx");
-
-        let unstaking_image = *cur_unstaking_images
+            .expect("snapshot must contain stake input for active operator");
+        let unstaking_image = *unstaking_images
             .get(&op_idx)
-            .expect("must have unstaking image for operator idx");
+            .expect("snapshot must contain unstaking image for active operator");
 
         let gsm_ctx = GraphSMCtx {
             graph_idx,
             deposit_outpoint,
             stake_outpoint,
             unstaking_image,
-            operator_table: cur_operator_table.clone(),
+            operator_table: active_operator_table.clone(),
         };
 
         let (gsm, duty) = GraphSM::new(gsm_ctx, height);
@@ -314,8 +307,6 @@ fn new_block_events(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use bitcoin::{Amount, Network, absolute, transaction};
     use strata_bridge_test_utils::bridge_fixtures::{TEST_MAGIC_BYTES, TEST_RECOVERY_DELAY};
 
@@ -454,8 +445,6 @@ mod tests {
         let duties = try_register_deposit(
             &deposit_cfg,
             &operator_table,
-            &BTreeMap::new(),
-            &BTreeMap::new(),
             &mut registry,
             &random_tx,
             100,

--- a/crates/orchestrator/src/events_router.rs
+++ b/crates/orchestrator/src/events_router.rs
@@ -62,23 +62,19 @@ fn route_gossipsub_msg(
             SMId::Deposit(*deposit_idx)
         }
         UnsignedGossipsubMsg::UnstakingDataExchange { operator_idx, .. } => {
-            todo!("STR-2924: route unstaking data exchange for operator {operator_idx}")
+            SMId::Stake(*operator_idx)
         }
         UnsignedGossipsubMsg::Musig2NoncesExchange(musig2_nonce) => match musig2_nonce {
             MuSig2Nonce::Deposit { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Nonce::Payout { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Nonce::Graph { graph_idx, .. } => SMId::Graph(*graph_idx),
-            MuSig2Nonce::Unstake { operator_idx, .. } => {
-                todo!("STR-2924: route unstaking nonce for operator {operator_idx}")
-            }
+            MuSig2Nonce::Unstake { operator_idx, .. } => SMId::Stake(*operator_idx),
         },
         UnsignedGossipsubMsg::Musig2SignaturesExchange(musig2_partial) => match musig2_partial {
             MuSig2Partial::Deposit { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Partial::Payout { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Partial::Graph { graph_idx, .. } => SMId::Graph(*graph_idx),
-            MuSig2Partial::Unstake { operator_idx, .. } => {
-                todo!("STR-2924: route unstaking partial for operator {operator_idx}")
-            }
+            MuSig2Partial::Unstake { operator_idx, .. } => SMId::Stake(*operator_idx),
         },
         UnsignedGossipsubMsg::NagRequestExchange(nag_request) => match &nag_request.payload {
             NagRequestPayload::DepositNonce { deposit_idx }
@@ -90,9 +86,7 @@ fn route_gossipsub_msg(
             | NagRequestPayload::GraphPartials { graph_idx } => SMId::Graph(*graph_idx),
             NagRequestPayload::UnstakingData { operator_idx }
             | NagRequestPayload::UnstakingNonces { operator_idx }
-            | NagRequestPayload::UnstakingPartials { operator_idx } => {
-                todo!("STR-2924: route unstaking nag for operator {operator_idx}")
-            }
+            | NagRequestPayload::UnstakingPartials { operator_idx } => SMId::Stake(*operator_idx),
         },
     };
 

--- a/crates/orchestrator/src/events_router.rs
+++ b/crates/orchestrator/src/events_router.rs
@@ -7,7 +7,7 @@ use strata_bridge_p2p_types::{
     MuSig2Nonce, MuSig2Partial, NagRequestPayload, UnsignedGossipsubMsg,
 };
 use strata_mosaic_client_api::MosaicEvent;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::{events_mux::UnifiedEvent, sm_registry::SMRegistry, sm_types::SMId};
 
@@ -62,19 +62,26 @@ fn route_gossipsub_msg(
             SMId::Deposit(*deposit_idx)
         }
         UnsignedGossipsubMsg::UnstakingDataExchange { operator_idx, .. } => {
+            debug!(%operator_idx, "routing UnstakingDataExchange to stake SM");
             SMId::Stake(*operator_idx)
         }
         UnsignedGossipsubMsg::Musig2NoncesExchange(musig2_nonce) => match musig2_nonce {
             MuSig2Nonce::Deposit { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Nonce::Payout { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Nonce::Graph { graph_idx, .. } => SMId::Graph(*graph_idx),
-            MuSig2Nonce::Unstake { operator_idx, .. } => SMId::Stake(*operator_idx),
+            MuSig2Nonce::Unstake { operator_idx, .. } => {
+                debug!(%operator_idx, "routing MuSig2Nonce::Unstake to stake SM");
+                SMId::Stake(*operator_idx)
+            }
         },
         UnsignedGossipsubMsg::Musig2SignaturesExchange(musig2_partial) => match musig2_partial {
             MuSig2Partial::Deposit { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Partial::Payout { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Partial::Graph { graph_idx, .. } => SMId::Graph(*graph_idx),
-            MuSig2Partial::Unstake { operator_idx, .. } => SMId::Stake(*operator_idx),
+            MuSig2Partial::Unstake { operator_idx, .. } => {
+                debug!(%operator_idx, "routing MuSig2Partial::Unstake to stake SM");
+                SMId::Stake(*operator_idx)
+            }
         },
         UnsignedGossipsubMsg::NagRequestExchange(nag_request) => match &nag_request.payload {
             NagRequestPayload::DepositNonce { deposit_idx }
@@ -86,7 +93,10 @@ fn route_gossipsub_msg(
             | NagRequestPayload::GraphPartials { graph_idx } => SMId::Graph(*graph_idx),
             NagRequestPayload::UnstakingData { operator_idx }
             | NagRequestPayload::UnstakingNonces { operator_idx }
-            | NagRequestPayload::UnstakingPartials { operator_idx } => SMId::Stake(*operator_idx),
+            | NagRequestPayload::UnstakingPartials { operator_idx } => {
+                debug!(%operator_idx, payload = ?nag_request.payload, "routing unstaking nag request to stake SM");
+                SMId::Stake(*operator_idx)
+            }
         },
     };
 

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -9,6 +9,7 @@
 //! - Driving state machines that implement the core business-logic of the bridge.
 //! - Providing a channel of communication between the various state machines in the bridge.
 
+pub mod applicator;
 pub mod duty_dispatcher;
 pub mod errors;
 pub mod events_classifier;

--- a/crates/orchestrator/src/persister.rs
+++ b/crates/orchestrator/src/persister.rs
@@ -7,7 +7,7 @@ use std::{
 
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb, types::WriteBatch};
 use thiserror::Error;
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     sm_registry::{RegistryInsertError, SMConfig, SMRegistry},
@@ -141,6 +141,16 @@ impl Persister {
                         } else {
                             error!("Attempted to persist graph state machine with index {graph_idx}, but it was not found in the registry");
                         }
+                    }
+                    // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
+                    // Persist stake state machines once the db layer supports them. For now, stake
+                    // SMs live in-memory only and are re-created from the operator table at
+                    // startup.
+                    SMId::Stake(operator_idx) => {
+                        warn!(
+                            %operator_idx,
+                            "stake state machine persistence not yet implemented; skipping"
+                        );
                     }
                 }
 

--- a/crates/orchestrator/src/persister.rs
+++ b/crates/orchestrator/src/persister.rs
@@ -7,7 +7,7 @@ use std::{
 
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb, types::WriteBatch};
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::error;
 
 use crate::{
     sm_registry::{RegistryInsertError, SMConfig, SMRegistry},
@@ -142,15 +142,12 @@ impl Persister {
                             error!("Attempted to persist graph state machine with index {graph_idx}, but it was not found in the registry");
                         }
                     }
-                    // TODO: <https://alpenlabs.atlassian.net/browse/STR-2924>
-                    // Persist stake state machines once the db layer supports them. For now, stake
-                    // SMs live in-memory only and are re-created from the operator table at
-                    // startup.
                     SMId::Stake(operator_idx) => {
-                        warn!(
-                            %operator_idx,
-                            "stake state machine persistence not yet implemented; skipping"
-                        );
+                        if let Some(stake_sm) = sm_registry.get_stake(&operator_idx) {
+                            write_batch.add_stake(stake_sm.clone());
+                        } else {
+                            error!("Attempted to persist stake state machine for operator {operator_idx}, but it was not found in the registry");
+                        }
                     }
                 }
 
@@ -183,6 +180,15 @@ impl Persister {
             .map_err(PersistError::DbErr)?
         {
             registry.insert_graph(graph_idx, graph_sm)?;
+        }
+
+        for (operator_idx, stake_sm) in self
+            .db
+            .get_all_stake_states()
+            .await
+            .map_err(PersistError::DbErr)?
+        {
+            registry.insert_stake(operator_idx, stake_sm)?;
         }
 
         Ok(registry)

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -1,32 +1,25 @@
 //! The main event loop that wires all pipeline stages together:
-//! `EventsMux` → classify → process → signal cascade → persist → dispatch.
-
-use std::collections::VecDeque;
+//! `EventsMux` → classify → `Applicator::apply_batch` → persist → dispatch.
 
 use strata_bridge_primitives::operator_table::OperatorTable;
-use strata_bridge_sm::graph::{
-    duties::GraphDuty,
-    events::{AdaptorsVerifiedEvent, GraphEvent},
-};
-use tracing::{info, trace, warn};
+use tracing::{info, trace};
 
 use crate::{
+    applicator::Applicator,
     duty_dispatcher::DutyDispatcher,
     errors::PipelineError,
     events_classifier::{offchain, onchain},
     events_mux::{EventsMux, UnifiedEvent},
     events_router,
-    persister::{PersistenceTracker, Persister},
-    signals_router,
-    sm_registry::{IgnoredEventReason, ProcessOutcome, SMRegistry},
-    sm_types::{SMEvent, SMId, UnifiedDuty},
+    persister::Persister,
+    sm_registry::SMRegistry,
 };
 
 /// The main pipeline that drives the orchestrator.
 ///
 /// Continuously pulls events from the multiplexer, classifies and routes them to state machines,
-/// processes them through the STF, cascades any resulting signals, persists state changes, and
-/// dispatches duties to executors.
+/// processes them through the [`Applicator`], persists state changes, and dispatches duties to
+/// executors.
 #[expect(missing_debug_implementations)]
 pub struct Pipeline {
     event_mux: EventsMux,
@@ -75,148 +68,46 @@ impl Pipeline {
                 routable => routable,
             };
 
-            // Stage 2: Classification
-            trace!(
-                ?event,
-                "classifying event and determining target state machines"
-            );
-            let (targets, new_duties): (Vec<(SMId, SMEvent)>, Vec<UnifiedDuty>) = match &event {
-                UnifiedEvent::Block(block_event) => onchain::classify_block(
-                    &initial_operator_table,
-                    &mut self.registry,
-                    block_event,
-                )?,
+            // Stage 2+3: Classify and process through Applicator
+            let mut applicator = Applicator::new(&mut self.registry);
+
+            match &event {
+                UnifiedEvent::Block(block_event) => {
+                    onchain::process_block(&mut applicator, &initial_operator_table, block_event)?;
+                }
 
                 _ => {
                     // P2P / assignment / ticks: route to SM ids, then classify each
-                    let sm_ids = events_router::route(&event, &self.registry);
-                    (
-                        sm_ids
-                            .into_iter()
-                            .filter_map(|sm_id| {
-                                offchain::classify(&sm_id, &event, &self.registry)
-                                    .map(|sm_event| (sm_id, sm_event))
-                            })
-                            .collect(),
-                        Vec::new(),
-                    )
+                    trace!(
+                        ?event,
+                        "classifying event and determining target state machines"
+                    );
+                    let sm_ids = events_router::route(&event, applicator.registry());
+                    let seed_events: Vec<_> = sm_ids
+                        .into_iter()
+                        .filter_map(|sm_id| {
+                            offchain::classify(&sm_id, &event, applicator.registry())
+                                .map(|sm_event| (sm_id, sm_event))
+                        })
+                        .collect();
+
+                    applicator.apply_batch(seed_events)?;
                 }
-            };
+            }
 
-            // Stages 3+4: Process targets + signal cascade
-            let (mut all_duties, tracker) = self.process_and_cascade(targets)?;
-            all_duties.extend(new_duties);
+            let (all_duties, tracker) = applicator.finish();
 
-            // Stage 5: Batch persistence
-
+            // Stage 4: Batch persistence
             let batches = tracker.into_batches();
             info!(count=%batches.len(), "persisting updated state machines batches");
             for batch in batches {
                 self.persister.persist_batch(batch, &self.registry).await?;
             }
 
-            // Stage 6: Dispatch duties
+            // Stage 5: Dispatch duties
             for duty in all_duties {
                 self.dispatcher.dispatch(duty);
             }
-        }
-    }
-
-    /// Processes all targets through the STF and cascades any resulting signals until the signal
-    /// queue is drained.
-    ///
-    /// Returns the accumulated duties and the persistence tracker recording which SMs were touched.
-    fn process_and_cascade(
-        &mut self,
-        targets: Vec<(SMId, SMEvent)>,
-    ) -> Result<(Vec<crate::sm_types::UnifiedDuty>, PersistenceTracker), PipelineError> {
-        let mut all_duties = Vec::new();
-        let mut signal_queue: VecDeque<(SMId, SMEvent)> = VecDeque::new();
-        let mut tracker = PersistenceTracker::new();
-
-        // Process initial targets
-        for (sm_id, sm_event) in targets {
-            self.process_event(
-                sm_id,
-                sm_event,
-                &mut all_duties,
-                &mut signal_queue,
-                &mut tracker,
-            )?;
-        }
-
-        all_duties
-            .iter()
-            .filter_map(|duty| {
-                if let UnifiedDuty::Graph(GraphDuty::VerifyAdaptors { graph_idx, .. }) = duty {
-                    Some((
-                        *graph_idx,
-                        GraphEvent::AdaptorsVerified(AdaptorsVerifiedEvent {}),
-                    ))
-                } else {
-                    None
-                }
-            })
-            .for_each(|(graph_idx, event)| {
-                info!(%graph_idx, "enqueuing fabricated AdaptorsVerified event");
-
-                signal_queue.push_back((graph_idx.into(), event.into()));
-            });
-
-        // Signal cascade: process signals until the queue is drained
-        while let Some((sm_id, sm_event)) = signal_queue.pop_front() {
-            self.process_event(
-                sm_id,
-                sm_event,
-                &mut all_duties,
-                &mut signal_queue,
-                &mut tracker,
-            )?;
-        }
-
-        Ok((all_duties, tracker))
-    }
-
-    /// Processes a single (SMId, SMEvent) pair through the registry's STF.
-    ///
-    /// On success, accumulates duties and enqueues any signal-derived events.
-    /// Ignored outcomes are non-fatal (logged and skipped). Fatal errors are propagated.
-    fn process_event(
-        &mut self,
-        sm_id: SMId,
-        sm_event: SMEvent,
-        all_duties: &mut Vec<crate::sm_types::UnifiedDuty>,
-        signal_queue: &mut VecDeque<(SMId, SMEvent)>,
-        tracker: &mut PersistenceTracker,
-    ) -> Result<(), PipelineError> {
-        match self.registry.process_event(&sm_id, sm_event) {
-            Ok(ProcessOutcome::Applied(output)) => {
-                all_duties.extend(output.duties);
-                tracker.record(sm_id);
-
-                for signal in output.signals {
-                    for (target_id, target_event) in
-                        signals_router::route_signal(&self.registry, signal)
-                    {
-                        tracker.link(sm_id, target_id);
-                        signal_queue.push_back((target_id, target_event));
-                    }
-                }
-
-                Ok(())
-            }
-            Ok(ProcessOutcome::Ignored { id, event, reason }) => {
-                match reason {
-                    IgnoredEventReason::Duplicate => {
-                        warn!(?id, %event, "duplicate event, skipping");
-                    }
-                    IgnoredEventReason::Rejected(rejected_reason) => {
-                        warn!(?id, %event, %rejected_reason, "event rejected by state machine, skipping");
-                    }
-                }
-                Ok(())
-            }
-            Err(e) => Err(e.into()),
         }
     }
 }

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -1,18 +1,22 @@
 //! The main event loop that wires all pipeline stages together:
 //! `EventsMux` → classify → `Applicator::apply_batch` → persist → dispatch.
 
-use strata_bridge_primitives::operator_table::OperatorTable;
+use std::collections::BTreeSet;
+
+use strata_bridge_primitives::{operator_table::OperatorTable, types::BitcoinBlockHeight};
+use strata_bridge_sm::stake::{context::StakeSMCtx, machine::StakeSM};
 use tracing::{info, trace};
 
 use crate::{
     applicator::Applicator,
     duty_dispatcher::DutyDispatcher,
-    errors::PipelineError,
+    errors::{PipelineError, ProcessError},
     events_classifier::{offchain, onchain},
     events_mux::{EventsMux, UnifiedEvent},
     events_router,
     persister::Persister,
     sm_registry::SMRegistry,
+    sm_types::{SMId, UnifiedDuty},
 };
 
 /// The main pipeline that drives the orchestrator.
@@ -51,7 +55,19 @@ impl Pipeline {
     /// The `initial_operator_table` needs to be constructed from a params file or similar source of
     /// truth for now. Eventually, this will be queried from the Operator State Machine in the
     /// registry.
-    pub async fn run(mut self, initial_operator_table: OperatorTable) -> Result<(), PipelineError> {
+    ///
+    /// Before entering the main event loop, this method bootstraps one [`StakeSM`] per operator in
+    /// the `initial_operator_table`. Any stake SMs already recovered from the database are
+    /// preserved; only missing ones are created. The `start_height` is used as the initial block
+    /// height for newly created stake SMs (typically the chain tip or the persisted cursor).
+    pub async fn run(
+        mut self,
+        initial_operator_table: OperatorTable,
+        start_height: BitcoinBlockHeight,
+    ) -> Result<(), PipelineError> {
+        self.bootstrap_stake_sms(&initial_operator_table, start_height)
+            .await?;
+
         loop {
             // Stage 1: Multiplex event streams
             let event = self.event_mux.next().await;
@@ -109,5 +125,46 @@ impl Pipeline {
                 self.dispatcher.dispatch(duty);
             }
         }
+    }
+
+    /// Creates one stake state machine per operator in `operator_table` that does not yet exist in
+    /// the registry. Persists the newly created machines and dispatches any constructor duties
+    /// (only the POV operator's SSM emits `PublishStakeData`).
+    async fn bootstrap_stake_sms(
+        &mut self,
+        operator_table: &OperatorTable,
+        start_height: BitcoinBlockHeight,
+    ) -> Result<(), PipelineError> {
+        let mut touched: BTreeSet<SMId> = BTreeSet::new();
+        let mut duties: Vec<UnifiedDuty> = Vec::new();
+
+        for op_idx in operator_table.operator_idxs() {
+            if self.registry.contains_id(&SMId::Stake(op_idx)) {
+                continue;
+            }
+
+            let ctx = StakeSMCtx::new(op_idx, operator_table.clone());
+            let (ssm, initial_duty) = StakeSM::new(ctx, start_height);
+            self.registry
+                .insert_stake(op_idx, ssm)
+                .map_err(ProcessError::from)?;
+            touched.insert(SMId::Stake(op_idx));
+            info!(%op_idx, %start_height, "bootstrapped stake state machine");
+
+            if let Some(duty) = initial_duty {
+                duties.push(duty.into());
+            }
+        }
+
+        if !touched.is_empty() {
+            self.persister
+                .persist_batch(touched, &self.registry)
+                .await?;
+        }
+        for duty in duties {
+            self.dispatcher.dispatch(duty);
+        }
+
+        Ok(())
     }
 }

--- a/crates/orchestrator/src/signals_router.rs
+++ b/crates/orchestrator/src/signals_router.rs
@@ -40,7 +40,7 @@ pub fn route_signal(registry: &SMRegistry, signal: Signal) -> Vec<(SMId, SMEvent
                         .get_deposit_ids()
                         .into_iter()
                         .filter(|idx| *idx == deposit_idx)
-                        .map(|deposit_id| (deposit_id.into(), event.clone()))
+                        .map(|deposit_id| (SMId::Deposit(deposit_id), event.clone()))
                         .collect()
                 }
             },

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -11,6 +11,7 @@ use strata_bridge_sm::{
     deposit::{config::DepositSMCfg, machine::DepositSM},
     errors::BridgeSMError,
     graph::{config::GraphSMCfg, machine::GraphSM},
+    stake::{config::StakeSMCfg, machine::StakeSM},
     state_machine::{SMOutput, StateMachine},
 };
 use thiserror::Error;
@@ -28,6 +29,8 @@ pub struct SMConfig {
     pub deposit: Arc<DepositSMCfg>,
     /// Static configuration for all graph state machines.
     pub graph: Arc<GraphSMCfg>,
+    /// Static configuration for all stake state machines.
+    pub stake: Arc<StakeSMCfg>,
 }
 
 /// The registry that holds all the active state machines in `strata-bridge`.
@@ -42,6 +45,9 @@ pub struct SMRegistry {
     // deposit index, change this to a `BTreeMap<DepositIdx, BTreeMap<OperatorIdx, GraphSM>>` or
     // maintain a separate index for that mapping.
     graphs: BTreeMap<GraphIdx, GraphSM>,
+    /// The state machines responsible for tracking an operator's stake, indexed by the operator
+    /// index. There is exactly one stake state machine per operator in the operator table.
+    stakes: BTreeMap<OperatorIdx, StakeSM>,
 }
 
 /// Invariant errors when inserting state machines into the registry.
@@ -53,6 +59,9 @@ pub enum RegistryInsertError {
     /// A graph SM already exists at this key.
     #[error("graph state machine already exists at index {0:?}")]
     GraphAlreadyExists(GraphIdx),
+    /// A stake SM already exists at this operator index.
+    #[error("stake state machine already exists for operator {0}")]
+    StakeAlreadyExists(OperatorIdx),
     /// The maximum deposit index has been reached.
     #[error("deposit index exhausted at {0}; cannot allocate a new deposit index")]
     DepositIdxExhausted(DepositIdx),
@@ -90,6 +99,7 @@ impl SMRegistry {
             cfg,
             deposits: BTreeMap::new(),
             graphs: BTreeMap::new(),
+            stakes: BTreeMap::new(),
         }
     }
 
@@ -102,6 +112,12 @@ impl SMRegistry {
     pub fn num_deposits(&self) -> usize {
         self.deposits.len()
     }
+
+    /// Gets the total number of stake state machines currently in the registry.
+    pub fn num_stakes(&self) -> usize {
+        self.stakes.len()
+    }
+
     /// Gets a list of IDs of all deposit state machines currently in the registry.
     pub fn get_deposit_ids(&self) -> Vec<DepositIdx> {
         self.deposits.keys().copied().collect()
@@ -112,12 +128,18 @@ impl SMRegistry {
         self.graphs.keys().copied().collect()
     }
 
+    /// Gets a list of operator indices for all stake state machines currently in the registry.
+    pub fn get_stake_ids(&self) -> Vec<OperatorIdx> {
+        self.stakes.keys().copied().collect()
+    }
+
     /// Gets the IDs of all the state machines currently in the registry.
     pub fn get_all_ids(&self) -> Vec<SMId> {
         self.deposits
             .keys()
             .map(|deposit_idx| SMId::Deposit(*deposit_idx))
             .chain(self.graphs.keys().map(|graph_idx| SMId::Graph(*graph_idx)))
+            .chain(self.stakes.keys().map(|op_idx| SMId::Stake(*op_idx)))
             .collect()
     }
 
@@ -133,6 +155,12 @@ impl SMRegistry {
         self.graphs.get(graph_idx)
     }
 
+    /// Gets a reference to the stake state machine for the given operator index, if it exists in
+    /// the registry.
+    pub fn get_stake(&self, operator_idx: &OperatorIdx) -> Option<&StakeSM> {
+        self.stakes.get(operator_idx)
+    }
+
     /// Returns an iterator over all deposit state machines and their indices.
     pub fn deposits(&self) -> impl Iterator<Item = (&DepositIdx, &DepositSM)> {
         self.deposits.iter()
@@ -143,11 +171,17 @@ impl SMRegistry {
         self.graphs.iter()
     }
 
+    /// Returns an iterator over all stake state machines and their operator indices.
+    pub fn stakes(&self) -> impl Iterator<Item = (&OperatorIdx, &StakeSM)> {
+        self.stakes.iter()
+    }
+
     /// Checks if an ID is present in the registry.
     pub fn contains_id(&self, id: &SMId) -> bool {
         match id {
             SMId::Deposit(deposit_idx) => self.deposits.contains_key(deposit_idx),
             SMId::Graph(graph_idx) => self.graphs.contains_key(graph_idx),
+            SMId::Stake(operator_idx) => self.stakes.contains_key(operator_idx),
         }
     }
 
@@ -210,6 +244,29 @@ impl SMRegistry {
         }
     }
 
+    /// Inserts a new stake state machine into the registry for the given operator index.
+    ///
+    /// Returns an error if a stake state machine already exists for this operator.
+    pub fn insert_stake(
+        &mut self,
+        operator_idx: OperatorIdx,
+        sm: StakeSM,
+    ) -> Result<(), RegistryInsertError> {
+        match self.stakes.entry(operator_idx) {
+            Entry::Vacant(entry) => {
+                entry.insert(sm);
+                Ok(())
+            }
+            Entry::Occupied(_) => {
+                error!(
+                    "Duplicate StakeSM insertion attempted for operator {}",
+                    operator_idx
+                );
+                Err(RegistryInsertError::StakeAlreadyExists(operator_idx))
+            }
+        }
+    }
+
     /// Looks up the state machine identified by `id` and resolves the operator index using the
     /// given [`OperatorKey`].
     ///
@@ -218,6 +275,7 @@ impl SMRegistry {
         let table = match id {
             SMId::Deposit(idx) => self.deposits.get(idx)?.context().operator_table(),
             SMId::Graph(idx) => self.graphs.get(idx)?.context().operator_table(),
+            SMId::Stake(idx) => self.stakes.get(idx)?.context().operator_table(),
         };
         match key {
             OperatorKey::Pov => Some(table.pov_idx()),
@@ -262,6 +320,22 @@ impl SMRegistry {
                         ProcessOutcome::Applied(SMOutput {
                             duties: out.duties.into_iter().map(UnifiedDuty::Graph).collect(),
                             signals: out.signals.into_iter().map(Into::into).collect(),
+                        })
+                    })
+                    .or_else(|err| sm_to_process_result(id, event, err))
+            }
+
+            (SMId::Stake(idx), SMEvent::Stake(stake_event)) => {
+                let sm = self
+                    .stakes
+                    .get_mut(idx)
+                    .ok_or(ProcessError::SMNotFound(*id))?;
+                let event = SMEvent::Stake(stake_event.clone());
+                sm.process_event(self.cfg.stake.clone(), *stake_event)
+                    .map(|out| {
+                        ProcessOutcome::Applied(SMOutput {
+                            duties: out.duties.into_iter().map(UnifiedDuty::Stake).collect(),
+                            signals: out.signals,
                         })
                     })
                     .or_else(|err| sm_to_process_result(id, event, err))

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -489,12 +489,14 @@ mod tests {
         deposit::events::{DepositEvent, NagReceivedEvent, NewBlockEvent as DepositNewBlock},
         graph::events::{GraphEvent, NewBlockEvent as GraphNewBlock},
     };
+    use strata_bridge_test_utils::prelude::generate_txid;
 
     use super::*;
     use crate::{
         sm_types::OperatorKey,
         testing::{
-            N_TEST_OPERATORS, TEST_POV_IDX, insert_deposit_with_graphs, test_empty_registry,
+            N_TEST_OPERATORS, TEST_POV_IDX, insert_confirmed_stake, insert_created_stake,
+            insert_deposit_with_graphs, insert_stakes_for_all_operators, test_empty_registry,
             test_operator_table, test_populated_registry,
         },
     };
@@ -617,7 +619,8 @@ mod tests {
         let registry = test_populated_registry(1);
         let ids = registry.get_all_ids();
 
-        // 1 deposit + N_TEST_OPERATORS graphs
+        // 1 deposit + N_TEST_OPERATORS graphs (test_populated_registry does not pre-bootstrap
+        // stake SMs — tests that exercise stake-gated logic compose those explicitly).
         assert_eq!(ids.len(), 1 + N_TEST_OPERATORS);
 
         let has_deposit = ids.iter().any(|id| matches!(id, SMId::Deposit(0)));
@@ -800,5 +803,146 @@ mod tests {
             Err(ProcessError::InvariantViolation(dep_id, dep_event, state, err_reason))
                 if err_reason == reason && state == state_str && dep_id == id && dep_event == event
         ));
+    }
+
+    // ===== Stake SM gating / snapshot tests =====
+
+    #[test]
+    fn all_operators_have_staked_is_false_for_fresh_bootstrap() {
+        // Fresh stake SMs sit in `Created`, which is before `has_staked()`.
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        insert_stakes_for_all_operators(&mut registry, &table);
+
+        assert!(!registry.all_operators_have_staked());
+    }
+
+    #[test]
+    fn all_operators_have_staked_is_true_once_every_operator_is_confirmed() {
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        for op_idx in table.operator_idxs() {
+            insert_confirmed_stake(&mut registry, op_idx, table.clone(), generate_txid());
+        }
+
+        assert!(registry.all_operators_have_staked());
+    }
+
+    #[test]
+    fn all_operators_have_staked_is_false_if_any_operator_is_pre_confirmed() {
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        // Confirm all operators except the last; give the last a `Created` SSM.
+        let op_idxs: Vec<_> = table.operator_idxs().into_iter().collect();
+        let last = *op_idxs.last().unwrap();
+        for &op_idx in op_idxs.iter().take(op_idxs.len() - 1) {
+            insert_confirmed_stake(&mut registry, op_idx, table.clone(), generate_txid());
+        }
+        insert_created_stake(&mut registry, last, table.clone());
+
+        assert!(!registry.all_operators_have_staked());
+    }
+
+    #[test]
+    fn is_operator_active_tracks_confirmed_state() {
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        assert!(!registry.is_operator_active_for_new_deposits(&TEST_POV_IDX));
+
+        insert_confirmed_stake(&mut registry, TEST_POV_IDX, table, generate_txid());
+
+        assert!(registry.is_operator_active_for_new_deposits(&TEST_POV_IDX));
+    }
+
+    #[test]
+    fn active_operator_snapshot_includes_only_confirmed_operators() {
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        // Confirm POV and a second operator; leave the third in `Created`.
+        let op_idxs: Vec<_> = table.operator_idxs().into_iter().collect();
+        let non_pov_confirmed = *op_idxs.iter().find(|idx| **idx != TEST_POV_IDX).unwrap();
+        let remaining = *op_idxs
+            .iter()
+            .find(|idx| **idx != TEST_POV_IDX && **idx != non_pov_confirmed)
+            .unwrap();
+
+        insert_confirmed_stake(&mut registry, TEST_POV_IDX, table.clone(), generate_txid());
+        insert_confirmed_stake(
+            &mut registry,
+            non_pov_confirmed,
+            table.clone(),
+            generate_txid(),
+        );
+        insert_created_stake(&mut registry, remaining, table.clone());
+
+        let snapshot = registry
+            .active_operator_snapshot(&table)
+            .expect("snapshot should succeed when POV is active");
+
+        let active_idxs = snapshot.operator_table.operator_idxs();
+        assert_eq!(active_idxs.len(), 2);
+        assert!(active_idxs.contains(&TEST_POV_IDX));
+        assert!(active_idxs.contains(&non_pov_confirmed));
+        assert_eq!(snapshot.stake_inputs.len(), 2);
+        assert_eq!(snapshot.unstaking_images.len(), 2);
+    }
+
+    #[test]
+    fn active_operator_snapshot_errors_when_pov_is_not_active() {
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        // Confirm only a non-POV operator; POV and one other stay in `Created`.
+        let op_idxs: Vec<_> = table.operator_idxs().into_iter().collect();
+        let non_pov = *op_idxs.iter().find(|idx| **idx != TEST_POV_IDX).unwrap();
+        insert_confirmed_stake(&mut registry, non_pov, table.clone(), generate_txid());
+
+        // Other operators need `Created` SSMs so the snapshot sees them at all.
+        for op_idx in op_idxs.iter().filter(|idx| **idx != non_pov) {
+            insert_created_stake(&mut registry, *op_idx, table.clone());
+        }
+
+        let err = registry
+            .active_operator_snapshot(&table)
+            .expect_err("snapshot should error when POV is not confirmed");
+        assert!(matches!(err, SnapshotError::PovNotActive(idx) if idx == TEST_POV_IDX));
+    }
+
+    #[test]
+    fn active_operator_snapshot_errors_when_operator_missing_stake_sm() {
+        let registry = test_empty_registry();
+        // Registry has no stake SMs at all; the operator table still has them.
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        let err = registry
+            .active_operator_snapshot(&table)
+            .expect_err("snapshot should error when a stake SM is missing from the registry");
+        assert!(matches!(err, SnapshotError::MissingStakeSM(_)));
+    }
+
+    #[test]
+    fn stake_inputs_use_stake_vout_from_confirmed_txid() {
+        use strata_bridge_tx_graph::transactions::stake::StakeTx;
+
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let stake_txid = generate_txid();
+        for op_idx in table.operator_idxs() {
+            let tx_for_op = if op_idx == TEST_POV_IDX {
+                stake_txid
+            } else {
+                generate_txid()
+            };
+            insert_confirmed_stake(&mut registry, op_idx, table.clone(), tx_for_op);
+        }
+
+        let snapshot = registry.active_operator_snapshot(&table).unwrap();
+        let pov_input = snapshot.stake_inputs.get(&TEST_POV_IDX).unwrap();
+        assert_eq!(pov_input.txid, stake_txid);
+        assert_eq!(pov_input.vout, StakeTx::STAKE_VOUT);
     }
 }

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -304,13 +304,20 @@ impl SMRegistry {
         }
     }
 
-    /// Returns `true` iff every operator that has a stake state machine in the registry has
-    /// reached [`StakeState::has_staked`] (i.e. `Confirmed`, `PreimageRevealed`, or `Unstaked`).
+    /// Returns `true` iff every operator in `operator_table` has a stake state machine in the
+    /// registry and each has reached [`StakeState::has_staked`] (i.e. `Confirmed`,
+    /// `PreimageRevealed`, or `Unstaked`).
     ///
     /// This is the activation gate for new deposits: no DSM/GSM instances may be created until
-    /// every configured operator has at least completed staking.
-    pub fn all_operators_have_staked(&self) -> bool {
-        self.stakes.values().all(|sm| sm.state().has_staked())
+    /// every configured operator has at least completed staking. A missing SSM for any configured
+    /// operator keeps the gate closed — this prevents the predicate from being vacuously true on
+    /// an empty / partially bootstrapped registry.
+    pub fn all_operators_have_staked(&self, operator_table: &OperatorTable) -> bool {
+        operator_table.operator_idxs().iter().all(|op_idx| {
+            self.stakes
+                .get(op_idx)
+                .is_some_and(|sm| sm.state().has_staked())
+        })
     }
 
     /// Returns `true` iff the given operator currently has a stake available
@@ -814,7 +821,7 @@ mod tests {
         let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         insert_stakes_for_all_operators(&mut registry, &table);
 
-        assert!(!registry.all_operators_have_staked());
+        assert!(!registry.all_operators_have_staked(&table));
     }
 
     #[test]
@@ -826,7 +833,7 @@ mod tests {
             insert_confirmed_stake(&mut registry, op_idx, table.clone(), generate_txid());
         }
 
-        assert!(registry.all_operators_have_staked());
+        assert!(registry.all_operators_have_staked(&table));
     }
 
     #[test]
@@ -842,7 +849,36 @@ mod tests {
         }
         insert_created_stake(&mut registry, last, table.clone());
 
-        assert!(!registry.all_operators_have_staked());
+        assert!(!registry.all_operators_have_staked(&table));
+    }
+
+    #[test]
+    fn all_operators_have_staked_is_false_if_any_configured_operator_has_no_ssm() {
+        // Only some of the configured operators have been bootstrapped, but each of those has
+        // reached `Confirmed`. The gate must stay closed because a configured operator is missing
+        // its SSM entirely — otherwise the predicate would be vacuously true over the SSMs that
+        // happen to exist.
+        let mut registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        let op_idxs: Vec<_> = table.operator_idxs().into_iter().collect();
+        let missing = *op_idxs.last().unwrap();
+        for &op_idx in op_idxs.iter().take(op_idxs.len() - 1) {
+            insert_confirmed_stake(&mut registry, op_idx, table.clone(), generate_txid());
+        }
+        assert!(registry.get_stake(&missing).is_none());
+
+        assert!(!registry.all_operators_have_staked(&table));
+    }
+
+    #[test]
+    fn all_operators_have_staked_is_false_for_empty_registry() {
+        // Guard against the predicate being vacuously true: a registry with zero SSMs must never
+        // open the activation gate for a non-empty configured operator set.
+        let registry = test_empty_registry();
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        assert!(!registry.all_operators_have_staked(&table));
     }
 
     #[test]

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -6,14 +6,19 @@ use std::{
     sync::Arc,
 };
 
-use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
+use bitcoin::{OutPoint, hashes::sha256};
+use strata_bridge_primitives::{
+    operator_table::OperatorTable,
+    types::{DepositIdx, GraphIdx, OperatorIdx},
+};
 use strata_bridge_sm::{
     deposit::{config::DepositSMCfg, machine::DepositSM},
     errors::BridgeSMError,
     graph::{config::GraphSMCfg, machine::GraphSM},
-    stake::{config::StakeSMCfg, machine::StakeSM},
+    stake::{config::StakeSMCfg, machine::StakeSM, state::StakeState},
     state_machine::{SMOutput, StateMachine},
 };
+use strata_bridge_tx_graph::transactions::stake::StakeTx;
 use thiserror::Error;
 use tracing::error;
 
@@ -65,6 +70,38 @@ pub enum RegistryInsertError {
     /// The maximum deposit index has been reached.
     #[error("deposit index exhausted at {0}; cannot allocate a new deposit index")]
     DepositIdxExhausted(DepositIdx),
+}
+
+/// A derived view of the operators that are currently eligible to participate in new deposits.
+///
+/// Constructed from the registry by filtering the full operator table down to operators whose
+/// stake state machine is in the [`StakeState::Confirmed`] state (i.e.
+/// [`StakeState::is_stake_available`]). The `stake_inputs` and `unstaking_images` maps contain the
+/// corresponding on-chain data for each active operator, extracted from the stake SM's confirmed
+/// state.
+#[derive(Debug, Clone)]
+pub struct ActiveOperatorSnapshot {
+    /// The filtered operator table containing only operators with a confirmed stake.
+    pub operator_table: OperatorTable,
+    /// The UTXO of the stake transaction per active operator, keyed by operator index. This is the
+    /// input that the per-operator [`GraphSM`] uses for slashing.
+    pub stake_inputs: BTreeMap<OperatorIdx, OutPoint>,
+    /// The unstaking hash image per active operator, keyed by operator index. This is the hash
+    /// that locks the claim-payout connector in the per-operator game graph.
+    pub unstaking_images: BTreeMap<OperatorIdx, sha256::Hash>,
+}
+
+/// Errors returned when constructing an [`ActiveOperatorSnapshot`].
+#[derive(Debug, Clone, Error)]
+pub enum SnapshotError {
+    /// The registry is missing a stake state machine for an operator present in the full table.
+    #[error("missing stake state machine for operator {0}")]
+    MissingStakeSM(OperatorIdx),
+    /// The point-of-view operator is not active for new deposits (its stake SM has moved past
+    /// [`StakeState::Confirmed`] or was never instantiated). This node cannot originate new
+    /// deposits while its own operator is not eligible.
+    #[error("point-of-view operator {0} is not active for new deposits")]
+    PovNotActive(OperatorIdx),
 }
 
 /// Reason why a state machine event was ignored as non-fatal.
@@ -265,6 +302,74 @@ impl SMRegistry {
                 Err(RegistryInsertError::StakeAlreadyExists(operator_idx))
             }
         }
+    }
+
+    /// Returns `true` iff every operator that has a stake state machine in the registry has
+    /// reached [`StakeState::has_staked`] (i.e. `Confirmed`, `PreimageRevealed`, or `Unstaked`).
+    ///
+    /// This is the activation gate for new deposits: no DSM/GSM instances may be created until
+    /// every configured operator has at least completed staking.
+    pub fn all_operators_have_staked(&self) -> bool {
+        self.stakes.values().all(|sm| sm.state().has_staked())
+    }
+
+    /// Returns `true` iff the given operator currently has a stake available
+    /// ([`StakeState::is_stake_available`], i.e. `Confirmed` and not yet winding down).
+    pub fn is_operator_active_for_new_deposits(&self, operator_idx: &OperatorIdx) -> bool {
+        self.stakes
+            .get(operator_idx)
+            .is_some_and(|sm| sm.state().is_stake_available())
+    }
+
+    /// Builds an [`ActiveOperatorSnapshot`] from the operators in `full_table` whose stake state
+    /// machine is currently in [`StakeState::Confirmed`].
+    ///
+    /// Returns an error if the point-of-view operator is not active, since this node cannot
+    /// originate new deposits while its own operator is winding down or absent.
+    pub fn active_operator_snapshot(
+        &self,
+        full_table: &OperatorTable,
+    ) -> Result<ActiveOperatorSnapshot, SnapshotError> {
+        let mut entries = Vec::new();
+        let mut stake_inputs = BTreeMap::new();
+        let mut unstaking_images = BTreeMap::new();
+
+        for op_idx in full_table.operator_idxs() {
+            let ssm = self
+                .stakes
+                .get(&op_idx)
+                .ok_or(SnapshotError::MissingStakeSM(op_idx))?;
+
+            let StakeState::Confirmed {
+                stake_data,
+                summary,
+                ..
+            } = ssm.state()
+            else {
+                continue;
+            };
+
+            let p2p_key = full_table
+                .idx_to_p2p_key(&op_idx)
+                .expect("operator from operator_idxs() must resolve");
+            let btc_key = full_table
+                .idx_to_btc_key(&op_idx)
+                .expect("operator from operator_idxs() must resolve");
+            entries.push((op_idx, p2p_key.clone(), btc_key));
+
+            stake_inputs.insert(op_idx, OutPoint::new(summary.stake, StakeTx::STAKE_VOUT));
+            unstaking_images.insert(op_idx, stake_data.unstaking_image);
+        }
+
+        let pov_idx = full_table.pov_idx();
+        let operator_table = OperatorTable::new(entries, move |(idx, _, _)| *idx == pov_idx)
+            .ok_or(SnapshotError::PovNotActive(pov_idx))?;
+
+        Ok(ActiveOperatorSnapshot {
+            operator_table,
+            stake_inputs,
+            unstaking_images,
+        })
     }
 
     /// Looks up the state machine identified by `id` and resolves the operator index using the

--- a/crates/orchestrator/src/sm_types.rs
+++ b/crates/orchestrator/src/sm_types.rs
@@ -21,11 +21,10 @@ pub enum SMId {
     Stake(OperatorIdx),
 }
 
-impl From<DepositIdx> for SMId {
-    fn from(deposit_idx: DepositIdx) -> Self {
-        SMId::Deposit(deposit_idx)
-    }
-}
+// Note: `DepositIdx` and `OperatorIdx` are both type aliases for `u32`, so a blanket
+// `From<u32>` impl would silently dispatch either index to a single `SMId` variant (a
+// footgun when constructing stake- or deposit-scoped ids). Use explicit
+// `SMId::Deposit(_)` / `SMId::Stake(_)` at the call site instead.
 
 impl From<GraphIdx> for SMId {
     fn from(graph_idx: GraphIdx) -> Self {

--- a/crates/orchestrator/src/sm_types.rs
+++ b/crates/orchestrator/src/sm_types.rs
@@ -2,10 +2,11 @@
 
 use std::fmt::Display;
 
-use strata_bridge_primitives::types::{DepositIdx, GraphIdx, P2POperatorPubKey};
+use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx, P2POperatorPubKey};
 use strata_bridge_sm::{
     deposit::{duties::DepositDuty, events::DepositEvent},
     graph::{duties::GraphDuty, events::GraphEvent},
+    stake::{duties::StakeDuty, events::StakeEvent},
 };
 
 /// The unique identifier for a state machine in `strata-bridge`.
@@ -15,6 +16,9 @@ pub enum SMId {
     Deposit(DepositIdx),
     /// IDs the state machine responsible for processing a graph with the given index.
     Graph(GraphIdx),
+    /// IDs the state machine responsible for tracking the stake of the operator with the given
+    /// index.
+    Stake(OperatorIdx),
 }
 
 impl From<DepositIdx> for SMId {
@@ -38,6 +42,7 @@ impl Display for SMId {
                 "Graph(deposit: {}, operator: {})",
                 graph_idx.deposit, graph_idx.operator
             ),
+            SMId::Stake(operator_idx) => write!(f, "Stake(operator: {})", operator_idx),
         }
     }
 }
@@ -58,6 +63,8 @@ pub enum SMEvent {
     Deposit(Box<DepositEvent>),
     /// An event related to the graph state machine.
     Graph(Box<GraphEvent>),
+    /// An event related to the stake state machine.
+    Stake(Box<StakeEvent>),
 }
 
 impl Display for SMEvent {
@@ -65,6 +72,7 @@ impl Display for SMEvent {
         match self {
             SMEvent::Deposit(event) => write!(f, "DepositEvent({event})"),
             SMEvent::Graph(event) => write!(f, "GraphEvent({event})"),
+            SMEvent::Stake(event) => write!(f, "StakeEvent({event})"),
         }
     }
 }
@@ -81,6 +89,12 @@ impl From<GraphEvent> for SMEvent {
     }
 }
 
+impl From<StakeEvent> for SMEvent {
+    fn from(event: StakeEvent) -> Self {
+        SMEvent::Stake(Box::new(event))
+    }
+}
+
 /// A wrapper for holding all the different types of duties that a state machine can emit after a
 /// successful STF.
 #[derive(Debug, Clone)]
@@ -90,6 +104,8 @@ pub enum UnifiedDuty {
     Deposit(DepositDuty),
     /// A duty related to the game graph.
     Graph(GraphDuty),
+    /// A duty related to an operator's stake.
+    Stake(StakeDuty),
 }
 
 impl From<DepositDuty> for UnifiedDuty {
@@ -100,5 +116,10 @@ impl From<DepositDuty> for UnifiedDuty {
 impl From<GraphDuty> for UnifiedDuty {
     fn from(duty: GraphDuty) -> Self {
         UnifiedDuty::Graph(duty)
+    }
+}
+impl From<StakeDuty> for UnifiedDuty {
+    fn from(duty: StakeDuty) -> Self {
+        UnifiedDuty::Stake(duty)
     }
 }

--- a/crates/orchestrator/src/testing.rs
+++ b/crates/orchestrator/src/testing.rs
@@ -15,6 +15,7 @@ use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
 use strata_bridge_sm::{
     deposit::{config::DepositSMCfg, machine::DepositSM},
     graph::{config::GraphSMCfg, context::GraphSMCtx, machine::GraphSM},
+    stake::config::StakeSMCfg,
 };
 // Re-export shared bridge fixtures so other test modules in this crate can use them.
 pub(crate) use strata_bridge_test_utils::bridge_fixtures::{
@@ -24,7 +25,10 @@ pub(crate) use strata_bridge_test_utils::bridge_fixtures::{
 use strata_bridge_test_utils::{
     bitcoin::generate_xonly_pubkey, bridge_fixtures::TEST_RECOVERY_DELAY,
 };
-use strata_bridge_tx_graph::{game_graph::ProtocolParams, transactions::prelude::DepositData};
+use strata_bridge_tx_graph::{
+    game_graph::ProtocolParams as GameProtocolParams,
+    stake_graph::ProtocolParams as StakeProtocolParams, transactions::prelude::DepositData,
+};
 use strata_predicate::PredicateKey;
 
 use crate::sm_registry::{SMConfig, SMRegistry};
@@ -64,7 +68,7 @@ pub(crate) fn test_graph_sm_cfg() -> Arc<GraphSMCfg> {
         .collect();
 
     Arc::new(GraphSMCfg {
-        game_graph_params: ProtocolParams {
+        game_graph_params: GameProtocolParams {
             network: Network::Regtest,
             magic_bytes: TEST_MAGIC_BYTES.into(),
             contest_timelock: relative::Height::from_height(10),
@@ -85,11 +89,24 @@ pub(crate) fn test_graph_sm_cfg() -> Arc<GraphSMCfg> {
     })
 }
 
-/// Creates a combined `SMConfig` from the test deposit and graph configs.
+/// Creates a test `StakeSMCfg`, mirroring `bridge-sm/stake/tests::TEST_CFG`.
+pub(crate) fn test_stake_sm_cfg() -> Arc<StakeSMCfg> {
+    Arc::new(StakeSMCfg {
+        protocol_params: StakeProtocolParams {
+            network: Network::Regtest,
+            magic_bytes: TEST_MAGIC_BYTES.into(),
+            unstaking_timelock: relative::Height::from_height(144),
+            stake_amount: Amount::from_sat(100_000_000),
+        },
+    })
+}
+
+/// Creates a combined `SMConfig` from the test deposit, graph, and stake configs.
 pub(crate) fn test_sm_config() -> SMConfig {
     SMConfig {
         deposit: test_deposit_sm_cfg(),
         graph: test_graph_sm_cfg(),
+        stake: test_stake_sm_cfg(),
     }
 }
 

--- a/crates/orchestrator/src/testing.rs
+++ b/crates/orchestrator/src/testing.rs
@@ -7,15 +7,23 @@
 use std::{num::NonZero, sync::Arc};
 
 use bitcoin::{
-    Amount, Network, OutPoint,
+    Amount, Network, OutPoint, Txid,
     hashes::{Hash, sha256},
     relative,
 };
-use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
+use strata_bridge_primitives::{
+    operator_table::OperatorTable,
+    types::{DepositIdx, GraphIdx, OperatorIdx},
+};
 use strata_bridge_sm::{
     deposit::{config::DepositSMCfg, machine::DepositSM},
     graph::{config::GraphSMCfg, context::GraphSMCtx, machine::GraphSM},
-    stake::config::StakeSMCfg,
+    stake::{
+        config::StakeSMCfg,
+        context::{MinimumStakeData, StakeSMCtx},
+        machine::StakeSM,
+        state::StakeState,
+    },
 };
 // Re-export shared bridge fixtures so other test modules in this crate can use them.
 pub(crate) use strata_bridge_test_utils::bridge_fixtures::{
@@ -23,11 +31,12 @@ pub(crate) use strata_bridge_test_utils::bridge_fixtures::{
     test_operator_table,
 };
 use strata_bridge_test_utils::{
-    bitcoin::generate_xonly_pubkey, bridge_fixtures::TEST_RECOVERY_DELAY,
+    bitcoin::generate_xonly_pubkey, bridge_fixtures::TEST_RECOVERY_DELAY, prelude::generate_txid,
 };
 use strata_bridge_tx_graph::{
     game_graph::ProtocolParams as GameProtocolParams,
-    stake_graph::ProtocolParams as StakeProtocolParams, transactions::prelude::DepositData,
+    stake_graph::{ProtocolParams as StakeProtocolParams, StakeGraphSummary},
+    transactions::prelude::DepositData,
 };
 use strata_predicate::PredicateKey;
 
@@ -165,8 +174,78 @@ pub(crate) fn insert_deposit_with_graphs(registry: &mut SMRegistry, deposit_idx:
     }
 }
 
+/// Inserts a [`StakeSM`] in the initial [`StakeState::Created`] state for the given operator into
+/// the registry.
+pub(crate) fn insert_created_stake(
+    registry: &mut SMRegistry,
+    operator_idx: OperatorIdx,
+    operator_table: OperatorTable,
+) {
+    let ctx = StakeSMCtx::new(operator_idx, operator_table);
+    let (ssm, _duty) = StakeSM::new(ctx, INITIAL_BLOCK_HEIGHT);
+    registry
+        .insert_stake(operator_idx, ssm)
+        .expect("test helper must not insert duplicate stake state machine");
+}
+
+/// Inserts one [`StakeSM`] per operator in the test operator table, each in the initial
+/// [`StakeState::Created`] state.
+pub(crate) fn insert_stakes_for_all_operators(
+    registry: &mut SMRegistry,
+    operator_table: &OperatorTable,
+) {
+    for op_idx in operator_table.operator_idxs() {
+        insert_created_stake(registry, op_idx, operator_table.clone());
+    }
+}
+
+/// Builds a [`StakeSM`] in [`StakeState::Confirmed`] for the given operator, with deterministic
+/// dummy values for stake-graph fields that are not relevant to the test being written.
+pub(crate) fn make_confirmed_stake_sm(
+    operator_idx: OperatorIdx,
+    operator_table: OperatorTable,
+    stake_txid: Txid,
+) -> StakeSM {
+    let stake_data = MinimumStakeData {
+        stake_funds: OutPoint::default(),
+        unstaking_image: sha256::Hash::all_zeros(),
+        unstaking_operator_desc: random_p2tr_desc(),
+    };
+    let summary = StakeGraphSummary {
+        stake: stake_txid,
+        unstaking_intent: generate_txid(),
+        unstaking: generate_txid(),
+    };
+    StakeSM {
+        context: StakeSMCtx::new(operator_idx, operator_table),
+        state: StakeState::Confirmed {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            stake_data,
+            summary,
+            signatures: Box::new(None),
+        },
+    }
+}
+
+/// Inserts a [`StakeSM`] in [`StakeState::Confirmed`] for `operator_idx` into the registry. The
+/// registry must not already contain a stake state machine for that operator — tests building
+/// scenarios with confirmed stakes should start from a registry without pre-bootstrapped stakes.
+pub(crate) fn insert_confirmed_stake(
+    registry: &mut SMRegistry,
+    operator_idx: OperatorIdx,
+    operator_table: OperatorTable,
+    stake_txid: Txid,
+) {
+    let sm = make_confirmed_stake_sm(operator_idx, operator_table, stake_txid);
+    registry
+        .insert_stake(operator_idx, sm)
+        .expect("test helper must not insert duplicate confirmed stake state machine");
+}
+
 /// Creates a pre-populated registry with `n_deposits` deposits, each with `N_TEST_OPERATORS` graph
-/// SMs.
+/// SMs. Stake state machines are intentionally **not** included — tests that exercise stake-gated
+/// logic should compose them via [`insert_stakes_for_all_operators`] or
+/// [`insert_confirmed_stake`].
 pub(crate) fn test_populated_registry(n_deposits: usize) -> SMRegistry {
     let mut registry = test_empty_registry();
     for i in 0..n_deposits {

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -7,7 +7,7 @@ use strata_identifiers::Buf32;
 
 use crate::types::{
     RpcAggregateSignatures, RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositInfo, RpcGraphData,
-    RpcOperatorStatus, RpcPendingWithdrawalInfo, RpcWithdrawalInfo,
+    RpcOperatorStakeInfo, RpcOperatorStatus, RpcPendingWithdrawalInfo, RpcWithdrawalInfo,
 };
 
 /// RPCs related to information about the client itself.
@@ -96,6 +96,10 @@ pub trait StrataBridgeMonitoringApi {
         &self,
         deposit_idx: DepositIdx,
     ) -> RpcResult<Option<RpcPendingWithdrawalInfo>>;
+
+    /// Get the stake status for every operator the node is tracking.
+    #[method(name = "stakeStatus")]
+    async fn get_stake_status(&self) -> RpcResult<Vec<RpcOperatorStakeInfo>>;
 }
 
 /// RPCs required for data availability.

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -226,3 +226,49 @@ pub struct RpcAggregateSignatures {
     /// Aggregate Schnorr signatures for the graph.
     pub signatures: Vec<Signature>,
 }
+
+/// Lifecycle state of an operator's stake.
+///
+/// The variants mirror [`strata_bridge_sm::stake::state::StakeState`] but carry only the
+/// information needed for external monitoring: the coarse phase label and, once available, the
+/// unstaking transaction id.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum RpcStakeState {
+    /// Initial state; no stake-related transactions have been produced yet.
+    Created,
+    /// Stake graph has been generated.
+    StakeGraphGenerated,
+    /// Unstaking musig2 nonces have been collected.
+    UnstakingNoncesCollected,
+    /// Unstaking musig2 partial signatures have been collected.
+    UnstakingSigned,
+    /// Stake transaction has been confirmed on-chain.
+    Confirmed {
+        /// Txid of the confirmed stake transaction.
+        stake_txid: Txid,
+    },
+    /// Unstaking preimage has been revealed on-chain.
+    PreimageRevealed,
+    /// Unstaking transaction has been confirmed on-chain.
+    Unstaked {
+        /// Txid of the confirmed unstaking transaction.
+        unstaking_txid: Txid,
+    },
+}
+
+/// Per-operator stake status.
+///
+/// The [`RpcStakeState`] discriminator + fields are flattened into this struct, so a `Confirmed`
+/// stake serialises as
+/// `{"operator_idx": 0, "state": "confirmed", "stake_txid": "…"}` rather than nesting the state
+/// under a sub-object. This keeps the JSON readable and easy to parse in consumers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcOperatorStakeInfo {
+    /// The operator this stake belongs to.
+    pub operator_idx: OperatorIdx,
+
+    /// Current stake state.
+    #[serde(flatten)]
+    pub state: RpcStakeState,
+}

--- a/functional-tests/envs/base_env.py
+++ b/functional-tests/envs/base_env.py
@@ -170,10 +170,11 @@ class BaseEnv(flexitest.EnvConfig):
         return s2_service, bridge_operator, self._asm_rpc_service
 
     def fund_operator(self, brpc, bridge_operator_props, wallet_addr):
-        """Fund an operator's wallets."""
-        sc_wallet_address = bridge_operator_props["sc_wallet_address"]
+        """Fund an operator's wallet.
+        Only the general wallet needs to be funded.
+        The node will take care of funding the stakechain wallet from the general wallet.
+        """
         general_wallet_address = bridge_operator_props["general_wallet_address"]
-        brpc.proxy.sendtoaddress(sc_wallet_address, self.funding_amount)
         brpc.proxy.sendtoaddress(general_wallet_address, self.funding_amount)
 
         # Generate blocks for finalization

--- a/functional-tests/envs/btc_config.py
+++ b/functional-tests/envs/btc_config.py
@@ -11,4 +11,4 @@ class BitcoinEnvConfig:
     block_generation_interval_secs: int = BLOCK_GENERATION_INTERVAL_SECS
     auto_mine: bool = True
     finalization_blocks: int = 10
-    funding_amount: float = 10.01
+    funding_amount: float = 30

--- a/functional-tests/rpc/types.py
+++ b/functional-tests/rpc/types.py
@@ -215,3 +215,34 @@ class RpcDisproveData:
     operator_descriptor: str
     wots_public_keys: dict
     n_of_n_sig: str
+
+
+class RpcStakeStateLabel(Enum):
+    """Lifecycle state of an operator's stake."""
+
+    CREATED = "created"
+    STAKE_GRAPH_GENERATED = "stake_graph_generated"
+    UNSTAKING_NONCES_COLLECTED = "unstaking_nonces_collected"
+    UNSTAKING_SIGNED = "unstaking_signed"
+    CONFIRMED = "confirmed"
+    PREIMAGE_REVEALED = "preimage_revealed"
+    UNSTAKED = "unstaked"
+
+
+@dataclass
+class RpcOperatorStakeInfo:
+    """Per-operator stake status returned by `stratabridge_stakeStatus`."""
+
+    operator_idx: int
+    state: RpcStakeStateLabel
+    stake_txid: str | None = None
+    unstaking_txid: str | None = None
+
+    @classmethod
+    def from_json(cls, data: dict) -> "RpcOperatorStakeInfo":
+        return cls(
+            operator_idx=int(data["operator_idx"]),
+            state=RpcStakeStateLabel(data["state"]),
+            stake_txid=data.get("stake_txid"),
+            unstaking_txid=data.get("unstaking_txid"),
+        )

--- a/functional-tests/tests/asm/fn_asm_rpc_test.py
+++ b/functional-tests/tests/asm/fn_asm_rpc_test.py
@@ -10,7 +10,6 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -29,6 +28,8 @@ class AsmBinaryTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -38,14 +39,6 @@ class AsmBinaryTest(StrataTestBase):
         # Send a deposit request and wait for completion
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")

--- a/functional-tests/tests/asm/fn_asm_rpc_test.py
+++ b/functional-tests/tests/asm/fn_asm_rpc_test.py
@@ -10,6 +10,7 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -37,10 +38,17 @@ class AsmBinaryTest(StrataTestBase):
         # Send a deposit request and wait for completion
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/asm/fn_assignment_duration_timeout.py
+++ b/functional-tests/tests/asm/fn_assignment_duration_timeout.py
@@ -12,6 +12,7 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -59,10 +60,17 @@ class AssignmentDurationTimeoutTest(StrataTestBase):
         # Send a deposit request and wait for completion
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/asm/fn_assignment_duration_timeout.py
+++ b/functional-tests/tests/asm/fn_assignment_duration_timeout.py
@@ -12,7 +12,6 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -48,6 +47,8 @@ class AssignmentDurationTimeoutTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -60,14 +61,6 @@ class AssignmentDurationTimeoutTest(StrataTestBase):
         # Send a deposit request and wait for completion
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")

--- a/functional-tests/tests/bridge/fn_concurrent_deposit_test.py
+++ b/functional-tests/tests/bridge/fn_concurrent_deposit_test.py
@@ -7,6 +7,7 @@ from rpc.types import RpcDepositStatusComplete
 from utils.bridge import get_bridge_nodes_and_rpcs
 from utils.deposit import wait_until_deposit_status, wait_until_drts_recognized
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import read_operator_key
 
 # Higher burial depth makes sequential processing more apparent
@@ -70,6 +71,13 @@ class ConcurrentDepositTest(StrataTestBase):
 
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
         bridge_rpc = bridge_rpcs[0]
+
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRTs")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
 
         # Send multiple DRTs simultaneously
         self.logger.info(f"Broadcasting {CONCURRENT_DRT_COUNT} DRTs")

--- a/functional-tests/tests/bridge/fn_concurrent_deposit_test.py
+++ b/functional-tests/tests/bridge/fn_concurrent_deposit_test.py
@@ -7,7 +7,6 @@ from rpc.types import RpcDepositStatusComplete
 from utils.bridge import get_bridge_nodes_and_rpcs
 from utils.deposit import wait_until_deposit_status, wait_until_drts_recognized
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import read_operator_key
 
 # Higher burial depth makes sequential processing more apparent
@@ -61,6 +60,7 @@ class ConcurrentDepositTest(StrataTestBase):
         CONCURRENT_DRT_COUNT = 3
 
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
 
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoind_props = bitcoind_service.props
@@ -70,14 +70,6 @@ class ConcurrentDepositTest(StrataTestBase):
         operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
 
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-        bridge_rpc = bridge_rpcs[0]
-
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRTs")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         # Send multiple DRTs simultaneously
         self.logger.info(f"Broadcasting {CONCURRENT_DRT_COUNT} DRTs")

--- a/functional-tests/tests/bridge/fn_deposit_test.py
+++ b/functional-tests/tests/bridge/fn_deposit_test.py
@@ -12,6 +12,7 @@ from utils.deposit import (
 )
 from utils.dev_cli import DevCli
 from utils.network import wait_until_p2p_connected
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     snapshot_log_offsets,
@@ -42,15 +43,24 @@ class BridgeDepositTest(StrataTestBase):
         # Test deposit
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoind_props = bitcoind_service.props
+        bitcoin_rpc = bitcoind_service.create_rpc()
 
         num_operators = len(bridge_nodes)
         operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
 
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
+
+        bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
-        bridge_rpc = bridge_rpcs[0]
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
 
         wait_until_deposit_status(bridge_rpc, deposit_id, RpcDepositStatusComplete)

--- a/functional-tests/tests/bridge/fn_deposit_test.py
+++ b/functional-tests/tests/bridge/fn_deposit_test.py
@@ -12,7 +12,6 @@ from utils.deposit import (
 )
 from utils.dev_cli import DevCli
 from utils.network import wait_until_p2p_connected
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     snapshot_log_offsets,
@@ -39,24 +38,16 @@ class BridgeDepositTest(StrataTestBase):
     def main(self, ctx: flexitest.RunContext):
         CONCURRENT_DRT_COUNT = 5
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
 
         # Test deposit
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoind_props = bitcoind_service.props
-        bitcoin_rpc = bitcoind_service.create_rpc()
 
         num_operators = len(bridge_nodes)
         operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
 
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")

--- a/functional-tests/tests/contest/fn_faulty_claim.py
+++ b/functional-tests/tests/contest/fn_faulty_claim.py
@@ -13,6 +13,7 @@ from utils.deposit import (
     wait_until_utxo_spent,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -69,11 +70,17 @@ class FaultyClaimContestedTest(StrataTestBase):
             bridge_protocol_params=self.bridge_protocol_params,
         )
 
+        bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
         # 1. Send deposit request and wait for completion
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")
-
-        bridge_rpc = bridge_rpcs[0]
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/contest/fn_faulty_claim.py
+++ b/functional-tests/tests/contest/fn_faulty_claim.py
@@ -13,7 +13,6 @@ from utils.deposit import (
     wait_until_utxo_spent,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -56,6 +55,8 @@ class FaultyClaimContestedTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
         asm_rpc = ctx.get_service("asm_rpc").create_rpc()
@@ -68,14 +69,6 @@ class FaultyClaimContestedTest(StrataTestBase):
             bitcoind_props,
             operator_key_infos,
             bridge_protocol_params=self.bridge_protocol_params,
-        )
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
         )
 
         # 1. Send deposit request and wait for completion

--- a/functional-tests/tests/payout/fn_contest_without_counterproof.py
+++ b/functional-tests/tests/payout/fn_contest_without_counterproof.py
@@ -12,7 +12,6 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -50,6 +49,8 @@ class ContestedPayoutCompletesWithoutCounterproofTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -66,14 +67,6 @@ class ContestedPayoutCompletesWithoutCounterproofTest(StrataTestBase):
             bitcoind_props,
             operator_key_infos,
             bridge_protocol_params=self.bridge_protocol_params,
-        )
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
         )
 
         drt_txid = dev_cli.send_deposit_request()

--- a/functional-tests/tests/payout/fn_contest_without_counterproof.py
+++ b/functional-tests/tests/payout/fn_contest_without_counterproof.py
@@ -12,6 +12,7 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -66,10 +67,17 @@ class ContestedPayoutCompletesWithoutCounterproofTest(StrataTestBase):
             operator_key_infos,
             bridge_protocol_params=self.bridge_protocol_params,
         )
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/payout/fn_coop_payout_test.py
+++ b/functional-tests/tests/payout/fn_coop_payout_test.py
@@ -14,6 +14,7 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -52,10 +53,17 @@ class CooperativePayoutTest(StrataTestBase):
         # Wait for DT and DRT
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/payout/fn_coop_payout_test.py
+++ b/functional-tests/tests/payout/fn_coop_payout_test.py
@@ -14,7 +14,6 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -40,6 +39,8 @@ class CooperativePayoutTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -53,14 +54,6 @@ class CooperativePayoutTest(StrataTestBase):
         # Wait for DT and DRT
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")

--- a/functional-tests/tests/payout/fn_fulfillment_idempotency_test.py
+++ b/functional-tests/tests/payout/fn_fulfillment_idempotency_test.py
@@ -31,6 +31,7 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     snapshot_log_offsets,
@@ -78,10 +79,17 @@ class FulfillmentIdempotencyTest(StrataTestBase):
         # --- Setup: Create deposit and trigger fulfillment assignment ---
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/payout/fn_fulfillment_idempotency_test.py
+++ b/functional-tests/tests/payout/fn_fulfillment_idempotency_test.py
@@ -31,7 +31,6 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     snapshot_log_offsets,
@@ -67,6 +66,8 @@ class FulfillmentIdempotencyTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -79,14 +80,6 @@ class FulfillmentIdempotencyTest(StrataTestBase):
         # --- Setup: Create deposit and trigger fulfillment assignment ---
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")

--- a/functional-tests/tests/payout/fn_uncontested_payout.py
+++ b/functional-tests/tests/payout/fn_uncontested_payout.py
@@ -13,6 +13,7 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -52,10 +53,17 @@ class UnContestedPayoutTest(StrataTestBase):
         # Wait for DT and DRT
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/payout/fn_uncontested_payout.py
+++ b/functional-tests/tests/payout/fn_uncontested_payout.py
@@ -13,7 +13,6 @@ from utils.deposit import (
     wait_until_drt_recognized,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -40,6 +39,8 @@ class UnContestedPayoutTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -53,14 +54,6 @@ class UnContestedPayoutTest(StrataTestBase):
         # Wait for DT and DRT
         bitcoind_props = bitcoind_service.props
         dev_cli = DevCli(bitcoind_props, operator_key_infos)
-
-        bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
 
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")

--- a/functional-tests/tests/timeouts/fn_bridge_proof_timeout.py
+++ b/functional-tests/tests/timeouts/fn_bridge_proof_timeout.py
@@ -12,6 +12,7 @@ from utils.deposit import (
     wait_until_utxo_spent,
 )
 from utils.dev_cli import DevCli
+from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -66,10 +67,17 @@ class BridgeProofTimeoutTest(StrataTestBase):
             operator_key_infos,
             bridge_protocol_params=self.bridge_protocol_params,
         )
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
 
         bridge_rpc = bridge_rpcs[0]
+        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
+        wait_until_all_operators_staked(
+            bridge_rpc,
+            bitcoin_rpc,
+            expected_operator_count=num_operators,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
         self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
 

--- a/functional-tests/tests/timeouts/fn_bridge_proof_timeout.py
+++ b/functional-tests/tests/timeouts/fn_bridge_proof_timeout.py
@@ -12,7 +12,6 @@ from utils.deposit import (
     wait_until_utxo_spent,
 )
 from utils.dev_cli import DevCli
-from utils.stake import wait_until_all_operators_staked
 from utils.utils import (
     read_operator_key,
     wait_for_tx_confirmation,
@@ -50,6 +49,8 @@ class BridgeProofTimeoutTest(StrataTestBase):
 
     def main(self, ctx: flexitest.RunContext):
         bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
 
@@ -69,13 +70,6 @@ class BridgeProofTimeoutTest(StrataTestBase):
         )
 
         bridge_rpc = bridge_rpcs[0]
-        self.logger.info("Waiting for all operators to complete staking before broadcasting DRT")
-        wait_until_all_operators_staked(
-            bridge_rpc,
-            bitcoin_rpc,
-            expected_operator_count=num_operators,
-        )
-
         drt_txid = dev_cli.send_deposit_request()
         self.logger.info(f"Broadcasted DRT: {drt_txid}")
         deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)

--- a/functional-tests/utils/bridge.py
+++ b/functional-tests/utils/bridge.py
@@ -1,5 +1,8 @@
+import logging
+
 from constants import BRIDGE_NETWORK_SIZE
 from utils.network import wait_until_p2p_connected
+from utils.stake import wait_until_all_operators_staked
 
 
 def get_bridge_nodes_and_rpcs(ctx, num_operators=BRIDGE_NETWORK_SIZE):
@@ -9,5 +12,13 @@ def get_bridge_nodes_and_rpcs(ctx, num_operators=BRIDGE_NETWORK_SIZE):
 
     # Verify operator connectivity
     wait_until_p2p_connected(bridge_rpcs)
+
+    bitcoind_service = ctx.get_service("bitcoin")
+    bitcoin_rpc = bitcoind_service.create_rpc()
+
+    logging.info("Waiting for all operators to complete staking")
+    wait_until_all_operators_staked(
+        bridge_rpcs[0], bitcoin_rpc, expected_operator_count=num_operators
+    )
 
     return bridge_nodes, bridge_rpcs

--- a/functional-tests/utils/stake.py
+++ b/functional-tests/utils/stake.py
@@ -1,0 +1,77 @@
+import logging
+
+from rpc.types import RpcOperatorStakeInfo, RpcStakeStateLabel
+from utils.utils import wait_for_tx_confirmation, wait_until
+
+
+def get_stake_status(bridge_rpc) -> list[RpcOperatorStakeInfo]:
+    """Return the bridge node's view of every operator's stake status."""
+    return [
+        RpcOperatorStakeInfo.from_json(entry) for entry in bridge_rpc.stratabridge_stakeStatus()
+    ]
+
+
+def wait_until_all_operators_staked(
+    bridge_rpc,
+    bitcoin_rpc,
+    expected_operator_count: int,
+    timeout: int = 300,
+) -> list[RpcOperatorStakeInfo]:
+    """Wait until the bridge node reports that every operator's stake is confirmed.
+
+    A stake is considered confirmed once its state is `confirmed` or later
+    (`preimage_revealed` / `unstaked`). This mirrors the orchestrator's
+    `all_operators_have_staked()` gate that unblocks DRT processing. When the
+    state is `confirmed` the returned `stake_txid` is additionally verified to
+    be present and confirmed on-chain so the gate can't fire on stale /
+    optimistic state.
+
+    Args:
+        bridge_rpc: RPC client for the bridge.
+        bitcoin_rpc: Bitcoin RPC client used to look up stake txids on-chain.
+        expected_operator_count: Number of operators that must appear in the
+            stake-status response. The call blocks until the node is tracking
+            this many stakes, protecting against premature ``True`` during
+            startup before every SSM has been bootstrapped.
+        timeout: Maximum wait time in seconds.
+    """
+    confirmed_states = {
+        RpcStakeStateLabel.CONFIRMED,
+        RpcStakeStateLabel.PREIMAGE_REVEALED,
+        RpcStakeStateLabel.UNSTAKED,
+    }
+    result: dict[str, list[RpcOperatorStakeInfo] | None] = {"stakes": None}
+
+    def check():
+        stakes = get_stake_status(bridge_rpc)
+        logging.info(f"Current stake status: {stakes}")
+        if len(stakes) < expected_operator_count:
+            return False
+        if not all(s.state in confirmed_states for s in stakes):
+            return False
+        result["stakes"] = stakes
+        return True
+
+    wait_until(
+        check,
+        timeout=timeout,
+        step=1,
+        error_msg=(
+            f"Timeout after {timeout}s waiting for all {expected_operator_count} "
+            "operators' stakes to reach `confirmed`"
+        ),
+    )
+    stakes = result["stakes"]
+    assert stakes is not None
+
+    for stake in stakes:
+        if stake.state is RpcStakeStateLabel.CONFIRMED:
+            assert stake.stake_txid is not None, (
+                f"operator {stake.operator_idx} reported `confirmed` without a stake_txid"
+            )
+            wait_for_tx_confirmation(bitcoin_rpc, stake.stake_txid)
+            logging.info(
+                f"Verified stake tx {stake.stake_txid} on-chain for operator {stake.operator_idx}"
+            )
+
+    return stakes

--- a/functional-tests/utils/utils.py
+++ b/functional-tests/utils/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import socket
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -275,18 +276,50 @@ def wait_until_bridge_ready(rpc_client, timeout: int = 120, step: int = 1):
 
 def wait_until_bitcoind_ready(rpc_client, timeout: int = 120, step: int = 1):
     """
-    Waits until the bitcoin client reports readiness.
+    Waits until bitcoind is fully ready: RPC server responsive and ZMQ publishers bound.
+
+    bitcoind binds its ZMQ publishers slightly after the RPC server becomes reachable, so
+    checking only `getblockcount` is insufficient — a client that attempts to subscribe in that
+    gap sees the ZMQ handshake time out. This helper first polls `getblockcount` for RPC
+    readiness, then polls `getzmqnotifications` and probes each advertised publisher endpoint
+    with a short TCP connect to confirm the listener is up.
 
     Args:
-        rpc_client: The RPC client to check for readiness
-        timeout: Timeout in seconds (default 120 seconds)
-        step: Poll interval in seconds (default 1 second)
+        rpc_client: The RPC client to check for readiness.
+        timeout: Timeout in seconds (default 120 seconds).
+        step: Poll interval in seconds (default 1 second).
     """
+
+    def rpc_ready() -> bool:
+        return rpc_client.proxy.getblockcount() is not None
+
+    def zmq_ready() -> bool:
+        notifications = rpc_client.proxy.getzmqnotifications()
+        if not notifications:
+            return False
+        for notification in notifications:
+            address = notification.get("address", "")
+            if not address.startswith("tcp://"):
+                return False
+            host_port = address[len("tcp://") :]
+            host, _, port_str = host_port.rpartition(":")
+            if not port_str.isdigit():
+                return False
+            port = int(port_str)
+            # bitcoind reports 0.0.0.0 when binding on all interfaces; connect locally.
+            probe_host = "127.0.0.1" if host in ("0.0.0.0", "") else host
+            try:
+                with socket.create_connection((probe_host, port), timeout=1):
+                    pass
+            except OSError:
+                return False
+        return True
+
     wait_until(
-        lambda: rpc_client.proxy.getblockcount() is not None,
+        lambda: rpc_ready() and zmq_ready(),
         timeout=timeout,
         step=step,
-        error_msg="Bitcoind did not start within timeout",
+        error_msg="Bitcoind did not become ready (RPC + ZMQ) within timeout",
     )
 
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR integrates the Stake SM into the orchestrator pipeline. This involves the following changes:

- The Stake SM is added as a first class citizen in the `SMId`, `SMEvent` and `SMRegistry`.
- Events related to the Stake SM are classified and routed to the appropriate instance of Stake SM.
- Deposits are gated by the presence of each known operator's stake.
- Bugfixes in the SSM executor and operator wallet.
- The funding outpoint for the stake transaction is also persisted in the database.
- An RPC to get the status of stakes has been added (to use in the functional tests and monitoring).
- In the functional tests, the funding amount used to seed the operator's wallets has been increased.

~~These changes depend upon the changes in #490 which should be merged before this PR.~~

Remaining changes that will be handled in a subsequent PR:

 - [ ] When a preimage is revealed in the `Unstaking Intent` transaction, a signal has to be produced and routed to the Graph SM for every unused graph for the unstaking operator. This preimage has to be added to every state in the Graph SM. This is a more involved change (as we have to be aware of FDB limits as well if there are too many graphs) and will be handled via https://alpenlabs.atlassian.net/browse/STR-3114.

Codex and Claude were used to brainstorm the required changes and Claude was used to apply them.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
~~The first three commits on this branch are from #490.~~

All commits are atomic and any commit with a large number of changes also contains a summary in the commit description.

The final two commits are added for robustness of the tests as there was some flakiness.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-2924