### PR TITLE
STR 3084: STF event validation missing for Bridge Proof and Counterproof NACK transactions

### DIFF
--- a/crates/bridge-sm/src/graph/events.rs
+++ b/crates/bridge-sm/src/graph/events.rs
@@ -95,9 +95,6 @@ pub struct ContestConfirmedEvent {
 /// Event notifying that a bridge proof transaction has been confirmed on-chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BridgeProofConfirmedEvent {
-    /// The txid of the bridge proof transaction.
-    pub bridge_proof_txid: Txid,
-
     /// The block height at which the bridge proof transaction was confirmed.
     pub bridge_proof_block_height: BitcoinBlockHeight,
 

--- a/crates/bridge-sm/src/graph/events.rs
+++ b/crates/bridge-sm/src/graph/events.rs
@@ -150,6 +150,9 @@ pub struct CounterProofNackConfirmedEvent {
     /// The txid of the counterproof NACK transaction.
     pub counterproof_nack_txid: Txid,
 
+    /// The counterproof NACK transaction.
+    pub tx: Transaction,
+
     /// The index of the watchtower who submitted the corresponding counterproof transaction.
     pub counterprover_idx: OperatorIdx,
 }

--- a/crates/bridge-sm/src/graph/events.rs
+++ b/crates/bridge-sm/src/graph/events.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Display;
 
-use bitcoin::{OutPoint, Txid};
+use bitcoin::{OutPoint, Transaction, Txid};
 use bitcoin_bosd::Descriptor;
 use musig2::{PartialSignature, PubNonce};
 use strata_bridge_p2p_types::NagRequestPayload;
@@ -100,6 +100,9 @@ pub struct BridgeProofConfirmedEvent {
 
     /// The block height at which the bridge proof transaction was confirmed.
     pub bridge_proof_block_height: BitcoinBlockHeight,
+
+    /// The bridge proof transaction.
+    pub tx: Transaction,
 
     /// The bridge proof.
     pub proof: ProofReceipt,

--- a/crates/bridge-sm/src/graph/events.rs
+++ b/crates/bridge-sm/src/graph/events.rs
@@ -147,9 +147,6 @@ pub struct CounterProofAckConfirmedEvent {
 /// Event notifying that a counterproof NACK transaction has been confirmed on-chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CounterProofNackConfirmedEvent {
-    /// The txid of the counterproof NACK transaction.
-    pub counterproof_nack_txid: Txid,
-
     /// The counterproof NACK transaction.
     pub tx: Transaction,
 

--- a/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
@@ -3,6 +3,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use bitcoin::{Txid, hashes::Hash};
+use strata_bridge_test_utils::bitcoin::generate_tx;
 use strata_predicate::PredicateKey;
 
 use crate::{
@@ -20,8 +21,8 @@ use crate::{
                 bridge_proof_posted_state, contested_state, counter_proof_posted_state,
                 counter_proof_posted_without_refuted_proof_state,
             },
-            test_deposit_params, test_graph_invalid_transition, test_graph_sm_cfg,
-            test_graph_transition,
+            test_bridge_proof_tx, test_deposit_params, test_graph_invalid_transition,
+            test_graph_sm_cfg, test_graph_transition,
         },
         watchtower::watchtower_slot_for_operator,
     },
@@ -32,9 +33,11 @@ use crate::{
 const BRIDGE_PROOF_BLOCK_HEIGHT: u64 = u64::MAX;
 
 fn bridge_proof_event() -> BridgeProofConfirmedEvent {
+    let tx = test_bridge_proof_tx();
     BridgeProofConfirmedEvent {
-        bridge_proof_txid: Txid::from_byte_array([0xAB; 32]),
+        bridge_proof_txid: tx.compute_txid(),
         bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx,
         proof: dummy_proof_receipt(),
     }
 }
@@ -334,6 +337,38 @@ fn event_duplicate() {
         from_state: counter_proof_posted_state(),
         event: GraphEvent::BridgeProofConfirmed(bridge_proof_event()),
         expected_error: |e| matches!(e, GSMError::Duplicate { .. }),
+    });
+}
+
+#[test]
+fn event_rejected_wrong_outpoint_from_contested() {
+    let event = BridgeProofConfirmedEvent {
+        bridge_proof_txid: Txid::from_byte_array([0xAB; 32]),
+        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx: generate_tx(0, 0),
+        proof: dummy_proof_receipt(),
+    };
+
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state: contested_state(),
+        event: GraphEvent::BridgeProofConfirmed(event),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn event_rejected_wrong_outpoint_from_counterproof_posted() {
+    let event = BridgeProofConfirmedEvent {
+        bridge_proof_txid: Txid::from_byte_array([0xAB; 32]),
+        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx: generate_tx(0, 0),
+        proof: dummy_proof_receipt(),
+    };
+
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state: counter_proof_posted_without_refuted_proof_state(),
+        event: GraphEvent::BridgeProofConfirmed(event),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
     });
 }
 

