### PR TITLE
Remove stale block height check from contested bridge proof timeout

### DIFF
--- a/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof_timeout.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof_timeout.rs
@@ -76,18 +76,6 @@ fn event_duplicate() {
 }
 
 #[test]
-fn event_rejected_old_height() {
-    test_graph_invalid_transition(GraphInvalidTransition {
-        from_state: contested_state(),
-        event: GraphEvent::BridgeProofTimeoutConfirmed(BridgeProofTimeoutConfirmedEvent {
-            bridge_proof_timeout_txid: TEST_GRAPH_SUMMARY.bridge_proof_timeout,
-            bridge_proof_timeout_block_height: 0,
-        }),
-        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
-    });
-}
-
-#[test]
 fn event_rejected_invalid_txid() {
     test_graph_invalid_transition(GraphInvalidTransition {
         from_state: contested_state(),

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -222,7 +222,7 @@ impl GraphSM {
     ) -> GSMResult<GSMOutput> {
         match self.state.clone() {
             GraphState::Contested {
-                last_block_height,
+                last_block_height: _,
                 graph_data,
                 graph_summary,
                 signatures,
@@ -230,13 +230,6 @@ impl GraphSM {
                 fulfillment_block_height: _,
                 contest_block_height,
             } => {
-                if event.bridge_proof_timeout_block_height < last_block_height {
-                    return Err(GSMError::rejected(
-                        self.state.clone(),
-                        event.into(),
-                        "event has old block height",
-                    ));
-                }
                 if event.bridge_proof_timeout_txid != graph_summary.bridge_proof_timeout {
                     return Err(GSMError::rejected(
                         self.state.clone(),


### PR DESCRIPTION
## Description
Drops the bridge_proof_timeout_block_height < last_block_height guard in the contested state's bridge proof timeout handler. 
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update