### PR TITLE
feat(rpc)!: update bridge monitoring API to use deposit indexes as keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10333,7 +10333,6 @@ dependencies = [
  "strata-bridge-sm",
  "strata-bridge-test-utils",
  "strata-bridge-tx-graph",
- "strata-identifiers",
  "strata-mosaic-client",
  "strata-mosaic-client-api",
  "strata-p2p",

--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -26,7 +26,6 @@ strata-bridge-tx-graph.workspace = true
 strata-mosaic-client.workspace = true
 strata-mosaic-client-api.workspace = true
 
-strata-identifiers.workspace = true
 strata-p2p.workspace = true
 strata-tasks.workspace = true
 

--- a/bin/strata-bridge/src/mode/services/rpc_server.rs
+++ b/bin/strata-bridge/src/mode/services/rpc_server.rs
@@ -2,7 +2,7 @@ use std::{fmt, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
-use bitcoin::{PublicKey, Txid};
+use bitcoin::PublicKey;
 use chrono::{DateTime, Utc};
 use jsonrpsee::{
     RpcModule,
@@ -24,9 +24,9 @@ use strata_bridge_rpc::{
         StrataBridgeControlApiServer, StrataBridgeDaApiServer, StrataBridgeMonitoringApiServer,
     },
     types::{
-        RpcActiveClaim, RpcAggregateSignatures, RpcBridgeDutyStatus, RpcClaimInfo, RpcClaimPhase,
-        RpcDepositInfo, RpcDepositStatus, RpcGraphData, RpcOperatorStakeInfo, RpcOperatorStatus,
-        RpcPendingWithdrawalInfo, RpcStakeState, RpcWithdrawalInfo,
+        RpcActiveClaim, RpcAggregateSignatures, RpcBridgeDutyStatus, RpcClaimPhase, RpcDepositInfo,
+        RpcDepositStatus, RpcGraphData, RpcOperatorStakeInfo, RpcOperatorStatus,
+        RpcPendingWithdrawalInfo, RpcReimbursementStatus, RpcStakeState, RpcWithdrawalStatus,
     },
 };
 use strata_bridge_sm::{
@@ -34,7 +34,6 @@ use strata_bridge_sm::{
     graph::{config::GraphSMCfg, context::GraphSMCtx, state::GraphState},
     stake::state::StakeState,
 };
-use strata_identifiers::Buf32;
 use strata_p2p::swarm::handle::CommandHandle;
 use strata_tasks::TaskExecutor;
 use tokio::{
@@ -271,53 +270,40 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
         }
     }
 
-    async fn get_deposit_requests(&self) -> RpcResult<Vec<Txid>> {
-        let cached_registry = self.cached_registry.read().await;
-        let deposit_requests = cached_registry
-            .deposits()
-            .map(|(_deposit_idx, dsm)| dsm.context().deposit_request_outpoint().txid)
-            .collect();
-
-        Ok(deposit_requests)
+    async fn get_deposit_indices(&self) -> RpcResult<Vec<DepositIdx>> {
+        Ok(self.cached_registry.read().await.get_deposit_ids())
     }
 
-    async fn get_deposit_request_info(
-        &self,
-        deposit_request_txid: Txid,
-    ) -> RpcResult<RpcDepositInfo> {
+    async fn get_deposit_info(&self, deposit_idx: DepositIdx) -> RpcResult<RpcDepositInfo> {
         let cached_registry = self.cached_registry.read().await;
 
-        let Some(info) = cached_registry
-            .deposits()
-            .into_iter()
-            .find(|(_deposit_idx, dsm)| {
-                dsm.context().deposit_request_outpoint().txid == deposit_request_txid
-            })
-            .map(|(_deposit_idx, dsm)| match dsm.state() {
-                DepositState::Created { .. }
-                | DepositState::GraphGenerated { .. }
-                | DepositState::DepositNoncesCollected { .. }
-                | DepositState::DepositPartialsCollected { .. } => RpcDepositStatus::InProgress,
-                DepositState::Aborted => RpcDepositStatus::Failed {
-                    reason: "Deposit request spent elsewhere".to_string(),
-                },
-                _ => RpcDepositStatus::Complete {
-                    deposit_txid: dsm.context().deposit_outpoint().txid,
-                },
-            })
-            .map(|status| RpcDepositInfo {
-                status,
-                deposit_request_txid,
-            })
-        else {
+        let Some(dsm) = cached_registry.get_deposit(&deposit_idx) else {
             return Err(rpc_error(
                 ErrorCode::InvalidParams,
-                "Deposit request not found",
-                deposit_request_txid,
+                "Deposit not found",
+                deposit_idx,
             ));
         };
 
-        Ok(info)
+        let deposit_request_txid = dsm.context().deposit_request_outpoint().txid;
+        let status = match dsm.state() {
+            DepositState::Created { .. }
+            | DepositState::GraphGenerated { .. }
+            | DepositState::DepositNoncesCollected { .. }
+            | DepositState::DepositPartialsCollected { .. } => RpcDepositStatus::InProgress,
+            DepositState::Aborted => RpcDepositStatus::Failed {
+                reason: "Deposit request spent elsewhere".to_string(),
+            },
+            _ => RpcDepositStatus::Complete {
+                deposit_txid: dsm.context().deposit_outpoint().txid,
+            },
+        };
+
+        Ok(RpcDepositInfo {
+            status,
+            deposit_idx,
+            deposit_request_txid,
+        })
     }
 
     async fn get_bridge_duties(&self) -> RpcResult<Vec<RpcBridgeDutyStatus>> {
@@ -335,28 +321,19 @@ impl StrataBridgeMonitoringApiServer for BridgeRpc {
         Ok(vec![])
     }
 
-    async fn get_withdrawals(&self) -> RpcResult<Vec<Buf32>> {
-        // TODO: <https://alpenlabs.atlassian.net/browse/STR-2657>
-        // Update this based on monitoring requirements.
-        Ok(vec![])
-    }
-
-    async fn get_withdrawal_info(
+    async fn get_withdrawal_status(
         &self,
-        _withdrawal_request_txid: Buf32,
-    ) -> RpcResult<Option<RpcWithdrawalInfo>> {
+        _deposit_idx: DepositIdx,
+    ) -> RpcResult<Option<RpcWithdrawalStatus>> {
         // TODO: <https://alpenlabs.atlassian.net/browse/STR-2657>
         // Update this based on monitoring requirements.
         Ok(None)
     }
 
-    async fn get_claims(&self) -> RpcResult<Vec<Txid>> {
-        // TODO: <https://alpenlabs.atlassian.net/browse/STR-2657>
-        // Update this based on monitoring requirements.
-        Ok(vec![])
-    }
-
-    async fn get_claim_info(&self, _claim_txid: Txid) -> RpcResult<Option<RpcClaimInfo>> {
+    async fn get_reimbursement_status(
+        &self,
+        _deposit_idx: DepositIdx,
+    ) -> RpcResult<Option<RpcReimbursementStatus>> {
         // TODO: <https://alpenlabs.atlassian.net/browse/STR-2657>
         // Update this based on monitoring requirements.
         Ok(None)

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -1,13 +1,13 @@
 //! Traits for the RPC server.
 
-use bitcoin::{PublicKey, Txid};
+use bitcoin::PublicKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
-use strata_identifiers::Buf32;
 
 use crate::types::{
-    RpcAggregateSignatures, RpcBridgeDutyStatus, RpcClaimInfo, RpcDepositInfo, RpcGraphData,
-    RpcOperatorStakeInfo, RpcOperatorStatus, RpcPendingWithdrawalInfo, RpcWithdrawalInfo,
+    RpcAggregateSignatures, RpcBridgeDutyStatus, RpcDepositInfo, RpcGraphData,
+    RpcOperatorStakeInfo, RpcOperatorStatus, RpcPendingWithdrawalInfo, RpcReimbursementStatus,
+    RpcWithdrawalStatus,
 };
 
 /// RPCs related to information about the client itself.
@@ -33,16 +33,13 @@ pub trait StrataBridgeMonitoringApi {
     #[method(name = "operatorStatus")]
     async fn get_operator_status(&self, operator_pk: PublicKey) -> RpcResult<RpcOperatorStatus>;
 
-    /// Get all deposit request [`Txid`]s.
-    #[method(name = "depositRequests")]
-    async fn get_deposit_requests(&self) -> RpcResult<Vec<Txid>>;
+    /// Get all known deposit indices.
+    #[method(name = "depositIndices")]
+    async fn get_deposit_indices(&self) -> RpcResult<Vec<DepositIdx>>;
 
-    /// Get deposit details using the deposit request [`Txid`].
+    /// Get deposit details using the deposit index.
     #[method(name = "depositInfo")]
-    async fn get_deposit_request_info(
-        &self,
-        deposit_request_txid: Txid,
-    ) -> RpcResult<RpcDepositInfo>;
+    async fn get_deposit_info(&self, deposit_idx: DepositIdx) -> RpcResult<RpcDepositInfo>;
 
     /// Get bridge duties.
     // TODO: <https://alpenlabs.atlassian.net/browse/STR-2703>
@@ -61,30 +58,19 @@ pub trait StrataBridgeMonitoringApi {
         operator_pk: PublicKey,
     ) -> RpcResult<Vec<RpcBridgeDutyStatus>>;
 
-    /// Get all withdrawal request txids.
-    ///
-    /// NOTE: These are not Bitcoin txids but [`Buf32`] representing the transaction IDs of the
-    /// withdrawal transactions in the sidesystem's execution environment.
-    #[method(name = "withdrawals")]
-    async fn get_withdrawals(&self) -> RpcResult<Vec<Buf32>>;
-
-    /// Get withdrawal details using withdrawal request txid.
-    ///
-    /// NOTE: This is not a Bitcoin txid but a [`Buf32`] representing the transaction ID of the
-    /// withdrawal transaction in the sidesystem's execution environment.
-    #[method(name = "withdrawalInfo")]
-    async fn get_withdrawal_info(
+    /// Get the status of a withdrawal by its deposit index.
+    #[method(name = "withdrawalStatus")]
+    async fn get_withdrawal_status(
         &self,
-        withdrawal_request_txid: Buf32,
-    ) -> RpcResult<Option<RpcWithdrawalInfo>>;
+        deposit_idx: DepositIdx,
+    ) -> RpcResult<Option<RpcWithdrawalStatus>>;
 
-    /// Get all claim transaction IDs.
-    #[method(name = "claims")]
-    async fn get_claims(&self) -> RpcResult<Vec<Txid>>;
-
-    /// Get claim details for a given claim transaction ID.
-    #[method(name = "claimInfo")]
-    async fn get_claim_info(&self, claim_txid: Txid) -> RpcResult<Option<RpcClaimInfo>>;
+    /// Get the reimbursement status for a withdrawal by its deposit index.
+    #[method(name = "reimbursementStatus")]
+    async fn get_reimbursement_status(
+        &self,
+        deposit_idx: DepositIdx,
+    ) -> RpcResult<Option<RpcReimbursementStatus>>;
 
     /// Get the withdrawals currently being processed.
     #[method(name = "pendingWithdrawals")]

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -3,7 +3,7 @@
 use bitcoin::Txid;
 use secp256k1::schnorr::Signature;
 use serde::{Deserialize, Serialize};
-use strata_bridge_primitives::types::{GraphIdx, OperatorIdx};
+use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
 use strata_bridge_sm::graph::context::GraphSMCtx;
 use strata_bridge_tx_graph::game_graph::{DepositParams, SetupParams};
 use strata_identifiers::Buf32;
@@ -41,30 +41,16 @@ pub enum RpcDepositStatus {
     },
 }
 
-/// Challenge step states for claims
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ChallengeStep {
-    /// Challenge step is "Claim".
-    Claim,
-
-    /// Challenge step is "Challenge".
-    Challenge,
-
-    /// Challenge step is "Assert".
-    Assert,
-}
-
 /// Represents a valid withdrawal status
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum RpcWithdrawalStatus {
-    /// Withdrawal is in progress.
+    /// Withdrawal is assigned or being processed, and no fulfillment transaction is known yet.
     InProgress,
 
-    /// Withdrawal has been fully processed and fulfilled.
+    /// Withdrawal has been fulfilled.
     Complete {
-        /// Transaction ID of the withdrawal fulfillment transaction.
+        /// Transaction ID of the operator's withdrawal fulfillment transaction.
         fulfillment_txid: Txid,
     },
 }
@@ -73,27 +59,36 @@ pub enum RpcWithdrawalStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum RpcReimbursementStatus {
-    /// Claim does not exist on-chain.
+    /// No reimbursement claim has been observed for this deposit's assigned operator.
     NotStarted,
 
-    /// Claim exists, challenge step is "Claim", no payout.
+    /// Reimbursement claim has been observed and is still in a non-terminal game phase.
     InProgress {
-        /// Challenge step.
-        challenge_step: ChallengeStep,
+        /// Transaction ID of the reimbursement claim transaction.
+        claim_txid: Txid,
+
+        /// Current non-terminal phase of the challenge-response game for this claim.
+        phase: RpcClaimPhase,
     },
 
-    /// Claim exists, challenge step is "Challenge" or "Assert", no payout.
-    Challenged {
-        /// Challenge step.
-        challenge_step: ChallengeStep,
+    /// Operator was slashed for this reimbursement claim.
+    Slashed {
+        /// Transaction ID of the slashed reimbursement claim transaction.
+        claim_txid: Txid,
     },
 
-    /// Operator was slashed, claim is no longer valid.
-    Cancelled,
+    /// Reimbursement claim path was aborted before payout or slashing completed.
+    Aborted {
+        /// Transaction ID of the aborted reimbursement claim transaction.
+        claim_txid: Txid,
+    },
 
-    /// Claim has been successfully reimbursed.
+    /// Reimbursement claim completed and paid out.
     Complete {
-        /// Payout transaction ID.
+        /// Transaction ID of the reimbursed claim transaction.
+        claim_txid: Txid,
+
+        /// Transaction ID of the reimbursement payout transaction.
         payout_txid: Txid,
     },
 }
@@ -104,31 +99,11 @@ pub struct RpcDepositInfo {
     /// Status of the deposit.
     pub status: RpcDepositStatus,
 
+    /// Bridge deposit index.
+    pub deposit_idx: DepositIdx,
+
     /// Transaction ID of the deposit request transaction (DRT).
     pub deposit_request_txid: Txid,
-}
-
-/// Represents withdrawal transaction details
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RpcWithdrawalInfo {
-    /// Status of the withdrawal.
-    pub status: RpcWithdrawalStatus,
-
-    /// Transaction ID of the withdrawal request transaction (WRT).
-    ///
-    /// NOTE: This is not a Bitcoin [`Txid`] but a [`Buf32`] representing the transaction ID of the
-    /// withdrawal transaction in the sidesystem's execution environment.
-    pub withdrawal_request_txid: Buf32,
-}
-
-/// Represents reimbursement transaction details
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RpcClaimInfo {
-    /// Transaction ID of the claim transaction.
-    pub claim_txid: Txid,
-
-    /// Status of the reimbursement.
-    pub status: RpcReimbursementStatus,
 }
 
 /// Represents a valid bridge duty status
@@ -190,16 +165,22 @@ pub struct RpcActiveClaim {
 pub enum RpcClaimPhase {
     /// Claim transaction confirmed on chain.
     Claimed,
+
     /// Contest transaction confirmed on chain.
     Contested,
+
     /// Operator's bridge proof posted on chain.
     BridgeProofPosted,
+
     /// Bridge proof timed out without valid proof.
     BridgeProofTimedout,
+
     /// Counter-proof posted by watchtowers.
     CounterProofPosted,
+
     /// All counter-proofs NACK'd on chain.
     AllNackd,
+
     /// A counter-proof ACK'd on chain.
     Acked,
 }
@@ -237,24 +218,31 @@ pub struct RpcAggregateSignatures {
 pub enum RpcStakeState {
     /// Initial state; no stake-related transactions have been produced yet.
     Created,
+
     /// Stake graph has been generated.
     StakeGraphGenerated,
+
     /// Unstaking musig2 nonces have been collected.
     UnstakingNoncesCollected,
+
     /// Unstaking musig2 partial signatures have been collected.
     UnstakingSigned,
+
     /// Stake transaction has been confirmed on-chain.
     Confirmed {
         /// Txid of the confirmed stake transaction.
         stake_txid: Txid,
     },
+
     /// Unstaking preimage has been revealed on-chain.
     PreimageRevealed,
+
     /// Unstaking transaction has been confirmed on-chain.
     Unstaked {
         /// Txid of the confirmed unstaking transaction.
         unstaking_txid: Txid,
     },
+
     /// Stake has been slashed by another operator.
     Slashed {
         /// Txid of the confirmed slash transaction.

--- a/functional-tests/rpc/types.py
+++ b/functional-tests/rpc/types.py
@@ -9,14 +9,6 @@ class RpcOperatorStatus(Enum):
     OFFLINE = "offline"
 
 
-class ChallengeStep(Enum):
-    """Challenge step states for claims."""
-
-    CLAIM = "claim"
-    CHALLENGE = "challenge"
-    ASSERT = "assert"
-
-
 class RpcClaimPhase(Enum):
     """Where an active claim sits in the challenge-response game."""
 
@@ -57,14 +49,14 @@ RpcDepositStatus = RpcDepositStatusInProgress | RpcDepositStatusFailed | RpcDepo
 
 @dataclass
 class RpcWithdrawalStatusInProgress:
-    """Withdrawal is in progress."""
+    """Withdrawal is assigned or being processed, with no known fulfillment tx."""
 
     status: str = "in_progress"
 
 
 @dataclass
 class RpcWithdrawalStatusComplete:
-    """Withdrawal has been fully processed and fulfilled."""
+    """Withdrawal has been fulfilled."""
 
     status: str = "complete"
     fulfillment_txid: str = ""
@@ -75,47 +67,50 @@ RpcWithdrawalStatus = RpcWithdrawalStatusInProgress | RpcWithdrawalStatusComplet
 
 @dataclass
 class RpcReimbursementStatusNotStarted:
-    """Claim does not exist on-chain."""
+    """No reimbursement claim has been observed for the assigned operator."""
 
     status: str = "not_started"
 
 
 @dataclass
 class RpcReimbursementStatusInProgress:
-    """Claim exists, challenge step is 'Claim', no payout."""
+    """Reimbursement claim is in a non-terminal challenge-response phase."""
 
     status: str = "in_progress"
-    challenge_step: str = ""
+    claim_txid: str = ""
+    phase: str = ""
 
 
 @dataclass
-class RpcReimbursementStatusChallenged:
-    """Claim exists, challenge step is 'Challenge' or 'Assert', no payout."""
+class RpcReimbursementStatusSlashed:
+    """Operator was slashed for this reimbursement claim."""
 
-    status: str = "challenged"
-    challenge_step: str = ""
+    status: str = "slashed"
+    claim_txid: str = ""
 
 
 @dataclass
-class RpcReimbursementStatusCancelled:
-    """Operator was slashed, claim is no longer valid."""
+class RpcReimbursementStatusAborted:
+    """Reimbursement claim path was aborted before payout or slashing completed."""
 
-    status: str = "cancelled"
+    status: str = "aborted"
+    claim_txid: str = ""
 
 
 @dataclass
 class RpcReimbursementStatusComplete:
-    """Claim has been successfully reimbursed."""
+    """Reimbursement claim completed and paid out."""
 
     status: str = "complete"
+    claim_txid: str = ""
     payout_txid: str = ""
 
 
 RpcReimbursementStatus = (
     RpcReimbursementStatusNotStarted
     | RpcReimbursementStatusInProgress
-    | RpcReimbursementStatusChallenged
-    | RpcReimbursementStatusCancelled
+    | RpcReimbursementStatusSlashed
+    | RpcReimbursementStatusAborted
     | RpcReimbursementStatusComplete
 )
 
@@ -125,23 +120,8 @@ class RpcDepositInfo:
     """Represents deposit transaction details."""
 
     status: RpcDepositStatus
+    deposit_idx: int
     deposit_request_txid: str
-
-
-@dataclass
-class RpcWithdrawalInfo:
-    """Represents withdrawal transaction details."""
-
-    status: RpcWithdrawalStatus
-    withdrawal_request_txid: str
-
-
-@dataclass
-class RpcClaimInfo:
-    """Represents reimbursement transaction details."""
-
-    claim_txid: str
-    status: RpcReimbursementStatus
 
 
 @dataclass

--- a/functional-tests/tests/concurrency/fn_concurrent_deposit_test.py
+++ b/functional-tests/tests/concurrency/fn_concurrent_deposit_test.py
@@ -80,22 +80,24 @@ class ConcurrentDepositTest(StrataTestBase):
 
         # Wait for all DRTs to be recognized
         self.logger.info("Waiting for all DRTs to be recognized")
-        wait_until_drts_recognized(bridge_rpc, drt_txids, timeout=180)
+        deposit_ids = wait_until_drts_recognized(bridge_rpc, drt_txids, timeout=180)
 
         # Wait for deposits to complete and collect deposit txids
         self.logger.info("Waiting for all deposits to complete")
         deposit_txids = []
-        for drt_txid in drt_txids:
+        for deposit_id in deposit_ids:
             deposit_info = wait_until_deposit_status(
                 bridge_rpc,
-                drt_txid,
+                deposit_id,
                 RpcDepositStatusComplete,
                 timeout=600,
             )
             deposit_txid = deposit_info.get("status").get("deposit_txid")
             if deposit_txid:
                 deposit_txids.append(deposit_txid)
-                self.logger.info(f"Deposit completed: DRT {drt_txid} -> DT {deposit_txid}")
+                self.logger.info(
+                    f"Deposit completed: deposit_idx {deposit_id} -> DT {deposit_txid}"
+                )
 
         assert len(deposit_txids) == CONCURRENT_DRT_COUNT, (
             f"Expected {CONCURRENT_DRT_COUNT} deposit txids, got {len(deposit_txids)}"

--- a/functional-tests/utils/deposit.py
+++ b/functional-tests/utils/deposit.py
@@ -26,17 +26,21 @@ def wait_until_deposit_utxo_spent(bitcoin_rpc: BitcoindClient, deposit_txid: str
     wait_until_utxo_spent(bitcoin_rpc, deposit_txid, DT_DEPOSIT_VOUT, timeout)
 
 
-def wait_until_drt_recognized(bridge_rpc, drt_txid: str, timeout=300) -> str | None:
+def _deposit_infos(bridge_rpc) -> list[dict]:
+    deposit_indices: list[int] = bridge_rpc.stratabridge_depositIndices()
+    logging.info(f"Current deposit indices: {deposit_indices}")
+
+    return [bridge_rpc.stratabridge_depositInfo(deposit_idx) for deposit_idx in deposit_indices]
+
+
+def wait_until_drt_recognized(bridge_rpc, drt_txid: str, timeout=300) -> int:
     """Wait until the deposit request with the specified txid is recognized."""
-    result: dict[str, str | None] = {"deposit_id": None}
+    result: dict[str, int | None] = {"deposit_id": None}
 
     def check_drt_recognized():
-        deposit_requests: list[str] = bridge_rpc.stratabridge_depositRequests()
-        logging.info(f"Current deposit requests: {deposit_requests}")
-
-        for txid in deposit_requests:
-            if txid == drt_txid:
-                result["deposit_id"] = txid
+        for deposit_info in _deposit_infos(bridge_rpc):
+            if deposit_info.get("deposit_request_txid") == drt_txid:
+                result["deposit_id"] = int(deposit_info["deposit_idx"])
                 return True
         return False
 
@@ -46,12 +50,13 @@ def wait_until_drt_recognized(bridge_rpc, drt_txid: str, timeout=300) -> str | N
         step=1,
         error_msg=f"Timeout after {timeout} seconds waiting for DRT {drt_txid} to be recognized",
     )
+    assert result["deposit_id"] is not None
     return result["deposit_id"]
 
 
 def wait_until_deposit_status(
     bridge_rpc,
-    deposit_id,
+    deposit_id: int,
     target_status: type[RpcDepositStatus],
     timeout=300,
 ) -> RpcDepositInfo | None:
@@ -59,7 +64,7 @@ def wait_until_deposit_status(
 
     Args:
         bridge_rpc: RPC client for the bridge
-        deposit_id: The deposit request txid
+        deposit_id: The deposit index
         target_status: Status to wait for
         timeout: Maximum wait time in seconds
     """
@@ -84,19 +89,21 @@ def wait_until_drts_recognized(
     bridge_rpc,
     drt_txids: list[str],
     timeout=300,
-) -> list[str]:
+) -> list[int]:
     """Wait until all DRTs in the batch are recognized."""
-    result: dict[str, list[str] | None] = {"deposit_ids": None}
+    result: dict[str, list[int] | None] = {"deposit_ids": None}
 
     def check_deposit_batch():
-        deposit_requests: list[str] = bridge_rpc.stratabridge_depositRequests()
-        logging.info(f"Current deposit requests: {deposit_requests}")
+        deposits_by_drt = {
+            deposit_info.get("deposit_request_txid"): int(deposit_info["deposit_idx"])
+            for deposit_info in _deposit_infos(bridge_rpc)
+        }
 
-        missing_txids = [drt_txid for drt_txid in drt_txids if drt_txid not in deposit_requests]
+        missing_txids = [drt_txid for drt_txid in drt_txids if drt_txid not in deposits_by_drt]
         if missing_txids:
             return False
 
-        result["deposit_ids"] = drt_txids
+        result["deposit_ids"] = [deposits_by_drt[drt_txid] for drt_txid in drt_txids]
         return True
 
     wait_until(
@@ -115,26 +122,29 @@ def wait_until_drts_reach_status_threshold(
     expected_status: type[RpcDepositStatus],
     threshold: int,
     timeout=300,
-) -> list[str]:
+) -> list[int]:
     """Wait until all DRTs are recognized and at least `threshold` reach `expected_status`.
 
     The threshold is evaluated only after every DRT in `drt_txids` appears in the
-    bridge RPC's deposit request list. This keeps the helper's semantics stable for
+    bridge RPC's deposit index list. This keeps the helper's semantics stable for
     restart tests where recognition and progress are checked as separate milestones.
     """
-    result: dict[str, list[str] | None] = {"deposit_ids": None}
+    result: dict[str, list[int] | None] = {"deposit_ids": None}
 
     def check_deposit_batch():
-        deposit_requests: list[str] = bridge_rpc.stratabridge_depositRequests()
-        logging.info(f"Current deposit requests: {deposit_requests}")
+        deposits_by_drt = {
+            deposit_info.get("deposit_request_txid"): int(deposit_info["deposit_idx"])
+            for deposit_info in _deposit_infos(bridge_rpc)
+        }
 
-        missing_txids = [drt_txid for drt_txid in drt_txids if drt_txid not in deposit_requests]
+        missing_txids = [drt_txid for drt_txid in drt_txids if drt_txid not in deposits_by_drt]
         if missing_txids:
             return False
 
         matching_status_count = 0
         for drt_txid in drt_txids:
-            deposit_info = bridge_rpc.stratabridge_depositInfo(drt_txid)
+            deposit_idx = deposits_by_drt[drt_txid]
+            deposit_info = bridge_rpc.stratabridge_depositInfo(deposit_idx)
             logging.info(f"Deposit info for {drt_txid}: {deposit_info}")
             status: str = deposit_info.get("status", {}).get("status")
             if status == expected_status.status:
@@ -149,7 +159,7 @@ def wait_until_drts_reach_status_threshold(
         )
 
         if matching_status_count >= threshold:
-            result["deposit_ids"] = drt_txids
+            result["deposit_ids"] = [deposits_by_drt[drt_txid] for drt_txid in drt_txids]
             return True
 
         return False


### PR DESCRIPTION
## Description

Update `StrataBridgeMonitoringApi` so the dashboard queries the bridge using deposit indexes (the bridge-owned identifier) instead of deposit-request and withdrawal-request txids. Withdrawal-request txids will come from the dashboard's own indexer.

- Add `depositIndexes`, `withdrawalStatus`, and `reimbursementStatus`.
- Switch `depositInfo` to take `DepositIdx`.
- Remove `depositRequests`, `withdrawals`, `withdrawalInfo`, `claims`, `claimInfo`, and the `RpcWithdrawalInfo`, `RpcClaimInfo`, `ChallengeStep` types they used.
- Reshape `RpcReimbursementStatus`: drop `Challenged`/`Cancelled`, add `Slashed { claim_txid }` and `Aborted { claim_txid }`, carry `claim_txid` in every claim-backed variant, and use `RpcClaimPhase` for the in-progress phase.
- Mirror the new shapes in `functional-tests/rpc/types.py` and migrate `functional-tests/utils/deposit.py` onto the index-keyed endpoints.

`withdrawalStatus` and `reimbursementStatus` are wired into the trait but stubbed to `Ok(None)` for now. Populating them requires retaining `fulfillment_txid`, `claim_txid`, and `payout_txid` on terminal state-machine variants, tracked as a follow-up.

This PR was created with help from Claude Code and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

[STR-3371](https://alpenlabs.atlassian.net/browse/STR-3371)

[STR-3371]: https://alpenlabs.atlassian.net/browse/STR-3371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