### PR TITLE
feat(ci): run fntest groups in parallel and merge codecov reports

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -24,6 +24,31 @@ jobs:
         id: extract-version
         uses: ./.github/actions/extract-rust-version
 
+  discover-groups:
+    name: Discover functional test groups
+    runs-on: ubuntu-latest
+    outputs:
+      groups: ${{ steps.list.outputs.groups }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: List test group directories
+        id: list
+        run: |
+          groups=$(find functional-tests/tests -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+            | sort \
+            | jq -R . \
+            | jq -sc .)
+          if [ "$groups" = "[]" ]; then
+            echo "ERROR: no test groups found under functional-tests/tests" >&2
+            exit 1
+          fi
+          echo "groups=$groups" >> "$GITHUB_OUTPUT"
+          echo "Discovered groups: $groups"
+
   lint:
     name: Lint functional test files
     runs-on: ubuntu-latest
@@ -57,10 +82,14 @@ jobs:
         run: uv run ruff check
 
   run:
-    name: Run functional tests and generate report
+    name: Run functional tests and generate report (${{ matrix.group }})
     runs-on: ubuntu-latest
-    needs: extract-rust-version
+    needs: [extract-rust-version, discover-groups]
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(needs.discover-groups.outputs.groups) }}
     env:
       OPENSSL_VERSION: "3.5.0"
       OPENSSL_CACHE_VERSION: "v2" # update this to refresh cache
@@ -180,6 +209,7 @@ jobs:
           NO_COLOR: "1"
           LOG_LEVEL: "info"
           PYTHON_VERSION: "3.12" # NOTE: (@Rajil1213) build fails with 3.13 since bitcoinlib (>=0.7.5,<0.8) uses an old version of numpy
+          TEST_GROUP: ${{ matrix.group }}
           shell: bash
         run: |
           export LLVM_PROFILE_FILE="$GITHUB_WORKSPACE/target/llvm-cov-target/strata-%p-%m.profraw"
@@ -192,23 +222,25 @@ jobs:
           which dev-cli
           cd functional-tests
           source ./env.bash
-          uv run --python "$PYTHON_VERSION" python entry.py
+          uv run --python "$PYTHON_VERSION" python entry.py -g "$TEST_GROUP"
 
       - name: Generate combined coverage lcov
         id: genFunctionalLcov
         continue-on-error: true
+        env:
+          TEST_GROUP: ${{ matrix.group }}
         run: |
           # cargo-llvm-cov expects default target dir and adds llvm-cov-target itself
           export CARGO_TARGET_DIR="$GITHUB_WORKSPACE/target"
           export LLVM_PROFILE_FILE="$GITHUB_WORKSPACE/target/llvm-cov-target/strata-%p-%m.profraw"
-          cargo llvm-cov report --lcov > lcov.functional.info
+          cargo llvm-cov report --lcov > "lcov.functional.${TEST_GROUP}.info"
       - name: Upload coverage lcov artifact
         if: steps.genFunctionalLcov.outcome == 'success'
         continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: functional-lcov
-          path: lcov.functional.info
+          name: functional-lcov-${{ matrix.group }}
+          path: lcov.functional.${{ matrix.group }}.info
 
       - name: Zip log files on failure
         if: steps.funcTestsRun.outcome == 'failure'
@@ -225,7 +257,7 @@ jobs:
         if: steps.funcTestsRun.outcome == 'failure'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: fntest_dd
+          name: fntest_dd-${{ matrix.group }}
           path: logs.zip
           retention-days: 30
           if-no-files-found: error
@@ -241,7 +273,7 @@ jobs:
     name: Check that all checks pass
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, run]
+    needs: [lint, discover-groups, run]
     timeout-minutes: 60
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -45,10 +45,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download functional test coverage
+      - name: Download functional test coverage (all groups)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: functional-lcov
+          pattern: functional-lcov-*
+          merge-multiple: true
 
       - name: Download unit test coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -60,8 +61,17 @@ jobs:
 
       - name: Merge test coverage
         run: |
+          shopt -s nullglob
+          functional_tracefiles=()
+          for f in lcov.functional.*.info; do
+            functional_tracefiles+=(--add-tracefile "./$f")
+          done
+          if [ ${#functional_tracefiles[@]} -eq 0 ]; then
+            echo "ERROR: no functional lcov files found to merge" >&2
+            exit 1
+          fi
           lcov --add-tracefile ./lcov.unit.info \
-            --add-tracefile ./lcov.functional.info \
+            "${functional_tracefiles[@]}" \
             --output-file ./lcov.info
 
       - name: Publish Test Coverage


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR updates the functional tests workflow to run each functional test group in parallel and merge their codecov reports before publishing. These groups are discovered automatically based on the directory layout of `functional-tests` and so the CI workflow does not need to be updated if we add/remove any groups.

As each group runs separately, any failure in one group does not affect another group's run. However, a partial code coverage report is still published. The overall execution time is dictated by the slowest group.

Claude was used to make these changes then verified both manually and with Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] CI
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->