### PR TITLE
STR-3009: GSM: PublishCounterProofNack executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8345,6 +8345,7 @@ dependencies = [
  "strata-bridge-test-utils",
  "strata-bridge-tx-graph",
  "strata-l1-txfmt",
+ "strata-mosaic-client-api",
  "strata-predicate",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/bridge-exec/src/errors.rs
+++ b/crates/bridge-exec/src/errors.rs
@@ -57,6 +57,10 @@ pub enum ExecutorError {
     /// Error interacting with the mosaic service.
     #[error("mosaic error: {0}")]
     MosaicErr(String),
+
+    /// A transaction or its template violates a protocol invariant
+    #[error("invalid transaction structure: {0}")]
+    InvalidTxStructure(String),
 }
 
 impl From<OneOf<(FdbBindingError, LayerError)>> for ExecutorError {

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -12,7 +12,7 @@ use strata_bridge_primitives::types::{DepositIdx, OperatorIdx};
 use strata_bridge_tx_graph::transactions::{
     bridge_proof::{BridgeProofData, BridgeProofTx},
     counterproof::CounterproofTx,
-    prelude::{ContestTx, CounterproofNackTx},
+    prelude::ContestTx,
 };
 use strata_mosaic_client_api::types::{G16ProofRaw, N_WITHDRAWAL_INPUT_WIRES};
 use tracing::{info, warn};
@@ -156,17 +156,6 @@ pub(super) async fn publish_counterproof_ack(
     .await
 }
 
-/// Signs and publishes the counterproof NACK transaction to reject an invalid counterproof.
-pub(super) async fn publish_counterproof_nack(
-    _output_handles: &OutputHandles,
-    _deposit_idx: DepositIdx,
-    _counter_prover_idx: OperatorIdx,
-    _counterproof_tx: Transaction,
-    _counterproof_nack_tx: CounterproofNackTx,
-) -> Result<(), ExecutorError> {
-    todo!("publish_counterproof_nack")
-}
-
 /// Publishes the signed slash transaction to Bitcoin.
 pub(super) async fn publish_slash(
     output_handles: &OutputHandles,
@@ -188,14 +177,15 @@ pub(super) async fn generate_and_publish_counterproof(
     counterproof_tx: CounterproofTx,
     operator_idx: OperatorIdx,
     deposit_idx: DepositIdx,
-    watchtower_idx: OperatorIdx,
+    // Will be wired in once mock counterproof data below is replaced with the real
+    // proof-to-counterproof conversion.
+    _watchtower_idx: OperatorIdx,
     n_of_n_signature: Signature,
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %operator_idx, "generating counterproof");
 
     // NOTE: (MdTeach) using mock counterproof data; replace with real proof-to-counterproof
     // conversion.
-    let _ = watchtower_idx;
     let counterproof_data = G16ProofRaw([0u8; N_WITHDRAWAL_INPUT_WIRES]);
 
     // Complete adaptor signatures via mosaic (we are the garbler/watchtower).

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -161,6 +161,7 @@ pub(super) async fn publish_counterproof_nack(
     _output_handles: &OutputHandles,
     _deposit_idx: DepositIdx,
     _counter_prover_idx: OperatorIdx,
+    _counterproof_tx: Transaction,
     _counterproof_nack_tx: CounterproofNackTx,
 ) -> Result<(), ExecutorError> {
     todo!("publish_counterproof_nack")

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -12,7 +12,7 @@ use strata_bridge_primitives::types::{DepositIdx, OperatorIdx};
 use strata_bridge_tx_graph::transactions::{
     bridge_proof::{BridgeProofData, BridgeProofTx},
     counterproof::CounterproofTx,
-    prelude::ContestTx,
+    prelude::{ContestTx, CounterproofNackTx},
 };
 use strata_mosaic_client_api::types::{G16ProofRaw, N_WITHDRAWAL_INPUT_WIRES};
 use tracing::{info, warn};
@@ -154,6 +154,16 @@ pub(super) async fn publish_counterproof_ack(
         TxStatus::is_buried,
     )
     .await
+}
+
+/// Signs and publishes the counterproof NACK transaction to reject an invalid counterproof.
+pub(super) async fn publish_counterproof_nack(
+    _output_handles: &OutputHandles,
+    _deposit_idx: DepositIdx,
+    _counter_prover_idx: OperatorIdx,
+    _counterproof_nack_tx: CounterproofNackTx,
+) -> Result<(), ExecutorError> {
+    todo!("publish_counterproof_nack")
 }
 
 /// Publishes the signed slash transaction to Bitcoin.

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -125,18 +125,22 @@ fn decode_completed_sigs(
     // that follow the per-byte operator signatures in the counterproof witness.
     const WANT: usize = N + 3;
 
-    let witness = &counterproof_tx.input[0].witness;
-    if witness.len() != WANT {
+    let witness_len = counterproof_tx.input[0].witness.len();
+    if witness_len != WANT {
         return Err(ExecutorError::InvalidTxStructure(format!(
-            "counterproof witness has {} elements, expected {WANT}",
-            witness.len(),
+            "counterproof witness has {witness_len} elements, expected {WANT}"
         )));
     }
 
-    let sigs: [Signature; N] = std::array::from_fn(|i| {
-        // operator_signatures were pushed `.rev()`, so undo that ordering.
-        Signature::from_slice(&witness[N - 1 - i])
-            .expect("on-chain counterproof signature must parse")
-    });
-    Ok(sigs)
+    // The witness layout is `[sig_{N-1}, .., sig_0, n-of-n sig, leaf script, control
+    // block]` — operator signatures pushed `.rev()`, then 3 trailing items. Reverse +
+    // skip(3) recovers `[sig_0, .., sig_{N-1}]`.
+    let mut items = counterproof_tx.input[0].witness.to_vec();
+    items.reverse();
+    let sigs: Vec<Signature> = items
+        .into_iter()
+        .skip(3)
+        .map(|w| Signature::from_slice(&w).expect("on-chain counterproof signature must parse"))
+        .collect();
+    Ok(sigs.try_into().expect("witness length validated above"))
 }

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -96,7 +96,7 @@ async fn sign_and_broadcast_nack(
     info!(
         %deposit_idx,
         %counterprover_idx,
-        elapsed_ms = evaluate_and_sign_start.elapsed().as_millis() as u64,
+        elapsed = ?evaluate_and_sign_start.elapsed(),
         "mosaic evaluate_and_sign completed",
     );
 

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -1,0 +1,249 @@
+//! Executor for the counterproof NACK transaction.
+
+use bitcoin::{
+    Amount, OutPoint, Sequence, TapSighashType, Transaction, TxIn, TxOut,
+    hashes::Hash,
+    sighash::{Prevouts, SighashCache},
+};
+use btc_tracker::event::TxStatus;
+use musig2::secp256k1::schnorr::Signature;
+use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
+use strata_bridge_primitives::{
+    scripts::{prelude::create_key_spend_hash, taproot::TaprootTweak},
+    types::{DepositIdx, OperatorIdx},
+};
+use strata_bridge_tx_graph::transactions::prelude::CounterproofNackTx;
+use strata_mosaic_client_api::types::{
+    CompletedSignatures, G16ProofRaw, N_DEPOSIT_INPUT_WIRES, N_WITHDRAWAL_INPUT_WIRES, Sighash,
+    Tweak,
+};
+use tracing::{info, warn};
+
+use crate::{
+    chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
+};
+
+/// Signs and publishes the counterproof NACK transaction to reject an invalid counterproof.
+pub(super) async fn publish_counterproof_nack(
+    output_handles: &OutputHandles,
+    deposit_idx: DepositIdx,
+    counter_prover_idx: OperatorIdx,
+    counterproof_tx: Transaction,
+    counterproof_nack_tx: CounterproofNackTx,
+) -> Result<(), ExecutorError> {
+    info!(%deposit_idx, %counter_prover_idx, "preparing counterproof nack");
+
+    let completed_signatures = decode_completed_sigs(&counterproof_tx)?;
+
+    let AttachedFunding {
+        nack_tx,
+        funding_outpoint,
+        prevouts,
+    } = attach_operator_funding(output_handles, counterproof_nack_tx).await?;
+
+    let result = sign_and_broadcast_nack(
+        output_handles,
+        counter_prover_idx,
+        deposit_idx,
+        completed_signatures,
+        nack_tx,
+        &prevouts,
+    )
+    .await;
+
+    if result.is_err() {
+        output_handles
+            .wallet
+            .write()
+            .await
+            .release_outpoints(&[funding_outpoint]);
+    }
+    result
+}
+
+/// Output of [`attach_operator_funding`]: the fully-populated NACK plus the leased funding
+/// outpoint (so the caller can release on failure) and a snapshot of all prevouts (needed
+/// because [`CounterproofNackTx::finalize_partial`] consumes the NACK by value).
+struct AttachedFunding {
+    nack_tx: CounterproofNackTx,
+    funding_outpoint: OutPoint,
+    prevouts: Vec<TxOut>,
+}
+
+/// Picks an operator-funded UTXO from the general wallet, leases it, and pushes a funding
+/// input + change output onto the NACK template. Single wallet write-lock — no race window
+/// between selection and the change-script lookup.
+async fn attach_operator_funding(
+    output_handles: &OutputHandles,
+    mut nack_tx: CounterproofNackTx,
+) -> Result<AttachedFunding, ExecutorError> {
+    const NACK_FIXED_FEE: Amount = Amount::from_sat(1_000);
+    const NACK_MIN_FUNDING_VALUE: Amount = Amount::from_sat(10_000);
+
+    let (funding_outpoint, funding_prevout, change_script) = {
+        let mut wallet = output_handles.wallet.write().await;
+        if let Err(e) = wallet.sync().await {
+            warn!(
+                ?e,
+                "could not sync wallet before nack funding selection; continuing"
+            );
+        }
+        let selected = wallet
+            .select_and_lease_general_utxo(|u| u.txout.value >= NACK_MIN_FUNDING_VALUE)
+            .ok_or_else(|| {
+                ExecutorError::WalletErr(format!(
+                    "no general utxo >= {} sat for counterproof nack funding",
+                    NACK_MIN_FUNDING_VALUE.to_sat()
+                ))
+            })?;
+        let change_script = wallet.general_script_buf().clone();
+        let outcome = (selected.outpoint, selected.txout, change_script);
+        drop(wallet);
+        outcome
+    };
+
+    let change_value = funding_prevout
+        .value
+        .checked_sub(NACK_FIXED_FEE)
+        .ok_or_else(|| {
+            ExecutorError::WalletErr(format!(
+                "funding utxo value {} sat is below fixed nack fee {} sat",
+                funding_prevout.value.to_sat(),
+                NACK_FIXED_FEE.to_sat(),
+            ))
+        })?;
+
+    nack_tx.push_input(
+        TxIn {
+            previous_output: funding_outpoint,
+            sequence: Sequence::MAX,
+            ..Default::default()
+        },
+        funding_prevout,
+    );
+    nack_tx.push_output(TxOut {
+        value: change_value,
+        script_pubkey: change_script,
+    });
+
+    let prevouts = nack_tx.prevouts().to_vec();
+    Ok(AttachedFunding {
+        nack_tx,
+        funding_outpoint,
+        prevouts,
+    })
+}
+
+/// Has mosaic sign the connector input, signs the funding input via the operator's general
+/// wallet, and broadcasts. The funding input is always the last one (`push_input` appends).
+#[allow(clippy::large_types_passed_by_value)] // mosaic's evaluate_and_sign takes CompletedSignatures by value
+async fn sign_and_broadcast_nack(
+    output_handles: &OutputHandles,
+    counter_prover_idx: OperatorIdx,
+    deposit_idx: DepositIdx,
+    completed_signatures: CompletedSignatures,
+    nack_tx: CounterproofNackTx,
+    prevouts: &[TxOut],
+) -> Result<(), ExecutorError> {
+    // Sighash + tap tweak for the connector input (key-path spend with `wt_i_fault` as the
+    // internal key; script-path is impossible by construction).
+    let signing_info = nack_tx.signing_info_partial();
+    let sighash: Sighash = *signing_info.sighash.as_ref();
+    let tweak: Option<Tweak> = match signing_info.tweak {
+        TaprootTweak::Key { tweak } => tweak.map(Hash::to_byte_array),
+        TaprootTweak::Script => {
+            return Err(ExecutorError::InvalidTxStructure(
+                "counterproof nack expected a key-path spend, got script".into(),
+            ));
+        }
+    };
+
+    info!(%deposit_idx, %counter_prover_idx, "calling mosaic evaluate_and_sign");
+    let wt_fault_signature = output_handles
+        .mosaic_client
+        .evaluate_and_sign(
+            counter_prover_idx,
+            deposit_idx,
+            G16ProofRaw([0u8; N_WITHDRAWAL_INPUT_WIRES]),
+            completed_signatures,
+            sighash,
+            tweak,
+        )
+        .await
+        .map_err(|e| {
+            warn!(%deposit_idx, %counter_prover_idx, ?e, "evaluate_and_sign failed");
+            ExecutorError::MosaicErr(format!("evaluate_and_sign: {e:?}"))
+        })?
+        .ok_or_else(|| {
+            ExecutorError::MosaicErr(
+                "evaluator failed to extract fault secret from counterproof".into(),
+            )
+        })?;
+
+    let mut signed_tx = nack_tx.finalize_partial(wt_fault_signature);
+
+    // Invariant: at sign time the NACK has exactly 2 prevouts — the connector input
+    // (index 0) and the funding input that `attach_operator_funding` appended (index 1).
+    // Trip loudly in tests if a future change adds another input between attach and sign.
+    debug_assert_eq!(
+        prevouts.len(),
+        2,
+        "expected exactly 2 prevouts (connector + funding) at sign time"
+    );
+    // Funding input is always the last one (push_input appends). Derive the index from
+    // the prevouts length rather than hardcoding `1`.
+    let funding_input_index = prevouts.len() - 1;
+    let mut sighash_cache = SighashCache::new(&signed_tx);
+    let funding_sighash = create_key_spend_hash(
+        &mut sighash_cache,
+        Prevouts::All(prevouts),
+        TapSighashType::Default,
+        funding_input_index,
+    )
+    .map_err(|e| ExecutorError::WalletErr(format!("nack funding sighash: {e}")))?;
+
+    let funding_signature = output_handles
+        .s2_client
+        .general_wallet_signer()
+        .sign(funding_sighash.as_ref(), None)
+        .await
+        .map_err(ExecutorError::SecretServiceErr)?;
+
+    signed_tx.input[funding_input_index]
+        .witness
+        .push(funding_signature.serialize());
+
+    info!(%deposit_idx, %counter_prover_idx, "publishing counterproof nack transaction");
+    publish_signed_transaction(
+        &output_handles.tx_driver,
+        &signed_tx,
+        "counterproof nack",
+        TxStatus::is_buried,
+    )
+    .await
+}
+
+/// Decodes the operator signatures from input[0] of an on-chain Counterproof tx.
+fn decode_completed_sigs(
+    counterproof_tx: &Transaction,
+) -> Result<CompletedSignatures, ExecutorError> {
+    const N: usize = N_DEPOSIT_INPUT_WIRES + N_WITHDRAWAL_INPUT_WIRES;
+    // `+ 3` accounts for the trailing n-of-n signature, leaf script, and control block
+    // that follow the per-byte operator signatures in the counterproof witness.
+    const WANT: usize = N + 3;
+
+    let witness = &counterproof_tx.input[0].witness;
+    if witness.len() != WANT {
+        return Err(ExecutorError::InvalidTxStructure(format!(
+            "counterproof witness has {} elements, expected {WANT}",
+            witness.len(),
+        )));
+    }
+
+    let sigs: [Signature; N] = std::array::from_fn(|i| {
+        // operator_signatures were pushed `.rev()`, so undo that ordering.
+        Signature::from_slice(&witness[N - 1 - i])
+            .expect("on-chain counterproof signature must parse")
+    });
+    Ok(sigs)
+}

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -1,15 +1,10 @@
 //! Executor for the counterproof NACK transaction.
 
-use bitcoin::{
-    Amount, OutPoint, Sequence, TapSighashType, Transaction, TxIn, TxOut,
-    hashes::Hash,
-    sighash::{Prevouts, SighashCache},
-};
+use bitcoin::{Transaction, TxOut, hashes::Hash};
 use btc_tracker::event::TxStatus;
 use musig2::secp256k1::schnorr::Signature;
-use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_primitives::{
-    scripts::{prelude::create_key_spend_hash, taproot::TaprootTweak},
+    scripts::taproot::TaprootTweak,
     types::{DepositIdx, OperatorIdx},
 };
 use strata_bridge_tx_graph::transactions::prelude::CounterproofNackTx;
@@ -29,124 +24,46 @@ pub(super) async fn publish_counterproof_nack(
     deposit_idx: DepositIdx,
     counter_prover_idx: OperatorIdx,
     counterproof_tx: Transaction,
-    counterproof_nack_tx: CounterproofNackTx,
+    mut counterproof_nack_tx: CounterproofNackTx,
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %counter_prover_idx, "preparing counterproof nack");
 
     let completed_signatures = decode_completed_sigs(&counterproof_tx)?;
 
-    let AttachedFunding {
-        nack_tx,
-        funding_outpoint,
-        prevouts,
-    } = attach_operator_funding(output_handles, counterproof_nack_tx).await?;
+    // Single output: forward the connector's dust value back to the operator's general
+    // wallet. The connector script is `minimal_non_dust` P2TR, so the output clears dust.
+    let connector_value = counterproof_nack_tx.prevouts()[0].value;
+    let payout_script = output_handles
+        .wallet
+        .read()
+        .await
+        .general_script_buf()
+        .clone();
+    counterproof_nack_tx.push_output(TxOut {
+        value: connector_value,
+        script_pubkey: payout_script,
+    });
 
-    let result = sign_and_broadcast_nack(
+    sign_and_broadcast_nack(
         output_handles,
         counter_prover_idx,
         deposit_idx,
         completed_signatures,
-        nack_tx,
-        &prevouts,
+        counterproof_nack_tx,
     )
-    .await;
-
-    if result.is_err() {
-        output_handles
-            .wallet
-            .write()
-            .await
-            .release_outpoints(&[funding_outpoint]);
-    }
-    result
+    .await
 }
 
-/// Output of [`attach_operator_funding`]: the fully-populated NACK plus the leased funding
-/// outpoint (so the caller can release on failure) and a snapshot of all prevouts (needed
-/// because [`CounterproofNackTx::finalize_partial`] consumes the NACK by value).
-struct AttachedFunding {
-    nack_tx: CounterproofNackTx,
-    funding_outpoint: OutPoint,
-    prevouts: Vec<TxOut>,
-}
-
-/// Picks an operator-funded UTXO from the general wallet, leases it, and pushes a funding
-/// input + change output onto the NACK template. Single wallet write-lock — no race window
-/// between selection and the change-script lookup.
-async fn attach_operator_funding(
-    output_handles: &OutputHandles,
-    mut nack_tx: CounterproofNackTx,
-) -> Result<AttachedFunding, ExecutorError> {
-    const NACK_FIXED_FEE: Amount = Amount::from_sat(1_000);
-    const NACK_MIN_FUNDING_VALUE: Amount = Amount::from_sat(10_000);
-
-    let (funding_outpoint, funding_prevout, change_script) = {
-        let mut wallet = output_handles.wallet.write().await;
-        if let Err(e) = wallet.sync().await {
-            warn!(
-                ?e,
-                "could not sync wallet before nack funding selection; continuing"
-            );
-        }
-        let selected = wallet
-            .select_and_lease_general_utxo(|u| u.txout.value >= NACK_MIN_FUNDING_VALUE)
-            .ok_or_else(|| {
-                ExecutorError::WalletErr(format!(
-                    "no general utxo >= {} sat for counterproof nack funding",
-                    NACK_MIN_FUNDING_VALUE.to_sat()
-                ))
-            })?;
-        let change_script = wallet.general_script_buf().clone();
-        let outcome = (selected.outpoint, selected.txout, change_script);
-        drop(wallet);
-        outcome
-    };
-
-    let change_value = funding_prevout
-        .value
-        .checked_sub(NACK_FIXED_FEE)
-        .ok_or_else(|| {
-            ExecutorError::WalletErr(format!(
-                "funding utxo value {} sat is below fixed nack fee {} sat",
-                funding_prevout.value.to_sat(),
-                NACK_FIXED_FEE.to_sat(),
-            ))
-        })?;
-
-    nack_tx.push_input(
-        TxIn {
-            previous_output: funding_outpoint,
-            sequence: Sequence::MAX,
-            ..Default::default()
-        },
-        funding_prevout,
-    );
-    nack_tx.push_output(TxOut {
-        value: change_value,
-        script_pubkey: change_script,
-    });
-
-    let prevouts = nack_tx.prevouts().to_vec();
-    Ok(AttachedFunding {
-        nack_tx,
-        funding_outpoint,
-        prevouts,
-    })
-}
-
-/// Has mosaic sign the connector input, signs the funding input via the operator's general
-/// wallet, and broadcasts. The funding input is always the last one (`push_input` appends).
-#[allow(clippy::large_types_passed_by_value)] // mosaic's evaluate_and_sign takes CompletedSignatures by value
+/// Asks mosaic for the connector signature, finalizes the tx, and broadcasts it.
 async fn sign_and_broadcast_nack(
     output_handles: &OutputHandles,
     counter_prover_idx: OperatorIdx,
     deposit_idx: DepositIdx,
     completed_signatures: CompletedSignatures,
     nack_tx: CounterproofNackTx,
-    prevouts: &[TxOut],
 ) -> Result<(), ExecutorError> {
-    // Sighash + tap tweak for the connector input (key-path spend with `wt_i_fault` as the
-    // internal key; script-path is impossible by construction).
+    // Key-path spend with `wt_i_fault` as the internal key; script-path is impossible by
+    // construction.
     let signing_info = nack_tx.signing_info_partial();
     let sighash: Sighash = *signing_info.sighash.as_ref();
     let tweak: Option<Tweak> = match signing_info.tweak {
@@ -180,38 +97,7 @@ async fn sign_and_broadcast_nack(
             )
         })?;
 
-    let mut signed_tx = nack_tx.finalize_partial(wt_fault_signature);
-
-    // Invariant: at sign time the NACK has exactly 2 prevouts — the connector input
-    // (index 0) and the funding input that `attach_operator_funding` appended (index 1).
-    // Trip loudly in tests if a future change adds another input between attach and sign.
-    debug_assert_eq!(
-        prevouts.len(),
-        2,
-        "expected exactly 2 prevouts (connector + funding) at sign time"
-    );
-    // Funding input is always the last one (push_input appends). Derive the index from
-    // the prevouts length rather than hardcoding `1`.
-    let funding_input_index = prevouts.len() - 1;
-    let mut sighash_cache = SighashCache::new(&signed_tx);
-    let funding_sighash = create_key_spend_hash(
-        &mut sighash_cache,
-        Prevouts::All(prevouts),
-        TapSighashType::Default,
-        funding_input_index,
-    )
-    .map_err(|e| ExecutorError::WalletErr(format!("nack funding sighash: {e}")))?;
-
-    let funding_signature = output_handles
-        .s2_client
-        .general_wallet_signer()
-        .sign(funding_sighash.as_ref(), None)
-        .await
-        .map_err(ExecutorError::SecretServiceErr)?;
-
-    signed_tx.input[funding_input_index]
-        .witness
-        .push(funding_signature.serialize());
+    let signed_tx = nack_tx.finalize_partial(wt_fault_signature);
 
     info!(%deposit_idx, %counter_prover_idx, "publishing counterproof nack transaction");
     publish_signed_transaction(

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -76,6 +76,7 @@ async fn sign_and_broadcast_nack(
     };
 
     info!(%deposit_idx, %counterprover_idx, "calling mosaic evaluate_and_sign");
+    let evaluate_and_sign_start = std::time::Instant::now();
     let wt_fault_signature = output_handles
         .mosaic_client
         .evaluate_and_sign(
@@ -96,6 +97,12 @@ async fn sign_and_broadcast_nack(
                 "evaluator failed to extract fault secret from counterproof".into(),
             )
         })?;
+    info!(
+        %deposit_idx,
+        %counterprover_idx,
+        elapsed_ms = evaluate_and_sign_start.elapsed().as_millis() as u64,
+        "mosaic evaluate_and_sign completed",
+    );
 
     let signed_tx = nack_tx.finalize_partial(wt_fault_signature);
 

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -1,16 +1,14 @@
 //! Executor for the counterproof NACK transaction.
 
-use bitcoin::{Transaction, TxOut, hashes::Hash};
+use bitcoin::{TxOut, hashes::Hash};
 use btc_tracker::event::TxStatus;
-use musig2::secp256k1::schnorr::Signature;
 use strata_bridge_primitives::{
     scripts::taproot::TaprootTweak,
     types::{DepositIdx, OperatorIdx},
 };
 use strata_bridge_tx_graph::transactions::prelude::CounterproofNackTx;
 use strata_mosaic_client_api::types::{
-    CompletedSignatures, G16ProofRaw, N_DEPOSIT_INPUT_WIRES, N_WITHDRAWAL_INPUT_WIRES, Sighash,
-    Tweak,
+    CompletedSignatures, G16ProofRaw, N_WITHDRAWAL_INPUT_WIRES, Sighash, Tweak,
 };
 use tracing::{info, warn};
 
@@ -23,12 +21,10 @@ pub(super) async fn publish_counterproof_nack(
     output_handles: &OutputHandles,
     deposit_idx: DepositIdx,
     counterprover_idx: OperatorIdx,
-    counterproof_tx: Transaction,
+    completed_signatures: CompletedSignatures,
     mut counterproof_nack_tx: CounterproofNackTx,
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %counterprover_idx, "preparing counterproof nack");
-
-    let completed_signatures = decode_completed_sigs(&counterproof_tx)?;
 
     // Single output: forward the connector's dust value back to the operator's general
     // wallet. The connector script is `minimal_non_dust` P2TR, so the output clears dust.
@@ -114,33 +110,4 @@ async fn sign_and_broadcast_nack(
         TxStatus::is_buried,
     )
     .await
-}
-
-/// Decodes the operator signatures from input[0] of an on-chain Counterproof tx.
-fn decode_completed_sigs(
-    counterproof_tx: &Transaction,
-) -> Result<CompletedSignatures, ExecutorError> {
-    const N: usize = N_DEPOSIT_INPUT_WIRES + N_WITHDRAWAL_INPUT_WIRES;
-    // `+ 3` accounts for the trailing n-of-n signature, leaf script, and control block
-    // that follow the per-byte operator signatures in the counterproof witness.
-    const WANT: usize = N + 3;
-
-    let witness_len = counterproof_tx.input[0].witness.len();
-    if witness_len != WANT {
-        return Err(ExecutorError::InvalidTxStructure(format!(
-            "counterproof witness has {witness_len} elements, expected {WANT}"
-        )));
-    }
-
-    // The witness layout is `[sig_{N-1}, .., sig_0, n-of-n sig, leaf script, control
-    // block]` — operator signatures pushed `.rev()`, then 3 trailing items. Reverse +
-    // skip(3) recovers `[sig_0, .., sig_{N-1}]`.
-    let mut items = counterproof_tx.input[0].witness.to_vec();
-    items.reverse();
-    let sigs: Vec<Signature> = items
-        .into_iter()
-        .skip(3)
-        .map(|w| Signature::from_slice(&w).expect("on-chain counterproof signature must parse"))
-        .collect();
-    Ok(sigs.try_into().expect("witness length validated above"))
 }

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -22,11 +22,11 @@ use crate::{
 pub(super) async fn publish_counterproof_nack(
     output_handles: &OutputHandles,
     deposit_idx: DepositIdx,
-    counter_prover_idx: OperatorIdx,
+    counterprover_idx: OperatorIdx,
     counterproof_tx: Transaction,
     mut counterproof_nack_tx: CounterproofNackTx,
 ) -> Result<(), ExecutorError> {
-    info!(%deposit_idx, %counter_prover_idx, "preparing counterproof nack");
+    info!(%deposit_idx, %counterprover_idx, "preparing counterproof nack");
 
     let completed_signatures = decode_completed_sigs(&counterproof_tx)?;
 
@@ -46,7 +46,7 @@ pub(super) async fn publish_counterproof_nack(
 
     sign_and_broadcast_nack(
         output_handles,
-        counter_prover_idx,
+        counterprover_idx,
         deposit_idx,
         completed_signatures,
         counterproof_nack_tx,
@@ -57,7 +57,7 @@ pub(super) async fn publish_counterproof_nack(
 /// Asks mosaic for the connector signature, finalizes the tx, and broadcasts it.
 async fn sign_and_broadcast_nack(
     output_handles: &OutputHandles,
-    counter_prover_idx: OperatorIdx,
+    counterprover_idx: OperatorIdx,
     deposit_idx: DepositIdx,
     completed_signatures: CompletedSignatures,
     nack_tx: CounterproofNackTx,
@@ -75,11 +75,11 @@ async fn sign_and_broadcast_nack(
         }
     };
 
-    info!(%deposit_idx, %counter_prover_idx, "calling mosaic evaluate_and_sign");
+    info!(%deposit_idx, %counterprover_idx, "calling mosaic evaluate_and_sign");
     let wt_fault_signature = output_handles
         .mosaic_client
         .evaluate_and_sign(
-            counter_prover_idx,
+            counterprover_idx,
             deposit_idx,
             G16ProofRaw([0u8; N_WITHDRAWAL_INPUT_WIRES]),
             completed_signatures,
@@ -88,7 +88,7 @@ async fn sign_and_broadcast_nack(
         )
         .await
         .map_err(|e| {
-            warn!(%deposit_idx, %counter_prover_idx, ?e, "evaluate_and_sign failed");
+            warn!(%deposit_idx, %counterprover_idx, ?e, "evaluate_and_sign failed");
             ExecutorError::MosaicErr(format!("evaluate_and_sign: {e:?}"))
         })?
         .ok_or_else(|| {
@@ -99,7 +99,7 @@ async fn sign_and_broadcast_nack(
 
     let signed_tx = nack_tx.finalize_partial(wt_fault_signature);
 
-    info!(%deposit_idx, %counter_prover_idx, "publishing counterproof nack transaction");
+    info!(%deposit_idx, %counterprover_idx, "publishing counterproof nack transaction");
     publish_signed_transaction(
         &output_handles.tx_driver,
         &signed_tx,

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -160,12 +160,14 @@ pub async fn execute_graph_duty(
         GraphDuty::PublishCounterProofNack {
             deposit_idx,
             counter_prover_idx,
+            counterproof_tx,
             counterproof_nack_tx,
         } => {
             publish_counterproof_nack(
                 &output_handles,
                 *deposit_idx,
                 *counter_prover_idx,
+                counterproof_tx.clone(),
                 counterproof_nack_tx.clone(),
             )
             .await

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -162,14 +162,14 @@ pub async fn execute_graph_duty(
         GraphDuty::PublishCounterProofNack {
             deposit_idx,
             counterprover_idx,
-            counterproof_tx,
+            completed_signatures,
             counterproof_nack_tx,
         } => {
             publish_counterproof_nack(
                 &output_handles,
                 *deposit_idx,
                 *counterprover_idx,
-                counterproof_tx.clone(),
+                *completed_signatures,
                 counterproof_nack_tx.clone(),
             )
             .await

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -3,6 +3,7 @@
 
 mod common;
 mod contested;
+mod counterproof_nack;
 mod uncontested;
 mod utils;
 
@@ -20,8 +21,9 @@ use crate::{
         contested::{
             generate_and_publish_bridge_proof, generate_and_publish_counterproof,
             publish_bridge_proof_timeout, publish_contest, publish_contested_payout,
-            publish_counterproof_ack, publish_counterproof_nack, publish_slash,
+            publish_counterproof_ack, publish_slash,
         },
+        counterproof_nack::publish_counterproof_nack,
         uncontested::publish_uncontested_payout,
     },
     output_handles::OutputHandles,

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         contested::{
             generate_and_publish_bridge_proof, generate_and_publish_counterproof,
             publish_bridge_proof_timeout, publish_contest, publish_contested_payout,
-            publish_counterproof_ack, publish_slash,
+            publish_counterproof_ack, publish_counterproof_nack, publish_slash,
         },
         uncontested::publish_uncontested_payout,
     },
@@ -157,8 +157,18 @@ pub async fn execute_graph_duty(
         GraphDuty::PublishCounterProofAck {
             signed_counter_proof_ack_tx,
         } => publish_counterproof_ack(&output_handles, signed_counter_proof_ack_tx).await,
-        GraphDuty::PublishCounterProofNack { .. } => {
-            todo!("PublishCounterProofNack")
+        GraphDuty::PublishCounterProofNack {
+            deposit_idx,
+            counter_prover_idx,
+            counterproof_nack_tx,
+        } => {
+            publish_counterproof_nack(
+                &output_handles,
+                *deposit_idx,
+                *counter_prover_idx,
+                counterproof_nack_tx.clone(),
+            )
+            .await
         }
         GraphDuty::PublishSlash { signed_slash_tx } => {
             publish_slash(&output_handles, signed_slash_tx).await

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -161,14 +161,14 @@ pub async fn execute_graph_duty(
         } => publish_counterproof_ack(&output_handles, signed_counter_proof_ack_tx).await,
         GraphDuty::PublishCounterProofNack {
             deposit_idx,
-            counter_prover_idx,
+            counterprover_idx,
             counterproof_tx,
             counterproof_nack_tx,
         } => {
             publish_counterproof_nack(
                 &output_handles,
                 *deposit_idx,
-                *counter_prover_idx,
+                *counterprover_idx,
                 counterproof_tx.clone(),
                 counterproof_nack_tx.clone(),
             )

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -61,9 +61,9 @@ pub async fn execute_stake_duty(
             )
             .await
         }
-        StakeDuty::PublishStake { tx } => {
-            info!(stake_txid=%tx.compute_txid(), "executing StakeDuty::PublishStake");
-            staking::publish_stake(&cfg, &output_handles, tx).await
+        StakeDuty::PublishStake { operator_idx, tx } => {
+            info!(%operator_idx, stake_txid=%tx.compute_txid(), "executing StakeDuty::PublishStake");
+            staking::publish_stake(&cfg, &output_handles, *operator_idx, tx).await
         }
         StakeDuty::PublishUnstakingIntent {
             unsigned_tx,

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -63,7 +63,7 @@ pub async fn execute_stake_duty(
         }
         StakeDuty::PublishStake { operator_idx, tx } => {
             info!(%operator_idx, stake_txid=%tx.compute_txid(), "executing StakeDuty::PublishStake");
-            staking::publish_stake(&cfg, &output_handles, *operator_idx, tx).await
+            staking::publish_stake(&cfg, &output_handles, tx).await
         }
         StakeDuty::PublishUnstakingIntent {
             unsigned_tx,

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -24,7 +24,7 @@ use strata_bridge_primitives::{
     types::OperatorIdx,
 };
 use strata_bridge_tx_graph::musig_functor::StakeFunctor;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
@@ -305,8 +305,15 @@ pub(crate) async fn publish_unstaking_partials(
 pub(crate) async fn publish_stake(
     cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
+    operator_idx: OperatorIdx,
     tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    let pov_idx = output_handles.operator_table.pov_idx();
+    if operator_idx != pov_idx {
+        debug!(%operator_idx, %pov_idx, "skipping PublishStake duty for foreign operator");
+        return Ok(());
+    }
+
     let stake_txid = tx.compute_txid();
     let funding_input = tx.input[0].previous_output;
 

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -24,7 +24,7 @@ use strata_bridge_primitives::{
     types::OperatorIdx,
 };
 use strata_bridge_tx_graph::musig_functor::StakeFunctor;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use crate::{
     chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
@@ -305,15 +305,8 @@ pub(crate) async fn publish_unstaking_partials(
 pub(crate) async fn publish_stake(
     cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
-    operator_idx: OperatorIdx,
     tx: &Transaction,
 ) -> Result<(), ExecutorError> {
-    let pov_idx = output_handles.operator_table.pov_idx();
-    if operator_idx != pov_idx {
-        debug!(%operator_idx, %pov_idx, "skipping PublishStake duty for foreign operator");
-        return Ok(());
-    }
-
     let stake_txid = tx.compute_txid();
     let funding_input = tx.input[0].previous_output;
 

--- a/crates/bridge-sm/Cargo.toml
+++ b/crates/bridge-sm/Cargo.toml
@@ -12,6 +12,7 @@ strata-bridge-connectors.workspace = true
 strata-bridge-p2p-types.workspace = true
 strata-bridge-primitives.workspace = true
 strata-bridge-tx-graph.workspace = true
+strata-mosaic-client-api.workspace = true
 
 strata-asm-common.workspace = true
 strata-asm-proto-bridge-v1-txs.workspace = true

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -248,6 +248,9 @@ pub enum GraphDuty {
         /// The index of the operator who submitted the counterproof.
         counter_prover_idx: OperatorIdx,
 
+        /// The counterproof transaction being NACKed.
+        counterproof_tx: Transaction,
+
         /// The unsigned counterproof NACK transaction to be published
         counterproof_nack_tx: CounterproofNackTx,
     },

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -14,7 +14,9 @@ use strata_bridge_primitives::{
     types::{DepositIdx, GraphIdx, OperatorIdx, P2POperatorPubKey},
 };
 use strata_bridge_tx_graph::transactions::{
-    claim::ClaimTx, counterproof::CounterproofTx, prelude::ContestTx,
+    claim::ClaimTx,
+    counterproof::CounterproofTx,
+    prelude::{ContestTx, CounterproofNackTx},
 };
 use zkaleido::ProofReceipt;
 
@@ -246,9 +248,8 @@ pub enum GraphDuty {
         /// The index of the operator who submitted the counterproof.
         counter_prover_idx: OperatorIdx,
 
-        /// The counterproof NACK transaction to be published (unsigned; signed by mosaic after GC
-        /// evaluation).
-        counterproof_nack_tx: Transaction,
+        /// The unsigned counterproof NACK transaction to be published
+        counterproof_nack_tx: CounterproofNackTx,
     },
 
     /// Publish a slash transaction.

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -18,6 +18,7 @@ use strata_bridge_tx_graph::transactions::{
     counterproof::CounterproofTx,
     prelude::{ContestTx, CounterproofNackTx},
 };
+use strata_mosaic_client_api::types::CompletedSignatures;
 use zkaleido::ProofReceipt;
 
 /// The nag duties that can be emitted to remind operators of missing graph signing data.
@@ -88,6 +89,7 @@ impl std::fmt::Display for NagDuty {
 
 /// The duties that need to be performed to drive the Graph State Machine forward.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[expect(clippy::large_enum_variant)]
 pub enum GraphDuty {
     /// Generate the data required to generate the graph.
     ///
@@ -248,8 +250,9 @@ pub enum GraphDuty {
         /// The index of the operator who submitted the counterproof.
         counterprover_idx: OperatorIdx,
 
-        /// The counterproof transaction being NACKed.
-        counterproof_tx: Transaction,
+        /// Per-byte operator signatures recovered from the counterproof witness;
+        /// forwarded to mosaic to extract the fault secret.
+        completed_signatures: CompletedSignatures,
 
         /// The unsigned counterproof NACK transaction to be published
         counterproof_nack_tx: CounterproofNackTx,

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -246,7 +246,7 @@ pub enum GraphDuty {
         deposit_idx: DepositIdx,
 
         /// The index of the operator who submitted the counterproof.
-        counter_prover_idx: OperatorIdx,
+        counterprover_idx: OperatorIdx,
 
         /// The counterproof transaction being NACKed.
         counterproof_tx: Transaction,

--- a/crates/bridge-sm/src/graph/events.rs
+++ b/crates/bridge-sm/src/graph/events.rs
@@ -128,11 +128,11 @@ pub struct BridgeProofTimeoutConfirmedEvent {
 /// Event notifying that a counterproof transaction has been confirmed on-chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CounterProofConfirmedEvent {
-    /// The txid of the counterproof transaction.
-    pub counterproof_txid: Txid,
-
     /// The block height at which the counterproof transaction was confirmed.
     pub counterproof_block_height: BitcoinBlockHeight,
+
+    /// The counterproof transaction.
+    pub tx: Transaction,
 
     /// The index of the watchtower who submitted the counterproof transaction.
     pub counterprover_idx: OperatorIdx,

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use bitcoin::{Txid, hashes::Hash};
+use strata_bridge_test_utils::bitcoin::generate_tx;
 use strata_bridge_tx_graph::{
     game_graph::GameConnectors,
     transactions::prelude::{CounterproofNackData, CounterproofNackTx},
@@ -22,8 +22,8 @@ use crate::{
                 TEST_FULFILLMENT_TXID, TEST_GRAPH_SUMMARY, all_state_variants,
                 bridge_proof_posted_state, contested_state,
             },
-            test_deposit_params, test_graph_invalid_transition, test_graph_sm_cfg,
-            test_graph_sm_ctx, test_graph_transition,
+            test_counterproof_tx, test_deposit_params, test_graph_invalid_transition,
+            test_graph_sm_cfg, test_graph_sm_ctx, test_graph_transition,
         },
         watchtower::watchtower_slot_for_operator,
     },
@@ -35,12 +35,12 @@ const COUNTERPROOF_BLOCK_HEIGHT: u64 = LATER_BLOCK_HEIGHT + 50;
 
 /// Creates a counterproof event for the given operator index using the test graph summary.
 fn counterproof_event(counterprover_idx: u32) -> CounterProofConfirmedEvent {
-    let watchtower_slot = watchtower_slot_for_operator(TEST_POV_IDX, counterprover_idx)
+    watchtower_slot_for_operator(TEST_POV_IDX, counterprover_idx)
         .expect("counterprover should have a watchtower slot");
 
     CounterProofConfirmedEvent {
-        counterproof_txid: TEST_GRAPH_SUMMARY.counterproofs[watchtower_slot].counterproof,
         counterproof_block_height: COUNTERPROOF_BLOCK_HEIGHT,
+        tx: test_counterproof_tx(),
         counterprover_idx,
     }
 }
@@ -70,6 +70,7 @@ fn expected_nack_duty(counterprover_idx: u32) -> GraphDuty {
     GraphDuty::PublishCounterProofNack {
         deposit_idx: ctx.deposit_idx(),
         counter_prover_idx: counterprover_idx,
+        counterproof_tx: test_counterproof_tx(),
         counterproof_nack_tx,
     }
 }
@@ -83,7 +84,7 @@ fn event_accepted_from_contested_pov() {
     let mut expected_counterproofs = BTreeMap::new();
     expected_counterproofs.insert(
         event.counterprover_idx,
-        (event.counterproof_txid, event.counterproof_block_height),
+        (event.tx.compute_txid(), event.counterproof_block_height),
     );
 
     test_graph_transition(GraphTransition {
@@ -112,7 +113,7 @@ fn event_accepted_from_contested_nonpov() {
     let mut expected_counterproofs = BTreeMap::new();
     expected_counterproofs.insert(
         event.counterprover_idx,
-        (event.counterproof_txid, event.counterproof_block_height),
+        (event.tx.compute_txid(), event.counterproof_block_height),
     );
 
     test_transition::<GraphSM, _, _, _, _, _, _, _>(
@@ -148,7 +149,7 @@ fn event_accepted_from_bridge_proof_posted_pov() {
     let mut expected_counterproofs = BTreeMap::new();
     expected_counterproofs.insert(
         event.counterprover_idx,
-        (event.counterproof_txid, event.counterproof_block_height),
+        (event.tx.compute_txid(), event.counterproof_block_height),
     );
 
     test_graph_transition(GraphTransition {
@@ -177,7 +178,7 @@ fn event_accepted_from_bridge_proof_posted_nonpov() {
     let mut expected_counterproofs = BTreeMap::new();
     expected_counterproofs.insert(
         event.counterprover_idx,
-        (event.counterproof_txid, event.counterproof_block_height),
+        (event.tx.compute_txid(), event.counterproof_block_height),
     );
 
     test_transition::<GraphSM, _, _, _, _, _, _, _>(
@@ -213,7 +214,7 @@ fn event_accepted_from_counter_proof_posted_pov() {
     let mut expected_counterproofs = BTreeMap::new();
     expected_counterproofs.insert(
         event.counterprover_idx,
-        (event.counterproof_txid, event.counterproof_block_height),
+        (event.tx.compute_txid(), event.counterproof_block_height),
     );
 
     // Start from an empty CounterProofPosted state (no prior counterproofs).
@@ -257,7 +258,7 @@ fn event_duplicate() {
     let mut existing_counterproofs = BTreeMap::new();
     existing_counterproofs.insert(
         event.counterprover_idx,
-        (event.counterproof_txid, event.counterproof_block_height),
+        (event.tx.compute_txid(), event.counterproof_block_height),
     );
 
     let from_state = GraphState::CounterProofPosted {
@@ -284,8 +285,8 @@ fn event_rejected_invalid_txid() {
     test_graph_invalid_transition(GraphInvalidTransition {
         from_state: contested_state(),
         event: GraphEvent::CounterProofConfirmed(CounterProofConfirmedEvent {
-            counterproof_txid: Txid::all_zeros(),
             counterproof_block_height: COUNTERPROOF_BLOCK_HEIGHT,
+            tx: generate_tx(0, 0),
             counterprover_idx: TEST_NONPOV_IDX,
         }),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),
@@ -297,8 +298,8 @@ fn event_rejected_invalid_operator_idx() {
     test_graph_invalid_transition(GraphInvalidTransition {
         from_state: contested_state(),
         event: GraphEvent::CounterProofConfirmed(CounterProofConfirmedEvent {
-            counterproof_txid: TEST_GRAPH_SUMMARY.counterproofs[0].counterproof,
             counterproof_block_height: COUNTERPROOF_BLOCK_HEIGHT,
+            tx: test_counterproof_tx(),
             counterprover_idx: u32::MAX,
         }),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
@@ -17,13 +17,14 @@ use crate::{
         state::GraphState,
         tests::{
             GraphInvalidTransition, GraphTransition, LATER_BLOCK_HEIGHT, TEST_NONPOV_IDX,
-            TEST_POV_IDX, create_nonpov_sm, dummy_proof_receipt, get_state,
+            TEST_POV_IDX, TestGraphTxKind, create_nonpov_sm, dummy_proof_receipt, get_state,
             mock_states::{
                 TEST_FULFILLMENT_TXID, TEST_GRAPH_SUMMARY, all_state_variants,
                 bridge_proof_posted_state, contested_state,
             },
-            test_counterproof_tx, test_deposit_params, test_graph_invalid_transition,
-            test_graph_sm_cfg, test_graph_sm_ctx, test_graph_transition,
+            test_completed_signatures, test_counterproof_tx, test_deposit_params,
+            test_graph_invalid_transition, test_graph_sm_cfg, test_graph_sm_ctx,
+            test_graph_transition,
         },
         watchtower::watchtower_slot_for_operator,
     },
@@ -70,7 +71,7 @@ fn expected_nack_duty(counterprover_idx: u32) -> GraphDuty {
     GraphDuty::PublishCounterProofNack {
         deposit_idx: ctx.deposit_idx(),
         counterprover_idx,
-        counterproof_tx: test_counterproof_tx(),
+        completed_signatures: test_completed_signatures(),
         counterproof_nack_tx,
     }
 }
@@ -318,6 +319,25 @@ fn event_invalid() {
             expected_error: |e| matches!(e, GSMError::InvalidEvent { .. }),
         });
     }
+}
+
+/// POV operator: a counterproof with the right txid but a witness of the wrong
+/// shape is rejected before any duty is emitted.
+#[test]
+fn event_rejected_invalid_counterproof_witness() {
+    // Empty-witness tx — same txid as `test_counterproof_tx()` (witness is excluded
+    // from txid), so it passes the txid lookup but fails the witness-shape check.
+    let bad_witness_tx = TestGraphTxKind::Counterproof.into();
+
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state: contested_state(),
+        event: GraphEvent::CounterProofConfirmed(CounterProofConfirmedEvent {
+            counterproof_block_height: COUNTERPROOF_BLOCK_HEIGHT,
+            tx: bad_witness_tx,
+            counterprover_idx: TEST_NONPOV_IDX,
+        }),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
 }
 
 /// Returns `true` if the state is valid for [`GraphEvent::CounterProofConfirmed`].

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
@@ -69,7 +69,7 @@ fn expected_nack_duty(counterprover_idx: u32) -> GraphDuty {
 
     GraphDuty::PublishCounterProofNack {
         deposit_idx: ctx.deposit_idx(),
-        counter_prover_idx: counterprover_idx,
+        counterprover_idx,
         counterproof_tx: test_counterproof_tx(),
         counterproof_nack_tx,
     }

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
@@ -70,7 +70,7 @@ fn expected_nack_duty(counterprover_idx: u32) -> GraphDuty {
     GraphDuty::PublishCounterProofNack {
         deposit_idx: ctx.deposit_idx(),
         counter_prover_idx: counterprover_idx,
-        counterproof_nack_tx: counterproof_nack_tx.as_ref().clone(),
+        counterproof_nack_tx,
     }
 }
 

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
@@ -226,6 +226,41 @@ fn event_rejected_wrong_outpoint() {
 }
 
 #[test]
+fn event_rejected_when_tx_is_counterproof_ack() {
+    let mut summary = test_graph_summary();
+    let slot = watchtower_slot_for_operator(TEST_POV_IDX, TEST_NONPOV_IDX)
+        .expect("non-pov idx must have a watchtower slot");
+    let ack_looking_as_nack = nack_tx_for_slot(slot);
+    summary.counterproofs[slot].counterproof_ack = ack_looking_as_nack.compute_txid();
+
+    let counterproof_txid = summary.counterproofs[0].counterproof;
+    let from_state = GraphState::CounterProofPosted {
+        last_block_height: LATER_BLOCK_HEIGHT,
+        graph_data: test_deposit_params(),
+        graph_summary: summary,
+        signatures: Default::default(),
+        fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+        contest_block_height: LATER_BLOCK_HEIGHT,
+        refuted_proof: None,
+        counterproofs_and_confs: BTreeMap::from([
+            (TEST_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
+            (SECOND_NONPOV_IDX, (counterproof_txid, LATER_BLOCK_HEIGHT)),
+        ]),
+        counterproof_nacks: BTreeMap::new(),
+    };
+
+    let event = CounterProofNackConfirmedEvent {
+        tx: ack_looking_as_nack,
+        counterprover_idx: TEST_NONPOV_IDX,
+    };
+    test_graph_invalid_transition(GraphInvalidTransition {
+        from_state,
+        event: GraphEvent::CounterProofNackConfirmed(event),
+        expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+    });
+}
+
+#[test]
 fn event_invalid() {
     for from_state in all_state_variants()
         .into_iter()

--- a/crates/bridge-sm/src/graph/tests/mock_states.rs
+++ b/crates/bridge-sm/src/graph/tests/mock_states.rs
@@ -347,7 +347,11 @@ pub(super) fn contested_payout_detecting_states() -> Vec<GraphState> {
 
 /// States that detect counterproof txids.
 pub(super) fn counterproof_detecting_states() -> Vec<GraphState> {
-    vec![contested_state(), bridge_proof_posted_state()]
+    vec![
+        contested_state(),
+        bridge_proof_posted_state(),
+        counter_proof_posted_state(),
+    ]
 }
 
 /// States that detect a payout connector spend (via admin or unstaking burn txs).

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -273,6 +273,10 @@ pub(super) fn test_bridge_proof_timeout_tx() -> Transaction {
     tx
 }
 
+pub(super) fn test_counterproof_tx() -> Transaction {
+    Transaction::from(TestGraphTxKind::Counterproof)
+}
+
 pub(super) fn test_counterproof_nack_tx() -> Transaction {
     generate_spending_tx(
         OutPoint {

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -37,6 +37,7 @@ use strata_bridge_tx_graph::{
     },
     transactions::prelude::{ClaimTx, ContestTx, CounterproofTx},
 };
+use strata_mosaic_client_api::types::CompletedSignatures;
 use strata_predicate::PredicateKey;
 use zkaleido::{Proof, ProofReceipt, PublicValues};
 
@@ -273,8 +274,30 @@ pub(super) fn test_bridge_proof_timeout_tx() -> Transaction {
     tx
 }
 
+/// Deterministic completed signatures fixture; used to assert duty payloads.
+pub(super) fn test_completed_signatures() -> CompletedSignatures {
+    std::array::from_fn(|i| {
+        let bytes = [(i as u8).wrapping_add(1); 64];
+        Signature::from_slice(&bytes).expect("64-byte slice parses as schnorr signature")
+    })
+}
+
 pub(super) fn test_counterproof_tx() -> Transaction {
-    Transaction::from(TestGraphTxKind::Counterproof)
+    // Witness layout: `[sig_{N-1}, .., sig_0, n-of-n sig, leaf script, control block]`.
+    let sigs = test_completed_signatures();
+    let mut witness_elements: Vec<Vec<u8>> =
+        sigs.iter().rev().map(|s| s.serialize().to_vec()).collect();
+    witness_elements.push(vec![0u8; 64]); // n-of-n sig placeholder
+    witness_elements.push(Vec::new()); // leaf script placeholder
+    witness_elements.push(Vec::new()); // control block placeholder
+
+    generate_spending_tx(
+        OutPoint {
+            vout: TestGraphTxKind::Counterproof as u32,
+            ..OutPoint::default()
+        },
+        &witness_elements,
+    )
 }
 
 pub(super) fn test_counterproof_nack_tx() -> Transaction {

--- a/crates/bridge-sm/src/graph/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tests/tx_classifier.rs
@@ -143,6 +143,21 @@ mod tests {
             graph_owner_idx,
             pov_idx,
         );
+        let counterproof_in_posted_result = counterproof_posted_sm.classify_tx(
+            &cfg,
+            &counterproof_txs[counterproof_slot],
+            LATER_BLOCK_HEIGHT,
+        );
+        match counterproof_in_posted_result {
+            Some(GraphEvent::CounterProofConfirmed(event)) => {
+                assert_eq!(event.counterprover_idx, expected_operator_idx);
+            }
+            _ => panic!(
+                "expected Some(CounterProofConfirmed) in CounterProofPosted but got \
+                 {counterproof_in_posted_result:?}"
+            ),
+        }
+
         let ack_result = counterproof_posted_sm.classify_tx(
             &cfg,
             &counterproof_ack_txs[counterproof_slot],
@@ -275,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_tx_recognizes_counterproof_in_contested_and_bridge_proof_posted() {
+    fn classify_tx_recognizes_counterproof_in_counterproof_detecting_states() {
         let cfg = test_graph_sm_cfg();
         for state in counterproof_detecting_states() {
             let sm = create_sm(state);

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -356,7 +356,7 @@ impl GraphSM {
                 // ACK/NACK output and is not a known counterproof ACK.
                 if !validate_counterproof_nack(
                     &graph_summary,
-                    self.context().operator_table().pov_idx(),
+                    self.context().operator_idx(),
                     event.counterprover_idx,
                     &event.tx,
                 ) {

--- a/crates/bridge-sm/src/graph/transitions/counterproof.rs
+++ b/crates/bridge-sm/src/graph/transitions/counterproof.rs
@@ -180,7 +180,7 @@ impl GraphSM {
 
             vec![GraphDuty::PublishCounterProofNack {
                 deposit_idx: self.context().deposit_idx(),
-                counter_prover_idx: event.counterprover_idx,
+                counterprover_idx: event.counterprover_idx,
                 counterproof_tx: event.tx.clone(),
                 counterproof_nack_tx,
             }]

--- a/crates/bridge-sm/src/graph/transitions/counterproof.rs
+++ b/crates/bridge-sm/src/graph/transitions/counterproof.rs
@@ -197,11 +197,7 @@ impl GraphSM {
         Ok(duties)
     }
 
-    /// Decodes the per-byte operator signatures from input[0] of an on-chain Counterproof tx.
-    ///
-    /// The witness layout is `[sig_{N-1}, .., sig_0, n-of-n sig, leaf script, control block]`
-    /// — operator signatures pushed `.rev()`, then 3 trailing items. Reverse + skip(3)
-    /// recovers `[sig_0, .., sig_{N-1}]`.
+    /// Decodes the per-byte operator signatures from an on-chain Counterproof tx, in byte order.
     fn decode_completed_sigs(
         &self,
         counterproof_tx: &Transaction,
@@ -221,6 +217,9 @@ impl GraphSM {
             ));
         }
 
+        // Witness layout is `[sig_{N-1}, .., sig_0, n-of-n sig, leaf script, control block]` —
+        // operator signatures pushed `.rev()`, then 3 trailing items. Reverse + skip(3) recovers
+        // `[sig_0, .., sig_{N-1}]`.
         let mut items = counterproof_tx.input[0].witness.to_vec();
         items.reverse();
         let sigs: Vec<Signature> = items

--- a/crates/bridge-sm/src/graph/transitions/counterproof.rs
+++ b/crates/bridge-sm/src/graph/transitions/counterproof.rs
@@ -1,8 +1,12 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use bitcoin::Transaction;
 use strata_bridge_tx_graph::{
     game_graph::{DepositParams, GameConnectors, GameGraphSummary},
     transactions::prelude::{CounterproofNackData, CounterproofNackTx},
+};
+use strata_mosaic_client_api::types::{
+    CompletedSignatures, N_DEPOSIT_INPUT_WIRES, N_WITHDRAWAL_INPUT_WIRES, Signature,
 };
 
 use crate::graph::{
@@ -178,10 +182,12 @@ impl GraphSM {
             let nack_data = CounterproofNackData { counterproof_txid };
             let counterproof_nack_tx = CounterproofNackTx::new(nack_data, *counterproof_connector);
 
+            let completed_signatures = self.decode_completed_sigs(&event.tx, event)?;
+
             vec![GraphDuty::PublishCounterProofNack {
                 deposit_idx: self.context().deposit_idx(),
                 counterprover_idx: event.counterprover_idx,
-                counterproof_tx: event.tx.clone(),
+                completed_signatures,
                 counterproof_nack_tx,
             }]
         } else {
@@ -189,5 +195,39 @@ impl GraphSM {
         };
 
         Ok(duties)
+    }
+
+    /// Decodes the per-byte operator signatures from input[0] of an on-chain Counterproof tx.
+    ///
+    /// The witness layout is `[sig_{N-1}, .., sig_0, n-of-n sig, leaf script, control block]`
+    /// — operator signatures pushed `.rev()`, then 3 trailing items. Reverse + skip(3)
+    /// recovers `[sig_0, .., sig_{N-1}]`.
+    fn decode_completed_sigs(
+        &self,
+        counterproof_tx: &Transaction,
+        event: &CounterProofConfirmedEvent,
+    ) -> GSMResult<CompletedSignatures> {
+        const N: usize = N_DEPOSIT_INPUT_WIRES + N_WITHDRAWAL_INPUT_WIRES;
+        // `+ 3` accounts for the trailing n-of-n signature, leaf script, and control block
+        // that follow the per-byte operator signatures in the counterproof witness.
+        const WANT: usize = N + 3;
+
+        let witness_len = counterproof_tx.input[0].witness.len();
+        if witness_len != WANT {
+            return Err(GSMError::rejected(
+                self.state.clone(),
+                event.clone().into(),
+                format!("counterproof witness has {witness_len} elements, expected {WANT}"),
+            ));
+        }
+
+        let mut items = counterproof_tx.input[0].witness.to_vec();
+        items.reverse();
+        let sigs: Vec<Signature> = items
+            .into_iter()
+            .skip(3)
+            .map(|w| Signature::from_slice(&w).expect("on-chain counterproof signature must parse"))
+            .collect();
+        Ok(sigs.try_into().expect("witness length validated above"))
     }
 }

--- a/crates/bridge-sm/src/graph/transitions/counterproof.rs
+++ b/crates/bridge-sm/src/graph/transitions/counterproof.rs
@@ -181,7 +181,7 @@ impl GraphSM {
             vec![GraphDuty::PublishCounterProofNack {
                 deposit_idx: self.context().deposit_idx(),
                 counter_prover_idx: event.counterprover_idx,
-                counterproof_nack_tx: counterproof_nack_tx.as_ref().clone(),
+                counterproof_nack_tx,
             }]
         } else {
             Vec::new()

--- a/crates/bridge-sm/src/graph/transitions/counterproof.rs
+++ b/crates/bridge-sm/src/graph/transitions/counterproof.rs
@@ -38,7 +38,7 @@ impl GraphSM {
                 let mut counterproofs_and_confs = BTreeMap::new();
                 counterproofs_and_confs.insert(
                     event.counterprover_idx,
-                    (event.counterproof_txid, event.counterproof_block_height),
+                    (event.tx.compute_txid(), event.counterproof_block_height),
                 );
 
                 self.state = GraphState::CounterProofPosted {
@@ -71,7 +71,7 @@ impl GraphSM {
                 let mut counterproofs_and_confs = BTreeMap::new();
                 counterproofs_and_confs.insert(
                     event.counterprover_idx,
-                    (event.counterproof_txid, event.counterproof_block_height),
+                    (event.tx.compute_txid(), event.counterproof_block_height),
                 );
 
                 self.state = GraphState::CounterProofPosted {
@@ -108,7 +108,7 @@ impl GraphSM {
 
                 counterproofs_and_confs.insert(
                     event.counterprover_idx,
-                    (event.counterproof_txid, event.counterproof_block_height),
+                    (event.tx.compute_txid(), event.counterproof_block_height),
                 );
 
                 self.state = GraphState::CounterProofPosted {
@@ -138,12 +138,14 @@ impl GraphSM {
         graph_data: &DepositParams,
         graph_summary: &GameGraphSummary,
     ) -> GSMResult<Vec<GraphDuty>> {
+        let counterproof_txid = event.tx.compute_txid();
+
         // Resolve the watchtower slot associated with the given counterproof transaction.
         let (watchtower_slot, _) = graph_summary
             .counterproofs
             .iter()
             .enumerate()
-            .find(|(_slot, summary)| summary.counterproof == event.counterproof_txid)
+            .find(|(_slot, summary)| summary.counterproof == counterproof_txid)
             .ok_or_else(|| {
                 GSMError::rejected(
                     self.state.clone(),
@@ -173,14 +175,13 @@ impl GraphSM {
                         )
                     })?;
 
-            let nack_data = CounterproofNackData {
-                counterproof_txid: event.counterproof_txid,
-            };
+            let nack_data = CounterproofNackData { counterproof_txid };
             let counterproof_nack_tx = CounterproofNackTx::new(nack_data, *counterproof_connector);
 
             vec![GraphDuty::PublishCounterProofNack {
                 deposit_idx: self.context().deposit_idx(),
                 counter_prover_idx: event.counterprover_idx,
+                counterproof_tx: event.tx.clone(),
                 counterproof_nack_tx,
             }]
         } else {

--- a/crates/bridge-sm/src/graph/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tx_classifier.rs
@@ -134,8 +134,8 @@ impl TxClassifier for GraphSM {
                 {
                     Some(GraphEvent::CounterProofConfirmed(
                         CounterProofConfirmedEvent {
-                            counterproof_txid: txid,
                             counterproof_block_height: height,
+                            tx: tx.clone(),
                             counterprover_idx,
                         },
                     ))
@@ -165,8 +165,8 @@ impl TxClassifier for GraphSM {
                 {
                     Some(GraphEvent::CounterProofConfirmed(
                         CounterProofConfirmedEvent {
-                            counterproof_txid: txid,
                             counterproof_block_height: height,
+                            tx: tx.clone(),
                             counterprover_idx,
                         },
                     ))

--- a/crates/bridge-sm/src/graph/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tx_classifier.rs
@@ -210,7 +210,8 @@ impl TxClassifier for GraphSM {
                 }
             }
 
-            // expects a bridge proof or counterproof ACK or NACK or payout burn
+            // expects a bridge proof, another watchtower's counterproof, or counterproof ACK or
+            // NACK or payout burn
             GraphState::CounterProofPosted { graph_summary, .. } => {
                 if txid == graph_summary.bridge_proof_timeout {
                     Some(GraphEvent::BridgeProofTimeoutConfirmed(
@@ -221,6 +222,16 @@ impl TxClassifier for GraphSM {
                     ))
                 } else if spends_contest_proof_connector(graph_summary.contest, tx) {
                     Some(bridge_proof_event(tx, height))
+                } else if let Some(counterprover_idx) =
+                    counterproof_operator_idx(graph_summary, &txid, self.context().operator_idx())
+                {
+                    Some(GraphEvent::CounterProofConfirmed(
+                        CounterProofConfirmedEvent {
+                            counterproof_block_height: height,
+                            tx: tx.clone(),
+                            counterprover_idx,
+                        },
+                    ))
                 } else if let Some(counterprover_idx) = counterproof_ack_operator_idx(
                     graph_summary,
                     &txid,

--- a/crates/bridge-sm/src/stake/duties.rs
+++ b/crates/bridge-sm/src/stake/duties.rs
@@ -23,6 +23,8 @@ pub enum StakeDuty {
     },
     /// Publish the stake transaction.
     PublishStake {
+        /// The index of the operator that owns the stake.
+        operator_idx: OperatorIdx,
         /// The unsigned stake transaction.
         tx: Transaction,
     },
@@ -114,7 +116,9 @@ impl std::fmt::Display for StakeDuty {
             Self::PublishStakeData { operator_idx } => {
                 format!("PublishStakeData (operator_idx: {operator_idx})")
             }
-            Self::PublishStake { .. } => "PublishStake".to_string(),
+            Self::PublishStake { operator_idx, .. } => {
+                format!("PublishStake (operator_idx: {operator_idx})")
+            }
             Self::PublishUnstakingNonces { .. } => "PublishUnstakingNonces".to_string(),
             Self::PublishUnstakingPartials { .. } => "PublishUnstakingPartials".to_string(),
             Self::PublishUnstakingIntent { .. } => "PublishUnstakingIntent".to_string(),

--- a/crates/bridge-sm/src/stake/handlers/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/handlers/retry_tick.rs
@@ -20,6 +20,7 @@ impl StakeSM {
             StakeState::UnstakingSigned { stake_data, .. } => {
                 let stake_graph = StakeGraph::new(stake_data.expand(*cfg, self.context()));
                 vec![StakeDuty::PublishStake {
+                    operator_idx: self.context().operator_idx(),
                     tx: stake_graph.stake.as_ref().clone(),
                 }]
             }

--- a/crates/bridge-sm/src/stake/handlers/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/handlers/retry_tick.rs
@@ -17,7 +17,9 @@ impl StakeSM {
     /// Emits retriable duties for the current state.
     pub(crate) fn process_retry_tick(&self, cfg: &StakeSMCfg) -> SSMResult<SSMOutput> {
         let duties = match self.state() {
-            StakeState::UnstakingSigned { stake_data, .. } => {
+            StakeState::UnstakingSigned { stake_data, .. }
+                if self.context().operator_table().pov_idx() == self.context().operator_idx() =>
+            {
                 let stake_graph = StakeGraph::new(stake_data.expand(*cfg, self.context()));
                 vec![StakeDuty::PublishStake {
                     operator_idx: self.context().operator_idx(),

--- a/crates/bridge-sm/src/stake/tests/mod.rs
+++ b/crates/bridge-sm/src/stake/tests/mod.rs
@@ -140,6 +140,18 @@ fn test_pov_owned_handler_output(output: StakeHandlerOutput) {
     });
 }
 
+/// Helper for testing handlers for stakes tracked but not owned by the POV
+/// (`create_nonpov_state_machine`).
+fn test_nonpov_handler_output(output: StakeHandlerOutput) {
+    test_nonpov_stake_transition(StakeTransition {
+        from_state: output.state.clone(),
+        event: output.event,
+        expected_state: output.state,
+        expected_duties: output.expected_duties,
+        expected_signals: vec![],
+    });
+}
+
 // ┌───────────────────────────────────────────────────────────────────┐
 // │                            Operators                              │
 // └───────────────────────────────────────────────────────────────────┘

--- a/crates/bridge-sm/src/stake/tests/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/retry_tick.rs
@@ -22,6 +22,20 @@ fn retry_publish_stake() {
 }
 
 #[test]
+fn retry_nothing_for_foreign_stake() {
+    test_nonpov_handler_output(StakeHandlerOutput {
+        state: StakeState::UnstakingSigned {
+            last_block_height: STAKE_HEIGHT,
+            stake_data: TEST_STAKE_DATA.clone(),
+            summary: *TEST_GRAPH_SUMMARY,
+            signatures: Box::new(*TEST_FINAL_SIGS),
+        },
+        event: RetryTickEvent.into(),
+        expected_duties: vec![],
+    });
+}
+
+#[test]
 fn retry_nothing() {
     let has_no_retriable_duty = [
         StakeState::Created {

--- a/crates/bridge-sm/src/stake/tests/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/retry_tick.rs
@@ -15,6 +15,7 @@ fn retry_publish_stake() {
         },
         event: RetryTickEvent.into(),
         expected_duties: vec![StakeDuty::PublishStake {
+            operator_idx: TEST_POV_IDX,
             tx: stake_graph.stake.as_ref().clone(),
         }],
     });

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -147,6 +147,25 @@ impl OperatorWallet {
         self.leased_outpoints.remove(outpoint)
     }
 
+    /// Selects the first non-anchor, non-leased general-wallet UTXO that satisfies
+    /// `predicate`, leases it to prevent concurrent duties from re-selecting the same
+    /// outpoint, and returns its [`LocalOutput`].
+    ///
+    /// Returns `None` if no UTXO matches.
+    pub fn select_and_lease_general_utxo(
+        &mut self,
+        predicate: impl Fn(&LocalOutput) -> bool,
+    ) -> Option<LocalOutput> {
+        // Snapshot the leased set so we can mutably borrow `self` after the search.
+        let leased: BTreeSet<OutPoint> = self.leased_outpoints.iter().copied().collect();
+        let selected = self
+            .general_utxos()
+            .filter(|u| !leased.contains(&u.outpoint))
+            .find(predicate)?;
+        self.lease(selected.outpoint);
+        Some(selected)
+    }
+
     /// Funds an unfunded version 3 transaction by adding inputs and change.
     ///
     /// Takes a transaction with outputs only and adds inputs from the general wallet to cover the

--- a/crates/tx-graph/src/transactions/not_presigned.rs
+++ b/crates/tx-graph/src/transactions/not_presigned.rs
@@ -100,6 +100,11 @@ macro_rules! impl_not_presigned_tx {
 
                 self.connector.get_signing_info(&mut cache, prevouts, $spend_path, 0)
             }
+
+            /// Returns the prevouts for every input in the transaction
+            pub fn prevouts(&self) -> &[TxOut] {
+                &self.prevouts
+            }
         }
 
         impl AsRef<Transaction> for $tx {

--- a/functional-tests/tests/slashing/fn_counterproof_ack.py
+++ b/functional-tests/tests/slashing/fn_counterproof_ack.py
@@ -119,6 +119,11 @@ class CounterproofAckTest(StrataTestBase):
         proof_spender_txid = find_utxo_spender_txid(bitcoin_rpc, contest_txid, CONTEST_PROOF_VOUT)
         self.logger.info(f"Contest-proof connector spent by tx: {proof_spender_txid}")
 
+        # Stop the graph owner so it cannot publish a counterproof NACK; without a NACK before
+        # `nack_timelock` matures, the counterprover's auto-published ACK wins the race.
+        bridge_nodes[graph_owner_idx].stop()
+        self.logger.info(f"Stopped op-{graph_owner_idx} so no counterproof NACK is published")
+
         # Wait for the contest payout output to be spent. The ACK candidate is the spender.
         wait_until_utxo_spent(bitcoin_rpc, contest_txid, CONTEST_PAYOUT_VOUT, timeout=600)
         ack_txid = find_utxo_spender_txid(bitcoin_rpc, contest_txid, CONTEST_PAYOUT_VOUT)

--- a/functional-tests/tests/uncontested_payout/fn_publish_counterproof_nack.py
+++ b/functional-tests/tests/uncontested_payout/fn_publish_counterproof_nack.py
@@ -52,7 +52,6 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
     def __init__(self, ctx: flexitest.InitContext):
         self.bridge_protocol_params = BridgeProtocolParams(
             contest_timelock=5,
-            ack_timelock=10,
             bridge_proof_predicate="NeverAccept",
         )
         ctx.set_env(
@@ -185,8 +184,9 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
                 f"Counterproof {counterproof_txid} ack/nack output spent (NACK published)"
             )
 
-        # Wait for the deposit UTXO to be spent — this fires once the full contested-payout path
-        # (including the NACKs) completes and the operator sweeps the deposit.
+        # The ack/nack vout we checked above could've been spent by either an ACK or a NACK,
+        # so seeing it spent isn't enough on its own. Waiting for the deposit to get swept is
+        # what tells us the NACK actually fired — only the contested-payout path gets there.
         wait_until_deposit_utxo_spent(bitcoin_rpc, deposit_txid, timeout=450)
         self.logger.info("Deposit UTXO confirmed spent after counterproof NACK + contested payout")
 

--- a/functional-tests/tests/uncontested_payout/fn_publish_counterproof_nack.py
+++ b/functional-tests/tests/uncontested_payout/fn_publish_counterproof_nack.py
@@ -1,0 +1,169 @@
+import flexitest
+
+from envs import BridgeNetworkEnv
+from envs.base_test import StrataTestBase
+from factory.bridge_operator.config_cfg import BridgeConfigParams
+from factory.bridge_operator.params_cfg import BridgeProtocolParams
+from rpc.types import RpcDepositStatusComplete
+from utils.bridge import get_bridge_nodes_and_rpcs
+from utils.deposit import (
+    wait_until_deposit_status,
+    wait_until_deposit_utxo_spent,
+    wait_until_drt_recognized,
+)
+from utils.dev_cli import DevCli
+from utils.utils import (
+    read_operator_key,
+    wait_for_tx_confirmation,
+    wait_until,
+)
+from utils.withdrawal import (
+    wait_until_active_valid_claim,
+    wait_until_bridge_proof_posted,
+    wait_until_counter_proof_posted,
+)
+
+
+@flexitest.register
+class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
+    """
+    Test that the POV operator publishes a counterproof NACK after watchtowers post a
+    counterproof, and the contested payout path completes end-to-end.
+
+    The bridge proof predicate is set to `NeverAccept` so every bridge proof fails
+    verification and watchtowers respond with a counterproof. The POV operator then
+    runs the mosaic-backed `evaluate_and_sign` flow and publishes a counterproof NACK
+    transaction. Once the NACKs and contested payout confirm, the deposit UTXO is spent.
+
+    Steps:
+    1. Complete a deposit
+    2. Submit a contest against the active claim
+    3. Wait for the bridge proof to be posted
+    4. Wait for the counterproof to be posted by watchtowers
+    5. Verify the deposit UTXO is spent after the NACK + contested-payout path completes
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        self.bridge_protocol_params = BridgeProtocolParams(
+            contest_timelock=5,
+            ack_timelock=10,
+            bridge_proof_predicate="NeverAccept",
+        )
+        ctx.set_env(
+            BridgeNetworkEnv(
+                bridge_protocol_params=self.bridge_protocol_params,
+                bridge_config_params=BridgeConfigParams(
+                    cooperative_payout_timeout=0,
+                ),
+            )
+        )
+
+    def main(self, ctx: flexitest.RunContext):
+        bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
+        bitcoind_service = ctx.get_service("bitcoin")
+        bitcoin_rpc = bitcoind_service.create_rpc()
+
+        num_operators = len(bridge_nodes)
+        operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
+
+        # Init ASM rpc
+        asm_service = ctx.get_service("asm_rpc")
+        asm_rpc = asm_service.create_rpc()
+
+        # Wait for DT and DRT
+        bitcoind_props = bitcoind_service.props
+        dev_cli = DevCli(
+            bitcoind_props,
+            operator_key_infos,
+            bridge_protocol_params=self.bridge_protocol_params,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
+        deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
+        self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
+
+        deposit_info = wait_until_deposit_status(bridge_rpc, deposit_id, RpcDepositStatusComplete)
+        assert deposit_info is not None, "Deposit did not complete"
+        self.logger.info("Deposit completed")
+        deposit_txid = deposit_info.get("status").get("deposit_txid")
+        self.logger.info(f"Deposit txid: {deposit_txid}")
+
+        # Now post mock checkpoint so that a withdrawal is assigned
+        recent_block_hash = bitcoin_rpc.proxy.getblockhash(bitcoin_rpc.proxy.getblockcount())
+        ckp_l1_txn = dev_cli.send_mock_checkpoint_from_tip(
+            asm_rpc,
+            recent_block_hash,
+            num_ol_slots=1,
+        )
+        ckp_block_hash = wait_for_tx_confirmation(bitcoin_rpc, ckp_l1_txn)
+        self.logger.info(f"Checkpoint tx {ckp_l1_txn} included in block {ckp_block_hash}")
+
+        # Wait for ASM to process the checkpoint, then wait for an active claim
+        wait_until(
+            lambda: len(asm_rpc.strata_asm_getAssignments(ckp_block_hash)) > 0,
+            timeout=300,
+            error_msg="ASM did not produce assignment",
+        )
+
+        active_claim = wait_until_active_valid_claim(bridge_rpc)
+        self.logger.info(
+            "Active claim %s for deposit %s assigned to operator %s",
+            active_claim.claim_txid,
+            active_claim.deposit_idx,
+            active_claim.assigned_operator,
+        )
+
+        claim_block_hash = wait_for_tx_confirmation(
+            bitcoin_rpc,
+            active_claim.claim_txid,
+            timeout=300,
+        )
+        self.logger.info(
+            f"Claim tx {active_claim.claim_txid} confirmed in block {claim_block_hash}"
+        )
+
+        # Use a different operator's node to contest
+        contester_idx = (active_claim.assigned_operator + 1) % num_operators
+        contester_node = bridge_nodes[contester_idx]
+        contester_rpc_url = f"http://127.0.0.1:{contester_node.props['rpc_port']}"
+
+        self.logger.info(f"Contesting with operator {contester_idx} via {contester_rpc_url}")
+        contester_seed = read_operator_key(contester_idx).SEED
+
+        contest_txid = dev_cli.send_contest(
+            deposit_idx=active_claim.deposit_idx,
+            operator_idx=active_claim.assigned_operator,
+            bridge_node_url=contester_rpc_url,
+            contester_node_idx=contester_idx,
+            seed=contester_seed,
+        )
+        self.logger.info(f"Broadcasted contest_txid: {contest_txid}")
+        contest_block_hash = wait_for_tx_confirmation(
+            bitcoin_rpc,
+            contest_txid,
+            timeout=300,
+        )
+        self.logger.info(f"Contest tx {contest_txid} confirmed in block {contest_block_hash}")
+
+        # The POV (assigned) operator's RPC observes the full game and emits the NACK duty.
+        pov_rpc = bridge_rpcs[active_claim.assigned_operator]
+
+        # Wait for bridge proof to be posted by the assigned operator
+        wait_until_bridge_proof_posted(pov_rpc, active_claim.deposit_idx)
+        self.logger.info("Bridge proof posted")
+
+        # With NeverAccept predicate, watchtowers reject the proof and publish counterproofs.
+        wait_until_counter_proof_posted(pov_rpc, active_claim.deposit_idx)
+        self.logger.info("Counterproof posted — watchtowers rejected the invalid bridge proof")
+
+        # The POV operator runs evaluate_and_sign via mosaic and publishes a NACK for each
+        # watchtower's counterproof. Wait for the deposit UTXO to be spent — this fires once the
+        # full contested-payout path (including the NACKs) completes and the operator sweeps the
+        # deposit.
+        wait_until_deposit_utxo_spent(bitcoin_rpc, deposit_txid, timeout=450)
+        self.logger.info("Deposit UTXO confirmed spent after counterproof NACK + contested payout")
+
+        return True

--- a/functional-tests/tests/uncontested_payout/fn_publish_counterproof_nack.py
+++ b/functional-tests/tests/uncontested_payout/fn_publish_counterproof_nack.py
@@ -1,5 +1,9 @@
 import flexitest
 
+from constants import (
+    CONTEST_WATCHTOWER_0_VOUT,
+    COUNTERPROOF_ACK_NACK_VOUT,
+)
 from envs import BridgeNetworkEnv
 from envs.base_test import StrataTestBase
 from factory.bridge_operator.config_cfg import BridgeConfigParams
@@ -10,9 +14,11 @@ from utils.deposit import (
     wait_until_deposit_status,
     wait_until_deposit_utxo_spent,
     wait_until_drt_recognized,
+    wait_until_utxo_spent,
 )
 from utils.dev_cli import DevCli
 from utils.utils import (
+    find_utxo_spender_txid,
     read_operator_key,
     wait_for_tx_confirmation,
     wait_until,
@@ -159,10 +165,28 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
         wait_until_counter_proof_posted(pov_rpc, active_claim.deposit_idx)
         self.logger.info("Counterproof posted — watchtowers rejected the invalid bridge proof")
 
-        # The POV operator runs evaluate_and_sign via mosaic and publishes a NACK for each
-        # watchtower's counterproof. Wait for the deposit UTXO to be spent — this fires once the
-        # full contested-payout path (including the NACKs) completes and the operator sweeps the
-        # deposit.
+        # Each watchtower spends one of contest's watchtower outputs with its counterproof.
+        # The POV operator then publishes a NACK that spends each counterproof's ack/nack output.
+        # Verify every watchtower's counterproof had its ack/nack output spent before asserting
+        # the deposit was swept.
+        num_watchtowers = num_operators - 1
+        for slot in range(num_watchtowers):
+            watchtower_vout = CONTEST_WATCHTOWER_0_VOUT + slot
+            wait_until_utxo_spent(bitcoin_rpc, contest_txid, watchtower_vout, timeout=300)
+            counterproof_txid = find_utxo_spender_txid(bitcoin_rpc, contest_txid, watchtower_vout)
+            self.logger.info(f"Watchtower slot {slot} counterproof tx: {counterproof_txid}")
+            wait_until_utxo_spent(
+                bitcoin_rpc,
+                counterproof_txid,
+                COUNTERPROOF_ACK_NACK_VOUT,
+                timeout=300,
+            )
+            self.logger.info(
+                f"Counterproof {counterproof_txid} ack/nack output spent (NACK published)"
+            )
+
+        # Wait for the deposit UTXO to be spent — this fires once the full contested-payout path
+        # (including the NACKs) completes and the operator sweeps the deposit.
         wait_until_deposit_utxo_spent(bitcoin_rpc, deposit_txid, timeout=450)
         self.logger.info("Deposit UTXO confirmed spent after counterproof NACK + contested payout")
 

--- a/functional-tests/utils/withdrawal.py
+++ b/functional-tests/utils/withdrawal.py
@@ -132,3 +132,27 @@ def wait_until_bridge_proof_timedout(
             f"Claim phase for deposit {deposit_idx} did not advance to bridge_proof_timedout"
         ),
     )
+
+
+def wait_until_all_nackd(
+    bridge_rpc,
+    deposit_idx: int,
+    timeout=600,
+) -> None:
+    """Wait until the pending withdrawal's assigned claim phase is 'all_nackd'."""
+
+    def check():
+        info_data = bridge_rpc.stratabridge_pendingWithdrawalInfo(deposit_idx)
+        if info_data is None:
+            return False
+        info = RpcPendingWithdrawalInfo.from_json(info_data)
+        if info.assigned_claim is None:
+            return False
+        return info.assigned_claim.phase == RpcClaimPhase.ALL_NACKD
+
+    wait_until(
+        check,
+        timeout=timeout,
+        step=1,
+        error_msg=f"Claim phase for deposit {deposit_idx} did not advance to all_nackd",
+    )

--- a/functional-tests/utils/withdrawal.py
+++ b/functional-tests/utils/withdrawal.py
@@ -132,27 +132,3 @@ def wait_until_bridge_proof_timedout(
             f"Claim phase for deposit {deposit_idx} did not advance to bridge_proof_timedout"
         ),
     )
-
-
-def wait_until_all_nackd(
-    bridge_rpc,
-    deposit_idx: int,
-    timeout=600,
-) -> None:
-    """Wait until the pending withdrawal's assigned claim phase is 'all_nackd'."""
-
-    def check():
-        info_data = bridge_rpc.stratabridge_pendingWithdrawalInfo(deposit_idx)
-        if info_data is None:
-            return False
-        info = RpcPendingWithdrawalInfo.from_json(info_data)
-        if info.assigned_claim is None:
-            return False
-        return info.assigned_claim.phase == RpcClaimPhase.ALL_NACKD
-
-    wait_until(
-        check,
-        timeout=timeout,
-        step=1,
-        error_msg=f"Claim phase for deposit {deposit_idx} did not advance to all_nackd",
-    )


### PR DESCRIPTION
## Description

* Implements the `PublishCounterProofNack`
* Scopes the `PublishStake` duty to its owning operator so the executor skips foreign-operator publishes.
* Functional test driving the Counterproof → NACK → Contested-Payout path


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

### Notes to Reviewers
Please review the pull request as a whole rather than examining each commit individually.

## Related Issues
Closes STR-3009
Closes STR-3089