### PR TITLE
hack(tx-graph): hardcode fees into bridge txs

### DIFF
--- a/bin/dev-cli/src/handlers/bridge_in.rs
+++ b/bin/dev-cli/src/handlers/bridge_in.rs
@@ -4,12 +4,13 @@ use std::str::FromStr;
 
 use alloy::primitives::Address as EvmAddress;
 use anyhow::Result;
-use bitcoin::{hex::DisplayHex, taproot::TaprootBuilder, Address, Amount, Network, ScriptBuf};
+use bitcoin::{hex::DisplayHex, taproot::TaprootBuilder, Address, Network, ScriptBuf};
 use miniscript::Miniscript;
 use musig2::KeyAggContext;
 use secp256k1::{Keypair, Parity, XOnlyPublicKey, SECP256K1};
 use strata_asm_proto_bridge_v1_txs::deposit_request::DrtHeaderAux;
 use strata_bridge_common::params::Params;
+use strata_bridge_tx_graph::transactions::deposit::DepositTx;
 use strata_identifiers::{AccountSerial, SubjectIdBytes};
 use strata_l1_txfmt::{MagicBytes, ParseConfig};
 use strata_ol_bridge_types::DepositDescriptor;
@@ -51,13 +52,11 @@ pub(crate) fn handle_bridge_in(args: BridgeInArgs) -> Result<()> {
         .aggregated_pubkey();
     let taproot_address = generate_taproot_address(params.network, timelock_script, agg_key);
 
-    let deposit_fees = Amount::from_sat(1_000);
-    let psbt = psbt_wallet.create_drt_psbt(
-        params.protocol.deposit_amount + deposit_fees,
-        &taproot_address,
-        metadata,
-        &params.network,
-    )?;
+    // The DRT must include `deposit_amount + deposit_fee` so the bridge's deposit
+    // transaction can pay its own fee.
+    let drt_amount = DepositTx::drt_required(params.protocol.deposit_amount);
+    let psbt =
+        psbt_wallet.create_drt_psbt(drt_amount, &taproot_address, metadata, &params.network)?;
     psbt_wallet.sign_and_broadcast_psbt(&psbt)?;
 
     Ok(())

--- a/bin/dev-cli/src/handlers/graph.rs
+++ b/bin/dev-cli/src/handlers/graph.rs
@@ -21,7 +21,7 @@ pub(crate) fn build_game_graph(
             params.protocol.contested_payout_timelock,
         ),
         // TODO: <https://alpenlabs.atlassian.net/browse/STR-2945>
-        // use the COUNTERPROOF_N_BYTES constant in a future refactor
+        // use the COUNTERPROOF_N_DATA constant in a future refactor
         // proof bytes (groth16) + deposit_idx (4 bytes)
         counterproof_n_data: NonZero::new(128 + 4).expect("non-zero"),
         deposit_amount: params.protocol.deposit_amount,

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -50,7 +50,8 @@ pub(in crate::mode) async fn init_operator_wallet(
     info!(%general_key, "operator wallet general key");
     let stakechain_key = s2_client.stakechain_wallet_signer().pubkey().await?;
     info!(%stakechain_key, "operator wallet stakechain key");
-    let operator_funds = compute_funding_amount(params);
+    let own_musig2_key = s2_client.musig2_signer().pubkey().await?;
+    let operator_funds = compute_funding_amount(params, own_musig2_key);
     let operator_wallet_config =
         OperatorWalletConfig::new(operator_funds, SEGWIT_MIN_AMOUNT, params.network);
     debug!(?operator_wallet_config, "operator wallet config");
@@ -74,7 +75,7 @@ pub(in crate::mode) async fn init_operator_wallet(
 ///
 /// This amount is not a constant since it depends upon the number of watchtowers that are allowed
 /// to contest a claim.
-fn compute_funding_amount(params: &Params) -> Amount {
+fn compute_funding_amount(params: &Params, own_musig2_key: XOnlyPublicKey) -> Amount {
     // Must match the value used in `orchestrator.rs::COUNTERPROOF_N_BYTES`. Hardcoded here too
     // because `Params` does not currently expose it.
     const COUNTERPROOF_N_BYTES: NonZero<usize> =
@@ -90,8 +91,15 @@ fn compute_funding_amount(params: &Params) -> Amount {
         sha256::Hash::from_slice(&[0u8; 32]).expect("must be a valid sha256 hash");
 
     // NOTE: (@Rajil1213)  musig2 keys are the watchtower keys for the time being until we separate
-    // the sets
-    let watchtower_keys: Vec<_> = params.keys.covenant.iter().map(|c| c.musig2).collect();
+    // the sets. Exclude the owner — graph construction in `bridge-sm` excludes the owner from
+    // watchtowers (see `GraphContext::watchtower_pubkeys`), so the funding amount must too.
+    let watchtower_keys: Vec<_> = params
+        .keys
+        .covenant
+        .iter()
+        .map(|c| c.musig2)
+        .filter(|k| *k != own_musig2_key)
+        .collect();
     // cast safety: covenant.len() is bounded by the number of operators, much smaller than u32::MAX
     let n_watchtowers = watchtower_keys.len() as u32;
     let contest_timelock = relative::Height::from_height(params.protocol.contest_timelock);

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -76,10 +76,10 @@ pub(in crate::mode) async fn init_operator_wallet(
 /// This amount is not a constant since it depends upon the number of watchtowers that are allowed
 /// to contest a claim.
 fn compute_funding_amount(params: &Params, own_musig2_key: XOnlyPublicKey) -> Amount {
-    // Must match the value used in `orchestrator.rs::COUNTERPROOF_N_BYTES`. Hardcoded here too
+    // Must match the value used in `orchestrator.rs::COUNTERPROOF_N_DATA`. Hardcoded here too
     // because `Params` does not currently expose it.
-    const COUNTERPROOF_N_BYTES: NonZero<usize> =
-        NonZero::new(128 + 4).expect("counterproof_n_bytes must be non-zero");
+    const COUNTERPROOF_N_DATA: NonZero<usize> =
+        NonZero::new(128 + 4).expect("counterproof_n_data must be non-zero");
 
     let network = params.network;
 
@@ -109,7 +109,7 @@ fn compute_funding_amount(params: &Params, own_musig2_key: XOnlyPublicKey) -> Am
         n_of_n_key,
         watchtower_keys,
         contest_timelock,
-        fee::claim_contest_surcharge(n_watchtowers, COUNTERPROOF_N_BYTES),
+        fee::claim_contest_surcharge(n_watchtowers, COUNTERPROOF_N_DATA),
     );
 
     let admin_key = params.keys.admin;

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -1,6 +1,6 @@
 //! Provides operator wallet initialization.
 
-use std::sync::Arc;
+use std::{num::NonZero, sync::Arc};
 
 use anyhow::anyhow;
 use bdk_bitcoind_rpc::bitcoincore_rpc;
@@ -13,12 +13,10 @@ use operator_wallet::{OperatorWallet, OperatorWalletConfig, sync::Backend};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_common::params::Params;
-use strata_bridge_connectors::{
-    Connector,
-    prelude::{ClaimContestConnector, ClaimPayoutConnector},
-};
+use strata_bridge_connectors::prelude::{ClaimContestConnector, ClaimPayoutConnector};
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb};
 use strata_bridge_primitives::constants::SEGWIT_MIN_AMOUNT;
+use strata_bridge_tx_graph::{fee, transactions::prelude::ClaimTx};
 use tracing::{debug, info};
 
 use crate::config::Config;
@@ -77,6 +75,11 @@ pub(in crate::mode) async fn init_operator_wallet(
 /// This amount is not a constant since it depends upon the number of watchtowers that are allowed
 /// to contest a claim.
 fn compute_funding_amount(params: &Params) -> Amount {
+    // Must match the value used in `orchestrator.rs::COUNTERPROOF_N_BYTES`. Hardcoded here too
+    // because `Params` does not currently expose it.
+    const COUNTERPROOF_N_BYTES: NonZero<usize> =
+        NonZero::new(128 + 4).expect("counterproof_n_bytes must be non-zero");
+
     let network = params.network;
 
     // The consensus-validity of the following two values do not affect the calculation of the
@@ -88,15 +91,22 @@ fn compute_funding_amount(params: &Params) -> Amount {
 
     // NOTE: (@Rajil1213)  musig2 keys are the watchtower keys for the time being until we separate
     // the sets
-    let watchtower_keys = params.keys.covenant.iter().map(|c| c.musig2).collect();
+    let watchtower_keys: Vec<_> = params.keys.covenant.iter().map(|c| c.musig2).collect();
+    // cast safety: covenant.len() is bounded by the number of operators, much smaller than u32::MAX
+    let n_watchtowers = watchtower_keys.len() as u32;
     let contest_timelock = relative::Height::from_height(params.protocol.contest_timelock);
 
-    let claim_contest_connector =
-        ClaimContestConnector::new(network, n_of_n_key, watchtower_keys, contest_timelock);
+    let claim_contest_connector = ClaimContestConnector::new(
+        network,
+        n_of_n_key,
+        watchtower_keys,
+        contest_timelock,
+        fee::claim_contest_surcharge(n_watchtowers, COUNTERPROOF_N_BYTES),
+    );
 
     let admin_key = params.keys.admin;
     let claim_payout_connector =
         ClaimPayoutConnector::new(network, n_of_n_key, admin_key, unstaking_image);
 
-    claim_contest_connector.value() + claim_payout_connector.value()
+    ClaimTx::claim_funds_required(&claim_contest_connector, &claim_payout_connector)
 }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -199,7 +199,7 @@ pub(super) fn build_sm_config(config: &Config, params: &Params) -> SMConfig {
             params.protocol.contested_payout_timelock,
         ),
         counterproof_n_data: NonZero::new(COUNTERPROOF_N_DATA)
-            .expect("counterproof_n_bytes must be non-zero"),
+            .expect("counterproof_n_data must be non-zero"),
         deposit_amount,
         stake_amount: params.protocol.stake_amount,
     };

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -24,8 +24,11 @@ use strata_bridge_primitives::{
     types::{BitcoinBlockHeight, DepositIdx, OperatorIdx},
 };
 use strata_bridge_sm::deposit::duties::{DepositDuty, NagDuty};
-use strata_bridge_tx_graph::transactions::prelude::{
-    CooperativePayoutTx, WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
+use strata_bridge_tx_graph::{
+    fee,
+    transactions::prelude::{
+        CooperativePayoutTx, WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
+    },
 };
 use tracing::{error, info, warn};
 
@@ -402,13 +405,17 @@ async fn fulfill_withdrawal(
         .checked_sub(cfg.operator_fee)
         .expect("deposit amount must be greater than operator fee");
 
-    // Get fee rate estimate from bitcoind
+    // Get fee rate estimate from bitcoind, bounded from below by `fee::FEE_RATE` so the
+    // withdrawal-fulfillment v3 transaction always meets the bridge's hardcoded minimum even
+    // on networks where `estimatesmartfee` returns a value below `minrelaytxfee`.
     let fee_rate = output_handles
         .bitcoind_rpc_client
         .estimate_smart_fee(1)
         .await
         .map_err(|e| ExecutorError::WalletErr(format!("failed to estimate fee: {e}")))?;
-    let fee_rate = FeeRate::from_sat_per_vb(fee_rate).unwrap_or(FeeRate::DUST);
+    let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
+        .unwrap_or(fee::FEE_RATE)
+        .max(fee::FEE_RATE);
 
     // Check if fee rate exceeds maximum configured rate
     if fee_rate > cfg.maximum_fee_rate {

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -413,9 +413,22 @@ async fn fulfill_withdrawal(
         .estimate_smart_fee(1)
         .await
         .map_err(|e| ExecutorError::WalletErr(format!("failed to estimate fee: {e}")))?;
+    info!(%fee_rate, "estimated fee rate for withdrawal fulfillment");
+
     let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
         .unwrap_or(fee::FEE_RATE)
         .max(fee::FEE_RATE);
+
+    // The following approach trades off maximal liveness for maximal safety:
+    // It is not safe to broadcast at a lower fee rate when the network fee rate is high as there is
+    // a chance that the fulfillment transaction will be settled after a reassignment, causing an
+    // operator to lose funds. The safest approach is to abort.
+    if fee_rate > cfg.maximum_fee_rate {
+        return Err(ExecutorError::FeeRateTooHigh {
+            fee_rate,
+            max: cfg.maximum_fee_rate,
+        });
+    }
 
     // Check if fee rate exceeds maximum configured rate
     if fee_rate > cfg.maximum_fee_rate {

--- a/crates/bridge-exec/src/errors.rs
+++ b/crates/bridge-exec/src/errors.rs
@@ -1,7 +1,7 @@
 //! Error types for the bridge-exec executors.
 
 use bdk_wallet::error::CreateTxError;
-use bitcoin::Txid;
+use bitcoin::{FeeRate, Txid};
 use foundationdb::FdbBindingError;
 use strata_bridge_db::fdb::errors::LayerError;
 use terrors::OneOf;
@@ -69,6 +69,15 @@ pub enum ExecutorError {
     /// A transaction or its template violates a protocol invariant
     #[error("invalid transaction structure: {0}")]
     InvalidTxStructure(String),
+
+    /// The fee rate estimated for a transaction exceeds the maximum allowed by the configuration.
+    #[error("fee rate {fee_rate} exceeds maximum of {max}")]
+    FeeRateTooHigh {
+        /// The fee rate that was estimated for the transaction.
+        fee_rate: FeeRate,
+        /// The maximum fee rate allowed by the configuration.
+        max: FeeRate,
+    },
 }
 
 impl From<OneOf<(FdbBindingError, LayerError)>> for ExecutorError {

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -4,7 +4,7 @@ use std::num::NonZero;
 
 use algebra::predicate;
 use bitcoin::{
-    FeeRate, OutPoint, TapSighashType, Txid, XOnlyPublicKey,
+    OutPoint, TapSighashType, Txid, XOnlyPublicKey,
     hashes::sha256,
     sighash::{Prevouts, SighashCache},
 };
@@ -21,6 +21,7 @@ use strata_bridge_primitives::{
 };
 use strata_bridge_sm::graph::{context::GraphSMCtx, machine::generate_game_graph};
 use strata_bridge_tx_graph::{
+    fee,
     game_graph::{DepositParams, GameGraph},
     transactions::claim::ClaimTx,
 };
@@ -161,10 +162,8 @@ async fn ensure_claim_funding_outpoint(
             Some(outpoint) => outpoint,
             None => {
                 warn!("could not acquire claim funding utxo. attempting refill...");
-                let psbt = wallet.refill_claim_funding_utxos(
-                    FeeRate::BROADCAST_MIN,
-                    cfg.funding_uxto_pool_size,
-                )?;
+                let psbt =
+                    wallet.refill_claim_funding_utxos(fee::FEE_RATE, cfg.funding_uxto_pool_size)?;
                 finalize_claim_funding_tx(
                     &output_handles.s2_client,
                     &output_handles.tx_driver,

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -6,7 +6,7 @@ use strata_bridge_primitives::{
     scripts::taproot::TaprootTweak,
     types::{DepositIdx, OperatorIdx},
 };
-use strata_bridge_tx_graph::transactions::prelude::CounterproofNackTx;
+use strata_bridge_tx_graph::{fee, transactions::prelude::CounterproofNackTx};
 use strata_mosaic_client_api::types::{
     CompletedSignatures, G16ProofRaw, N_WITHDRAWAL_INPUT_WIRES, Sighash, Tweak,
 };
@@ -26,9 +26,12 @@ pub(super) async fn publish_counterproof_nack(
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %counterprover_idx, "preparing counterproof nack");
 
-    // Single output: forward the connector's dust value back to the operator's general
-    // wallet. The connector script is `minimal_non_dust` P2TR, so the output clears dust.
+    // Single output: forward the connector's dust value (minus the nack tx fee) back to the
+    // operator's general wallet. The connector script is `minimal_non_dust` P2TR plus the
+    // surcharge that funds this nack tx's fee, so the output still clears dust after the
+    // subtraction.
     let connector_value = counterproof_nack_tx.prevouts()[0].value;
+    let payout_value = connector_value - fee::counterproof_nack_fee();
     let payout_script = output_handles
         .wallet
         .read()
@@ -36,7 +39,7 @@ pub(super) async fn publish_counterproof_nack(
         .general_script_buf()
         .clone();
     counterproof_nack_tx.push_output(TxOut {
-        value: connector_value,
+        value: payout_value,
         script_pubkey: payout_script,
     });
 

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -16,14 +16,14 @@ use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PubNonce};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
-use strata_bridge_connectors::{Connector, prelude::UnstakingIntentOutput};
+use strata_bridge_connectors::prelude::UnstakingIntentOutput;
 use strata_bridge_db::traits::BridgeDb;
 use strata_bridge_p2p_types::UnstakingInput;
 use strata_bridge_primitives::{
     scripts::taproot::{TaprootTweak, create_key_spend_hash, finalize_input},
     types::OperatorIdx,
 };
-use strata_bridge_tx_graph::musig_functor::StakeFunctor;
+use strata_bridge_tx_graph::{fee, musig_functor::StakeFunctor, transactions::prelude::StakeTx};
 use tracing::{error, info, warn};
 
 use crate::{
@@ -108,8 +108,7 @@ async fn create_stake_funding_tx(
 
     let fee_rate = FeeRate::from_sat_per_vb(fee_rate).unwrap_or(DEFAULT_FEE_RATE);
 
-    let unstaking_intent_dust = unstaking_intent_dust_value(cfg.network);
-    let funding_amount = cfg.stake_amount + unstaking_intent_dust;
+    let funding_amount = stake_funding_amount(cfg.network, cfg.stake_amount);
 
     info!(%fee_rate, %funding_amount, "creating stake funding transaction");
     let psbt = {
@@ -310,26 +309,24 @@ pub(crate) async fn publish_stake(
     let stake_txid = tx.compute_txid();
     let funding_input = tx.input[0].previous_output;
 
-    let unstaking_intent_dust = unstaking_intent_dust_value(cfg.network);
-
     // The stake tx spends a single funding UTXO in the stakechain wallet and is not presigned by
     // the covenant, so key-path sign it with the stakechain wallet signer before broadcasting.
     // Reconstruct the prevout from known values: the funding UTXO is always at the stakechain
-    // address with value `stake_amount + unstaking_intent_output.value()`.
+    // address with value `stake_amount + unstaking_intent_output.value() + stake_fee`.
     let stakechain_script = {
         let wallet = output_handles.wallet.read().await;
         wallet.stakechain_script_buf().clone()
     };
-    let stake_funding_amount = cfg.stake_amount + unstaking_intent_dust;
+    let funding_amount = stake_funding_amount(cfg.network, cfg.stake_amount);
     let prevout = TxOut {
         script_pubkey: stakechain_script,
-        value: stake_funding_amount,
+        value: funding_amount,
     };
 
     info!(
         %stake_txid,
         %funding_input,
-        %stake_funding_amount,
+        %funding_amount,
         "signing stake transaction with stakechain wallet signer"
     );
 
@@ -361,16 +358,23 @@ pub(crate) async fn publish_stake(
     Ok(())
 }
 
-/// Returns the dust value of an [`UnstakingIntentOutput`] on the given network.
+/// Returns the wallet UTXO value needed to fund the stake transaction on the given network.
 ///
-/// The stake transaction spends its funding UTXO into the NOfN connector (`stake_amount`), the
-/// unstaking-intent connector, and a zero-value CPFP anchor.
-fn unstaking_intent_dust_value(network: Network) -> Amount {
-    // `UnstakingIntentOutput::value()` is the P2TR script's `minimal_non_dust()` and therefore
-    // depends only on the script kind — not on the particular n-of-n key or unstaking image. We
-    // supply a dummy x-only pubkey (the generator point's x-coordinate) and a zero image so we can
-    // compute the value without a secret-service round trip.
+/// The stake transaction spends this UTXO into the NOfN stake connector (`stake_amount`), the
+/// unstaking-intent connector (with its presigned-tx fee surcharge baked in), a zero-value CPFP
+/// anchor, and the stake transaction's own fee.
+fn stake_funding_amount(network: Network, stake_amount: Amount) -> Amount {
+    // `UnstakingIntentOutput::value()` is the P2TR script's `minimal_non_dust()` plus a surcharge
+    // that depends only on the script kind — not on the particular n-of-n key or unstaking image.
+    // We supply a dummy x-only pubkey (the generator point's x-coordinate) and a zero image so we
+    // can compute the value without a secret-service round trip.
     let dummy_pubkey = XOnlyPublicKey::from_slice(&bitcoin::key::constants::GENERATOR_X)
         .expect("valid x-only key");
-    UnstakingIntentOutput::new(network, dummy_pubkey, sha256::Hash::all_zeros()).value()
+    let unstaking_intent_output = UnstakingIntentOutput::new(
+        network,
+        dummy_pubkey,
+        sha256::Hash::all_zeros(),
+        fee::unstaking_intent_surcharge(),
+    );
+    StakeTx::stake_funds_required(stake_amount, &unstaking_intent_output)
 }

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -103,6 +103,7 @@ async fn create_stake_funding_tx(
         .bitcoind_rpc_client
         .estimate_smart_fee(1)
         .await?;
+    info!(%fee_rate, "fetched fee rate from bitcoind");
 
     // Bound the rate from below by `fee::FEE_RATE` so this v3 (TRUC) funding transaction
     // always meets the bridge's hardcoded minimum, even on networks like signet where
@@ -110,6 +111,13 @@ async fn create_stake_funding_tx(
     let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
         .unwrap_or(fee::FEE_RATE)
         .max(fee::FEE_RATE);
+
+    if fee_rate > cfg.maximum_fee_rate {
+        return Err(ExecutorError::FeeRateTooHigh {
+            fee_rate,
+            max: cfg.maximum_fee_rate,
+        });
+    }
 
     let funding_amount = stake_funding_amount(cfg.network, cfg.stake_amount);
 

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -98,15 +98,18 @@ async fn create_stake_funding_tx(
     cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
 ) -> Result<Transaction, ExecutorError> {
-    const DEFAULT_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(5);
-
     info!("fetching fee rate from bitcoind");
     let fee_rate = output_handles
         .bitcoind_rpc_client
         .estimate_smart_fee(1)
         .await?;
 
-    let fee_rate = FeeRate::from_sat_per_vb(fee_rate).unwrap_or(DEFAULT_FEE_RATE);
+    // Bound the rate from below by `fee::FEE_RATE` so this v3 (TRUC) funding transaction
+    // always meets the bridge's hardcoded minimum, even on networks like signet where
+    // `estimatesmartfee` may return a value below `minrelaytxfee`.
+    let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
+        .unwrap_or(fee::FEE_RATE)
+        .max(fee::FEE_RATE);
 
     let funding_amount = stake_funding_amount(cfg.network, cfg.stake_amount);
 

--- a/crates/bridge-sm/src/deposit/tests/mod.rs
+++ b/crates/bridge-sm/src/deposit/tests/mod.rs
@@ -189,7 +189,9 @@ pub(super) fn test_deposit_txn() -> DepositTx {
         magic_bytes: TEST_MAGIC_BYTES.into(),
     };
 
-    // Create connectors with matching network, internal_key, and value
+    // Create connectors with matching network, internal_key, and value. The
+    // deposit-request connector must include `deposit_amount + deposit_fee` so the deposit tx
+    // can pay its own fee.
     let deposit_connector = NOfNConnector::new(Network::Regtest, n_of_n_pubkey, amount);
 
     let deposit_request_connector = DepositRequestConnector::new(
@@ -197,7 +199,7 @@ pub(super) fn test_deposit_txn() -> DepositTx {
         n_of_n_pubkey,
         depositor_pubkey,
         timelock,
-        amount,
+        DepositTx::drt_required(amount),
     );
 
     DepositTx::new(data, deposit_connector, deposit_request_connector)

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -5,7 +5,7 @@
 use std::{fs, path::Path, str::FromStr};
 
 use bitcoin::{hex::DisplayHex, Amount, Network};
-use bitcoin_bosd::Descriptor;
+use bitcoin_bosd::{Descriptor, DescriptorType};
 use libp2p::identity::ed25519::PublicKey as Libp2pKey;
 use secp256k1::XOnlyPublicKey;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -188,10 +188,15 @@ where
             let p2p = Libp2pKey::try_from_bytes(&p2p)
                 .unwrap_or_else(|_| panic!("Failed to decode Libp2pKey at index {i}"));
 
-            let payout_descriptor = k
+            let payout_descriptor: Descriptor = k
                 .payout_descriptor
                 .parse()
                 .unwrap_or_else(|_| panic!("Failed to parse payout descriptor at index {i}"));
+            assert!(
+                payout_descriptor.type_tag() == DescriptorType::P2tr,
+                "payout descriptor at index {i} must be P2TR (fee constants assume \
+                 P2TR-sized operator/watchtower outputs)"
+            );
 
             CovenantKeys {
                 musig2,

--- a/crates/connectors/src/claim_contest.rs
+++ b/crates/connectors/src/claim_contest.rs
@@ -19,10 +19,14 @@ pub struct ClaimContestConnector {
     // invariant: watchtower_pubkeys.len() <= u32::MAX
     watchtower_pubkeys: Vec<XOnlyPublicKey>,
     contest_timelock: relative::Height,
+    surcharge: Amount,
 }
 
 impl ClaimContestConnector {
     /// Creates a new connector.
+    ///
+    /// `surcharge` is added on top of the base value to fund downstream presigned tx fees.
+    /// Pass `Amount::ZERO` if no fee is needed.
     ///
     /// # Panics
     ///
@@ -32,6 +36,7 @@ impl ClaimContestConnector {
         n_of_n_pubkey: XOnlyPublicKey,
         watchtower_pubkeys: Vec<XOnlyPublicKey>,
         contest_timelock: relative::Height,
+        surcharge: Amount,
     ) -> Self {
         assert!(
             watchtower_pubkeys.len() <= u32::MAX as usize,
@@ -43,6 +48,7 @@ impl ClaimContestConnector {
             n_of_n_pubkey,
             watchtower_pubkeys,
             contest_timelock,
+            surcharge,
         }
     }
 
@@ -93,8 +99,9 @@ impl Connector for ClaimContestConnector {
     fn value(&self) -> Amount {
         let minimal_non_dust = self.script_pubkey().minimal_non_dust();
         // NOTE: (@uncomputable) correctness is asserted in tx-graph crate:
-        // presigned transactions pay zero fees
+        // contest tx output sum + contest tx fee == claim_contest input value.
         minimal_non_dust * u64::from(CONTEST_WATCHTOWER_0_VOUT + self.n_watchtowers())
+            + self.surcharge
     }
 
     fn to_leaf_index(&self, spend_path: Self::SpendPath) -> Option<usize> {
@@ -217,6 +224,7 @@ mod tests {
                     .map(|key| key.x_only_public_key().0)
                     .collect(),
                 DELTA_CONTEST,
+                Amount::ZERO,
             )
         }
 

--- a/crates/connectors/src/contest_counterproof.rs
+++ b/crates/connectors/src/contest_counterproof.rs
@@ -23,6 +23,7 @@ pub struct ContestCounterproofOutput {
     n_of_n_pubkey: XOnlyPublicKey,
     operator_pubkey: XOnlyPublicKey,
     n_data: NonZero<usize>,
+    surcharge: Amount,
 }
 
 impl ContestCounterproofOutput {
@@ -32,18 +33,21 @@ impl ContestCounterproofOutput {
     /// that are exchanged. This does not include labels that have already been
     /// exchanged at setup time.
     ///
-    /// `n_data` is equal to the number of required operator signatures.
+    /// `surcharge` is added on top of the base value to fund downstream presigned tx fees.
+    /// Pass `Amount::ZERO` if no fee is needed.
     pub const fn new(
         network: Network,
         n_of_n_pubkey: XOnlyPublicKey,
         operator_pubkey: XOnlyPublicKey,
         n_data: NonZero<usize>,
+        surcharge: Amount,
     ) -> Self {
         Self {
             network,
             n_of_n_pubkey,
             operator_pubkey,
             n_data,
+            surcharge,
         }
     }
 
@@ -83,7 +87,7 @@ impl Connector for ContestCounterproofOutput {
     }
 
     fn value(&self) -> Amount {
-        self.script_pubkey().minimal_non_dust()
+        self.script_pubkey().minimal_non_dust() + self.surcharge
     }
 
     fn to_leaf_index(&self, _spend_path: Self::SpendPath) -> Option<usize> {
@@ -151,6 +155,7 @@ mod tests {
             n_of_n_keypair.x_only_public_key().0,
             operator_keypair.x_only_public_key().0,
             N_DATA,
+            Amount::ZERO,
         );
 
         // Create a transaction that funds the connector.

--- a/crates/connectors/src/test_utils.rs
+++ b/crates/connectors/src/test_utils.rs
@@ -307,40 +307,43 @@ impl BitcoinNode {
             .expect("should be able to extract the txid")
     }
 
-    /// Submits a package of transactions to the mempool,
-    /// asserting that the package is accepted.
+    /// Broadcasts the parent transaction, asserting it is accepted by the mempool.
     ///
     /// # Panics
     ///
-    /// This method panics if the package is not accepted by the mempool.
+    /// This method panics if the parent is not accepted by the mempool.
     pub fn submit_package(&self, transactions: &[Transaction; 2]) {
-        let result = self
-            .client()
-            .submit_package(transactions, None, None)
-            .expect("should be able to submit package");
-        if result.package_msg != "success" {
-            dbg!(result);
-            panic!("Package submission failed. Is the package invalid?");
+        let [parent, _child] = transactions;
+
+        // NOTE: (@Rajil1213) Broadcast both the parent and the child as a package once CPFP is
+        // properly implemented downstream and intrinsic fees are removed from the presigned parent
+        // transactions.
+        if let Err(parent_err) = self.client().send_raw_transaction(parent) {
+            panic!("Expected parent to be accepted by the mempool, but it was rejected: {parent_err:?}");
         }
-        assert!(
-            result.tx_results.len() == 2,
-            "tx_results should have 2 elements"
-        );
     }
 
-    /// Submits a package of transactions to the mempool,
-    /// asserting that the package is _not accepted_.
+    /// Asserts that neither the parent broadcast on its own nor the `[parent, child]`
+    /// package is accepted by the mempool.
     ///
     /// # Panics
     ///
-    /// This method panics if the package is _accepted_ by the mempool.
+    /// This method panics if either the standalone parent broadcast or the package
+    /// submission succeeds.
     pub fn submit_package_invalid(&self, transactions: &[Transaction; 2]) {
-        let result = self
+        let [parent, _child] = transactions;
+        let parent_result = self.client().send_raw_transaction(parent);
+        assert!(
+            parent_result.is_err(),
+            "expected parent broadcast to be rejected, but it was accepted: \
+             {parent_result:?}"
+        );
+        let package_result = self
             .client()
             .submit_package(transactions, None, None)
             .expect("should be able to submit package");
-        if result.package_msg == "success" {
-            dbg!(result);
+        if package_result.package_msg == "success" {
+            dbg!(package_result);
             panic!("Expected package submission to fail, but it succeeded.");
         }
     }

--- a/crates/connectors/src/timelocked.rs
+++ b/crates/connectors/src/timelocked.rs
@@ -171,6 +171,7 @@ impl ContestProofConnector {
         operator_pubkey: XOnlyPublicKey,
         game_index: NonZero<u32>,
         proof_timelock: relative::Height,
+        surcharge: Amount,
     ) -> Self {
         let operator_key_tweak = Self::operator_key_tweak(game_index);
         // This can only fail if the private key of operator_pubkey equals
@@ -188,7 +189,7 @@ impl ContestProofConnector {
             timelock: proof_timelock,
             value: Amount::ZERO,
         };
-        inner.value = inner.script_pubkey().minimal_non_dust();
+        inner.value = inner.script_pubkey().minimal_non_dust() + surcharge;
         Self(inner)
     }
 
@@ -276,6 +277,7 @@ impl CounterproofConnector {
         n_of_n_pubkey: XOnlyPublicKey,
         wt_i_fault_pubkey: XOnlyPublicKey,
         nack_timelock: relative::Height,
+        surcharge: Amount,
     ) -> Self {
         let mut inner = TimelockedConnector {
             network,
@@ -284,7 +286,7 @@ impl CounterproofConnector {
             timelock: nack_timelock,
             value: Amount::ZERO,
         };
-        inner.value = inner.script_pubkey().minimal_non_dust();
+        inner.value = inner.script_pubkey().minimal_non_dust() + surcharge;
         Self(inner)
     }
 }

--- a/crates/connectors/src/unstaking_intent.rs
+++ b/crates/connectors/src/unstaking_intent.rs
@@ -14,19 +14,25 @@ pub struct UnstakingIntentOutput {
     network: Network,
     n_of_n_pubkey: XOnlyPublicKey,
     unstaking_image: sha256::Hash,
+    surcharge: Amount,
 }
 
 impl UnstakingIntentOutput {
     /// Creates a new connector.
+    ///
+    /// `surcharge` is added on top of the base value to fund downstream presigned tx fees.
+    /// Pass `Amount::ZERO` if no fee is needed.
     pub const fn new(
         network: Network,
         n_of_n_pubkey: XOnlyPublicKey,
         unstaking_image: sha256::Hash,
+        surcharge: Amount,
     ) -> Self {
         Self {
             network,
             n_of_n_pubkey,
             unstaking_image,
+            surcharge,
         }
     }
 }
@@ -55,7 +61,7 @@ impl Connector for UnstakingIntentOutput {
     }
 
     fn value(&self) -> Amount {
-        self.script_pubkey().minimal_non_dust()
+        self.script_pubkey().minimal_non_dust() + self.surcharge
     }
 
     fn to_leaf_index(&self, _spend_path: Self::SpendPath) -> Option<usize> {
@@ -114,6 +120,7 @@ mod tests {
                 Network::Regtest,
                 self.n_of_n_keypair.x_only_public_key().0,
                 sha256::Hash::hash(&self.unstaking_preimage),
+                Amount::ZERO,
             )
         }
 

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -35,7 +35,7 @@ use strata_bridge_sm::{
     },
     tx_classifier::TxClassifier,
 };
-use strata_bridge_tx_graph::transactions::prelude::DepositData;
+use strata_bridge_tx_graph::transactions::{deposit::DepositTx, prelude::DepositData};
 use tracing::{Level, error, info, warn};
 
 use crate::{
@@ -180,6 +180,20 @@ fn try_register_deposit(
         error!("invalid DRT: expected spendable output at index 1, ignoring");
         return Ok(Vec::new());
     };
+
+    // The deposit-request UTXO must include the deposit amount plus the bridge's hardcoded
+    // deposit-tx fee — without that surplus the deposit transaction would have insufficient
+    // fee to relay.
+    let drt_required = DepositTx::drt_required(deposit_cfg.deposit_amount);
+    if deposit_request_output.value < drt_required {
+        error!(
+            drt_value = %deposit_request_output.value,
+            %drt_required,
+            "invalid DRT: spendable output value is less than deposit_amount + deposit_fee, ignoring"
+        );
+        return Ok(Vec::new());
+    }
+
     let deposit_request_outpoint = bitcoin::OutPoint::new(drt_txid, 1);
     let deposit_data = DepositData {
         deposit_idx: deposit_idx_offset,

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -4,9 +4,9 @@
 //! Setting [`FEE_RATE_SAT_PER_VB`] to `0` disables fees entirely (matches the original
 //! zero-fee behaviour) without removing any code.
 //!
-//! All vsize formulas are closed-form functions of the two graph parameters (`n_watchtowers`
-//! and `n_data`). Numbers are pinned by `tests::pin_*` unit tests that build the actual
-//! finalized transactions and assert that `vsize × FEE_RATE_SAT_PER_VB == fee`.
+//! Vsizes are closed-form functions of the two graph parameters (`n_watchtowers` and
+//! `n_data`). Numbers are pinned by `tests::pin_*` unit tests that build the actual finalized
+//! transactions and assert that `vsize × FEE_RATE_SAT_PER_VB == fee`.
 //!
 //! Each fee corresponds to a specific presigned transaction; see the comments below for
 //! which transaction each constant belongs to.
@@ -17,9 +17,21 @@
 //! - Operator/watchtower descriptors are P2TR in tests; production uses BOSD which resolves to
 //!   bech32 / P2TR scripts of similar size.
 
-use std::num::NonZero;
+use std::{num::NonZero, sync::LazyLock};
 
-use bitcoin::{Amount, FeeRate};
+use bitcoin::{
+    blockdata::constants::WITNESS_SCALE_FACTOR,
+    consensus::encode::VarInt,
+    key::TweakedPublicKey,
+    relative,
+    secp256k1::{Keypair, SecretKey, SECP256K1},
+    taproot::LeafVersion,
+    Amount, FeeRate, Network, ScriptBuf, TxOut, XOnlyPublicKey,
+};
+use strata_bridge_connectors::{
+    prelude::{ClaimContestConnector, ContestCounterproofOutput},
+    Connector,
+};
 
 /// Fee rate (sat/vb) that every presigned transaction pays.
 ///
@@ -29,12 +41,9 @@ use bitcoin::{Amount, FeeRate};
 ///
 /// Set back to `2` (or any positive value) to re-enable fees once CPFP needs them
 /// disabled again.
-pub const FEE_RATE_SAT_PER_VB: u64 = 2;
+pub(crate) const FEE_RATE_SAT_PER_VB: u64 = 2;
 
-/// [`FEE_RATE_SAT_PER_VB`] as a `FeeRate`, for use as a floor on wallet-built transactions
-/// (claim-funding refill, stake funding, withdrawal fulfillment) so that the bridge node
-/// never broadcasts a transaction below this rate even if `estimatesmartfee` returns
-/// something lower (or absent on networks without enough fee history, like signet).
+/// [`FEE_RATE_SAT_PER_VB`] as a [`FeeRate`].
 pub const FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(FEE_RATE_SAT_PER_VB);
 
 /// Multiplies a vsize (in vbytes) by [`FEE_RATE_SAT_PER_VB`] to produce a fee.
@@ -42,24 +51,46 @@ const fn fee_for_vsize(vsize: u64) -> Amount {
     Amount::from_sat(vsize.saturating_mul(FEE_RATE_SAT_PER_VB))
 }
 
+/// P2TR `script_pubkey` for use as a synthetic placeholder when querying rust-bitcoin for
+/// output-shape data (vbyte size, dust threshold). Tweaking the placeholder pubkey is
+/// unnecessary for shape-only queries, so [`TweakedPublicKey::dangerous_assume_tweaked`] is
+/// used directly.
+static PLACEHOLDER_P2TR_SCRIPT_PUBKEY: LazyLock<ScriptBuf> = LazyLock::new(|| {
+    ScriptBuf::new_p2tr_tweaked(TweakedPublicKey::dangerous_assume_tweaked(
+        placeholder_xonly(0),
+    ))
+});
+
 /// Value to put on every cpfp anchor output (`KeyedAnchor`/`MultiAnchor`).
 ///
 /// When [`FEE_RATE_SAT_PER_VB`] is `0`, returns `Amount::ZERO` — anchors stay at zero, matching
 /// the original zero-fee TRUC behaviour where bitcoin core's relay policy permits dust outputs
 /// only when the parent pays no fee.
 ///
-/// When [`FEE_RATE_SAT_PER_VB`] is non-zero, returns the P2TR `minimal_non_dust` threshold so
-/// the parent can pay a fee without bitcoin core rejecting it as `dust, tx with dust output
-/// must be 0-fee`. Bitcoin core's dust formula for a 34-byte P2TR script_pubkey at
-/// `DUST_RELAY_TX_FEE = 3000` is `(32 + 4 + 1 + 26 + 4 + 8 + 34) * 3 / 1 = 327` sat. We use
-/// `330` sat as a small margin.
-pub const fn anchor_dust_value() -> Amount {
+/// When [`FEE_RATE_SAT_PER_VB`] is non-zero, returns rust-bitcoin's `Script::minimal_non_dust`
+/// for a P2TR script_pubkey, the smallest amount bitcoin core's relay policy accepts on a tx
+/// that pays a fee.
+pub(crate) fn anchor_dust_value() -> Amount {
     if FEE_RATE_SAT_PER_VB == 0 {
         Amount::ZERO
     } else {
-        Amount::from_sat(330)
+        PLACEHOLDER_P2TR_SCRIPT_PUBKEY.minimal_non_dust()
     }
 }
+
+/// Vbytes contributed by a single P2TR output, from rust-bitcoin's `TxOut::size`.
+static P2TR_OUTPUT_VBYTES: LazyLock<u64> = LazyLock::new(|| {
+    TxOut {
+        value: Amount::ZERO,
+        script_pubkey: PLACEHOLDER_P2TR_SCRIPT_PUBKEY.clone(),
+    }
+    .size() as u64
+});
+
+/// Witness vbytes added per counterproof `n_data` byte (three extra script bytes
+/// weighing 3 wu + one extra schnorr signature in the witness weighing 65 wu = 68 wu /
+/// [`WITNESS_SCALE_FACTOR`] after amortising the steady-state varint encoding).
+const COUNTERPROOF_PER_DATA_BYTE_VBYTES: u64 = 17;
 
 // -------------------------------------------------------------------------------------------------
 // Per-tx vsize formulas. Hardcoded and pinned by unit tests below.
@@ -73,69 +104,105 @@ pub const fn anchor_dust_value() -> Amount {
 ///
 /// Structure: 1 wallet input (P2TR key path) + 3 P2TR outputs (claim_contest, claim_payout,
 /// anchor).
-const CLAIM_VSIZE: u64 = 154;
+const CLAIM_VSIZE: u64 = 197;
 
 /// Predicted vsize of [`crate::transactions::uncontested_payout::UncontestedPayoutTx`] in vbytes.
 ///
 /// Structure: 3 inputs (NOfN key path, ClaimContest uncontested script path, ClaimPayout key path)
 /// + 1 P2TR output.
-const UNCONTESTED_PAYOUT_VSIZE: u64 = 235;
+const UNCONTESTED_PAYOUT_VSIZE: u64 = 268;
 
-/// Base predicted vsize of [`crate::transactions::contest::ContestTx`].
-///
-/// Per-watchtower additional vsize is [`CONTEST_PER_WATCHTOWER_VSIZE`].
-const CONTEST_BASE_VSIZE: u64 = 226;
+/// Vsize of [`crate::transactions::contest::ContestTx`] excluding per-watchtower outputs and
+/// the variable taproot control block of the spent leaf. Empirically measured: header + 1
+/// input non-witness + 3 fixed P2TR dust outputs (proof, payout, slash) + 1 P2TR cpfp anchor
+/// + 2 schnorr signatures + leaf script in the witness.
+const CONTEST_FIXED_VBYTES: u64 = 273;
 
-/// Per-watchtower vsize contribution to [`crate::transactions::contest::ContestTx`].
+/// Predicted vsize of [`crate::transactions::contest::ContestTx`] in vbytes.
 ///
-/// Each watchtower adds 1 P2TR output (counterproof_x) of 43 non-witness bytes = 43 vbytes.
-const CONTEST_PER_WATCHTOWER_VSIZE: u64 = 43;
+/// Non-linear in `n_watchtowers` because the spent `ClaimContestConnector` leaf carries a
+/// taproot control block whose size depends on the leaf's position in the tap tree built by
+/// rust-bitcoin's `TaprootBuilder`. The control-block contribution is queried from the
+/// connector's `TaprootSpendInfo` rather than computed by hand.
+fn contest_vsize(n_watchtowers: u32) -> u64 {
+    let n = n_watchtowers as u64;
+    CONTEST_FIXED_VBYTES
+        + *P2TR_OUTPUT_VBYTES * n
+        + contest_input_control_block_vsize(n_watchtowers)
+}
 
 /// Predicted vsize of [`crate::transactions::bridge_proof_timeout::BridgeProofTimeoutTx`].
 ///
-/// Structure: 2 script-path inputs (ContestProof timeout, ContestPayout normal) + 1 P2TR output.
-/// MultiAnchor output's tap-tree depth scales with watchtower count, but its script_pubkey is
-/// always 34 bytes.
-const BRIDGE_PROOF_TIMEOUT_VSIZE: u64 = 197;
+/// Structure: 2 script-path inputs (ContestProof timeout, ContestPayout normal) + 1 P2TR
+/// output. MultiAnchor output's tap-tree depth scales with watchtower count, but its
+/// script_pubkey is always 34 bytes.
+const BRIDGE_PROOF_TIMEOUT_VSIZE: u64 = 187;
 
-/// Base predicted vsize of [`crate::transactions::counterproof::CounterproofTx`].
-///
-/// Per-`n_data`-byte additional vsize is [`COUNTERPROOF_PER_DATA_BYTE_VSIZE`].
-const COUNTERPROOF_BASE_VSIZE: u64 = 168;
+/// Vsize of [`crate::transactions::counterproof::CounterproofTx`] with `n_data = 0` and the
+/// 1-byte short witness-item length-prefix in effect. Empirically measured: header + 1 input
+/// non-witness + 1 counterproof-connector P2TR output + 1 cpfp anchor + the witness's n-of-n
+/// signature + script header + control block.
+const COUNTERPROOF_FIXED_VBYTES: u64 = 179;
 
-/// Per-`n_data`-byte vsize contribution to [`crate::transactions::counterproof::CounterproofTx`].
+/// Predicted vsize of [`crate::transactions::counterproof::CounterproofTx`] in vbytes.
 ///
-/// Each `n_data` byte adds one OP_TUCK + OP_CHECKSIGVERIFY + OP_CODESEPARATOR triple (~3 bytes
-/// in script) plus one 64-byte schnorr signature in the witness. Witness bytes contribute
-/// 1 wu each → 1/4 vbyte each. Script bytes contribute 4 wu each → 1 vbyte each.
-const COUNTERPROOF_PER_DATA_BYTE_VSIZE: u64 = 19;
+/// Each `n_data` byte adds one `OP_TUCK + OP_CHECKSIGVERIFY + OP_CODESEPARATOR` triple to the
+/// counterproof leaf script and one 64-byte schnorr operator signature to the witness, for a
+/// measured [`COUNTERPROOF_PER_DATA_BYTE_VBYTES`] vbytes per byte. [`COUNTERPROOF_FIXED_VBYTES`]
+/// assumes the witness-item varint length-prefix for the leaf script is one byte; once the
+/// script crosses the boundary where rust-bitcoin's [`VarInt::size`] grows, the extra prefix
+/// bytes are added back in.
+fn counterproof_vsize(n_data: NonZero<usize>) -> u64 {
+    let n = n_data.get() as u64;
+    let connector = ContestCounterproofOutput::new(
+        Network::Regtest,
+        placeholder_xonly(0),
+        placeholder_xonly(1),
+        n_data,
+        Amount::ZERO,
+    );
+    let leaf_script = connector
+        .leaf_scripts()
+        .into_iter()
+        .next()
+        .expect("ContestCounterproofOutput has a single leaf script");
+    let script_prefix_bytes = VarInt::from(leaf_script.len()).size() as u64;
+    let prefix_extra_wu = script_prefix_bytes - 1;
+    COUNTERPROOF_FIXED_VBYTES
+        + COUNTERPROOF_PER_DATA_BYTE_VBYTES * n
+        + prefix_extra_wu.div_ceil(WITNESS_SCALE_FACTOR as u64)
+}
 
 /// Predicted vsize of [`crate::transactions::counterproof_ack::CounterproofAckTx`].
 ///
 /// Structure: 2 inputs (Counterproof timeout script path, ContestPayout normal key path)
 /// + 1 P2TR output (cpfp anchor).
-const COUNTERPROOF_ACK_VSIZE: u64 = 197;
+const COUNTERPROOF_ACK_VSIZE: u64 = 187;
 
 /// Predicted vsize of [`crate::transactions::contested_payout::ContestedPayoutTx`].
 ///
 /// Structure: 4 inputs (deposit NOfN key, claim_payout key, contest_payout timeout script,
 /// contest_slash normal key) + 1 P2TR output.
-const CONTESTED_PAYOUT_VSIZE: u64 = 313;
+const CONTESTED_PAYOUT_VSIZE: u64 = 302;
 
-/// Base predicted vsize of [`crate::transactions::slash::SlashTx`].
+/// Vsize of [`crate::transactions::slash::SlashTx`] excluding per-watchtower outputs.
+/// Empirically measured: header + 2 inputs (contest_slash timeout script-path + stake N/N
+/// key-path) + 1 SPS-50 OP_RETURN header output + the witness's signature + script + control
+/// block for the timeout-spend leaf.
+const SLASH_FIXED_VBYTES: u64 = 165;
+
+/// Predicted vsize of [`crate::transactions::slash::SlashTx`] in vbytes.
 ///
-/// Structure: 2 inputs (contest_slash timeout script, stake NOfN key) +
-/// SPS-50 header output + N watchtower outputs.
-/// Per-watchtower additional vsize is [`SLASH_PER_WATCHTOWER_VSIZE`].
-const SLASH_BASE_VSIZE: u64 = 195;
-
-/// Per-watchtower vsize contribution to [`crate::transactions::slash::SlashTx`].
-const SLASH_PER_WATCHTOWER_VSIZE: u64 = 43;
+/// Linear in `n_watchtowers`: the spent `ContestSlashConnector` has a single-leaf tap tree
+/// (no control-block growth), and each watchtower adds one P2TR output.
+fn slash_vsize(n_watchtowers: u32) -> u64 {
+    SLASH_FIXED_VBYTES + *P2TR_OUTPUT_VBYTES * n_watchtowers as u64
+}
 
 /// Predicted vsize of [`crate::transactions::stake::StakeTx`].
 ///
 /// Structure: 1 wallet input (P2TR key path) + 3 P2TR outputs.
-const STAKE_VSIZE: u64 = 154;
+const STAKE_VSIZE: u64 = 197;
 
 /// Predicted vsize of [`crate::transactions::unstaking_intent::UnstakingIntentTx`].
 ///
@@ -146,103 +213,152 @@ const UNSTAKING_INTENT_VSIZE: u64 = 211;
 /// Predicted vsize of [`crate::transactions::unstaking::UnstakingTx`].
 ///
 /// Structure: 2 inputs (UnstakingOutput timeout script, stake NOfN key) + 1 P2TR output.
-const UNSTAKING_VSIZE: u64 = 197;
+const UNSTAKING_VSIZE: u64 = 187;
 
 /// Predicted vsize of [`crate::transactions::deposit::DepositTx`].
 ///
 /// Structure: 1 input (DepositRequestConnector key path) + 2 outputs (SPS-50 OP_RETURN + N/N
 /// P2TR).
-const DEPOSIT_VSIZE: u64 = 158;
+const DEPOSIT_VSIZE: u64 = 132;
 
 /// Predicted vsize of [`crate::transactions::cooperative_payout::CooperativePayoutTx`].
 ///
 /// Structure: 1 input (deposit NOfN key path) + 1 P2TR operator output.
-const COOPERATIVE_PAYOUT_VSIZE: u64 = 130;
+const COOPERATIVE_PAYOUT_VSIZE: u64 = 111;
 
-/// Predicted vsize of [`crate::transactions::not_presigned::CounterproofNackTx`] in production,
-/// where the operator does **not** add a funding input — the fee is taken out of the
-/// `CounterproofConnector`'s pre-inflated value (its surcharge equals
-/// [`counterproof_ack_fee`], which is larger than this nack fee, so the math works out).
+/// Predicted vsize of [`crate::transactions::not_presigned::CounterproofNackTx`].
 ///
-/// Structure: 1 input (CounterproofConnector script-path) + 1 P2TR operator output.
-const COUNTERPROOF_NACK_VSIZE: u64 = 130;
+/// Structure: 1 input (CounterproofConnector script-path) + 1 P2TR output.
+const COUNTERPROOF_NACK_VSIZE: u64 = 111;
+
+/// Deterministic x-only pubkey for the given seed. The tap tree's merkle structure is
+/// determined by the leaves' `TapLeafHash`es, so distinct watchtower pubkeys are required to
+/// reproduce the production tree shape — duplicate scripts would coalesce in the lookup.
+fn placeholder_xonly(seed: u32) -> XOnlyPublicKey {
+    let mut bytes = [1u8; 32];
+    bytes[0..4].copy_from_slice(&seed.wrapping_add(1).to_le_bytes());
+    let sk = SecretKey::from_slice(&bytes).expect("non-zero 32-byte slice is a valid secret key");
+    Keypair::from_secret_key(SECP256K1, &sk)
+        .x_only_public_key()
+        .0
+}
+
+/// Witness vsize contribution of the largest contested-leaf control block of a
+/// `ClaimContestConnector` with the given watchtower count.
+///
+/// For non-power-of-two leaf counts, rust-bitcoin's `TaprootBuilder` places some leaves at a
+/// shallower depth than others. Since `ContestTx` is built once with a single fee but
+/// `ContestTx::finalize` accepts any watchtower index, the watchtower with the deepest leaf
+/// drives the tx's largest possible vsize — picking that leaf here keeps the tx at or above
+/// 2 sat/vb regardless of which watchtower contests (shallower-leaf contests will overpay
+/// slightly, which is conservative for relay).
+///
+/// # Panics
+///
+/// Panics if `n_watchtowers == 0`, since `ContestTx` is only constructed for graphs with at
+/// least one watchtower.
+fn contest_input_control_block_vsize(n_watchtowers: u32) -> u64 {
+    assert!(
+        n_watchtowers >= 1,
+        "contest tx requires at least one watchtower"
+    );
+    let watchtower_pubkeys = (0..n_watchtowers).map(placeholder_xonly).collect();
+    let connector = ClaimContestConnector::new(
+        Network::Regtest,
+        placeholder_xonly(u32::MAX),
+        watchtower_pubkeys,
+        relative::Height::from_height(1),
+        Amount::ZERO,
+    );
+    let spend_info = connector.spend_info();
+    let mut leaf_scripts = connector.leaf_scripts();
+    // Drop the trailing uncontested-payout leaf — `ContestTx` only spends contested leaves.
+    leaf_scripts.truncate(n_watchtowers as usize);
+    let max_control_block_bytes = leaf_scripts
+        .into_iter()
+        .map(|leaf| {
+            spend_info
+                .control_block(&(leaf, LeafVersion::TapScript))
+                .expect("contested leaf was just included in the tap tree")
+                .serialize()
+                .len() as u64
+        })
+        .max()
+        .expect("n_watchtowers >= 1 so at least one contested leaf exists");
+    let prefix_bytes = VarInt::from(max_control_block_bytes).size() as u64;
+    (prefix_bytes + max_control_block_bytes).div_ceil(WITNESS_SCALE_FACTOR as u64)
+}
 
 // -------------------------------------------------------------------------------------------------
 // Per-tx fees. Each is `vsize × FEE_RATE_SAT_PER_VB`.
 // -------------------------------------------------------------------------------------------------
 
 /// Fee for [`crate::transactions::claim::ClaimTx`].
-pub const fn claim_fee() -> Amount {
+pub(crate) const fn claim_fee() -> Amount {
     fee_for_vsize(CLAIM_VSIZE)
 }
 
 /// Fee for [`crate::transactions::uncontested_payout::UncontestedPayoutTx`].
-pub const fn uncontested_payout_fee() -> Amount {
+pub(crate) const fn uncontested_payout_fee() -> Amount {
     fee_for_vsize(UNCONTESTED_PAYOUT_VSIZE)
 }
 
 /// Fee for [`crate::transactions::contest::ContestTx`].
-pub const fn contest_fee(n_watchtowers: u32) -> Amount {
-    fee_for_vsize(CONTEST_BASE_VSIZE + (n_watchtowers as u64) * CONTEST_PER_WATCHTOWER_VSIZE)
+pub(crate) fn contest_fee(n_watchtowers: u32) -> Amount {
+    fee_for_vsize(contest_vsize(n_watchtowers))
 }
 
 /// Fee for [`crate::transactions::bridge_proof_timeout::BridgeProofTimeoutTx`].
-pub const fn bridge_proof_timeout_fee() -> Amount {
+pub(crate) const fn bridge_proof_timeout_fee() -> Amount {
     fee_for_vsize(BRIDGE_PROOF_TIMEOUT_VSIZE)
 }
 
 /// Fee for [`crate::transactions::counterproof::CounterproofTx`].
-pub const fn counterproof_fee(n_data: NonZero<usize>) -> Amount {
-    fee_for_vsize(
-        COUNTERPROOF_BASE_VSIZE + (n_data.get() as u64) * COUNTERPROOF_PER_DATA_BYTE_VSIZE,
-    )
+pub(crate) fn counterproof_fee(n_data: NonZero<usize>) -> Amount {
+    fee_for_vsize(counterproof_vsize(n_data))
 }
 
 /// Fee for [`crate::transactions::counterproof_ack::CounterproofAckTx`].
-pub const fn counterproof_ack_fee() -> Amount {
+pub(crate) const fn counterproof_ack_fee() -> Amount {
     fee_for_vsize(COUNTERPROOF_ACK_VSIZE)
 }
 
 /// Fee for [`crate::transactions::contested_payout::ContestedPayoutTx`].
-pub const fn contested_payout_fee() -> Amount {
+pub(crate) const fn contested_payout_fee() -> Amount {
     fee_for_vsize(CONTESTED_PAYOUT_VSIZE)
 }
 
 /// Fee for [`crate::transactions::slash::SlashTx`].
-pub const fn slash_fee(n_watchtowers: u32) -> Amount {
-    fee_for_vsize(SLASH_BASE_VSIZE + (n_watchtowers as u64) * SLASH_PER_WATCHTOWER_VSIZE)
+pub(crate) fn slash_fee(n_watchtowers: u32) -> Amount {
+    fee_for_vsize(slash_vsize(n_watchtowers))
 }
 
 /// Fee for [`crate::transactions::stake::StakeTx`].
-pub const fn stake_fee() -> Amount {
+pub(crate) const fn stake_fee() -> Amount {
     fee_for_vsize(STAKE_VSIZE)
 }
 
 /// Fee for [`crate::transactions::unstaking_intent::UnstakingIntentTx`].
-pub const fn unstaking_intent_fee() -> Amount {
+pub(crate) const fn unstaking_intent_fee() -> Amount {
     fee_for_vsize(UNSTAKING_INTENT_VSIZE)
 }
 
 /// Fee for [`crate::transactions::unstaking::UnstakingTx`].
-pub const fn unstaking_fee() -> Amount {
+pub(crate) const fn unstaking_fee() -> Amount {
     fee_for_vsize(UNSTAKING_VSIZE)
 }
 
 /// Fee for [`crate::transactions::deposit::DepositTx`].
-///
-/// The fee comes from the depositor's deposit-request UTXO carrying
-/// `deposit_amount + deposit_fee()`; the bridge cannot inject extra value into the deposit tx.
-pub const fn deposit_fee() -> Amount {
+pub(crate) const fn deposit_fee() -> Amount {
     fee_for_vsize(DEPOSIT_VSIZE)
 }
 
 /// Fee for [`crate::transactions::cooperative_payout::CooperativePayoutTx`].
-pub const fn cooperative_payout_fee() -> Amount {
+pub(crate) const fn cooperative_payout_fee() -> Amount {
     fee_for_vsize(COOPERATIVE_PAYOUT_VSIZE)
 }
 
-/// Fee for the [`crate::transactions::not_presigned::CounterproofNackTx`] as broadcast in
-/// production with a single wallet P2TR funding input and a single wallet P2TR output.
+/// Fee for [`crate::transactions::not_presigned::CounterproofNackTx`].
 pub const fn counterproof_nack_fee() -> Amount {
     fee_for_vsize(COUNTERPROOF_NACK_VSIZE)
 }
@@ -255,20 +371,20 @@ pub const fn counterproof_nack_fee() -> Amount {
 
 /// Surcharge for `CounterproofConnector`. Funds the [`counterproof_ack_fee`] of
 /// [`crate::transactions::counterproof_ack::CounterproofAckTx`].
-pub const fn counterproof_surcharge() -> Amount {
+pub(crate) const fn counterproof_surcharge() -> Amount {
     counterproof_ack_fee()
 }
 
 /// Surcharge for `ContestProofConnector`. Funds the [`bridge_proof_timeout_fee`] of
 /// [`crate::transactions::bridge_proof_timeout::BridgeProofTimeoutTx`].
-pub const fn contest_proof_surcharge() -> Amount {
+pub(crate) const fn contest_proof_surcharge() -> Amount {
     bridge_proof_timeout_fee()
 }
 
 /// Surcharge for `ContestCounterproofOutput`. Funds the [`counterproof_fee`] of
 /// [`crate::transactions::counterproof::CounterproofTx`], the cpfp anchor dust on that tx,
 /// plus the inflation that `CounterproofConnector` carries (= [`counterproof_ack_fee`]).
-pub fn contest_counterproof_surcharge(n_data: NonZero<usize>) -> Amount {
+pub(crate) fn contest_counterproof_surcharge(n_data: NonZero<usize>) -> Amount {
     counterproof_fee(n_data) + counterproof_ack_fee() + anchor_dust_value()
 }
 
@@ -287,4 +403,442 @@ pub fn claim_contest_surcharge(n_watchtowers: u32, n_data: NonZero<usize>) -> Am
 /// [`crate::transactions::unstaking_intent::UnstakingIntentTx`] plus that tx's cpfp anchor dust.
 pub fn unstaking_intent_surcharge() -> Amount {
     unstaking_intent_fee() + anchor_dust_value()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pinning tests that build each presigned transaction with dummy signatures of the
+    //! correct size, measure the actual finalized `vsize`, and assert it matches the
+    //! hardcoded `*_VSIZE` constants above. If any connector's witness composition drifts
+    //! (e.g., a leaf script gains an opcode), one of these tests will fail loudly rather
+    //! than the bridge silently broadcasting an underpaying transaction in production.
+    use std::num::NonZero;
+
+    use bitcoin::{
+        hashes::{sha256, Hash},
+        relative,
+        secp256k1::{rand::random, schnorr, Keypair},
+        Amount, Network, OutPoint, Transaction, TxOut, Witness,
+    };
+    use bitcoin_bosd::Descriptor;
+    use strata_bridge_connectors::prelude::{
+        ContestCounterproofWitness, DepositRequestConnector, NOfNConnector, UnstakingIntentWitness,
+    };
+    use strata_bridge_test_utils::prelude::generate_keypair;
+
+    use super::*;
+    use crate::{
+        game_graph::{DepositParams, GameData, GameGraph, KeyData, ProtocolParams, SetupParams},
+        stake_graph::{
+            ProtocolParams as StakeProtocolParams, SetupParams as StakeSetupParams, StakeData,
+            StakeGraph,
+        },
+        transactions::prelude::{
+            CooperativePayoutData, CooperativePayoutTx, CounterproofNackData, CounterproofNackTx,
+            DepositData, DepositTx,
+        },
+    };
+
+    const N_WATCHTOWERS: usize = 10;
+    const N_DATA: NonZero<usize> = NonZero::new(132).unwrap();
+    const DEPOSIT_AMOUNT: Amount = Amount::from_int_btc(10);
+    /// Picked so the per-watchtower stake (`STAKE_AMOUNT / n_watchtowers`) is an integer for
+    /// every `n_watchtowers` exercised by the per-`n` `pin_slash_vsize_at_*` tests, since
+    /// `SlashTx::new` asserts `STAKE_AMOUNT.to_sat() % n_watchtowers == 0`.
+    /// `2520` = LCM(1..=10).
+    const STAKE_AMOUNT: Amount = Amount::from_sat(2_520_000_000);
+
+    /// Returns a 64-byte schnorr signature of the right size. The bytes are arbitrary —
+    /// signature verification isn't performed; only the on-the-wire size matters for
+    /// vsize measurement.
+    fn dummy_sig() -> schnorr::Signature {
+        schnorr::Signature::from_slice(&[0xAA; 64]).expect("64 bytes is a valid sig length")
+    }
+
+    /// P2TR-keyspend witness (single 64-byte schnorr signature) for wallet-funded inputs.
+    fn dummy_p2tr_keyspend_witness() -> Witness {
+        let mut w = Witness::new();
+        w.push(dummy_sig().serialize());
+        w
+    }
+
+    /// A bag of dummy keys and a preimage covering every signing role in the graph.
+    struct TestSigner {
+        n_of_n: Keypair,
+        operator: Keypair,
+        admin: Keypair,
+        unstaking_preimage: [u8; 32],
+        watchtowers: Vec<Keypair>,
+        wt_faults: Vec<Keypair>,
+    }
+
+    impl TestSigner {
+        fn generate(n_watchtowers: usize) -> Self {
+            Self {
+                n_of_n: generate_keypair(),
+                operator: generate_keypair(),
+                admin: generate_keypair(),
+                unstaking_preimage: random(),
+                watchtowers: (0..n_watchtowers).map(|_| generate_keypair()).collect(),
+                wt_faults: (0..n_watchtowers).map(|_| generate_keypair()).collect(),
+            }
+        }
+    }
+
+    /// Builds a `GameData` for a graph with `n_watchtowers` watchtowers and `n_data`-byte
+    /// counterproofs, with arbitrary (non-on-chain) outpoints.
+    fn test_game_data(signer: &TestSigner, n_watchtowers: u32, n_data: NonZero<usize>) -> GameData {
+        let operator_xonly = signer.operator.x_only_public_key().0;
+        let payout_descriptor = Descriptor::new_p2tr(&operator_xonly.serialize())
+            .expect("32-byte x-only key is a valid p2tr payload");
+
+        let protocol = ProtocolParams {
+            network: Network::Regtest,
+            magic_bytes: (*b"ALPN").into(),
+            contest_timelock: relative::Height::from_height(10),
+            proof_timelock: relative::Height::from_height(5),
+            ack_timelock: relative::Height::from_height(10),
+            nack_timelock: relative::Height::from_height(5),
+            contested_payout_timelock: relative::Height::from_height(15),
+            counterproof_n_data: n_data,
+            deposit_amount: DEPOSIT_AMOUNT,
+            stake_amount: STAKE_AMOUNT,
+        };
+        let n_wt = n_watchtowers as usize;
+        let keys = KeyData {
+            n_of_n_pubkey: signer.n_of_n.x_only_public_key().0,
+            operator_pubkey: operator_xonly,
+            operator_adaptor_pubkeys: vec![operator_xonly; n_wt],
+            watchtower_pubkeys: signer
+                .watchtowers
+                .iter()
+                .take(n_wt)
+                .map(|k| k.x_only_public_key().0)
+                .collect(),
+            admin_pubkey: signer.admin.x_only_public_key().0,
+            unstaking_image: sha256::Hash::hash(&signer.unstaking_preimage),
+            wt_fault_pubkeys: signer
+                .wt_faults
+                .iter()
+                .take(n_wt)
+                .map(|k| k.x_only_public_key().0)
+                .collect(),
+            operator_descriptor: payout_descriptor.clone(),
+            slash_watchtower_descriptors: vec![payout_descriptor; n_wt],
+        };
+        let setup = SetupParams {
+            operator_index: 0,
+            stake_outpoint: OutPoint::null(),
+            keys,
+        };
+        GameData {
+            protocol,
+            setup: setup.clone(),
+            deposit: DepositParams {
+                game_index: NonZero::new(1).unwrap(),
+                claim_funds: OutPoint::null(),
+                deposit_outpoint: OutPoint::null(),
+                adaptor_pubkeys: setup.keys.operator_adaptor_pubkeys.clone(),
+                fault_pubkeys: setup.keys.wt_fault_pubkeys.clone(),
+            },
+        }
+    }
+
+    fn test_stake_data(signer: &TestSigner) -> StakeData {
+        let operator_xonly = signer.operator.x_only_public_key().0;
+        StakeData {
+            protocol: StakeProtocolParams {
+                network: Network::Regtest,
+                magic_bytes: (*b"ALPN").into(),
+                unstaking_timelock: relative::Height::from_height(10),
+                stake_amount: STAKE_AMOUNT,
+            },
+            setup: StakeSetupParams {
+                operator_index: 0,
+                operator_pubkey: operator_xonly,
+                n_of_n_pubkey: signer.n_of_n.x_only_public_key().0,
+                unstaking_image: sha256::Hash::hash(&signer.unstaking_preimage),
+                unstaking_operator_descriptor: Descriptor::new_p2tr(&operator_xonly.serialize())
+                    .unwrap(),
+                stake_funds: OutPoint::null(),
+            },
+        }
+    }
+
+    /// Replaces every input's witness with a P2TR key-path schnorr signature and returns
+    /// the finalized-vsize of the tx.
+    fn vsize_with_keyspend_witnesses(mut tx: Transaction) -> u64 {
+        for input in &mut tx.input {
+            input.witness = dummy_p2tr_keyspend_witness();
+        }
+        tx.weight().to_vbytes_ceil()
+    }
+
+    fn pin(actual_vsize: u64, predicted_vsize: u64, label: &str) {
+        assert_eq!(
+            actual_vsize, predicted_vsize,
+            "{label}: actual vsize {actual_vsize} differs from predicted {predicted_vsize}; \
+             update the constant in fee.rs to match the new connector witness shape"
+        );
+    }
+
+    #[test]
+    fn pin_claim_vsize() {
+        // ClaimTx is funded by an external wallet (P2TR key-path). Attach a 64-byte
+        // schnorr witness to the single input and measure.
+        let signer = TestSigner::generate(N_WATCHTOWERS);
+        let game = test_game_data(&signer, N_WATCHTOWERS as u32, N_DATA);
+        let (graph, _) = GameGraph::new(game);
+        let tx = graph.claim.as_ref().clone();
+        pin(vsize_with_keyspend_witnesses(tx), CLAIM_VSIZE, "claim");
+    }
+
+    #[test]
+    fn pin_uncontested_payout_vsize() {
+        let signer = TestSigner::generate(N_WATCHTOWERS);
+        let (graph, _) = GameGraph::new(test_game_data(&signer, N_WATCHTOWERS as u32, N_DATA));
+        let signed = graph
+            .uncontested_payout
+            .finalize([dummy_sig(), dummy_sig(), dummy_sig()]);
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            UNCONTESTED_PAYOUT_VSIZE,
+            "uncontested_payout",
+        );
+    }
+
+    // Includes the boundary points where rust-bitcoin's `TaprootBuilder` shifts the contested
+    // leaf to a deeper merkle path (n=1→2, n=3→4, n=5→8) so a drift at any depth step is caught.
+    // Iterates every watchtower index because for non-power-of-two leaf counts some leaves are
+    // shallower than others; `contest_vsize` is conservative (sized for the deepest leaf) so the
+    // measured vsize for any index must be ≤ predicted.
+    #[test]
+    fn pin_contest_vsize() {
+        for n_watchtowers in [1u32, 2, 3, 4, 5, 8, 10] {
+            let signer = TestSigner::generate(n_watchtowers as usize);
+            let (graph, _) = GameGraph::new(test_game_data(&signer, n_watchtowers, N_DATA));
+            let predicted = contest_vsize(n_watchtowers);
+            for watchtower_index in 0..n_watchtowers {
+                let signed =
+                    graph
+                        .contest
+                        .clone()
+                        .finalize(dummy_sig(), watchtower_index, dummy_sig());
+                let actual = signed.weight().to_vbytes_ceil();
+                assert!(
+                    actual <= predicted,
+                    "contest(n_watchtowers={n_watchtowers}, watchtower_index={watchtower_index}): \
+                     actual vsize {actual} exceeds predicted {predicted}"
+                );
+            }
+            // The deepest leaf should match exactly — at least one watchtower must hit it.
+            let deepest = (0..n_watchtowers)
+                .map(|i| {
+                    graph
+                        .contest
+                        .clone()
+                        .finalize(dummy_sig(), i, dummy_sig())
+                        .weight()
+                        .to_vbytes_ceil()
+                })
+                .max()
+                .expect("at least one watchtower");
+            pin(
+                deepest,
+                predicted,
+                &format!("contest(n_watchtowers={n_watchtowers}, deepest)"),
+            );
+        }
+    }
+
+    #[test]
+    fn pin_bridge_proof_timeout_vsize() {
+        let signer = TestSigner::generate(N_WATCHTOWERS);
+        let (graph, _) = GameGraph::new(test_game_data(&signer, N_WATCHTOWERS as u32, N_DATA));
+        let signed = graph
+            .bridge_proof_timeout
+            .finalize([dummy_sig(), dummy_sig()]);
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            BRIDGE_PROOF_TIMEOUT_VSIZE,
+            "bridge_proof_timeout",
+        );
+    }
+
+    // Includes the boundary point where the counterproof leaf script crosses 252 bytes (at
+    // `n_data = 63`) and the witness-item length-prefix grows from 1 byte to 3 bytes, so
+    // drifts at the boundary are caught separately from drifts in the per-byte slope. The
+    // last value is the production size (groth16 proof bytes + 4-byte deposit_idx).
+    #[test]
+    fn pin_counterproof_vsize() {
+        for n_data in [1, 62, 63, 64, N_DATA.get()] {
+            let n_data = NonZero::new(n_data).unwrap();
+            let signer = TestSigner::generate(N_WATCHTOWERS);
+            let (graph, _) = GameGraph::new(test_game_data(&signer, N_WATCHTOWERS as u32, n_data));
+            let cf = graph.counterproofs[0].counterproof.clone();
+            let witness = ContestCounterproofWitness {
+                n_of_n_signature: dummy_sig(),
+                operator_signatures: vec![dummy_sig(); n_data.get()],
+            };
+            let signed = cf.finalize(&witness);
+            pin(
+                signed.weight().to_vbytes_ceil(),
+                counterproof_vsize(n_data),
+                &format!("counterproof(n_data={})", n_data.get()),
+            );
+        }
+    }
+
+    #[test]
+    fn pin_counterproof_ack_vsize() {
+        let signer = TestSigner::generate(N_WATCHTOWERS);
+        let (graph, _) = GameGraph::new(test_game_data(&signer, N_WATCHTOWERS as u32, N_DATA));
+        let signed = graph.counterproofs[0]
+            .counterproof_ack
+            .clone()
+            .finalize([dummy_sig(), dummy_sig()]);
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            COUNTERPROOF_ACK_VSIZE,
+            "counterproof_ack",
+        );
+    }
+
+    #[test]
+    fn pin_contested_payout_vsize() {
+        let signer = TestSigner::generate(N_WATCHTOWERS);
+        let (graph, _) = GameGraph::new(test_game_data(&signer, N_WATCHTOWERS as u32, N_DATA));
+        let signed =
+            graph
+                .contested_payout
+                .finalize([dummy_sig(), dummy_sig(), dummy_sig(), dummy_sig()]);
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            CONTESTED_PAYOUT_VSIZE,
+            "contested_payout",
+        );
+    }
+
+    // Slash is linear in watchtower count (no taproot tree growth in the spent leaf), so a
+    // few representative values are sufficient.
+    #[test]
+    fn pin_slash_vsize() {
+        for n_watchtowers in [1u32, 5, 10] {
+            let signer = TestSigner::generate(n_watchtowers as usize);
+            let (graph, _) = GameGraph::new(test_game_data(&signer, n_watchtowers, N_DATA));
+            let signed = graph.slash.finalize([dummy_sig(), dummy_sig()]);
+            pin(
+                signed.weight().to_vbytes_ceil(),
+                slash_vsize(n_watchtowers),
+                &format!("slash(n_watchtowers={n_watchtowers})"),
+            );
+        }
+    }
+
+    #[test]
+    fn pin_stake_vsize() {
+        let signer = TestSigner::generate(0);
+        let graph = StakeGraph::new(test_stake_data(&signer));
+        let tx = graph.stake.as_ref().clone();
+        pin(vsize_with_keyspend_witnesses(tx), STAKE_VSIZE, "stake");
+    }
+
+    #[test]
+    fn pin_unstaking_intent_vsize() {
+        let signer = TestSigner::generate(0);
+        let graph = StakeGraph::new(test_stake_data(&signer));
+        let signed = graph.unstaking_intent.finalize(&UnstakingIntentWitness {
+            n_of_n_signature: dummy_sig(),
+            unstaking_preimage: signer.unstaking_preimage,
+        });
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            UNSTAKING_INTENT_VSIZE,
+            "unstaking_intent",
+        );
+    }
+
+    #[test]
+    fn pin_unstaking_vsize() {
+        let signer = TestSigner::generate(0);
+        let graph = StakeGraph::new(test_stake_data(&signer));
+        let signed = graph.unstaking.finalize([dummy_sig(), dummy_sig()]);
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            UNSTAKING_VSIZE,
+            "unstaking",
+        );
+    }
+
+    #[test]
+    fn pin_deposit_vsize() {
+        // The DepositTx has 1 timelocked-key-path input and an OP_RETURN + N/N P2TR output.
+        let signer = TestSigner::generate(0);
+        let n_of_n = signer.n_of_n.x_only_public_key().0;
+        let depositor = signer.operator.x_only_public_key().0;
+        let deposit_request = DepositRequestConnector::new(
+            Network::Regtest,
+            n_of_n,
+            depositor,
+            relative::Height::from_height(1_008),
+            DepositTx::drt_required(DEPOSIT_AMOUNT),
+        );
+        let deposit_connector = NOfNConnector::new(Network::Regtest, n_of_n, DEPOSIT_AMOUNT);
+        let data = DepositData {
+            deposit_idx: 0,
+            deposit_request_outpoint: OutPoint::null(),
+            magic_bytes: (*b"ALPN").into(),
+        };
+        let signed = DepositTx::new(data, deposit_connector, deposit_request).finalize(dummy_sig());
+        pin(signed.weight().to_vbytes_ceil(), DEPOSIT_VSIZE, "deposit");
+    }
+
+    #[test]
+    fn pin_cooperative_payout_vsize() {
+        let signer = TestSigner::generate(0);
+        let n_of_n = signer.n_of_n.x_only_public_key().0;
+        let operator_xonly = signer.operator.x_only_public_key().0;
+        let descriptor = Descriptor::new_p2tr(&operator_xonly.serialize()).unwrap();
+        let deposit_connector = NOfNConnector::new(Network::Regtest, n_of_n, DEPOSIT_AMOUNT);
+        let signed = CooperativePayoutTx::new(
+            CooperativePayoutData {
+                deposit_outpoint: OutPoint::null(),
+            },
+            deposit_connector,
+            descriptor,
+        )
+        .finalize(dummy_sig());
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            COOPERATIVE_PAYOUT_VSIZE,
+            "cooperative_payout",
+        );
+    }
+
+    #[test]
+    fn pin_counterproof_nack_vsize() {
+        // In production, CounterproofNackTx has just the connector input and a single
+        // P2TR operator-wallet output (no wallet-funded extra input). Build that shape.
+        let signer = TestSigner::generate(N_WATCHTOWERS);
+        let (graph, connectors) =
+            GameGraph::new(test_game_data(&signer, N_WATCHTOWERS as u32, N_DATA));
+        let mut nack = CounterproofNackTx::new(
+            CounterproofNackData {
+                counterproof_txid: graph.counterproofs[0].counterproof.as_ref().compute_txid(),
+            },
+            connectors.counterproof[0],
+        );
+        let operator_descriptor =
+            Descriptor::new_p2tr(&signer.operator.x_only_public_key().0.serialize()).unwrap();
+        nack.push_output(TxOut {
+            value: nack.prevouts()[0].value - counterproof_nack_fee(),
+            script_pubkey: operator_descriptor.to_script(),
+        });
+        let signed = nack.finalize_partial(dummy_sig());
+        pin(
+            signed.weight().to_vbytes_ceil(),
+            COUNTERPROOF_NACK_VSIZE,
+            "counterproof_nack",
+        );
+    }
 }

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -1,0 +1,246 @@
+//! Hardcoded fees for presigned transactions.
+//!
+//! Until CPFP is implemented, every presigned transaction must pay its own fee.
+//! Setting [`FEE_RATE_SAT_PER_VB`] to `0` disables fees entirely (matches the original
+//! zero-fee behaviour) without removing any code.
+//!
+//! All vsize formulas are closed-form functions of the two graph parameters (`n_watchtowers`
+//! and `n_data`). Numbers are pinned by `tests::pin_*` unit tests that build the actual
+//! finalized transactions and assert that `vsize × FEE_RATE_SAT_PER_VB == fee`.
+//!
+//! Each fee corresponds to a specific presigned transaction; see the comments below for
+//! which transaction each constant belongs to.
+//!
+//! Output sizes are taken from real outputs:
+//! - P2TR script_pubkey is 34 bytes.
+//! - SPS-50 OP_RETURN script_pubkey is variable but small (taken from the actual data).
+//! - Operator/watchtower descriptors are P2TR in tests; production uses BOSD which resolves to
+//!   bech32 / P2TR scripts of similar size.
+
+use std::num::NonZero;
+
+use bitcoin::Amount;
+
+/// Fee rate (sat/vb) that every presigned transaction pays.
+///
+/// Set to `0` to disable fees entirely — every helper in this module then returns
+/// `Amount::ZERO`, every connector surcharge collapses to zero, and every per-tx
+/// `value_in - value_out` becomes zero again, matching the original behaviour.
+///
+/// Set back to `2` (or any positive value) to re-enable fees once CPFP needs them
+/// disabled again.
+pub const FEE_RATE_SAT_PER_VB: u64 = 2;
+
+/// Multiplies a vsize (in vbytes) by [`FEE_RATE_SAT_PER_VB`] to produce a fee.
+const fn fee_for_vsize(vsize: u64) -> Amount {
+    Amount::from_sat(vsize.saturating_mul(FEE_RATE_SAT_PER_VB))
+}
+
+/// Value to put on every cpfp anchor output (`KeyedAnchor`/`MultiAnchor`).
+///
+/// When [`FEE_RATE_SAT_PER_VB`] is `0`, returns `Amount::ZERO` — anchors stay at zero, matching
+/// the original zero-fee TRUC behaviour where bitcoin core's relay policy permits dust outputs
+/// only when the parent pays no fee.
+///
+/// When [`FEE_RATE_SAT_PER_VB`] is non-zero, returns the P2TR `minimal_non_dust` threshold so
+/// the parent can pay a fee without bitcoin core rejecting it as `dust, tx with dust output
+/// must be 0-fee`. Bitcoin core's dust formula for a 34-byte P2TR script_pubkey at
+/// `DUST_RELAY_TX_FEE = 3000` is `(32 + 4 + 1 + 26 + 4 + 8 + 34) * 3 / 1 = 327` sat. We use
+/// `330` sat as a small margin.
+pub const fn anchor_dust_value() -> Amount {
+    if FEE_RATE_SAT_PER_VB == 0 {
+        Amount::ZERO
+    } else {
+        Amount::from_sat(330)
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Per-tx vsize formulas. Hardcoded and pinned by unit tests below.
+//
+// These are the predicted finalized vsizes (vbytes, ceil-rounded). Vsize = ceil(weight / 4).
+// Each value was determined by constructing the actual finalized transaction in a unit test
+// and reading `tx.weight().to_vbytes_ceil()`.
+// -------------------------------------------------------------------------------------------------
+
+/// Predicted vsize of [`crate::transactions::claim::ClaimTx`] in vbytes.
+///
+/// Structure: 1 wallet input (P2TR key path) + 3 P2TR outputs (claim_contest, claim_payout,
+/// anchor).
+const CLAIM_VSIZE: u64 = 154;
+
+/// Predicted vsize of [`crate::transactions::uncontested_payout::UncontestedPayoutTx`] in vbytes.
+///
+/// Structure: 3 inputs (NOfN key path, ClaimContest uncontested script path, ClaimPayout key path)
+/// + 1 P2TR output.
+const UNCONTESTED_PAYOUT_VSIZE: u64 = 235;
+
+/// Base predicted vsize of [`crate::transactions::contest::ContestTx`].
+///
+/// Per-watchtower additional vsize is [`CONTEST_PER_WATCHTOWER_VSIZE`].
+const CONTEST_BASE_VSIZE: u64 = 226;
+
+/// Per-watchtower vsize contribution to [`crate::transactions::contest::ContestTx`].
+///
+/// Each watchtower adds 1 P2TR output (counterproof_x) of 43 non-witness bytes = 43 vbytes.
+const CONTEST_PER_WATCHTOWER_VSIZE: u64 = 43;
+
+/// Predicted vsize of [`crate::transactions::bridge_proof_timeout::BridgeProofTimeoutTx`].
+///
+/// Structure: 2 script-path inputs (ContestProof timeout, ContestPayout normal) + 1 P2TR output.
+/// MultiAnchor output's tap-tree depth scales with watchtower count, but its script_pubkey is
+/// always 34 bytes.
+const BRIDGE_PROOF_TIMEOUT_VSIZE: u64 = 197;
+
+/// Base predicted vsize of [`crate::transactions::counterproof::CounterproofTx`].
+///
+/// Per-`n_data`-byte additional vsize is [`COUNTERPROOF_PER_DATA_BYTE_VSIZE`].
+const COUNTERPROOF_BASE_VSIZE: u64 = 168;
+
+/// Per-`n_data`-byte vsize contribution to [`crate::transactions::counterproof::CounterproofTx`].
+///
+/// Each `n_data` byte adds one OP_TUCK + OP_CHECKSIGVERIFY + OP_CODESEPARATOR triple (~3 bytes
+/// in script) plus one 64-byte schnorr signature in the witness. Witness bytes contribute
+/// 1 wu each → 1/4 vbyte each. Script bytes contribute 4 wu each → 1 vbyte each.
+const COUNTERPROOF_PER_DATA_BYTE_VSIZE: u64 = 19;
+
+/// Predicted vsize of [`crate::transactions::counterproof_ack::CounterproofAckTx`].
+///
+/// Structure: 2 inputs (Counterproof timeout script path, ContestPayout normal key path)
+/// + 1 P2TR output (cpfp anchor).
+const COUNTERPROOF_ACK_VSIZE: u64 = 197;
+
+/// Predicted vsize of [`crate::transactions::contested_payout::ContestedPayoutTx`].
+///
+/// Structure: 4 inputs (deposit NOfN key, claim_payout key, contest_payout timeout script,
+/// contest_slash normal key) + 1 P2TR output.
+const CONTESTED_PAYOUT_VSIZE: u64 = 313;
+
+/// Base predicted vsize of [`crate::transactions::slash::SlashTx`].
+///
+/// Structure: 2 inputs (contest_slash timeout script, stake NOfN key) +
+/// SPS-50 header output + N watchtower outputs.
+/// Per-watchtower additional vsize is [`SLASH_PER_WATCHTOWER_VSIZE`].
+const SLASH_BASE_VSIZE: u64 = 195;
+
+/// Per-watchtower vsize contribution to [`crate::transactions::slash::SlashTx`].
+const SLASH_PER_WATCHTOWER_VSIZE: u64 = 43;
+
+/// Predicted vsize of [`crate::transactions::stake::StakeTx`].
+///
+/// Structure: 1 wallet input (P2TR key path) + 3 P2TR outputs.
+const STAKE_VSIZE: u64 = 154;
+
+/// Predicted vsize of [`crate::transactions::unstaking_intent::UnstakingIntentTx`].
+///
+/// Structure: 1 script-path input (UnstakingIntentOutput) + 3 outputs (header + unstaking +
+/// anchor).
+const UNSTAKING_INTENT_VSIZE: u64 = 211;
+
+/// Predicted vsize of [`crate::transactions::unstaking::UnstakingTx`].
+///
+/// Structure: 2 inputs (UnstakingOutput timeout script, stake NOfN key) + 1 P2TR output.
+const UNSTAKING_VSIZE: u64 = 197;
+
+// -------------------------------------------------------------------------------------------------
+// Per-tx fees. Each is `vsize × FEE_RATE_SAT_PER_VB`.
+// -------------------------------------------------------------------------------------------------
+
+/// Fee for [`crate::transactions::claim::ClaimTx`].
+pub const fn claim_fee() -> Amount {
+    fee_for_vsize(CLAIM_VSIZE)
+}
+
+/// Fee for [`crate::transactions::uncontested_payout::UncontestedPayoutTx`].
+pub const fn uncontested_payout_fee() -> Amount {
+    fee_for_vsize(UNCONTESTED_PAYOUT_VSIZE)
+}
+
+/// Fee for [`crate::transactions::contest::ContestTx`].
+pub const fn contest_fee(n_watchtowers: u32) -> Amount {
+    fee_for_vsize(CONTEST_BASE_VSIZE + (n_watchtowers as u64) * CONTEST_PER_WATCHTOWER_VSIZE)
+}
+
+/// Fee for [`crate::transactions::bridge_proof_timeout::BridgeProofTimeoutTx`].
+pub const fn bridge_proof_timeout_fee() -> Amount {
+    fee_for_vsize(BRIDGE_PROOF_TIMEOUT_VSIZE)
+}
+
+/// Fee for [`crate::transactions::counterproof::CounterproofTx`].
+pub const fn counterproof_fee(n_data: NonZero<usize>) -> Amount {
+    fee_for_vsize(
+        COUNTERPROOF_BASE_VSIZE + (n_data.get() as u64) * COUNTERPROOF_PER_DATA_BYTE_VSIZE,
+    )
+}
+
+/// Fee for [`crate::transactions::counterproof_ack::CounterproofAckTx`].
+pub const fn counterproof_ack_fee() -> Amount {
+    fee_for_vsize(COUNTERPROOF_ACK_VSIZE)
+}
+
+/// Fee for [`crate::transactions::contested_payout::ContestedPayoutTx`].
+pub const fn contested_payout_fee() -> Amount {
+    fee_for_vsize(CONTESTED_PAYOUT_VSIZE)
+}
+
+/// Fee for [`crate::transactions::slash::SlashTx`].
+pub const fn slash_fee(n_watchtowers: u32) -> Amount {
+    fee_for_vsize(SLASH_BASE_VSIZE + (n_watchtowers as u64) * SLASH_PER_WATCHTOWER_VSIZE)
+}
+
+/// Fee for [`crate::transactions::stake::StakeTx`].
+pub const fn stake_fee() -> Amount {
+    fee_for_vsize(STAKE_VSIZE)
+}
+
+/// Fee for [`crate::transactions::unstaking_intent::UnstakingIntentTx`].
+pub const fn unstaking_intent_fee() -> Amount {
+    fee_for_vsize(UNSTAKING_INTENT_VSIZE)
+}
+
+/// Fee for [`crate::transactions::unstaking::UnstakingTx`].
+pub const fn unstaking_fee() -> Amount {
+    fee_for_vsize(UNSTAKING_VSIZE)
+}
+
+// -------------------------------------------------------------------------------------------------
+// Connector surcharges. These are added to a connector's base value so the downstream
+// transaction's input arrives with the fee already included. Used for transactions whose
+// outputs are all dust connectors / cpfp anchors and cannot absorb a fee without underflowing.
+// -------------------------------------------------------------------------------------------------
+
+/// Surcharge for `CounterproofConnector`. Funds the [`counterproof_ack_fee`] of
+/// [`crate::transactions::counterproof_ack::CounterproofAckTx`].
+pub const fn counterproof_surcharge() -> Amount {
+    counterproof_ack_fee()
+}
+
+/// Surcharge for `ContestProofConnector`. Funds the [`bridge_proof_timeout_fee`] of
+/// [`crate::transactions::bridge_proof_timeout::BridgeProofTimeoutTx`].
+pub const fn contest_proof_surcharge() -> Amount {
+    bridge_proof_timeout_fee()
+}
+
+/// Surcharge for `ContestCounterproofOutput`. Funds the [`counterproof_fee`] of
+/// [`crate::transactions::counterproof::CounterproofTx`], the cpfp anchor dust on that tx,
+/// plus the inflation that `CounterproofConnector` carries (= [`counterproof_ack_fee`]).
+pub fn contest_counterproof_surcharge(n_data: NonZero<usize>) -> Amount {
+    counterproof_fee(n_data) + counterproof_ack_fee() + anchor_dust_value()
+}
+
+/// Surcharge for `ClaimContestConnector`. Funds the [`contest_fee`], the contest tx's cpfp
+/// anchor dust, plus the inflation that all of [`crate::transactions::contest::ContestTx`]'s
+/// outputs carry: `ContestProofConnector` (`bridge_proof_timeout_fee`) and the per-watchtower
+/// `ContestCounterproofOutput` (`contest_counterproof_surcharge(n_data)`).
+pub fn claim_contest_surcharge(n_watchtowers: u32, n_data: NonZero<usize>) -> Amount {
+    contest_fee(n_watchtowers)
+        + bridge_proof_timeout_fee()
+        + anchor_dust_value()
+        + contest_counterproof_surcharge(n_data) * u64::from(n_watchtowers)
+}
+
+/// Surcharge for `UnstakingIntentOutput`. Funds the [`unstaking_intent_fee`] of
+/// [`crate::transactions::unstaking_intent::UnstakingIntentTx`] plus that tx's cpfp anchor dust.
+pub fn unstaking_intent_surcharge() -> Amount {
+    unstaking_intent_fee() + anchor_dust_value()
+}

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -142,6 +142,25 @@ const UNSTAKING_INTENT_VSIZE: u64 = 211;
 /// Structure: 2 inputs (UnstakingOutput timeout script, stake NOfN key) + 1 P2TR output.
 const UNSTAKING_VSIZE: u64 = 197;
 
+/// Predicted vsize of [`crate::transactions::deposit::DepositTx`].
+///
+/// Structure: 1 input (DepositRequestConnector key path) + 2 outputs (SPS-50 OP_RETURN + N/N
+/// P2TR).
+const DEPOSIT_VSIZE: u64 = 158;
+
+/// Predicted vsize of [`crate::transactions::cooperative_payout::CooperativePayoutTx`].
+///
+/// Structure: 1 input (deposit NOfN key path) + 1 P2TR operator output.
+const COOPERATIVE_PAYOUT_VSIZE: u64 = 130;
+
+/// Predicted vsize of [`crate::transactions::not_presigned::CounterproofNackTx`] in production,
+/// where the operator does **not** add a funding input — the fee is taken out of the
+/// `CounterproofConnector`'s pre-inflated value (its surcharge equals
+/// [`counterproof_ack_fee`], which is larger than this nack fee, so the math works out).
+///
+/// Structure: 1 input (CounterproofConnector script-path) + 1 P2TR operator output.
+const COUNTERPROOF_NACK_VSIZE: u64 = 130;
+
 // -------------------------------------------------------------------------------------------------
 // Per-tx fees. Each is `vsize × FEE_RATE_SAT_PER_VB`.
 // -------------------------------------------------------------------------------------------------
@@ -201,6 +220,25 @@ pub const fn unstaking_intent_fee() -> Amount {
 /// Fee for [`crate::transactions::unstaking::UnstakingTx`].
 pub const fn unstaking_fee() -> Amount {
     fee_for_vsize(UNSTAKING_VSIZE)
+}
+
+/// Fee for [`crate::transactions::deposit::DepositTx`].
+///
+/// The fee comes from the depositor's deposit-request UTXO carrying
+/// `deposit_amount + deposit_fee()`; the bridge cannot inject extra value into the deposit tx.
+pub const fn deposit_fee() -> Amount {
+    fee_for_vsize(DEPOSIT_VSIZE)
+}
+
+/// Fee for [`crate::transactions::cooperative_payout::CooperativePayoutTx`].
+pub const fn cooperative_payout_fee() -> Amount {
+    fee_for_vsize(COOPERATIVE_PAYOUT_VSIZE)
+}
+
+/// Fee for the [`crate::transactions::not_presigned::CounterproofNackTx`] as broadcast in
+/// production with a single wallet P2TR funding input and a single wallet P2TR output.
+pub const fn counterproof_nack_fee() -> Amount {
+    fee_for_vsize(COUNTERPROOF_NACK_VSIZE)
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -19,7 +19,7 @@
 
 use std::num::NonZero;
 
-use bitcoin::Amount;
+use bitcoin::{Amount, FeeRate};
 
 /// Fee rate (sat/vb) that every presigned transaction pays.
 ///
@@ -30,6 +30,12 @@ use bitcoin::Amount;
 /// Set back to `2` (or any positive value) to re-enable fees once CPFP needs them
 /// disabled again.
 pub const FEE_RATE_SAT_PER_VB: u64 = 2;
+
+/// [`FEE_RATE_SAT_PER_VB`] as a `FeeRate`, for use as a floor on wallet-built transactions
+/// (claim-funding refill, stake funding, withdrawal fulfillment) so that the bridge node
+/// never broadcasts a transaction below this rate even if `estimatesmartfee` returns
+/// something lower (or absent on networks without enough fee history, like signet).
+pub const FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(FEE_RATE_SAT_PER_VB);
 
 /// Multiplies a vsize (in vbytes) by [`FEE_RATE_SAT_PER_VB`] to produce a fee.
 const fn fee_for_vsize(vsize: u64) -> Amount {

--- a/crates/tx-graph/src/game_graph.rs
+++ b/crates/tx-graph/src/game_graph.rs
@@ -987,11 +987,34 @@ mod tests {
             assert_eq!(child.version, Version(3));
             let slash = game.slash.finalize(presigned.slash);
             assert_eq!(slash.version, Version(3));
-            let package = [slash, child];
+            let package = [slash.clone(), child];
 
             node.submit_package_invalid(&package);
             node.mine_blocks(1);
             node.submit_package(&package);
+
+            let total_output_amount: Amount = slash.output.iter().map(|o| o.value).sum();
+            let total_input_amount: Amount = slash
+                .input
+                .iter()
+                .map(|i| {
+                    let outpoint = i.previous_output;
+                    let tx = node
+                        .client()
+                        .get_raw_transaction(outpoint.txid)
+                        .unwrap()
+                        .transaction()
+                        .unwrap();
+                    tx.output[outpoint.vout as usize].value
+                })
+                .sum();
+            let slash_fee = total_input_amount - total_output_amount;
+            let slash_fee_rate = slash_fee.to_sat().div_ceil(slash.vsize() as u64);
+
+            assert!(
+                slash_fee_rate >= crate::fee::FEE_RATE_SAT_PER_VB,
+                "slash fee must be greater than or equal to the minimum fee rate"
+            );
 
             return;
         };

--- a/crates/tx-graph/src/game_graph.rs
+++ b/crates/tx-graph/src/game_graph.rs
@@ -530,11 +530,16 @@ impl GameConnectors {
             "too many watchtowers"
         );
 
+        // cast safety: asserted above that len(watchtowers) <= u32::MAX
+        let n_watchtowers = keys.watchtower_pubkeys.len() as u32;
+        let n_data = protocol.counterproof_n_data;
+
         let claim_contest = ClaimContestConnector::new(
             protocol.network,
             keys.n_of_n_pubkey,
             keys.watchtower_pubkeys.clone(),
             protocol.contest_timelock,
+            crate::fee::claim_contest_surcharge(n_watchtowers, n_data),
         );
         let claim_payout = ClaimPayoutConnector::new(
             protocol.network,
@@ -553,6 +558,7 @@ impl GameConnectors {
             keys.operator_pubkey,
             game_index,
             protocol.proof_timelock,
+            crate::fee::contest_proof_surcharge(),
         );
         let contest_payout = ContestPayoutConnector::new(
             protocol.network,
@@ -567,6 +573,7 @@ impl GameConnectors {
         // One `ContestCounterproofOutput` per watchtower, bound to the adaptor pubkey that
         // mosaic issued for the `(evaluator=owner, garbler=watchtower)` tableset. Each entry
         // becomes a distinct output on the Contest tx.
+        let contest_counterproof_surcharge = crate::fee::contest_counterproof_surcharge(n_data);
         let contest_counterproof: Vec<_> = keys
             .operator_adaptor_pubkeys
             .iter()
@@ -577,9 +584,11 @@ impl GameConnectors {
                     keys.n_of_n_pubkey,
                     operator_adaptor_pubkey,
                     protocol.counterproof_n_data,
+                    contest_counterproof_surcharge,
                 )
             })
             .collect();
+        let counterproof_surcharge = crate::fee::counterproof_surcharge();
         let counterproof: Vec<_> = keys
             .wt_fault_pubkeys
             .iter()
@@ -590,6 +599,7 @@ impl GameConnectors {
                     keys.n_of_n_pubkey,
                     wt_fault_pubkey,
                     protocol.nack_timelock,
+                    counterproof_surcharge,
                 )
             })
             .collect();
@@ -703,11 +713,14 @@ mod tests {
             NOfNConnector::new(protocol.network, keys.n_of_n_pubkey, DEPOSIT_AMOUNT);
         let stake_connector =
             NOfNConnector::new(protocol.network, keys.n_of_n_pubkey, STAKE_AMOUNT);
+        // cast safety: N_WATCHTOWERS is a small constant that fits in u32.
+        let n_watchtowers = N_WATCHTOWERS as u32;
         let claim_contest_connector = ClaimContestConnector::new(
             protocol.network,
             keys.n_of_n_pubkey,
             keys.watchtower_pubkeys.clone(),
             protocol.contest_timelock,
+            crate::fee::claim_contest_surcharge(n_watchtowers, protocol.counterproof_n_data),
         );
         let claim_payout_connector = ClaimPayoutConnector::new(
             protocol.network,
@@ -715,7 +728,8 @@ mod tests {
             keys.admin_pubkey,
             keys.unstaking_image,
         );
-        let claim_funds_amount = claim_contest_connector.value() + claim_payout_connector.value();
+        let claim_funds_amount =
+            ClaimTx::claim_funds_required(&claim_contest_connector, &claim_payout_connector);
 
         // ┌───────────────────────────────────────────────────────────────────┐
         // │                       Funding Transaction                         │

--- a/crates/tx-graph/src/lib.rs
+++ b/crates/tx-graph/src/lib.rs
@@ -1,5 +1,13 @@
 //! This crate enables the creation and verification of a Glock transaction graph.
 
+#![expect(
+    rustdoc::private_intra_doc_links,
+    reason = "Public docs link to pub(crate) helpers (e.g. fee surcharge math, anchor dust \
+              value) for context. The links resolve when docs are built with \
+              `--document-private-items`; in public-API rustdoc they degrade to plain \
+              code-style text."
+)]
+
 pub mod fee;
 pub mod game_graph;
 pub mod musig_functor;

--- a/crates/tx-graph/src/lib.rs
+++ b/crates/tx-graph/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate enables the creation and verification of a Glock transaction graph.
 
+pub mod fee;
 pub mod game_graph;
 pub mod musig_functor;
 pub mod stake_graph;

--- a/crates/tx-graph/src/stake_graph.rs
+++ b/crates/tx-graph/src/stake_graph.rs
@@ -96,6 +96,7 @@ impl StakeGraph {
             protocol.network,
             setup.n_of_n_pubkey,
             setup.unstaking_image,
+            crate::fee::unstaking_intent_surcharge(),
         );
         let unstaking_output = UnstakingOutput::new(
             protocol.network,
@@ -189,7 +190,6 @@ mod tests {
     use strata_bridge_connectors::{
         prelude::{UnstakingIntentOutput, UnstakingIntentWitness},
         test_utils::BitcoinNode,
-        Connector,
     };
     use strata_bridge_primitives::scripts::prelude::{create_tx, create_tx_ins};
     use strata_bridge_test_utils::prelude::generate_keypair;
@@ -239,7 +239,11 @@ mod tests {
             protocol.network,
             setup.n_of_n_pubkey,
             setup.unstaking_image,
+            crate::fee::unstaking_intent_surcharge(),
         );
+
+        let stake_funds_amount =
+            StakeTx::stake_funds_required(protocol.stake_amount, &unstaking_intent_output);
 
         // ┌───────────────────────────────────────────────────────────────────┐
         // │                       Funding Transaction                         │
@@ -253,14 +257,11 @@ mod tests {
         let input = create_tx_ins([node.next_coinbase_outpoint()]);
         let output = vec![
             TxOut {
-                value: protocol.stake_amount + unstaking_intent_output.value(),
+                value: stake_funds_amount,
                 script_pubkey: node.wallet_address().script_pubkey(),
             },
             TxOut {
-                value: node.coinbase_amount()
-                    - protocol.stake_amount
-                    - unstaking_intent_output.value()
-                    - FEE_AMOUNT,
+                value: node.coinbase_amount() - stake_funds_amount - FEE_AMOUNT,
                 script_pubkey: node.wallet_address().script_pubkey(),
             },
         ];

--- a/crates/tx-graph/src/transactions/bridge_proof_timeout.rs
+++ b/crates/tx-graph/src/transactions/bridge_proof_timeout.rs
@@ -48,10 +48,11 @@ impl BridgeProofTimeoutTx {
         watchtower_pubkeys: Vec<XOnlyPublicKey>,
     ) -> Self {
         debug_assert!(contest_proof_connector.network() == contest_payout_connector.network());
+        let fee = crate::fee::bridge_proof_timeout_fee();
         let cpfp_connector = MultiAnchor::new(
             contest_proof_connector.network(),
             watchtower_pubkeys,
-            contest_proof_connector.value() + contest_payout_connector.value(),
+            contest_proof_connector.value() + contest_payout_connector.value() - fee,
         );
 
         let prevouts = [
@@ -81,8 +82,8 @@ impl BridgeProofTimeoutTx {
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
         debug_assert!(
-            value_in == value_out,
-            "tx should pay zero fees (value in = {value_in}, value out = {value_out})"
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/claim.rs
+++ b/crates/tx-graph/src/transactions/claim.rs
@@ -31,6 +31,21 @@ impl ClaimTx {
     /// Index of the CPFP output.
     pub const CPFP_VOUT: u32 = 2;
 
+    /// Returns the total funding amount that the wallet must provide in
+    /// [`ClaimData::claim_funds`].
+    ///
+    /// The connector outputs are funded directly from this UTXO; the surplus is the tx fee.
+    /// The cpfp anchor output is funded too (its value is [`crate::fee::anchor_dust_value`]).
+    pub fn claim_funds_required(
+        claim_contest: &ClaimContestConnector,
+        claim_payout: &ClaimPayoutConnector,
+    ) -> Amount {
+        claim_contest.value()
+            + claim_payout.value()
+            + crate::fee::anchor_dust_value()
+            + crate::fee::claim_fee()
+    }
+
     /// Creates a claim transaction.
     pub fn new(
         data: ClaimData,
@@ -42,7 +57,7 @@ impl ClaimTx {
         let cpfp_connector = KeyedAnchor::new(
             claim_contest_connector.network(),
             operator_pubkey,
-            Amount::ZERO,
+            crate::fee::anchor_dust_value(),
         );
 
         let input = create_tx_ins([data.claim_funds]);

--- a/crates/tx-graph/src/transactions/contest.rs
+++ b/crates/tx-graph/src/transactions/contest.rs
@@ -79,7 +79,7 @@ impl ContestTx {
         let cpfp_connector = MultiAnchor::new(
             claim_contest_connector.network(),
             watchtower_pubkeys,
-            Amount::ZERO,
+            crate::fee::anchor_dust_value(),
         );
 
         let prevouts = [claim_contest_connector.tx_out()];
@@ -102,11 +102,12 @@ impl ContestTx {
         output.extend(counterproof_outputs.iter().map(|o| o.tx_out()));
         output.push(cpfp_connector.tx_out());
 
+        let fee = crate::fee::contest_fee(claim_contest_connector.n_watchtowers());
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
         debug_assert!(
-            value_in == value_out,
-            "tx should pay zero fees (value in = {value_in}, value out = {value_out})"
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/contested_payout.rs
+++ b/crates/tx-graph/src/transactions/contested_payout.rs
@@ -99,19 +99,21 @@ impl ContestedPayoutTx {
                 ..Default::default()
             },
         ];
+        let fee = crate::fee::contested_payout_fee();
         let output = vec![TxOut {
             value: deposit_connector.value()
                 + claim_payout_connector.value()
                 + contest_payout_connector.value()
-                + contest_slash_connector.value(),
+                + contest_slash_connector.value()
+                - fee,
             script_pubkey: operator_descriptor.to_script(),
         }];
 
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
         debug_assert!(
-            value_in == value_out,
-            "tx should pay zero fees (value in = {value_in}, value out = {value_out})"
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/cooperative_payout.rs
+++ b/crates/tx-graph/src/transactions/cooperative_payout.rs
@@ -64,10 +64,18 @@ impl CooperativePayoutTx {
             sequence: deposit_connector.sequence(NOfNSpend),
             ..Default::default()
         }];
+        let fee = crate::fee::cooperative_payout_fee();
         let output = vec![TxOut {
-            value: deposit_connector.value(),
+            value: deposit_connector.value() - fee,
             script_pubkey: operator_descriptor.to_script(),
         }];
+
+        let value_in: bitcoin::Amount = prevouts.iter().map(|x| x.value).sum();
+        let value_out: bitcoin::Amount = output.iter().map(|x| x.value).sum();
+        debug_assert!(
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
+        );
 
         let tx = Transaction {
             version: Version(3),

--- a/crates/tx-graph/src/transactions/counterproof.rs
+++ b/crates/tx-graph/src/transactions/counterproof.rs
@@ -4,7 +4,7 @@ use bitcoin::{
     absolute,
     sighash::{Prevouts, SighashCache},
     transaction::Version,
-    Amount, OutPoint, Psbt, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
+    OutPoint, Psbt, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
 };
 use secp256k1::Message;
 use strata_bridge_connectors::{
@@ -53,16 +53,20 @@ impl CounterproofTx {
         watchtower_pubkey: XOnlyPublicKey,
     ) -> Self {
         debug_assert!(contest_counterproof_output.network() == counterproof_connector.network());
-        debug_assert!(
-            contest_counterproof_output.value() == counterproof_connector.value(),
-            "tx should have zero fees (value in = {}, value out = {}",
-            contest_counterproof_output.value(),
-            counterproof_connector.value()
-        );
+        let fee = crate::fee::counterproof_fee(contest_counterproof_output.n_data());
         let cpfp_connector = KeyedAnchor::new(
             contest_counterproof_output.network(),
             watchtower_pubkey,
-            Amount::ZERO,
+            crate::fee::anchor_dust_value(),
+        );
+        debug_assert!(
+            contest_counterproof_output.value()
+                == counterproof_connector.value() + cpfp_connector.value() + fee,
+            "tx must pay {} fees (value in = {}, value out = {} + {})",
+            fee,
+            contest_counterproof_output.value(),
+            counterproof_connector.value(),
+            cpfp_connector.value(),
         );
 
         let prevouts = [contest_counterproof_output.tx_out()];

--- a/crates/tx-graph/src/transactions/counterproof_ack.rs
+++ b/crates/tx-graph/src/transactions/counterproof_ack.rs
@@ -53,10 +53,11 @@ impl CounterproofAckTx {
         watchtower_pubkey: XOnlyPublicKey,
     ) -> Self {
         debug_assert!(counterproof_connector.network() == contest_payout_connector.network());
+        let fee = crate::fee::counterproof_ack_fee();
         let cpfp_connector = KeyedAnchor::new(
             counterproof_connector.network(),
             watchtower_pubkey,
-            counterproof_connector.value() + contest_payout_connector.value(),
+            counterproof_connector.value() + contest_payout_connector.value() - fee,
         );
 
         let prevouts = [
@@ -86,8 +87,8 @@ impl CounterproofAckTx {
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
         debug_assert!(
-            value_in == value_out,
-            "tx should pay zero fees (value in = {value_in}, value out = {value_out})"
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/deposit.rs
+++ b/crates/tx-graph/src/transactions/deposit.rs
@@ -59,7 +59,17 @@ impl DepositTx {
     /// Number of transaction inputs.
     pub const N_INPUTS: usize = 1;
 
+    /// Returns the minimum value the depositor must put in the deposit-request UTXO so that
+    /// the bridge's deposit transaction can pay its own fee.
+    pub fn drt_required(deposit_amount: Amount) -> Amount {
+        deposit_amount + crate::fee::deposit_fee()
+    }
+
     /// Creates a deposit transaction.
+    ///
+    /// The depositor's deposit-request UTXO must carry at least
+    /// `deposit_connector.value() + crate::fee::deposit_fee()` so the deposit transaction can
+    /// pay its own fee. Surplus beyond that is also paid as fee.
     pub fn new(
         data: DepositData,
         deposit_connector: NOfNConnector,
@@ -67,6 +77,14 @@ impl DepositTx {
     ) -> Self {
         debug_assert!(deposit_connector.network() == deposit_request_connector.network());
         debug_assert!(deposit_connector.internal_key() == deposit_request_connector.internal_key());
+        let fee = crate::fee::deposit_fee();
+        debug_assert!(
+            deposit_request_connector.value() >= deposit_connector.value() + fee,
+            "deposit-request UTXO must include at least {fee} of fee \
+             (drt value = {}, deposit value = {})",
+            deposit_request_connector.value(),
+            deposit_connector.value(),
+        );
 
         let prevouts = [deposit_request_connector.tx_out()];
         let input = vec![TxIn {

--- a/crates/tx-graph/src/transactions/slash.rs
+++ b/crates/tx-graph/src/transactions/slash.rs
@@ -116,29 +116,31 @@ impl SlashTx {
         ];
 
         // cast safety: n_watchtowers fits in u32 (asserted via slice length being non-empty above
-        // and by upstream callers). The slash tx fee is taken from the first watchtower's stake
-        // share — that share is bounded by the per-watchtower stake amount, which is real funds
-        // and orders of magnitude larger than the fee.
+        // and by upstream callers). The slash tx fee is distributed across every watchtower
+        // output by rounding the per-watchtower share up — the tx may overpay by at most
+        // `n_watchtowers - 1` sats, which is acceptable slippage.
         let fee = crate::fee::slash_fee(watchtower_descriptors.len() as u32);
-        let first_output_value = watchtower_stake + first_extra - fee;
+        let fee_per_watchtower = Amount::from_sat(fee.to_sat().div_ceil(n_watchtowers));
         let mut output = vec![TxOut {
             script_pubkey: data.header_leaf_script(),
             value: Amount::ZERO,
         }];
         output.push(TxOut {
             script_pubkey: watchtower_descriptors[0].to_script(),
-            value: first_output_value,
+            value: watchtower_stake + first_extra - fee_per_watchtower,
         });
         output.extend(watchtower_descriptors.iter().skip(1).map(|x| TxOut {
             script_pubkey: x.to_script(),
-            value: watchtower_stake + other_extra,
+            value: watchtower_stake + other_extra - fee_per_watchtower,
         }));
 
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
+        let actual_fee = value_in - value_out;
         debug_assert!(
-            value_in == value_out + fee,
-            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
+            actual_fee >= fee && actual_fee.to_sat() < fee.to_sat() + n_watchtowers,
+            "tx must pay between {fee} and {fee_upper} fees (value in = {value_in}, value out = {value_out}, actual fee = {actual_fee})",
+            fee_upper = Amount::from_sat(fee.to_sat() + n_watchtowers - 1)
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/slash.rs
+++ b/crates/tx-graph/src/transactions/slash.rs
@@ -115,13 +115,19 @@ impl SlashTx {
             },
         ];
 
+        // cast safety: n_watchtowers fits in u32 (asserted via slice length being non-empty above
+        // and by upstream callers). The slash tx fee is taken from the first watchtower's stake
+        // share — that share is bounded by the per-watchtower stake amount, which is real funds
+        // and orders of magnitude larger than the fee.
+        let fee = crate::fee::slash_fee(watchtower_descriptors.len() as u32);
+        let first_output_value = watchtower_stake + first_extra - fee;
         let mut output = vec![TxOut {
             script_pubkey: data.header_leaf_script(),
             value: Amount::ZERO,
         }];
         output.push(TxOut {
             script_pubkey: watchtower_descriptors[0].to_script(),
-            value: watchtower_stake + first_extra,
+            value: first_output_value,
         });
         output.extend(watchtower_descriptors.iter().skip(1).map(|x| TxOut {
             script_pubkey: x.to_script(),
@@ -131,8 +137,8 @@ impl SlashTx {
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
         debug_assert!(
-            value_in == value_out,
-            "tx should pay zero fees (value in = {value_in}, value out = {value_out})"
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/stake.rs
+++ b/crates/tx-graph/src/transactions/stake.rs
@@ -38,6 +38,21 @@ impl StakeTx {
     /// Number of transaction inputs.
     pub const N_INPUTS: usize = 1;
 
+    /// Returns the total funding amount that the wallet must provide in
+    /// [`StakeData::stake_funds`].
+    ///
+    /// The connector outputs are funded directly from this UTXO; the surplus is the tx fee.
+    /// The cpfp anchor output is funded too (its value is [`crate::fee::anchor_dust_value`]).
+    pub fn stake_funds_required(
+        stake_amount: Amount,
+        unstaking_intent_output: &UnstakingIntentOutput,
+    ) -> Amount {
+        stake_amount
+            + unstaking_intent_output.value()
+            + crate::fee::anchor_dust_value()
+            + crate::fee::stake_fee()
+    }
+
     /// Creates a stake transaction.
     pub fn new(
         data: StakeData,
@@ -49,7 +64,7 @@ impl StakeTx {
         let cpfp_connector = KeyedAnchor::new(
             unstaking_intent_output.network(),
             operator_pubkey,
-            Amount::ZERO,
+            crate::fee::anchor_dust_value(),
         );
 
         let input = vec![TxIn {

--- a/crates/tx-graph/src/transactions/uncontested_payout.rs
+++ b/crates/tx-graph/src/transactions/uncontested_payout.rs
@@ -82,18 +82,20 @@ impl UncontestedPayoutTx {
                 ..Default::default()
             },
         ];
+        let fee = crate::fee::uncontested_payout_fee();
         let output = vec![TxOut {
             value: deposit_connector.value()
                 + claim_contest_connector.value()
-                + claim_payout_connector.value(),
+                + claim_payout_connector.value()
+                - fee,
             script_pubkey: operator_descriptor.to_script(),
         }];
 
         let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
         let value_out: Amount = output.iter().map(|x| x.value).sum();
         debug_assert!(
-            value_in == value_out,
-            "tx should pay zero fees (value in = {value_in}, value out = {value_out})"
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
         );
 
         let tx = Transaction {

--- a/crates/tx-graph/src/transactions/unstaking.rs
+++ b/crates/tx-graph/src/transactions/unstaking.rs
@@ -70,10 +70,18 @@ impl UnstakingTx {
                 ..Default::default()
             },
         ];
+        let fee = crate::fee::unstaking_fee();
         let output = vec![TxOut {
             script_pubkey: operator_descriptor.to_script(),
-            value: unstaking_output.value() + stake_connector.value(),
+            value: unstaking_output.value() + stake_connector.value() - fee,
         }];
+
+        let value_in: bitcoin::Amount = prevouts.iter().map(|x| x.value).sum();
+        let value_out: bitcoin::Amount = output.iter().map(|x| x.value).sum();
+        debug_assert!(
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
+        );
 
         let tx = Transaction {
             version: Version(3),

--- a/crates/tx-graph/src/transactions/unstaking_intent.rs
+++ b/crates/tx-graph/src/transactions/unstaking_intent.rs
@@ -74,7 +74,7 @@ impl UnstakingIntentTx {
         let cpfp_connector = KeyedAnchor::new(
             unstaking_intent_output.network(),
             operator_pubkey,
-            Amount::ZERO,
+            crate::fee::anchor_dust_value(),
         );
 
         let prevouts = [unstaking_intent_output.tx_out()];
@@ -94,6 +94,14 @@ impl UnstakingIntentTx {
             unstaking_output.tx_out(),
             cpfp_connector.tx_out(),
         ];
+
+        let fee = crate::fee::unstaking_intent_fee();
+        let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
+        let value_out: Amount = output.iter().map(|x| x.value).sum();
+        debug_assert!(
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
+        );
 
         let tx = Transaction {
             version: Version(3),

--- a/functional-tests/factory/bitcoin/__init__.py
+++ b/functional-tests/factory/bitcoin/__init__.py
@@ -25,6 +25,10 @@ class BitcoinFactory(flexitest.Factory):
         zmq_rawtx = self.next_port()
         zmq_sequence = self.next_port()
 
+        # Run bitcoind with mainnet-like fee and dust policies so the bridge node's
+        # transactions must pay at least the minimum relay fee (1 sat/vB) and respect the
+        # dust threshold. This catches regressions where any tx-graph transaction is
+        # broadcast with zero fee or with a dust output.
         cmd = [
             "bitcoind",
             "-regtest",
@@ -33,11 +37,8 @@ class BitcoinFactory(flexitest.Factory):
             "-printtoconsole",
             "-server=1",
             "-txindex=1",
-            "-acceptnonstdtxn=1",
+            "-acceptnonstdtxn=0",
             "-fallbackfee=0.00001",
-            "-minrelaytxfee=0",
-            "-blockmintxfee=0",
-            "-dustrelayfee=0",
             f"-datadir={datadir}",
             f"-rpcport={rpc_port}",
             "-rpcbind=0.0.0.0",


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR hardcodes fees into each transaction broadcasted by the bridge node at a fixed fee rate of 2 sat/vb (subject to bikeshedding). This change is required until we implement CPFP. So for now, the approach used here optimizes for speed of implementation rather than elegance of the overall API.

As the shape of the transaction graph is dictated only by the number of watchtowers and the counterproof data, all the vsize's of the transactions have been precomputed (and asserted against the actual size via tests). Then the input amount of each transaction has been inflated to cover the fees. The same check has also been applied to non-presigned transactions namely:
- the deposit transaction so that any DRT with insufficient fees are dropped, and
- the cooperative payout transaction. 

Transactions funded by wallets already use the current fee rate but an additional change has been made so that the fee rate does not drop below the hardcoded fee rate value (of 2 sat/vb). This applies to the transactions that create UTXOs to fund claim and stake transactions.

All the tests have been updated so that that spawned bitcoin node does not accept 0-fee transactions anymore.

Claude was used for planning and making the changes (especially the size calculations). Codex was used to review the changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
To make it easier to revert these _code changes_, this PR should be squash-merged.
Note that reverting _this feature_ only involves setting the hardcoded fee rate to 0.
Setting the priority to P0 as this blocks our imminent deployment on signet.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3379