### PR TITLE
chore(audit): ignore hickory-proto advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -17,4 +17,23 @@ ignore = [
   "RUSTSEC-2026-0098",
   "RUSTSEC-2026-0099",
   "RUSTSEC-2026-0104",
+
+  # hickory-proto 0.25.2 pulled transitively via libp2p-mdns 0.48.0 and
+  # libp2p-dns 0.44.0 (libp2p 0.56.0 → strata-p2p). Latest published
+  # libp2p-mdns 0.48.0 still pins hickory-proto ^0.25.2; blocked on a
+  # libp2p upstream release. The bump is in flight in
+  # https://github.com/libp2p/rust-libp2p/pull/6395 (open, hickory 0.25 → 0.26).
+  #
+  # RUSTSEC-2026-0119: O(n²) DNS name compression during message encoding.
+  # Fix exists upstream (>=0.26.1) but is unreachable until libp2p bumps.
+  # Tracked upstream: https://github.com/libp2p/rust-libp2p/issues/6411.
+  #
+  # RUSTSEC-2026-0118: NSEC3 closest-encloser proof validation can enter
+  # an unbounded loop on cross-zone responses. No fixed upgrade is
+  # available. Low risk for this codebase: hickory is only reached via
+  # libp2p's peer-discovery/dns paths, and we do not perform DNSSEC
+  # validation on untrusted records.
+  # Tracked upstream: https://github.com/libp2p/rust-libp2p/issues/6412.
+  "RUSTSEC-2026-0118",
+  "RUSTSEC-2026-0119",
 ]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR ignores the new `cargo-audit` advisories for `hickory-proto` (brought by `libp2p`) for now while we wait on upstream fixes.

Claude was used to investigate usage points and upstream fixes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->