### PR TITLE
chore(deps): update `rust-webpki`

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,9 +8,13 @@ ignore = [
   "RUSTSEC-2026-0002",
 
   # rustls-webpki 0.101.7 pulled by bitreq (via bitcoind-async-client).
-  # bitreq still depends on rustls 0.21 which requires 0.101.x; fix needs >=0.103.12.
+  # bitreq still depends on rustls 0.21 which requires 0.101.x; fix needs >=0.103.13.
   # Low risk: only used for bitcoind RPC connections to known/trusted endpoints.
-  # Upstream fix: https://github.com/rust-bitcoin/corepc/pull/536
+  # Upstream bump to rustls 0.23 / rustls-webpki 0.103 merged but unreleased:
+  # https://github.com/rust-bitcoin/corepc/pull/556 (latest published bitreq 0.3.4
+  # from 2026-02-17 predates the 2026-04-19 merge). Once released, cargo update
+  # will pull rustls-webpki 0.103.13+ via semver on the new branch.
   "RUSTSEC-2026-0098",
   "RUSTSEC-2026-0099",
+  "RUSTSEC-2026-0104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4953,7 +4953,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.28",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "thiserror 2.0.18",
  "x509-parser",
  "yasna",
@@ -6909,7 +6909,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -6959,7 +6959,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -6980,7 +6980,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
@@ -7005,9 +7005,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR bumps the version of `rust-webpki` which contains the fix for the latest reported vulnerability. There is also a transitive dependency on this crate from `bitreq` which does not have this update yet. So, the new advisory has been whitelisted for now.

Claude was used to check for the status of upstream fixes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->