### PR TITLE
feat(ssm): handle slashed state

### DIFF
--- a/bin/strata-bridge/src/mode/services/rpc_server.rs
+++ b/bin/strata-bridge/src/mode/services/rpc_server.rs
@@ -443,6 +443,9 @@ const fn stake_state_to_rpc(state: &StakeState) -> RpcStakeState {
         StakeState::Unstaked { unstaking_txid, .. } => RpcStakeState::Unstaked {
             unstaking_txid: *unstaking_txid,
         },
+        StakeState::Slashed { slash_txid, .. } => RpcStakeState::Slashed {
+            slash_txid: *slash_txid,
+        },
     }
 }
 

--- a/crates/bridge-sm/src/stake/events.rs
+++ b/crates/bridge-sm/src/stake/events.rs
@@ -61,6 +61,14 @@ pub struct UnstakingConfirmedEvent {
     pub tx: Transaction,
 }
 
+/// Event notifying that a slash transaction (spending the stake output but
+/// distinct from the legitimate unstaking transaction) has been confirmed on-chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlashConfirmedEvent {
+    /// The confirmed slash transaction.
+    pub tx: Transaction,
+}
+
 /// Event signalling that a new bitcoin block has been observed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewBlockEvent {
@@ -100,6 +108,8 @@ pub enum StakeEvent {
     PreimageRevealed(PreimageRevealedEvent),
     /// The unstaking transaction has been confirmed on-chain.
     UnstakingConfirmed(UnstakingConfirmedEvent),
+    /// A slash transaction has been confirmed on-chain.
+    SlashConfirmed(SlashConfirmedEvent),
     /// A new block has been observed on-chain.
     NewBlock(NewBlockEvent),
     /// Event signalling that retriable duties should be emitted for the current state.
@@ -119,6 +129,7 @@ impl std::fmt::Display for StakeEvent {
             Self::StakeConfirmed(_) => "StakeConfirmed",
             Self::PreimageRevealed(_) => "PreimageRevealed",
             Self::UnstakingConfirmed(_) => "UnstakingConfirmed",
+            Self::SlashConfirmed(_) => "SlashConfirmed",
             Self::NewBlock(_) => "NewBlock",
             Self::RetryTick(_) => "RetryTick",
             Self::NagTick(_) => "NagTick",
@@ -178,6 +189,12 @@ impl std::fmt::Display for UnstakingConfirmedEvent {
     }
 }
 
+impl std::fmt::Display for SlashConfirmedEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SlashConfirmed via {}", self.tx.compute_txid())
+    }
+}
+
 impl std::fmt::Display for NewBlockEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "NewBlock at height {}", self.block_height)
