### PR TITLE
[codex] STR-3200 add dev-cli release workflow

### DIFF
--- a/.github/workflows/dev-cli-release.yml
+++ b/.github/workflows/dev-cli-release.yml
@@ -102,6 +102,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/.github/workflows/dev-cli-release.yml
+++ b/.github/workflows/dev-cli-release.yml
@@ -1,0 +1,121 @@
+name: dev-cli-release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  extract-rust-version:
+    name: Extract toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
+
+  build-dev-cli:
+    name: Build dev-cli (${{ matrix.asset_suffix }})
+    runs-on: ${{ matrix.runner }}
+    needs: extract-rust-version
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset_suffix: linux-x86_64
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            asset_suffix: darwin-arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        env:
+          RUST_NIGHTLY: ${{ needs.extract-rust-version.outputs.nightly-version }}
+        run: |
+          rustup toolchain install "$RUST_NIGHTLY" --profile minimal
+          rustup default "$RUST_NIGHTLY"
+          rustup target add "${{ matrix.target }}"
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Build dev-cli
+        run: cargo build --locked --release --bin dev-cli --target "${{ matrix.target }}"
+
+      - name: Package release artifact
+        env:
+          ASSET_SUFFIX: ${{ matrix.asset_suffix }}
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME}"
+          else
+            VERSION="$(git rev-parse --short=12 HEAD)"
+          fi
+
+          ARCHIVE_NAME="dev-cli-${VERSION}-${ASSET_SUFFIX}.tar.gz"
+
+          mkdir -p dist
+          tar -C "target/${{ matrix.target }}/release" -czf "dist/${ARCHIVE_NAME}" dev-cli
+          (
+            cd dist
+            shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
+          )
+
+      - name: Upload packaged artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: dev-cli-${{ matrix.asset_suffix }}
+          path: dist/*
+          retention-days: 14
+
+  publish-release-assets:
+    name: Publish dev-cli release assets
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: build-dev-cli
+    permissions:
+      contents: write
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" dist/* --clobber
+          else
+            gh release create "$TAG_NAME" dist/* --title "$TAG_NAME" --generate-notes
+          fi

--- a/.github/workflows/dev-cli-release.yml
+++ b/.github/workflows/dev-cli-release.yml
@@ -115,8 +115,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          RELEASE_ARGS=(--title "$TAG_NAME" --generate-notes)
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            RELEASE_ARGS+=(--prerelease)
+          fi
+
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             gh release upload "$TAG_NAME" dist/* --clobber
           else
-            gh release create "$TAG_NAME" dist/* --title "$TAG_NAME" --generate-notes
+            gh release create "$TAG_NAME" dist/* "${RELEASE_ARGS[@]}"
           fi

--- a/.github/workflows/dev-cli-release.yml
+++ b/.github/workflows/dev-cli-release.yml
@@ -1,6 +1,7 @@
 name: dev-cli-release
 
 on:
+  pull_request:
   workflow_dispatch:
   push:
     tags:

--- a/bin/dev-cli/README.md
+++ b/bin/dev-cli/README.md
@@ -2,6 +2,13 @@
 
 Strata Bridge CLI for dev environment.
 
+## Distribution
+
+Native `dev-cli` binaries are published in two forms:
+
+- GitHub Actions artifacts on manual runs of `.github/workflows/dev-cli-release.yml`
+- GitHub release assets when a `v*` tag is pushed
+
 ## Commands
 
 ### `bridge-in`


### PR DESCRIPTION
## What changed
Added a dedicated `dev-cli` distribution workflow and a short README note describing where operators can fetch prebuilt binaries.

## Why
External operators should not need to compile `dev-cli` locally just to derive onboarding outputs. The repo already builds `dev-cli` in CI, but it did not package or publish downloadable binaries.

## Scope
- add `.github/workflows/dev-cli-release.yml`
- build native `dev-cli` release binaries for Linux x86_64 and macOS arm64
- upload packaged binaries and SHA-256 files as workflow artifacts on manual runs
- publish the same files as GitHub release assets on `v*` tags
- document the distribution path in `bin/dev-cli/README.md`

## Validation
- `git diff --check`
- YAML parse check with Ruby

## Jira
- STR-3200
