### PR TITLE
fix(devcli): support new deposit descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,6 +1724,7 @@ source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.10.0#a55e1e7c85a4
 dependencies = [
  "arbitrary",
  "bitcoin",
+ "borsh",
  "hex-conservative",
  "secp256k1 0.29.1",
  "serde",
@@ -2775,6 +2776,7 @@ dependencies = [
  "strata-identifiers",
  "strata-l1-envelope-fmt",
  "strata-l1-txfmt",
+ "strata-ol-bridge-types",
  "strata-test-utils-arb",
  "tokio",
  "tracing",
@@ -6343,7 +6345,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.28",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7881,7 +7883,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-msgs",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6)",
  "strata-asm-proto-checkpoint-msgs",
  "strata-btc-types",
  "strata-codec",
@@ -7899,7 +7901,7 @@ dependencies = [
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6)",
  "strata-crypto",
 ]
 
@@ -7912,10 +7914,27 @@ dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.10.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=a38db6018a646708f24f115a8b10ff1d74f879c6)",
  "strata-btc-types",
  "strata-codec",
  "strata-l1-txfmt",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "strata-asm-proto-bridge-v1-types"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.7#7b271f196f7fefad92c52fb98f1b9bd5b7680495"
+dependencies = [
+ "arbitrary",
+ "bitcoin-bosd 0.10.0",
+ "bitvec",
+ "borsh",
+ "serde",
+ "ssz",
+ "ssz_derive",
+ "strata-btc-types",
+ "strata-identifiers",
  "thiserror 2.0.18",
 ]
 
@@ -8573,6 +8592,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-ol-bridge-types"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=565fafccf2fe181d2f93003f9135ceed126a01ad#565fafccf2fe181d2f93003f9135ceed126a01ad"
+dependencies = [
+ "arbitrary",
+ "borsh",
+ "serde",
+ "ssz",
+ "ssz_derive",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.7)",
+ "strata-codec",
+ "strata-identifiers",
+ "strata-primitives",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "strata-p2p"
 version = "0.3.7"
 source = "git+https://github.com/alpenlabs/strata-p2p.git?tag=v0.3.7#6182180f7f5cc74134af0caab090854033e144cf"
@@ -8607,6 +8643,22 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "zkaleido-sp1-groth16-verifier",
+]
+
+[[package]]
+name = "strata-primitives"
+version = "0.3.0-alpha.1"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=565fafccf2fe181d2f93003f9135ceed126a01ad#565fafccf2fe181d2f93003f9135ceed126a01ad"
+dependencies = [
+ "bitcoin",
+ "bitcoin-bosd 0.10.0",
+ "borsh",
+ "hex",
+ "serde",
+ "strata-btc-types",
+ "strata-crypto",
+ "strata-identifiers",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,9 @@ strata-bridge-tx-graph = { path = "crates/tx-graph" }
 strata-mosaic-client = { path = "crates/mosaic-client" }
 strata-mosaic-client-api = { path = "crates/mosaic-client-api" }
 
+# Dependencies from alpenlabs/alpen pinned to commit 565fafcc (main @ 2026-04-30)
+strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "565fafccf2fe181d2f93003f9135ceed126a01ad" }
+
 # Dependencies from alpenlabs/asm pinned to commit a38db601
 asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "a38db6018a646708f24f115a8b10ff1d74f879c6" }
 strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "a38db6018a646708f24f115a8b10ff1d74f879c6" }

--- a/bin/dev-cli/Cargo.toml
+++ b/bin/dev-cli/Cargo.toml
@@ -27,6 +27,7 @@ strata-crypto.workspace = true
 strata-identifiers.workspace = true
 strata-l1-envelope-fmt.workspace = true
 strata-l1-txfmt.workspace = true
+strata-ol-bridge-types.workspace = true
 strata-test-utils-arb.workspace = true
 
 alloy.workspace = true

--- a/bin/dev-cli/src/handlers/bridge_in.rs
+++ b/bin/dev-cli/src/handlers/bridge_in.rs
@@ -10,8 +10,9 @@ use musig2::KeyAggContext;
 use secp256k1::{Keypair, Parity, XOnlyPublicKey, SECP256K1};
 use strata_asm_proto_bridge_v1_txs::deposit_request::DrtHeaderAux;
 use strata_bridge_common::params::Params;
-use strata_codec::VarVec;
+use strata_identifiers::{AccountSerial, SubjectIdBytes};
 use strata_l1_txfmt::{MagicBytes, ParseConfig};
+use strata_ol_bridge_types::DepositDescriptor;
 use tracing::info;
 
 use crate::{
@@ -70,15 +71,24 @@ fn build_sps50_metadata(
     ee_address: &EvmAddress,
     recovery_pubkey: &XOnlyPublicKey,
 ) -> Result<Vec<u8>> {
-    let destination = VarVec::from_vec(ee_address.to_vec())
-        .expect("EVM address must fit in DRT destination bytes");
+    let alpen_subject_bytes =
+        SubjectIdBytes::try_new(ee_address.to_vec()).expect("must be valid subject bytes");
+
+    // 0..127 are reserved, 128 is for `Alpen`
+    let alpen_account_serial: AccountSerial = AccountSerial::reserved(127).incr();
+    let deposit_descriptor = DepositDescriptor::new(alpen_account_serial, alpen_subject_bytes)
+        .expect("AccountSerial for Alpen is always within valid range");
+    let destination = deposit_descriptor.encode_to_varvec();
 
     let header_aux = DrtHeaderAux::new(recovery_pubkey.serialize(), destination)
-        .expect("header aux creation should succeed");
+        .expect("header aux creation must succeed");
 
     let tag_data = header_aux.build_tag_data();
+    info!(tag_data=%tag_data.aux_data().to_lower_hex_string(), "built SPS-50 aux data for DRT");
+
     let config = ParseConfig::new(magic_bytes);
     let encoded = config.encode_tag_buf(&tag_data.as_ref())?;
+    info!(encoded=%encoded.to_lower_hex_string(), "encoded SPS-50 metadata for OP_RETURN");
 
     Ok(encoded)
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR updates the `bridge-in` handler in the `dev-cli` to use the `DepositDescriptor` as expected in the OL with multi-EE support. This is required only for completeness (and end-to-end testing of the strata stack) as both the ASM and the bridge continue to accept deposit requests with malformed deposit descriptors.

AI was not used for these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->