### PR TITLE
feat(ci): cache external static binaries

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -191,24 +191,58 @@ jobs:
           RUSTFLAGS="-Cinstrument-coverage" cargo build --locked -p secret-service --bin secret-service --target-dir "$COV_TARGET_DIR"
           cargo build --locked --bin dev-cli --target-dir "$COV_TARGET_DIR"
 
-      - name: Install mosaic binary
+      - name: Resolve external binary versions
+        id: bin-versions
         run: |
           MOSAIC_REV=$(grep 'mosaic-rpc-api.*rev' Cargo.toml | sed 's/.*rev = "\([^"]*\)".*/\1/')
           if [ -z "$MOSAIC_REV" ]; then
             echo "ERROR: failed to extract mosaic rev from Cargo.toml" >&2
             exit 1
           fi
-          cargo install --git https://github.com/alpenlabs/mosaic --rev "$MOSAIC_REV" --features=reduced-circuits --root "$GITHUB_WORKSPACE/target/mosaic" mosaic
-          echo "$GITHUB_WORKSPACE/target/mosaic/bin" >> "$GITHUB_PATH"
-
-      - name: Install asm binary
-        run: |
           ASM_TAG=$(grep 'strata-asm-worker.*tag' Cargo.toml | sed 's/.*tag = "\([^"]*\)".*/\1/')
           if [ -z "$ASM_TAG" ]; then
             echo "ERROR: failed to extract asm tag from Cargo.toml" >&2
             exit 1
           fi
+          {
+            echo "mosaic-rev=$MOSAIC_REV"
+            echo "asm-tag=$ASM_TAG"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached mosaic binary
+        id: cache-mosaic
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ github.workspace }}/target/mosaic
+          key: ${{ runner.os }}-mosaic-${{ steps.bin-versions.outputs.mosaic-rev }}-${{ needs.extract-rust-version.outputs.nightly-version }}
+
+      - name: Install mosaic binary
+        if: steps.cache-mosaic.outputs.cache-hit != 'true'
+        env:
+          MOSAIC_REV: ${{ steps.bin-versions.outputs.mosaic-rev }}
+        run: |
+          cargo install --git https://github.com/alpenlabs/mosaic --rev "$MOSAIC_REV" --features=reduced-circuits --root "$GITHUB_WORKSPACE/target/mosaic" mosaic
+
+      - name: Add mosaic binary to PATH
+        run: |
+          echo "$GITHUB_WORKSPACE/target/mosaic/bin" >> "$GITHUB_PATH"
+
+      - name: Restore cached asm-runner binary
+        id: cache-asm
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ github.workspace }}/target/asm
+          key: ${{ runner.os }}-asm-runner-${{ steps.bin-versions.outputs.asm-tag }}-${{ needs.extract-rust-version.outputs.nightly-version }}
+
+      - name: Install asm binary
+        if: steps.cache-asm.outputs.cache-hit != 'true'
+        env:
+          ASM_TAG: ${{ steps.bin-versions.outputs.asm-tag }}
+        run: |
           cargo install --git https://github.com/alpenlabs/asm --tag "$ASM_TAG" --root "$GITHUB_WORKSPACE/target/asm" strata-asm-runner
+
+      - name: Add asm binary to PATH
+        run: |
           echo "$GITHUB_WORKSPACE/target/asm/bin" >> "$GITHUB_PATH"
 
       - name: Run functional tests


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR updates the functional tests workflow to cache external binaries (`mosaic`, `asm-runner`) and use them instead of installing them every time. The cache is dependent upon:

- The CI runner OS.
- The rev/tag in the workspace `Cargo.toml`.
- The rustc toolchain version.

Claude was used to author these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] CI
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.
 
## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->