@@ -223,6 +240,7 @@ impl_into_stake_event!(UnstakingPartialsReceivedEvent, UnstakingPartialsReceived
 impl_into_stake_event!(StakeConfirmedEvent, StakeConfirmed);
 impl_into_stake_event!(PreimageRevealedEvent, PreimageRevealed);
 impl_into_stake_event!(UnstakingConfirmedEvent, UnstakingConfirmed);
+impl_into_stake_event!(SlashConfirmedEvent, SlashConfirmed);
 impl_into_stake_event!(NewBlockEvent, NewBlock);
 impl_into_stake_event!(RetryTickEvent, RetryTick);
 impl_into_stake_event!(NagTickEvent, NagTick);

--- a/crates/bridge-sm/src/stake/machine.rs
+++ b/crates/bridge-sm/src/stake/machine.rs
@@ -49,6 +49,7 @@ impl StateMachine for StakeSM {
             StakeEvent::StakeConfirmed(event) => self.process_stake_confirmed(event),
             StakeEvent::PreimageRevealed(event) => self.process_preimage_revealed(event),
             StakeEvent::UnstakingConfirmed(event) => self.process_unstaking_confirmed(event),
+            StakeEvent::SlashConfirmed(event) => self.process_slash_confirmed(event),
             StakeEvent::NewBlock(event) => self.process_new_block(cfg, event),
             StakeEvent::RetryTick(RetryTickEvent) => self.process_retry_tick(&cfg),
             StakeEvent::NagTick(NagTickEvent) => self.process_nag_tick(),

--- a/crates/bridge-sm/src/stake/mod.rs
+++ b/crates/bridge-sm/src/stake/mod.rs
@@ -7,6 +7,7 @@ pub mod errors;
 pub mod events;
 mod handlers;
 pub mod machine;
+mod predicates;
 pub mod state;
 mod transitions;
 mod tx_classifier;

--- a/crates/bridge-sm/src/stake/predicates.rs
+++ b/crates/bridge-sm/src/stake/predicates.rs
@@ -1,0 +1,18 @@
+//! Pure predicates over stake-graph data used by the state machine.
+
+use bitcoin::{OutPoint, Transaction};
+use strata_bridge_tx_graph::{stake_graph::StakeGraphSummary, transactions::prelude::StakeTx};
+
+/// Returns true if the transaction spends the stake output of the stake transaction
+/// without being the legitimate unstaking transaction.
+pub(crate) fn is_slash_tx(summary: &StakeGraphSummary, tx: &Transaction) -> bool {
+    let stake_outpoint = OutPoint {
+        txid: summary.stake,
+        vout: StakeTx::STAKE_VOUT,
+    };
+    let spends_stake_output = tx
+        .input
+        .iter()
+        .any(|txin| txin.previous_output == stake_outpoint);
+    spends_stake_output && tx.compute_txid() != summary.unstaking
+}

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -128,11 +128,14 @@ impl StakeState {
     /// Returns true if staking has happened.
     ///
     /// This means that other state machines can start working.
-    /// This predicate returns true even after unstaking has completed.
+    /// This predicate returns true even after unstaking has completed or after being slashed.
     pub const fn has_staked(&self) -> bool {
         matches!(
             self,
-            Self::Confirmed { .. } | Self::PreimageRevealed { .. } | Self::Unstaked { .. }
+            Self::Confirmed { .. }
+                | Self::PreimageRevealed { .. }
+                | Self::Unstaked { .. }
+                | Self::Slashed { .. }
         )
     }
 
@@ -149,15 +152,23 @@ impl StakeState {
     /// Returns true if this operator has been removed from the future covenant.
     ///
     /// Complement of [`is_stake_available`](Self::is_stake_available) for operators that have
-    /// already staked: `PreimageRevealed` and `Unstaked` states indicate the operator is
-    /// winding down and must not be included in future covenant signing sessions.
+    /// already staked: `PreimageRevealed`, `Unstaked` and `Slashed` states indicate the operator
+    /// is no longer available and must not be included in future covenant signing sessions.
     pub const fn is_removed_from_future_covenant(&self) -> bool {
-        matches!(self, Self::PreimageRevealed { .. } | Self::Unstaked { .. })
+        matches!(
+            self,
+            Self::PreimageRevealed { .. } | Self::Unstaked { .. } | Self::Slashed { .. }
+        )
     }
 
     /// Returns true if the stake is fully unstaked.
     pub const fn is_unstaked(&self) -> bool {
         matches!(self, Self::Unstaked { .. })
+    }
+
+    /// Returns true if the stake has been slashed.
+    pub const fn is_slashed(&self) -> bool {
+        matches!(self, Self::Slashed { .. })
     }
 
     /// Returns the unstaking preimage once revealed.
@@ -166,6 +177,7 @@ impl StakeState {
             Self::PreimageRevealed { preimage, .. } | Self::Unstaked { preimage, .. } => {
                 Some(*preimage)
             }
+            Self::Slashed { preimage, .. } => *preimage,
             _ => None,
         }
     }

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -80,12 +80,12 @@ pub enum StakeState {
         last_block_height: BitcoinBlockHeight,
         /// Data that is required to construct the stake graph.
         stake_data: MinimumStakeData,
+        /// Collection of all TXIDs in the stake graph.
+        summary: StakeGraphSummary,
         /// The revealed unstaking preimage.
         preimage: [u8; 32],
         /// Block height where the unstaking intent transaction was confirmed.
         unstaking_intent_block_height: BitcoinBlockHeight,
-        /// ID of the expected unstaking transaction.
-        expected_unstaking_txid: Txid,
         /// 1 signature per musig transaction input.
         ///
         /// The signatures may be absent if an operator chose to withhold their partial signature

--- a/crates/bridge-sm/src/stake/state.rs
+++ b/crates/bridge-sm/src/stake/state.rs
@@ -99,6 +99,22 @@ pub enum StakeState {
         /// ID of the confirmed unstaking transaction.
         unstaking_txid: Txid,
     },
+    /// The operator's stake has been slashed by another operator.
+    ///
+    /// A slash transaction is any transaction that spends the stake output of the stake
+    /// transaction but is not the legitimate unstaking transaction.
+    Slashed {
+        /// Collection of all TXIDs in the stake graph.
+        summary: StakeGraphSummary,
+        /// Txid of the confirmed slash transaction.
+        slash_txid: Txid,
+        /// The unstaking preimage if the transition occurred from
+        /// [`StakeState::PreimageRevealed`].
+        ///
+        /// This is required by downstream state machines (e.g. for the unstaking burn) when
+        /// the operator had already revealed the preimage prior to being slashed.
+        preimage: Option<[u8; 32]>,
+    },
 }
 
 impl StakeState {
@@ -176,7 +192,7 @@ impl StakeState {
             | Self::PreimageRevealed {
                 last_block_height, ..
             } => Some(*last_block_height),
-            Self::Unstaked { .. } => None,
+            Self::Unstaked { .. } | Self::Slashed { .. } => None,
         }
     }
 
@@ -202,7 +218,7 @@ impl StakeState {
             | Self::PreimageRevealed {
                 last_block_height, ..
             } => Some(last_block_height),
-            Self::Unstaked { .. } => None,
+            Self::Unstaked { .. } | Self::Slashed { .. } => None,
         }
     }
 }
@@ -217,6 +233,7 @@ impl Display for StakeState {
             Self::Confirmed { .. } => "Confirmed",
             Self::PreimageRevealed { .. } => "PreimageRevealed",
             Self::Unstaked { .. } => "Unstaked",
+            Self::Slashed { .. } => "Slashed",
         };
 
         write!(f, "{label}")

--- a/crates/bridge-sm/src/stake/tests/introspection.rs
+++ b/crates/bridge-sm/src/stake/tests/introspection.rs
@@ -1,0 +1,106 @@
+//! Unit tests for introspection methods on [`StakeState`].
+
+use super::*;
+use crate::stake::state::StakeState;
+
+fn confirmed_state() -> StakeState {
+    StakeState::Confirmed {
+        last_block_height: STAKE_HEIGHT,
+        stake_data: TEST_STAKE_DATA.clone(),
+        summary: *TEST_GRAPH_SUMMARY,
+        signatures: Some(*TEST_FINAL_SIGS).into(),
+    }
+}
+
+fn preimage_revealed_state() -> StakeState {
+    StakeState::PreimageRevealed {
+        last_block_height: UNSTAKING_INTENT_HEIGHT,
+        stake_data: TEST_STAKE_DATA.clone(),
+        summary: *TEST_GRAPH_SUMMARY,
+        preimage: TEST_UNSTAKING_PREIMAGE,
+        unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
+        signatures: Some(*TEST_FINAL_SIGS).into(),
+    }
+}
+
+fn unstaked_state() -> StakeState {
+    StakeState::Unstaked {
+        preimage: TEST_UNSTAKING_PREIMAGE,
+        unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+    }
+}
+
+fn slashed_from_confirmed() -> StakeState {
+    StakeState::Slashed {
+        summary: *TEST_GRAPH_SUMMARY,
+        slash_txid: slash_tx().compute_txid(),
+        preimage: None,
+    }
+}
+
+fn slashed_from_preimage_revealed() -> StakeState {
+    StakeState::Slashed {
+        summary: *TEST_GRAPH_SUMMARY,
+        slash_txid: slash_tx().compute_txid(),
+        preimage: Some(TEST_UNSTAKING_PREIMAGE),
+    }
+}
+
+#[test]
+fn is_slashed_only_for_slashed_state() {
+    let cases = [
+        (confirmed_state(), false),
+        (preimage_revealed_state(), false),
+        (unstaked_state(), false),
+        (slashed_from_confirmed(), true),
+        (slashed_from_preimage_revealed(), true),
+    ];
+
+    for (state, expected) in cases {
+        assert_eq!(
+            state.is_slashed(),
+            expected,
+            "is_slashed mismatch in state {state}"
+        );
+    }
+}
+
+#[test]
+fn has_staked_includes_slashed() {
+    assert!(slashed_from_confirmed().has_staked());
+    assert!(slashed_from_preimage_revealed().has_staked());
+}
+
+#[test]
+fn is_removed_from_future_covenant_includes_slashed() {
+    assert!(slashed_from_confirmed().is_removed_from_future_covenant());
+    assert!(slashed_from_preimage_revealed().is_removed_from_future_covenant());
+}
+
+#[test]
+fn is_stake_available_excludes_slashed() {
+    assert!(!slashed_from_confirmed().is_stake_available());
+    assert!(!slashed_from_preimage_revealed().is_stake_available());
+}
+
+#[test]
+fn preimage_returns_none_when_slashed_before_reveal() {
+    assert_eq!(slashed_from_confirmed().preimage(), None);
+}
+
+#[test]
+fn preimage_returned_when_slashed_after_reveal() {
+    assert_eq!(
+        slashed_from_preimage_revealed().preimage(),
+        Some(TEST_UNSTAKING_PREIMAGE)
+    );
+}
+
+#[test]
+fn last_processed_block_height_is_none_in_slashed() {
+    assert!(
+        slashed_from_confirmed()
+            .last_processed_block_height()
+            .is_none()
+    );
+}

--- a/crates/bridge-sm/src/stake/tests/mod.rs
+++ b/crates/bridge-sm/src/stake/tests/mod.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use bitcoin::{
-    Amount, Network, OutPoint,
+    Amount, Network, OutPoint, Transaction,
     hashes::{Hash, sha256},
     relative,
 };
@@ -33,12 +33,14 @@ use strata_bridge_primitives::{
     key_agg::create_agg_ctx, operator_table::OperatorTable, types::P2POperatorPubKey,
 };
 use strata_bridge_test_utils::{
+    bitcoin::generate_spending_tx,
     bridge_fixtures::{TEST_MAGIC_BYTES, TEST_POV_IDX, random_p2tr_desc},
     prelude::generate_keypair,
 };
 use strata_bridge_tx_graph::{
     musig_functor::StakeFunctor,
     stake_graph::{ProtocolParams, StakeGraph, StakeGraphSummary},
+    transactions::prelude::StakeTx,
 };
 
 use crate::{
@@ -246,6 +248,19 @@ static TEST_GRAPH_SUMMARY: LazyLock<StakeGraphSummary> = LazyLock::new(|| TEST_G
 const STAKE_HEIGHT: u64 = 100;
 /// Block height of the unstaking intent transaction.
 const UNSTAKING_INTENT_HEIGHT: u64 = 200;
+
+/// Builds a transaction that spends the stake output of the test stake transaction
+/// (so it qualifies as a slash transaction).
+fn slash_tx() -> Transaction {
+    generate_spending_tx(
+        OutPoint {
+            txid: TEST_GRAPH_SUMMARY.stake,
+            vout: StakeTx::STAKE_VOUT,
+        },
+        // Arbitrary witness data — keeps the txid distinct from the unstaking tx.
+        &[vec![0x42]],
+    )
+}
 
 // ┌───────────────────────────────────────────────────────────────────┐
 // │                             Musig2                                │

--- a/crates/bridge-sm/src/stake/tests/mod.rs
+++ b/crates/bridge-sm/src/stake/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Unit tests for the Stake State Machine.
 
+mod introspection;
 mod nag_received;
 mod nag_tick;
 mod new_block;

--- a/crates/bridge-sm/src/stake/tests/mod.rs
+++ b/crates/bridge-sm/src/stake/tests/mod.rs
@@ -6,6 +6,7 @@ mod new_block;
 mod preimage_revealed;
 mod prop_tests;
 mod retry_tick;
+mod slash_confirmed;
 mod stake_confirmed;
 mod stake_data_received;
 mod tx_classifier;

--- a/crates/bridge-sm/src/stake/tests/nag_received.rs
+++ b/crates/bridge-sm/src/stake/tests/nag_received.rs
@@ -117,7 +117,7 @@ fn reject_nag_received_stake_data() {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {
@@ -198,7 +198,7 @@ fn reject_nag_received_unstaking_nonces() {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {
@@ -279,7 +279,7 @@ fn reject_nag_received_unstaking_partials() {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/tests/nag_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/nag_tick.rs
@@ -112,7 +112,7 @@ fn dont_nag_when_nothing_is_missing() {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/tests/new_block.rs
+++ b/crates/bridge-sm/src/stake/tests/new_block.rs
@@ -37,7 +37,7 @@ fn states_with_last_block_height(last_block_height: u64) -> [StakeState; 6] {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
     ]
@@ -52,7 +52,7 @@ fn preimage_revealed_state(
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: Some(*TEST_FINAL_SIGS).into(),
     }
 }
@@ -159,7 +159,7 @@ fn preimage_revealed_timelock_mature_nonpov_no_duty() {
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: None.into(),
     };
     let expected_state = StakeState::PreimageRevealed {
@@ -167,7 +167,7 @@ fn preimage_revealed_timelock_mature_nonpov_no_duty() {
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: None.into(),
     };
 

--- a/crates/bridge-sm/src/stake/tests/preimage_revealed.rs
+++ b/crates/bridge-sm/src/stake/tests/preimage_revealed.rs
@@ -21,7 +21,7 @@ fn revealed_state() -> StakeState {
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: Some(*TEST_FINAL_SIGS).into(),
     }
 }
@@ -32,7 +32,7 @@ fn revealed_state_without_signatures() -> StakeState {
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: None.into(),
     }
 }

--- a/crates/bridge-sm/src/stake/tests/prop_tests.rs
+++ b/crates/bridge-sm/src/stake/tests/prop_tests.rs
@@ -97,7 +97,7 @@ impl Arbitrary for StakeState {
                     stake_data: TEST_STAKE_DATA.clone(),
                     preimage: TEST_UNSTAKING_PREIMAGE,
                     unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-                    expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+                    summary: *TEST_GRAPH_SUMMARY,
                     signatures: Box::new(Some(*TEST_FINAL_SIGS)),
                 }
             }),

--- a/crates/bridge-sm/src/stake/tests/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/retry_tick.rs
@@ -66,7 +66,7 @@ fn retry_nothing() {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/tests/slash_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/slash_confirmed.rs
@@ -2,7 +2,6 @@
 
 use bitcoin::{OutPoint, Transaction};
 use strata_bridge_test_utils::bitcoin::{generate_spending_tx, generate_txid};
-use strata_bridge_tx_graph::transactions::prelude::StakeTx;
 
 use super::*;
 use crate::stake::{errors::SSMError, events::SlashConfirmedEvent, state::StakeState};
@@ -68,19 +67,6 @@ fn unstaked_state() -> StakeState {
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
     }
-}
-
-/// A transaction that spends the stake output of the stake transaction
-/// (so it qualifies as a slash transaction).
-fn slash_tx() -> Transaction {
-    generate_spending_tx(
-        OutPoint {
-            txid: TEST_GRAPH_SUMMARY.stake,
-            vout: StakeTx::STAKE_VOUT,
-        },
-        // Arbitrary witness data — keeps the txid distinct from the unstaking tx.
-        &[vec![0x42]],
-    )
 }
 
 /// A transaction that does not spend the stake output, so it must not be classified as a slash.

--- a/crates/bridge-sm/src/stake/tests/slash_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/slash_confirmed.rs
@@ -1,0 +1,181 @@
+//! Unit tests for [`StakeSM::process_slash_confirmed`].
+
+use bitcoin::{OutPoint, Transaction};
+use strata_bridge_test_utils::bitcoin::{generate_spending_tx, generate_txid};
+use strata_bridge_tx_graph::transactions::prelude::StakeTx;
+
+use super::*;
+use crate::stake::{errors::SSMError, events::SlashConfirmedEvent, state::StakeState};
+
+fn confirmed_state() -> StakeState {
+    StakeState::Confirmed {
+        last_block_height: STAKE_HEIGHT,
+        stake_data: TEST_STAKE_DATA.clone(),
+        summary: *TEST_GRAPH_SUMMARY,
+        signatures: Some(*TEST_FINAL_SIGS).into(),
+    }
+}
+
+fn preimage_revealed_state() -> StakeState {
+    StakeState::PreimageRevealed {
+        last_block_height: UNSTAKING_INTENT_HEIGHT,
+        stake_data: TEST_STAKE_DATA.clone(),
+        summary: *TEST_GRAPH_SUMMARY,
+        preimage: TEST_UNSTAKING_PREIMAGE,
+        unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
+        signatures: Some(*TEST_FINAL_SIGS).into(),
+    }
+}
+
+fn invalid_states() -> [StakeState; 4] {
+    [
+        StakeState::Created {
+            last_block_height: STAKE_HEIGHT,
+        },
+        StakeState::StakeGraphGenerated {
+            last_block_height: STAKE_HEIGHT,
+            stake_data: TEST_STAKE_DATA.clone(),
+            summary: *TEST_GRAPH_SUMMARY,
+            pub_nonces: TEST_PUB_NONCES_MAP.clone(),
+        },
+        StakeState::UnstakingNoncesCollected {
+            last_block_height: STAKE_HEIGHT,
+            stake_data: TEST_STAKE_DATA.clone(),
+            summary: *TEST_GRAPH_SUMMARY,
+            pub_nonces: TEST_PUB_NONCES_MAP.clone(),
+            agg_nonces: TEST_AGG_NONCES.clone().boxed(),
+            partial_signatures: TEST_PARTIAL_SIGS_MAP.clone(),
+        },
+        StakeState::UnstakingSigned {
+            last_block_height: STAKE_HEIGHT,
+            stake_data: TEST_STAKE_DATA.clone(),
+            summary: *TEST_GRAPH_SUMMARY,
+            signatures: Box::new(*TEST_FINAL_SIGS),
+        },
+    ]
+}
+
+fn slashed_state() -> StakeState {
+    StakeState::Slashed {
+        summary: *TEST_GRAPH_SUMMARY,
+        slash_txid: slash_tx().compute_txid(),
+        preimage: None,
+    }
+}
+
+fn unstaked_state() -> StakeState {
+    StakeState::Unstaked {
+        preimage: TEST_UNSTAKING_PREIMAGE,
+        unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+    }
+}
+
+/// A transaction that spends the stake output of the stake transaction
+/// (so it qualifies as a slash transaction).
+fn slash_tx() -> Transaction {
+    generate_spending_tx(
+        OutPoint {
+            txid: TEST_GRAPH_SUMMARY.stake,
+            vout: StakeTx::STAKE_VOUT,
+        },
+        // Arbitrary witness data — keeps the txid distinct from the unstaking tx.
+        &[vec![0x42]],
+    )
+}
+
+/// A transaction that does not spend the stake output, so it must not be classified as a slash.
+fn non_slash_tx() -> Transaction {
+    generate_spending_tx(
+        OutPoint {
+            txid: generate_txid(),
+            vout: 0,
+        },
+        &[],
+    )
+}
+
+#[test]
+fn accept_slash_from_confirmed() {
+    test_stake_transition(StakeTransition {
+        from_state: confirmed_state(),
+        event: SlashConfirmedEvent { tx: slash_tx() }.into(),
+        expected_state: StakeState::Slashed {
+            summary: *TEST_GRAPH_SUMMARY,
+            slash_txid: slash_tx().compute_txid(),
+            preimage: None,
+        },
+        expected_duties: vec![],
+        expected_signals: vec![],
+    });
+}
+
+#[test]
+fn accept_slash_from_preimage_revealed() {
+    test_stake_transition(StakeTransition {
+        from_state: preimage_revealed_state(),
+        event: SlashConfirmedEvent { tx: slash_tx() }.into(),
+        expected_state: StakeState::Slashed {
+            summary: *TEST_GRAPH_SUMMARY,
+            slash_txid: slash_tx().compute_txid(),
+            preimage: Some(TEST_UNSTAKING_PREIMAGE),
+        },
+        expected_duties: vec![],
+        expected_signals: vec![],
+    });
+}
+
+#[test]
+fn reject_non_slash_tx_in_confirmed() {
+    test_stake_invalid_transition(StakeInvalidTransition {
+        from_state: confirmed_state(),
+        event: SlashConfirmedEvent { tx: non_slash_tx() }.into(),
+        expected_error: |e| matches!(e, SSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn reject_non_slash_tx_in_preimage_revealed() {
+    test_stake_invalid_transition(StakeInvalidTransition {
+        from_state: preimage_revealed_state(),
+        event: SlashConfirmedEvent { tx: non_slash_tx() }.into(),
+        expected_error: |e| matches!(e, SSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn reject_unstaking_tx_in_preimage_revealed() {
+    // The legitimate unstaking transaction also spends the stake output but must not be
+    // classified as a slash.
+    let unstaking_tx = TEST_GRAPH
+        .unstaking
+        .clone()
+        .finalize(TEST_FINAL_SIGS.unstaking);
+
+    test_stake_invalid_transition(StakeInvalidTransition {
+        from_state: preimage_revealed_state(),
+        event: SlashConfirmedEvent { tx: unstaking_tx }.into(),
+        expected_error: |e| matches!(e, SSMError::Rejected { .. }),
+    });
+}
+
+#[test]
+fn reject_slash_in_terminal_states() {
+    for from_state in [slashed_state(), unstaked_state()] {
+        test_stake_invalid_transition(StakeInvalidTransition {
+            from_state,
+            event: SlashConfirmedEvent { tx: slash_tx() }.into(),
+            expected_error: |e| matches!(e, SSMError::Rejected { .. }),
+        });
+    }
+}
+
+#[test]
+fn reject_slash_in_invalid_states() {
+    for from_state in invalid_states() {
+        test_stake_invalid_transition(StakeInvalidTransition {
+            from_state,
+            event: SlashConfirmedEvent { tx: slash_tx() }.into(),
+            expected_error: |e| matches!(e, SSMError::InvalidEvent { .. }),
+        });
+    }
+}

--- a/crates/bridge-sm/src/stake/tests/stake_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/stake_confirmed.rs
@@ -44,7 +44,7 @@ fn invalid_states() -> [StakeState; 2] {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/tests/stake_data_received.rs
+++ b/crates/bridge-sm/src/stake/tests/stake_data_received.rs
@@ -35,7 +35,7 @@ fn invalid_states() -> [StakeState; 5] {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/stake/tests/tx_classifier.rs
@@ -67,6 +67,11 @@ fn all_state_variants() -> Vec<StakeState> {
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
         },
+        StakeState::Slashed {
+            summary: *TEST_GRAPH_SUMMARY,
+            slash_txid: slash_tx().compute_txid(),
+            preimage: None,
+        },
     ]
 }
 
@@ -113,6 +118,19 @@ fn classify_unstaking_tx() {
         matches!(result, Some(StakeEvent::UnstakingConfirmed(_))),
         "expected Some(UnstakingConfirmed) but got {result:?}"
     );
+}
+
+#[test]
+fn classify_slash_tx() {
+    for state in [confirmed_state(), preimage_revealed_state()] {
+        let sm = create_state_machine(state.clone());
+        let result = sm.classify_tx(&TEST_CFG, &slash_tx(), CLASSIFICATION_HEIGHT);
+
+        assert!(
+            matches!(result, Some(StakeEvent::SlashConfirmed(_))),
+            "expected Some(SlashConfirmed) but got {result:?} in state {state}"
+        );
+    }
 }
 
 #[test]
@@ -171,6 +189,17 @@ fn ignore_relevant_tx_in_mismatching_states() {
             unstaking_result.is_some(),
             expect_unstaking,
             "unexpected unstaking classification in state {state}"
+        );
+
+        let slash_result = sm.classify_tx(&TEST_CFG, &slash_tx(), CLASSIFICATION_HEIGHT);
+        let expect_slash = matches!(
+            state,
+            StakeState::Confirmed { .. } | StakeState::PreimageRevealed { .. }
+        );
+        assert_eq!(
+            slash_result.is_some(),
+            expect_slash,
+            "unexpected slash classification in state {state}"
         );
     }
 }

--- a/crates/bridge-sm/src/stake/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/stake/tests/tx_classifier.rs
@@ -43,7 +43,7 @@ fn preimage_revealed_state() -> StakeState {
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: Some(*TEST_FINAL_SIGS).into(),
     }
 }

--- a/crates/bridge-sm/src/stake/tests/unstaking_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_confirmed.rs
@@ -11,7 +11,7 @@ fn preimage_revealed_state() -> StakeState {
         stake_data: TEST_STAKE_DATA.clone(),
         preimage: TEST_UNSTAKING_PREIMAGE,
         unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-        expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+        summary: *TEST_GRAPH_SUMMARY,
         signatures: Some(*TEST_FINAL_SIGS).into(),
     }
 }

--- a/crates/bridge-sm/src/stake/tests/unstaking_nonces_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_nonces_received.rs
@@ -44,7 +44,7 @@ fn invalid_states() -> [StakeState; 5] {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
@@ -42,7 +42,7 @@ fn invalid_states() -> [StakeState; 5] {
             stake_data: TEST_STAKE_DATA.clone(),
             preimage: TEST_UNSTAKING_PREIMAGE,
             unstaking_intent_block_height: UNSTAKING_INTENT_HEIGHT,
-            expected_unstaking_txid: TEST_GRAPH_SUMMARY.unstaking,
+            summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
         StakeState::Unstaked {

--- a/crates/bridge-sm/src/stake/transitions/mod.rs
+++ b/crates/bridge-sm/src/stake/transitions/mod.rs
@@ -2,6 +2,7 @@
 
 mod new_block;
 mod preimage_revealed;
+mod slash_confirmed;
 mod stake_confirmed;
 mod stake_data_received;
 mod unstaking_confirmed;

--- a/crates/bridge-sm/src/stake/transitions/preimage_revealed.rs
+++ b/crates/bridge-sm/src/stake/transitions/preimage_revealed.rs
@@ -69,9 +69,9 @@ impl StakeSM {
                 self.state = StakeState::PreimageRevealed {
                     last_block_height: event.block_height,
                     stake_data: stake_data.clone(),
+                    summary: *summary,
                     preimage,
                     unstaking_intent_block_height: event.block_height,
-                    expected_unstaking_txid: summary.unstaking,
                     signatures: Box::new(*signatures.clone()),
                 };
 

--- a/crates/bridge-sm/src/stake/transitions/preimage_revealed.rs
+++ b/crates/bridge-sm/src/stake/transitions/preimage_revealed.rs
@@ -80,7 +80,7 @@ impl StakeSM {
             StakeState::PreimageRevealed { .. } => {
                 Err(SSMError::duplicate(self.state().clone(), event.into()))
             }
-            StakeState::Unstaked { .. } => Err(SSMError::rejected(
+            StakeState::Unstaked { .. } | StakeState::Slashed { .. } => Err(SSMError::rejected(
                 self.state().clone(),
                 event.into(),
                 "Terminal states reject all incoming events",

--- a/crates/bridge-sm/src/stake/transitions/slash_confirmed.rs
+++ b/crates/bridge-sm/src/stake/transitions/slash_confirmed.rs
@@ -1,21 +1,77 @@
-use crate::stake::{
-    errors::SSMResult,
-    events::SlashConfirmedEvent,
-    machine::{SSMOutput, StakeSM},
+use crate::{
+    stake::{
+        errors::{SSMError, SSMResult},
+        events::SlashConfirmedEvent,
+        machine::{SSMOutput, StakeSM},
+        predicates::is_slash_tx,
+        state::StakeState,
+    },
+    state_machine::SMOutput,
 };
 
 impl StakeSM {
     /// Processes the [`SlashConfirmedEvent`].
     ///
-    /// Transitions from [`StakeState::Confirmed`](crate::stake::state::StakeState::Confirmed) or
-    /// [`StakeState::PreimageRevealed`](crate::stake::state::StakeState::PreimageRevealed) to
-    /// [`StakeState::Slashed`](crate::stake::state::StakeState::Slashed) when the observed
-    /// transaction spends the stake output of the stake transaction and is not the legitimate
-    /// unstaking transaction.
+    /// Transitions from [`StakeState::Confirmed`] or [`StakeState::PreimageRevealed`]
+    /// to [`StakeState::Slashed`] when the observed transaction spends the stake output
+    /// of the stake transaction and is not the legitimate unstaking transaction.
     pub(crate) fn process_slash_confirmed(
         &mut self,
-        _event: SlashConfirmedEvent,
+        event: SlashConfirmedEvent,
     ) -> SSMResult<SSMOutput> {
-        todo!("implement slash confirmation transition")
+        match self.state() {
+            StakeState::Created { .. }
+            | StakeState::StakeGraphGenerated { .. }
+            | StakeState::UnstakingNoncesCollected { .. }
+            | StakeState::UnstakingSigned { .. } => Err(SSMError::invalid_event(
+                self.state().clone(),
+                event.into(),
+                Some(format!(
+                    "Slash confirmation is invalid before stake is confirmed: {}",
+                    self.state()
+                )),
+            )),
+            StakeState::Confirmed { summary, .. } => {
+                if !is_slash_tx(summary, &event.tx) {
+                    return Err(SSMError::rejected(
+                        self.state().clone(),
+                        event.into(),
+                        "Transaction does not spend the stake output (not a slash transaction)",
+                    ));
+                }
+
+                self.state = StakeState::Slashed {
+                    summary: *summary,
+                    slash_txid: event.tx.compute_txid(),
+                    preimage: None,
+                };
+
+                Ok(SMOutput::new())
+            }
+            StakeState::PreimageRevealed {
+                summary, preimage, ..
+            } => {
+                if !is_slash_tx(summary, &event.tx) {
+                    return Err(SSMError::rejected(
+                        self.state().clone(),
+                        event.into(),
+                        "Transaction does not spend the stake output (not a slash transaction)",
+                    ));
+                }
+
+                self.state = StakeState::Slashed {
+                    summary: *summary,
+                    slash_txid: event.tx.compute_txid(),
+                    preimage: Some(*preimage),
+                };
+
+                Ok(SMOutput::new())
+            }
+            StakeState::Slashed { .. } | StakeState::Unstaked { .. } => Err(SSMError::rejected(
+                self.state().clone(),
+                event.into(),
+                "Terminal state rejects all incoming events",
+            )),
+        }
     }
 }

--- a/crates/bridge-sm/src/stake/transitions/slash_confirmed.rs
+++ b/crates/bridge-sm/src/stake/transitions/slash_confirmed.rs
@@ -1,0 +1,21 @@
+use crate::stake::{
+    errors::SSMResult,
+    events::SlashConfirmedEvent,
+    machine::{SSMOutput, StakeSM},
+};
+
+impl StakeSM {
+    /// Processes the [`SlashConfirmedEvent`].
+    ///
+    /// Transitions from [`StakeState::Confirmed`](crate::stake::state::StakeState::Confirmed) or
+    /// [`StakeState::PreimageRevealed`](crate::stake::state::StakeState::PreimageRevealed) to
+    /// [`StakeState::Slashed`](crate::stake::state::StakeState::Slashed) when the observed
+    /// transaction spends the stake output of the stake transaction and is not the legitimate
+    /// unstaking transaction.
+    pub(crate) fn process_slash_confirmed(
+        &mut self,
+        _event: SlashConfirmedEvent,
+    ) -> SSMResult<SSMOutput> {
+        todo!("implement slash confirmation transition")
+    }
+}

--- a/crates/bridge-sm/src/stake/transitions/unstaking_confirmed.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_confirmed.rs
@@ -48,7 +48,7 @@ impl StakeSM {
 
                 Ok(SMOutput::new())
             }
-            StakeState::Unstaked { .. } => Err(SSMError::rejected(
+            StakeState::Unstaked { .. } | StakeState::Slashed { .. } => Err(SSMError::rejected(
                 self.state().clone(),
                 event.into(),
                 "Terminal state rejects all incoming events",

--- a/crates/bridge-sm/src/stake/transitions/unstaking_confirmed.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_confirmed.rs
@@ -31,11 +31,9 @@ impl StakeSM {
                 )),
             )),
             StakeState::PreimageRevealed {
-                preimage,
-                expected_unstaking_txid,
-                ..
+                preimage, summary, ..
             } => {
-                if event.tx.compute_txid() != *expected_unstaking_txid {
+                if event.tx.compute_txid() != summary.unstaking {
                     return Err(SSMError::rejected(
                         self.state().clone(),
                         event.into(),
@@ -45,7 +43,7 @@ impl StakeSM {
 
                 self.state = StakeState::Unstaked {
                     preimage: *preimage,
-                    unstaking_txid: *expected_unstaking_txid,
+                    unstaking_txid: summary.unstaking,
                 };
 
                 Ok(SMOutput::new())

--- a/crates/bridge-sm/src/stake/tx_classifier.rs
+++ b/crates/bridge-sm/src/stake/tx_classifier.rs
@@ -46,7 +46,9 @@ impl TxClassifier for StakeSM {
                 Some(UnstakingConfirmedEvent { tx: tx.clone() }.into())
             }
 
-            StakeState::PreimageRevealed { .. } | StakeState::Unstaked { .. } => None,
+            StakeState::PreimageRevealed { .. }
+            | StakeState::Unstaked { .. }
+            | StakeState::Slashed { .. } => None,
         }
     }
 }

--- a/crates/bridge-sm/src/stake/tx_classifier.rs
+++ b/crates/bridge-sm/src/stake/tx_classifier.rs
@@ -42,10 +42,7 @@ impl TxClassifier for StakeSM {
                     .into()
                 })
             }
-            StakeState::PreimageRevealed {
-                expected_unstaking_txid,
-                ..
-            } if txid == *expected_unstaking_txid => {
+            StakeState::PreimageRevealed { summary, .. } if txid == summary.unstaking => {
                 Some(UnstakingConfirmedEvent { tx: tx.clone() }.into())
             }
 

--- a/crates/bridge-sm/src/stake/tx_classifier.rs
+++ b/crates/bridge-sm/src/stake/tx_classifier.rs
@@ -5,8 +5,12 @@ use strata_bridge_primitives::types::BitcoinBlockHeight;
 
 use crate::{
     stake::{
-        events::{PreimageRevealedEvent, StakeConfirmedEvent, UnstakingConfirmedEvent},
+        events::{
+            PreimageRevealedEvent, SlashConfirmedEvent, StakeConfirmedEvent,
+            UnstakingConfirmedEvent,
+        },
         machine::StakeSM,
+        predicates::is_slash_tx,
         state::StakeState,
     },
     tx_classifier::TxClassifier,
@@ -33,20 +37,25 @@ impl TxClassifier for StakeSM {
             | StakeState::UnstakingSigned { summary, .. } => {
                 (txid == summary.stake).then(|| StakeConfirmedEvent { tx: tx.clone() }.into())
             }
-            StakeState::Confirmed { summary, .. } => {
-                (txid == summary.unstaking_intent).then(|| {
-                    PreimageRevealedEvent {
-                        tx: tx.clone(),
-                        block_height: height,
-                    }
-                    .into()
-                })
+            StakeState::Confirmed { summary, .. } if txid == summary.unstaking_intent => Some(
+                PreimageRevealedEvent {
+                    tx: tx.clone(),
+                    block_height: height,
+                }
+                .into(),
+            ),
+            StakeState::Confirmed { summary, .. } if is_slash_tx(summary, tx) => {
+                Some(SlashConfirmedEvent { tx: tx.clone() }.into())
             }
             StakeState::PreimageRevealed { summary, .. } if txid == summary.unstaking => {
                 Some(UnstakingConfirmedEvent { tx: tx.clone() }.into())
             }
+            StakeState::PreimageRevealed { summary, .. } if is_slash_tx(summary, tx) => {
+                Some(SlashConfirmedEvent { tx: tx.clone() }.into())
+            }
 
-            StakeState::PreimageRevealed { .. }
+            StakeState::Confirmed { .. }
+            | StakeState::PreimageRevealed { .. }
             | StakeState::Unstaked { .. }
             | StakeState::Slashed { .. } => None,
         }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -255,6 +255,11 @@ pub enum RpcStakeState {
         /// Txid of the confirmed unstaking transaction.
         unstaking_txid: Txid,
     },
+    /// Stake has been slashed by another operator.
+    Slashed {
+        /// Txid of the confirmed slash transaction.
+        slash_txid: Txid,
+    },
 }
 
 /// Per-operator stake status.


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR is the equivalent of the design docs PR: https://github.com/alpenlabs/bridge-sm-design-docs/pull/25 which:

- Adds a new `Slashed` state to the SSM.
- Supports the transitions: `PreimageRevealed` -> `Slashed` and `Confirmed` -> `Slashed`.
- Updates the `tx_classifier` to identify the slash transaction.
- Updates the introspection APIs to account for the `Slashed` state.

Claude was use to generate the code and tests off of the design doc.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
This change is required for properly handling the presence of the unstaking preimage in the GSM transitions.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->