--- a/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
@@ -373,6 +373,43 @@ fn event_rejected_wrong_outpoint_from_counterproof_posted() {
 }
 
 #[test]
+fn event_rejected_bridge_proof_timeout_txid_from_contested() {
+    // Use a valid bridge proof tx (spends contest proof connector) but set the
+    // event txid to the bridge proof timeout txid, simulating a misclassified
+    // timeout transaction.
+    let tx = test_bridge_proof_tx();
+    let event = BridgeProofConfirmedEvent {
+        bridge_proof_txid: TEST_GRAPH_SUMMARY.bridge_proof_timeout,
+        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx,
+        proof: dummy_proof_receipt(),
+    };
+
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state: contested_state(),
+        event: GraphEvent::BridgeProofConfirmed(event),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn event_rejected_bridge_proof_timeout_txid_from_counterproof_posted() {
+    let tx = test_bridge_proof_tx();
+    let event = BridgeProofConfirmedEvent {
+        bridge_proof_txid: TEST_GRAPH_SUMMARY.bridge_proof_timeout,
+        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx,
+        proof: dummy_proof_receipt(),
+    };
+
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state: counter_proof_posted_without_refuted_proof_state(),
+        event: GraphEvent::BridgeProofConfirmed(event),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
+}
+
+#[test]
 fn event_invalid() {
     for from_state in all_state_variants()
         .into_iter()

--- a/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
@@ -33,11 +33,9 @@ use crate::{
 const BRIDGE_PROOF_BLOCK_HEIGHT: u64 = u64::MAX;
 
 fn bridge_proof_event() -> BridgeProofConfirmedEvent {
-    let tx = test_bridge_proof_tx();
     BridgeProofConfirmedEvent {
-        bridge_proof_txid: tx.compute_txid(),
         bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
-        tx,
+        tx: test_bridge_proof_tx(),
         proof: dummy_proof_receipt(),
     }
 }
@@ -63,7 +61,7 @@ fn event_accepted_pov_no_duties() {
             signatures: vec![],
             fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
             contest_block_height: LATER_BLOCK_HEIGHT,
-            bridge_proof_txid: event.bridge_proof_txid,
+            bridge_proof_txid: event.tx.compute_txid(),
             bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
             proof: dummy_proof_receipt(),
         },
@@ -91,7 +89,7 @@ fn watchtower_skips_counterproof_when_proof_valid() {
                 signatures: vec![],
                 fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
                 contest_block_height: LATER_BLOCK_HEIGHT,
-                bridge_proof_txid: event.bridge_proof_txid,
+                bridge_proof_txid: event.tx.compute_txid(),
                 bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
                 proof: dummy_proof_receipt(),
             },
@@ -132,7 +130,7 @@ fn watchtower_emits_counterproof_when_proof_invalid() {
                 signatures: vec![],
                 fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
                 contest_block_height: LATER_BLOCK_HEIGHT,
-                bridge_proof_txid: event.bridge_proof_txid,
+                bridge_proof_txid: event.tx.compute_txid(),
                 bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
                 proof: dummy_proof_receipt(),
             },
@@ -238,7 +236,7 @@ fn pov_watchtower_skips_counterproof_even_when_proof_invalid() {
                 signatures: vec![],
                 fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
                 contest_block_height: LATER_BLOCK_HEIGHT,
-                bridge_proof_txid: event.bridge_proof_txid,
+                bridge_proof_txid: event.tx.compute_txid(),
                 bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
                 proof: dummy_proof_receipt(),
             },
@@ -343,7 +341,6 @@ fn event_duplicate() {
 #[test]
 fn event_rejected_wrong_outpoint_from_contested() {
     let event = BridgeProofConfirmedEvent {
-        bridge_proof_txid: Txid::from_byte_array([0xAB; 32]),
         bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
         tx: generate_tx(0, 0),
         proof: dummy_proof_receipt(),
@@ -359,7 +356,6 @@ fn event_rejected_wrong_outpoint_from_contested() {
 #[test]
 fn event_rejected_wrong_outpoint_from_counterproof_posted() {
     let event = BridgeProofConfirmedEvent {
-        bridge_proof_txid: Txid::from_byte_array([0xAB; 32]),
         bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
         tx: generate_tx(0, 0),
         proof: dummy_proof_receipt(),
@@ -374,19 +370,13 @@ fn event_rejected_wrong_outpoint_from_counterproof_posted() {
 
 #[test]
 fn event_rejected_bridge_proof_timeout_txid_from_contested() {
-    // Use a valid bridge proof tx (spends contest proof connector) but set the
-    // event txid to the bridge proof timeout txid, simulating a misclassified
-    // timeout transaction.
-    let tx = test_bridge_proof_tx();
-    let event = BridgeProofConfirmedEvent {
-        bridge_proof_txid: TEST_GRAPH_SUMMARY.bridge_proof_timeout,
-        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
-        tx,
-        proof: dummy_proof_receipt(),
-    };
+    // Set bridge_proof_timeout to the bridge proof tx's txid so the validation
+    // rejects it even though it spends the correct contest proof connector.
+    let event = bridge_proof_event();
+    let from_state = contested_state_with_timeout_txid(event.tx.compute_txid());
 
     test_graph_invalid_transition(GraphInvalidTransition {
-        from_state: contested_state(),
+        from_state,
         event: GraphEvent::BridgeProofConfirmed(event),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),
     });
@@ -394,16 +384,12 @@ fn event_rejected_bridge_proof_timeout_txid_from_contested() {
 
 #[test]
 fn event_rejected_bridge_proof_timeout_txid_from_counterproof_posted() {
-    let tx = test_bridge_proof_tx();
-    let event = BridgeProofConfirmedEvent {
-        bridge_proof_txid: TEST_GRAPH_SUMMARY.bridge_proof_timeout,
-        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
-        tx,
-        proof: dummy_proof_receipt(),
-    };
+    let event = bridge_proof_event();
+    let from_state =
+        counter_proof_posted_without_refuted_proof_state_with_timeout_txid(event.tx.compute_txid());
 
     test_graph_invalid_transition(GraphInvalidTransition {
-        from_state: counter_proof_posted_without_refuted_proof_state(),
+        from_state,
         event: GraphEvent::BridgeProofConfirmed(event),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),
     });
@@ -420,6 +406,41 @@ fn event_invalid() {
             event: GraphEvent::BridgeProofConfirmed(bridge_proof_event()),
             expected_error: |e| matches!(e, GSMError::InvalidEvent { .. }),
         });
+    }
+}
+
+/// Builds a `Contested` state with `bridge_proof_timeout` set to the given txid.
+fn contested_state_with_timeout_txid(timeout_txid: bitcoin::Txid) -> GraphState {
+    let mut summary = TEST_GRAPH_SUMMARY.clone();
+    summary.bridge_proof_timeout = timeout_txid;
+    GraphState::Contested {
+        last_block_height: LATER_BLOCK_HEIGHT,
+        graph_data: test_deposit_params(),
+        graph_summary: summary,
+        signatures: Default::default(),
+        fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+        fulfillment_block_height: Some(LATER_BLOCK_HEIGHT),
+        contest_block_height: LATER_BLOCK_HEIGHT,
+    }
+}
+
+/// Builds a `CounterProofPosted` state (no refuted proof) with `bridge_proof_timeout` set to the
+/// given txid.
+fn counter_proof_posted_without_refuted_proof_state_with_timeout_txid(
+    timeout_txid: bitcoin::Txid,
+) -> GraphState {
+    let mut summary = TEST_GRAPH_SUMMARY.clone();
+    summary.bridge_proof_timeout = timeout_txid;
+    GraphState::CounterProofPosted {
+        last_block_height: LATER_BLOCK_HEIGHT,
+        graph_data: test_deposit_params(),
+        graph_summary: summary,
+        signatures: Default::default(),
+        fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+        contest_block_height: LATER_BLOCK_HEIGHT,
+        refuted_proof: None,
+        counterproofs_and_confs: Default::default(),
+        counterproof_nacks: Default::default(),
     }
 }
 

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
@@ -5,8 +5,14 @@
 
 use std::collections::BTreeMap;
 
-use strata_bridge_test_utils::prelude::generate_txid;
-use strata_bridge_tx_graph::game_graph::GameGraphSummary;
+use bitcoin::OutPoint;
+use strata_bridge_test_utils::{
+    bitcoin::{generate_spending_tx, generate_tx},
+    prelude::generate_txid,
+};
+use strata_bridge_tx_graph::{
+    game_graph::GameGraphSummary, transactions::counterproof::CounterproofTx,
+};
 
 use crate::{
     graph::{
@@ -16,7 +22,7 @@ use crate::{
         state::GraphState,
         tests::{
             GraphInvalidTransition, GraphTransition, LATER_BLOCK_HEIGHT, TEST_NONPOV_IDX,
-            build_test_graph_summary, create_nonpov_sm, get_state,
+            TEST_POV_IDX, build_test_graph_summary, create_nonpov_sm, get_state,
             mock_states::{
                 TEST_FULFILLMENT_TXID, all_nackd_state, all_state_variants,
                 counter_proof_posted_state,
@@ -24,6 +30,7 @@ use crate::{
             test_deposit_params, test_graph_invalid_transition, test_graph_sm_cfg,
             test_graph_transition,
         },
+        watchtower::watchtower_slot_for_operator,
     },
     testing::test_transition,
 };
@@ -36,10 +43,27 @@ fn test_graph_summary() -> GameGraphSummary {
     build_test_graph_summary(2)
 }
 
+/// Creates a NACK tx that spends the ACK/NACK output of the counterproof at the given
+/// watchtower slot in the two-slot test summary.
+fn nack_tx_for_slot(slot: usize) -> bitcoin::Transaction {
+    let summary = test_graph_summary();
+    generate_spending_tx(
+        OutPoint {
+            txid: summary.counterproofs[slot].counterproof,
+            vout: CounterproofTx::ACK_NACK_VOUT,
+        },
+        &[],
+    )
+}
+
 /// Creates a nack event for the given counterprover.
 fn nack_event(counterprover_idx: u32) -> CounterProofNackConfirmedEvent {
+    let slot = watchtower_slot_for_operator(TEST_POV_IDX, counterprover_idx)
+        .expect("nack_event called with graph owner index");
+    let tx = nack_tx_for_slot(slot);
     CounterProofNackConfirmedEvent {
-        counterproof_nack_txid: generate_txid(),
+        counterproof_nack_txid: tx.compute_txid(),
+        tx,
         counterprover_idx,
     }
 }
@@ -178,10 +202,65 @@ fn event_rejected_no_counterproof_posted() {
 
 #[test]
 fn event_rejected_invalid_operator_idx() {
+    let event = CounterProofNackConfirmedEvent {
+        counterproof_nack_txid: generate_txid(),
+        tx: generate_tx(0, 0),
+        counterprover_idx: u32::MAX,
+    };
     test_graph_invalid_transition(GraphInvalidTransition {
         from_state: counter_proof_posted_state_with_nacks(&[]),
-        event: GraphEvent::CounterProofNackConfirmed(nack_event(u32::MAX)),
+        event: GraphEvent::CounterProofNackConfirmed(event),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn event_rejected_wrong_outpoint() {
+    let event = CounterProofNackConfirmedEvent {
+        counterproof_nack_txid: generate_txid(),
+        tx: generate_tx(0, 0),
+        counterprover_idx: TEST_NONPOV_IDX,
+    };
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state: counter_proof_posted_state_with_nacks(&[]),
+        event: GraphEvent::CounterProofNackConfirmed(event),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn valid_nack_ignores_spoofed_event_txid() {
+    // The event's `counterproof_nack_txid` field is set to the ACK txid, but the STF
+    // validates against the actual tx (whose computed txid differs). The event should
+    // still be accepted because the tx itself is a legitimate NACK.
+    let summary = test_graph_summary();
+    let nack_tx = nack_tx_for_slot(0);
+    let event = CounterProofNackConfirmedEvent {
+        counterproof_nack_txid: summary.counterproofs[0].counterproof_ack,
+        tx: nack_tx,
+        counterprover_idx: TEST_NONPOV_IDX,
+    };
+
+    let counterproof_txid = summary.counterproofs[0].counterproof;
+    test_graph_transition(GraphTransition {
+        from_state: counter_proof_posted_state_with_nacks(&[]),
+        event: GraphEvent::CounterProofNackConfirmed(event.clone()),
+        expected_state: GraphState::CounterProofPosted {
+            last_block_height: LATER_BLOCK_HEIGHT,
+            graph_data: test_deposit_params(),
+            graph_summary: summary,
+            signatures: Default::default(),
+            fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+            contest_block_height: LATER_BLOCK_HEIGHT,
+            refuted_proof: None,
+            counterproofs_and_confs: BTreeMap::from([
+                (TEST_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
+                (SECOND_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
+            ]),
+            counterproof_nacks: BTreeMap::from([(TEST_NONPOV_IDX, event.counterproof_nack_txid)]),
+        },
+        expected_duties: vec![],
+        expected_signals: vec![],
     });
 }
 

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
@@ -62,7 +62,6 @@ fn nack_event(counterprover_idx: u32) -> CounterProofNackConfirmedEvent {
         .expect("nack_event called with graph owner index");
     let tx = nack_tx_for_slot(slot);
     CounterProofNackConfirmedEvent {
-        counterproof_nack_txid: tx.compute_txid(),
         tx,
         counterprover_idx,
     }
@@ -115,7 +114,7 @@ fn first_nack_stays_in_counter_proof_posted() {
                 (TEST_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
                 (SECOND_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
             ]),
-            counterproof_nacks: BTreeMap::from([(TEST_NONPOV_IDX, event.counterproof_nack_txid)]),
+            counterproof_nacks: BTreeMap::from([(TEST_NONPOV_IDX, event.tx.compute_txid())]),
         },
         expected_duties: vec![],
         expected_signals: vec![],
@@ -203,7 +202,6 @@ fn event_rejected_no_counterproof_posted() {
 #[test]
 fn event_rejected_invalid_operator_idx() {
     let event = CounterProofNackConfirmedEvent {
-        counterproof_nack_txid: generate_txid(),
         tx: generate_tx(0, 0),
         counterprover_idx: u32::MAX,
     };
@@ -217,7 +215,6 @@ fn event_rejected_invalid_operator_idx() {
 #[test]
 fn event_rejected_wrong_outpoint() {
     let event = CounterProofNackConfirmedEvent {
-        counterproof_nack_txid: generate_txid(),
         tx: generate_tx(0, 0),
         counterprover_idx: TEST_NONPOV_IDX,
     };
@@ -225,42 +222,6 @@ fn event_rejected_wrong_outpoint() {
         from_state: counter_proof_posted_state_with_nacks(&[]),
         event: GraphEvent::CounterProofNackConfirmed(event),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),
-    });
-}
-
-#[test]
-fn valid_nack_ignores_spoofed_event_txid() {
-    // The event's `counterproof_nack_txid` field is set to the ACK txid, but the STF
-    // validates against the actual tx (whose computed txid differs). The event should
-    // still be accepted because the tx itself is a legitimate NACK.
-    let summary = test_graph_summary();
-    let nack_tx = nack_tx_for_slot(0);
-    let event = CounterProofNackConfirmedEvent {
-        counterproof_nack_txid: summary.counterproofs[0].counterproof_ack,
-        tx: nack_tx,
-        counterprover_idx: TEST_NONPOV_IDX,
-    };
-
-    let counterproof_txid = summary.counterproofs[0].counterproof;
-    test_graph_transition(GraphTransition {
-        from_state: counter_proof_posted_state_with_nacks(&[]),
-        event: GraphEvent::CounterProofNackConfirmed(event.clone()),
-        expected_state: GraphState::CounterProofPosted {
-            last_block_height: LATER_BLOCK_HEIGHT,
-            graph_data: test_deposit_params(),
-            graph_summary: summary,
-            signatures: Default::default(),
-            fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
-            contest_block_height: LATER_BLOCK_HEIGHT,
-            refuted_proof: None,
-            counterproofs_and_confs: BTreeMap::from([
-                (TEST_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
-                (SECOND_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
-            ]),
-            counterproof_nacks: BTreeMap::from([(TEST_NONPOV_IDX, event.counterproof_nack_txid)]),
-        },
-        expected_duties: vec![],
-        expected_signals: vec![],
     });
 }
 

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -97,19 +97,6 @@ impl GraphSM {
         cfg: Arc<GraphSMCfg>,
         event: BridgeProofConfirmedEvent,
     ) -> GSMResult<GSMOutput> {
-        // Ensure the bridge proof tx actually spends the contest proof connector.
-        let validate_spend = |contest_txid, event: BridgeProofConfirmedEvent| {
-            if spends_contest_proof_connector(contest_txid, &event.tx) {
-                Ok(event)
-            } else {
-                Err(GSMError::rejected(
-                    self.state.clone(),
-                    event.into(),
-                    "bridge proof tx does not spend the contest proof connector",
-                ))
-            }
-        };
-
         match self.state.clone() {
             GraphState::Contested {
                 graph_data,
@@ -119,7 +106,15 @@ impl GraphSM {
                 contest_block_height,
                 ..
             } => {
-                let event = validate_spend(graph_summary.contest, event)?;
+                if !validate_bridge_proof_spend(&graph_summary, &event) {
+                    return Err(GSMError::rejected(
+                        self.state.clone(),
+                        event.into(),
+                        "bridge proof tx does not spend the contest proof connector \
+                         or matches bridge proof timeout txid",
+                    ));
+                }
+
                 let bridge_proof = event.proof.clone();
 
                 let is_watchtower =
@@ -187,7 +182,15 @@ impl GraphSM {
                     return Err(GSMError::duplicate(self.state.clone(), event.into()));
                 }
 
-                let event = validate_spend(graph_summary.contest, event)?;
+                if !validate_bridge_proof_spend(&graph_summary, &event) {
+                    return Err(GSMError::rejected(
+                        self.state.clone(),
+                        event.into(),
+                        "bridge proof tx does not spend the contest proof connector \
+                         or matches bridge proof timeout txid",
+                    ));
+                }
+
                 let bridge_proof = event.proof.clone();
                 let pov_idx = self.context().operator_table().pov_idx();
                 let is_watchtower = self.context().operator_idx() != pov_idx;
@@ -539,6 +542,16 @@ impl GraphSM {
             state => Err(GSMError::invalid_event(state, event.into(), None)),
         }
     }
+}
+
+/// Validates that the bridge proof tx spends the contest proof connector
+/// and is not the bridge proof timeout transaction.
+fn validate_bridge_proof_spend(
+    summary: &GameGraphSummary,
+    event: &BridgeProofConfirmedEvent,
+) -> bool {
+    event.bridge_proof_txid != summary.bridge_proof_timeout
+        && spends_contest_proof_connector(summary.contest, &event.tx)
 }
 
 /// Validates that `tx` spends the NACK output of the counterproof transaction.

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -160,7 +160,7 @@ impl GraphSM {
                     signatures: signatures.clone(),
                     fulfillment_txid,
                     contest_block_height,
-                    bridge_proof_txid: event.bridge_proof_txid,
+                    bridge_proof_txid: event.tx.compute_txid(),
                     bridge_proof_block_height: event.bridge_proof_block_height,
                     proof: bridge_proof,
                 };
@@ -550,7 +550,7 @@ fn validate_bridge_proof_spend(
     summary: &GameGraphSummary,
     event: &BridgeProofConfirmedEvent,
 ) -> bool {
-    event.bridge_proof_txid != summary.bridge_proof_timeout
+    event.tx.compute_txid() != summary.bridge_proof_timeout
         && spends_contest_proof_connector(summary.contest, &event.tx)
 }
 

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -3,17 +3,20 @@ use std::sync::Arc;
 use strata_bridge_primitives::proof::verify_bridge_proof;
 use strata_bridge_tx_graph::game_graph::GameConnectors;
 
-use crate::graph::{
-    config::GraphSMCfg,
-    duties::GraphDuty,
-    errors::{GSMError, GSMResult},
-    events::{
-        BridgeProofConfirmedEvent, BridgeProofTimeoutConfirmedEvent, ContestConfirmedEvent,
-        CounterProofAckConfirmedEvent, CounterProofNackConfirmedEvent, SlashConfirmedEvent,
+use crate::{
+    graph::{
+        config::GraphSMCfg,
+        duties::GraphDuty,
+        errors::{GSMError, GSMResult},
+        events::{
+            BridgeProofConfirmedEvent, BridgeProofTimeoutConfirmedEvent, ContestConfirmedEvent,
+            CounterProofAckConfirmedEvent, CounterProofNackConfirmedEvent, SlashConfirmedEvent,
+        },
+        machine::{GSMOutput, GraphSM, generate_game_graph},
+        state::GraphState,
+        watchtower::watchtower_slot_for_operator,
     },
-    machine::{GSMOutput, GraphSM, generate_game_graph},
-    state::GraphState,
-    watchtower::watchtower_slot_for_operator,
+    tx_classifier::spends_contest_proof_connector,
 };
 
 impl GraphSM {
@@ -93,6 +96,19 @@ impl GraphSM {
         cfg: Arc<GraphSMCfg>,
         event: BridgeProofConfirmedEvent,
     ) -> GSMResult<GSMOutput> {
+        // Ensure the bridge proof tx actually spends the contest proof connector.
+        let validate_spend = |contest_txid, event: BridgeProofConfirmedEvent| {
+            if spends_contest_proof_connector(contest_txid, &event.tx) {
+                Ok(event)
+            } else {
+                Err(GSMError::rejected(
+                    self.state.clone(),
+                    event.into(),
+                    "bridge proof tx does not spend the contest proof connector",
+                ))
+            }
+        };
+
         match self.state.clone() {
             GraphState::Contested {
                 graph_data,
@@ -102,6 +118,7 @@ impl GraphSM {
                 contest_block_height,
                 ..
             } => {
+                let event = validate_spend(graph_summary.contest, event)?;
                 let bridge_proof = event.proof.clone();
 
                 let is_watchtower =
@@ -169,6 +186,7 @@ impl GraphSM {
                     return Err(GSMError::duplicate(self.state.clone(), event.into()));
                 }
 
+                let event = validate_spend(graph_summary.contest, event)?;
                 let bridge_proof = event.proof.clone();
                 let pov_idx = self.context().operator_table().pov_idx();
                 let is_watchtower = self.context().operator_idx() != pov_idx;

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use strata_bridge_primitives::proof::verify_bridge_proof;
-use strata_bridge_tx_graph::game_graph::GameConnectors;
+use bitcoin::Transaction;
+use strata_bridge_primitives::{proof::verify_bridge_proof, types::OperatorIdx};
+use strata_bridge_tx_graph::game_graph::{GameConnectors, GameGraphSummary};
 
 use crate::{
     graph::{
@@ -16,7 +17,7 @@ use crate::{
         state::GraphState,
         watchtower::watchtower_slot_for_operator,
     },
-    tx_classifier::spends_contest_proof_connector,
+    tx_classifier::{spends_contest_proof_connector, spends_counterproof_ack_nack},
 };
 
 impl GraphSM {
@@ -332,9 +333,20 @@ impl GraphSM {
                 counterproofs_and_confs,
                 mut counterproof_nacks,
             } => {
-                // TODO: <https://alpenlabs.atlassian.net/browse/STR-3086>
-                // Add validation of the counterproof_nack_txid asserting that it spends
-                // the corresponding counterproof transaction.
+                // Validate that the NACK tx spends the correct counterproof
+                // ACK/NACK output and is not a known counterproof ACK.
+                if !validate_counterproof_nack(
+                    &graph_summary,
+                    self.context().operator_table().pov_idx(),
+                    event.counterprover_idx,
+                    &event.tx,
+                ) {
+                    return Err(GSMError::rejected(
+                        self.state.clone(),
+                        event.into(),
+                        "counterproof NACK tx does not spend the expected counterproof outpoint",
+                    ));
+                }
 
                 // Ensure a counterproof was posted by this operator before accepting a NACK.
                 if !counterproofs_and_confs.contains_key(&event.counterprover_idx) {
@@ -527,4 +539,19 @@ impl GraphSM {
             state => Err(GSMError::invalid_event(state, event.into(), None)),
         }
     }
+}
+
+/// Validates that `tx` spends the NACK output of the counterproof transaction.
+fn validate_counterproof_nack(
+    summary: &GameGraphSummary,
+    graph_owner_idx: OperatorIdx,
+    counterprover_idx: OperatorIdx,
+    tx: &Transaction,
+) -> bool {
+    watchtower_slot_for_operator(graph_owner_idx, counterprover_idx)
+        .and_then(|slot| summary.counterproofs.get(slot))
+        .is_some_and(|cp| {
+            tx.compute_txid() != cp.counterproof_ack
+                && spends_counterproof_ack_nack(cp.counterproof, tx)
+        })
 }

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -367,7 +367,7 @@ impl GraphSM {
                 if counterproof_nacks.contains_key(&event.counterprover_idx) {
                     return Err(GSMError::duplicate(self.state.clone(), event.into()));
                 }
-                counterproof_nacks.insert(event.counterprover_idx, event.counterproof_nack_txid);
+                counterproof_nacks.insert(event.counterprover_idx, event.tx.compute_txid());
 
                 // Transition to AllNackd once every possible counterproof has been nack'd
                 // (all watchtower slots), otherwise stay in CounterProofPosted.

--- a/crates/bridge-sm/src/graph/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tx_classifier.rs
@@ -248,6 +248,7 @@ impl TxClassifier for GraphSM {
                         |counterprover_idx| {
                             GraphEvent::CounterProofNackConfirmed(CounterProofNackConfirmedEvent {
                                 counterproof_nack_txid: txid,
+                                tx: tx.clone(),
                                 counterprover_idx,
                             })
                         },

--- a/crates/bridge-sm/src/graph/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tx_classifier.rs
@@ -128,7 +128,7 @@ impl TxClassifier for GraphSM {
                 // if it's not a Bridge Proof Timeout tx and still spends the contest proof
                 // connector, then it has to be a Bridge Proof tx.
                 } else if spends_contest_proof_connector(graph_summary.contest, tx) {
-                    Some(bridge_proof_event(tx, txid, height))
+                    Some(bridge_proof_event(tx, height))
                 } else if let Some(counterprover_idx) =
                     counterproof_operator_idx(graph_summary, &txid, self.context().operator_idx())
                 {
@@ -220,7 +220,7 @@ impl TxClassifier for GraphSM {
                         },
                     ))
                 } else if spends_contest_proof_connector(graph_summary.contest, tx) {
-                    Some(bridge_proof_event(tx, txid, height))
+                    Some(bridge_proof_event(tx, height))
                 } else if let Some(counterprover_idx) = counterproof_ack_operator_idx(
                     graph_summary,
                     &txid,
@@ -298,11 +298,7 @@ impl TxClassifier for GraphSM {
     }
 }
 
-fn bridge_proof_event(
-    tx: &Transaction,
-    txid: bitcoin::Txid,
-    height: BitcoinBlockHeight,
-) -> GraphEvent {
+fn bridge_proof_event(tx: &Transaction, height: BitcoinBlockHeight) -> GraphEvent {
     let mut proof_and_public_values = vec![];
     tx.output.iter().for_each(|output| {
         if output.script_pubkey.is_op_return() {
@@ -324,7 +320,6 @@ fn bridge_proof_event(
     );
 
     GraphEvent::BridgeProofConfirmed(BridgeProofConfirmedEvent {
-        bridge_proof_txid: txid,
         bridge_proof_block_height: height,
         tx: tx.clone(),
         proof: proof_receipt,

--- a/crates/bridge-sm/src/graph/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tx_classifier.rs
@@ -247,7 +247,6 @@ impl TxClassifier for GraphSM {
                     nack_counterprover_idx(graph_summary, self.context().operator_idx(), tx).map(
                         |counterprover_idx| {
                             GraphEvent::CounterProofNackConfirmed(CounterProofNackConfirmedEvent {
-                                counterproof_nack_txid: txid,
                                 tx: tx.clone(),
                                 counterprover_idx,
                             })

--- a/crates/bridge-sm/src/graph/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tx_classifier.rs
@@ -326,6 +326,7 @@ fn bridge_proof_event(
     GraphEvent::BridgeProofConfirmed(BridgeProofConfirmedEvent {
         bridge_proof_txid: txid,
         bridge_proof_block_height: height,
+        tx: tx.clone(),
         proof: proof_receipt,
     })
 }

--- a/crates/bridge-sm/src/tx_classifier.rs
+++ b/crates/bridge-sm/src/tx_classifier.rs
@@ -79,6 +79,17 @@ pub fn spends_contest_proof_connector(contest_txid: Txid, tx: &Transaction) -> b
         .any(|input| input.previous_output == contest_proof_outpoint)
 }
 
+/// Checks if the transaction spends the ACK/NACK output of the given counterproof transaction.
+pub fn spends_counterproof_ack_nack(counterproof_txid: Txid, tx: &Transaction) -> bool {
+    let ack_nack_outpoint = OutPoint {
+        txid: counterproof_txid,
+        vout: CounterproofTx::ACK_NACK_VOUT,
+    };
+    tx.input
+        .iter()
+        .any(|input| input.previous_output == ack_nack_outpoint)
+}
+
 /// Checks if the transaction ID is that of a counterproof transaction.
 pub fn is_counterproof_txid(summary: &GameGraphSummary, txid: &Txid) -> bool {
     summary
@@ -136,14 +147,7 @@ pub fn nack_counterprover_idx(
         .iter()
         .enumerate()
         .find_map(|(watchtower_slot, summary)| {
-            let expected_counterproof_outpoint = OutPoint {
-                txid: summary.counterproof,
-                vout: CounterproofTx::ACK_NACK_VOUT,
-            };
-
-            tx.input
-                .iter()
-                .any(|txin| txin.previous_output == expected_counterproof_outpoint)
+            spends_counterproof_ack_nack(summary.counterproof, tx)
                 .then(|| watchtower_slot_to_operator_idx(watchtower_slot, graph_owner_idx))
         })
 }


### PR DESCRIPTION
## Description
* Validates bridge proof tx spends the contest outpoint
* Adds spend-validation for CounterproofNackConfirmedEvent

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

