### PR TITLE
feat: handle availability of unstaking preimage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11316,7 +11316,10 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "ed25519-dalek",
+ "hkdf",
+ "make_buf",
  "secp256k1 0.29.1",
+ "sha2 0.10.9",
  "strata-bridge-primitives",
  "thiserror 2.0.18",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,6 +3791,7 @@ dependencies = [
  "strata-asm-proto-checkpoint-txs",
  "strata-asm-proto-checkpoint-types",
  "strata-bridge-common",
+ "strata-bridge-connectors",
  "strata-bridge-key-deriv",
  "strata-bridge-primitives",
  "strata-bridge-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11270,6 +11270,7 @@ name = "strata-bridge-exec"
 version = "0.1.0"
 dependencies = [
  "algebra",
+ "bdk_bitcoind_rpc",
  "bdk_wallet",
  "bitcoin",
  "bitcoin-bosd 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ foundationdb = { git = "https://github.com/foundationdb-rs/foundationdb-rs", rev
 ] }
 futures = "0.3.32"
 hex = { version = "0.4.3", features = ["serde"] }
+hkdf = "0.12.4"
 indexmap = "2.13.0"
 jsonrpsee = "0.26.0"
 libp2p = { version = "0.56.0", features = [

--- a/bin/dev-cli/Cargo.toml
+++ b/bin/dev-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 jsonrpsee = { workspace = true, features = ["http-client"] }
 strata-bridge-common.workspace = true
+strata-bridge-connectors.workspace = true
 strata-bridge-key-deriv.workspace = true
 strata-bridge-primitives.workspace = true
 strata-bridge-rpc = { workspace = true, features = ["client"] }

--- a/bin/dev-cli/src/cli.rs
+++ b/bin/dev-cli/src/cli.rs
@@ -28,6 +28,9 @@ pub(crate) enum Commands {
 
     /// Post a claim transaction.
     Claim(ClaimArgs),
+
+    /// Post an unstaking intent transaction.
+    UnstakingIntent(UnstakingIntentArgs),
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -133,6 +136,25 @@ pub(crate) struct ClaimArgs {
     pub(crate) bridge_node_url: String,
 
     #[arg(long, help = "hex-encoded seed of the claiming operator")]
+    pub(crate) seed: String,
+
+    #[arg(long, help = "the path to the params file")]
+    pub(crate) params: PathBuf,
+
+    #[clap(flatten)]
+    pub(crate) btc_args: BtcArgs,
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Post an unstaking intent transaction", version)]
+pub(crate) struct UnstakingIntentArgs {
+    #[arg(long, help = "operator index of the stake graph")]
+    pub(crate) operator_idx: u32,
+
+    #[arg(long, help = "url of the bridge node RPC")]
+    pub(crate) bridge_node_url: String,
+
+    #[arg(long, help = "hex-encoded seed of the unstaking operator")]
     pub(crate) seed: String,
 
     #[arg(long, help = "the path to the params file")]

--- a/bin/dev-cli/src/handlers/mod.rs
+++ b/bin/dev-cli/src/handlers/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod contest;
 pub(crate) mod derive_keys;
 mod graph;
 mod rpc;
+pub(crate) mod unstaking_intent;
 mod wallet;

--- a/bin/dev-cli/src/handlers/unstaking_intent.rs
+++ b/bin/dev-cli/src/handlers/unstaking_intent.rs
@@ -1,0 +1,126 @@
+use anyhow::bail;
+use bitcoin::hashes::{sha256, Hash};
+use bitcoincore_rpc::RpcApi;
+use strata_bridge_common::params::Params;
+use strata_bridge_connectors::prelude::UnstakingIntentWitness;
+use strata_bridge_key_deriv::PreimageIkm;
+use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeDaApiClient};
+use strata_bridge_tx_graph::{
+    musig_functor::StakeFunctor,
+    stake_graph::{StakeData, StakeGraph},
+};
+use tracing::info;
+
+use crate::{
+    cli,
+    handlers::{derive_keys, rpc},
+};
+
+const STAKE_TX_INDEX: u32 = 0;
+
+/// Post an unstaking intent transaction for the given operator stake graph.
+pub(crate) async fn handle_unstaking_intent(args: cli::UnstakingIntentArgs) -> anyhow::Result<()> {
+    let params = Params::from_path(&args.params)?;
+    let operator_keys = derive_keys::derive_operator_keys(&args.seed, params.network)?;
+    let preimage_ikm = PreimageIkm::derive(operator_keys.base_xpriv())
+        .map_err(|e| anyhow::anyhow!("failed to derive stakechain preimage ikm: {}", e))?;
+
+    let btc_client =
+        rpc::get_btc_client(&args.btc_args.url, args.btc_args.user, args.btc_args.pass)?;
+    let bridge_rpc_client = rpc::get_bridge_client(&args.bridge_node_url)?;
+
+    if let Err(e) = btc_client.get_blockchain_info() {
+        bail!(
+            "unable to reach bitcoin node at {}: {}",
+            args.btc_args.url,
+            e
+        );
+    }
+
+    if let Err(e) = bridge_rpc_client.get_uptime().await {
+        bail!(
+            "unable to reach bridge node at {}: {}",
+            args.bridge_node_url,
+            e
+        );
+    }
+
+    info!(operator_idx = args.operator_idx, "posting unstaking intent");
+
+    let stake_data = bridge_rpc_client
+        .get_stake_data(args.operator_idx)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fetch stake data: {}", e))?;
+    let stake_data = match stake_data {
+        Some(data) => data,
+        None => bail!("no stake data found for operator {}", args.operator_idx),
+    };
+    if stake_data.context.operator_idx() != args.operator_idx {
+        bail!(
+            "stake data operator mismatch: requested {}, got {}",
+            args.operator_idx,
+            stake_data.context.operator_idx()
+        );
+    }
+    info!(operator_idx = args.operator_idx, "fetched stake data");
+
+    let agg_sigs = bridge_rpc_client
+        .get_stake_aggregate_signatures(args.operator_idx)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fetch stake aggregate signatures: {}", e))?;
+    let agg_sigs = match agg_sigs {
+        Some(sigs) => sigs,
+        None => bail!(
+            "no aggregate stake signatures found for operator {}",
+            args.operator_idx
+        ),
+    };
+    if agg_sigs.operator_idx != args.operator_idx {
+        bail!(
+            "stake aggregate signature operator mismatch: requested {}, got {}",
+            args.operator_idx,
+            agg_sigs.operator_idx
+        );
+    }
+    info!(
+        operator_idx = args.operator_idx,
+        "fetched stake aggregate signatures"
+    );
+
+    let stake_funds = stake_data.setup.stake_funds;
+    let preimage = preimage_ikm.derive_preimage(stake_funds.txid, stake_funds.vout, STAKE_TX_INDEX);
+    let preimage_hash = sha256::Hash::hash(&preimage);
+    if preimage_hash != stake_data.setup.unstaking_image {
+        bail!(
+            "derived preimage hash {} does not match stake data unstaking image {}",
+            preimage_hash,
+            stake_data.setup.unstaking_image
+        );
+    }
+    info!(%stake_funds, %preimage_hash, "derived matching unstaking preimage");
+
+    let stake_graph = StakeGraph::new(StakeData {
+        protocol: stake_data.protocol,
+        setup: stake_data.setup,
+    });
+    let presigned = StakeFunctor::unpack(agg_sigs.signatures)
+        .ok_or_else(|| anyhow::anyhow!("invalid aggregate signature count for stake graph"))?;
+    let witness = UnstakingIntentWitness {
+        n_of_n_signature: presigned.unstaking_intent[0],
+        unstaking_preimage: preimage,
+    };
+    let unstaking_intent_tx = stake_graph.unstaking_intent.finalize(&witness);
+    let expected_txid = unstaking_intent_tx.compute_txid();
+
+    let txid = btc_client
+        .send_raw_transaction(&unstaking_intent_tx)
+        .map_err(|e| anyhow::anyhow!("failed to broadcast unstaking intent transaction: {}", e))?;
+    info!(
+        operator_idx = args.operator_idx,
+        %txid,
+        %expected_txid,
+        "broadcast unstaking intent transaction"
+    );
+
+    Ok(())
+}

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use handlers::derive_keys;
 use strata_bridge_common::logging::{self, LoggerConfig};
 
-use crate::handlers::{bridge_in, checkpoint, claim, contest};
+use crate::handlers::{bridge_in, checkpoint, claim, contest, unstaking_intent};
 
 mod cli;
 
@@ -24,5 +24,8 @@ async fn main() -> Result<(), Error> {
         }
         cli::Commands::Contest(args) => contest::handle_contest(args).await,
         cli::Commands::Claim(args) => claim::handle_claim(args).await,
+        cli::Commands::UnstakingIntent(args) => {
+            unstaking_intent::handle_unstaking_intent(args).await
+        }
     }
 }

--- a/bin/secret-service/Cargo.toml
+++ b/bin/secret-service/Cargo.toml
@@ -7,17 +7,18 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-secret-service-proto = { version = "0.1.0", path = "../../crates/secret-service-proto" }
-secret-service-server = { version = "0.1.0", path = "../../crates/secret-service-server" }
+secret-service-proto.workspace = true
+secret-service-server.workspace = true
 strata-bridge-key-deriv.workspace = true
 strata-bridge-primitives.workspace = true
+
+make_buf = { git = "https://github.com/alpenlabs/make_buf", version = "1.0.0" }
 
 bitcoin.workspace = true
 cache-advisor = "1.0.16"
 colored = "3.1.1"
-hkdf = "0.12.4"
+hkdf.workspace = true
 libp2p-identity = { workspace = true, features = ["ed25519"] }
-make_buf = { git = "https://github.com/alpenlabs/make_buf", version = "1.0.0" }
 musig2.workspace = true
 rand.workspace = true
 rcgen = "0.13.2"
@@ -36,7 +37,7 @@ tikv-jemallocator = "0.6"
 
 [dev-dependencies]
 rcgen = "0.13.2"
-secret-service-client = { path = "../../crates/secret-service-client" }
+secret-service-client.workspace = true
 
 [features]
 default = []

--- a/bin/secret-service/src/seeded_impl/preimage.rs
+++ b/bin/secret-service/src/seeded_impl/preimage.rs
@@ -1,10 +1,7 @@
 //! In-memory persistence for preimages.
 
-use bitcoin::{bip32::Xpriv, hashes::Hash, Txid};
-use hkdf::Hkdf;
-use make_buf::make_buf;
+use bitcoin::{bip32::Xpriv, Txid};
 use secret_service_proto::v2::traits::{Preimages, Server};
-use sha2::Sha256;
 use strata_bridge_key_deriv::PreimageIkm;
 
 /// Secret data for the preimages.
@@ -31,15 +28,7 @@ impl Preimages<Server> for Preimg {
         prestake_vout: u32,
         stake_index: u32,
     ) -> [u8; 32] {
-        let hk = Hkdf::<Sha256>::new(None, &*self.ikm);
-        let mut okm = [0u8; 32];
-        let info = make_buf! {
-            (prestake_txid.as_raw_hash().as_byte_array(), 32),
-            (&prestake_vout.to_le_bytes(), 4),
-            (&stake_index.to_le_bytes(), 4)
-        };
-        hk.expand(&info, &mut okm)
-            .expect("32 is a valid length for Sha256 to output");
-        okm
+        self.ikm
+            .derive_preimage(prestake_txid, prestake_vout, stake_index)
     }
 }

--- a/bin/strata-bridge/src/mode/rpc_server/da.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/da.rs
@@ -1,0 +1,60 @@
+//! Helpers that derive DA RPC responses from recovered state-machine state.
+
+use bitcoin::secp256k1::schnorr;
+use strata_bridge_primitives::types::OperatorIdx;
+use strata_bridge_rpc::types::{RpcStakeAggregateSignatures, RpcStakeData};
+use strata_bridge_sm::stake::{
+    config::StakeSMCfg,
+    context::{MinimumStakeData, StakeSMCtx},
+    state::StakeState,
+};
+use strata_bridge_tx_graph::musig_functor::StakeFunctor;
+
+pub(super) fn stake_data_response(
+    context: &StakeSMCtx,
+    state: &StakeState,
+    stake_cfg: &StakeSMCfg,
+) -> Option<RpcStakeData> {
+    let stake_data = minimum_stake_data_from_state(state)?;
+    let full_stake_data = stake_data.expand(*stake_cfg, context);
+
+    Some(RpcStakeData {
+        context: context.clone(),
+        protocol: full_stake_data.protocol,
+        setup: full_stake_data.setup,
+    })
+}
+
+pub(super) fn stake_aggregate_signatures_response(
+    operator_idx: OperatorIdx,
+    state: &StakeState,
+) -> Option<RpcStakeAggregateSignatures> {
+    let signatures = stake_aggregate_signatures_from_state(state)?;
+
+    Some(RpcStakeAggregateSignatures {
+        operator_idx,
+        signatures: (*signatures).pack().to_vec(),
+    })
+}
+
+const fn minimum_stake_data_from_state(state: &StakeState) -> Option<&MinimumStakeData> {
+    match state {
+        StakeState::StakeGraphGenerated { stake_data, .. }
+        | StakeState::UnstakingNoncesCollected { stake_data, .. }
+        | StakeState::UnstakingSigned { stake_data, .. }
+        | StakeState::Confirmed { stake_data, .. }
+        | StakeState::PreimageRevealed { stake_data, .. } => Some(stake_data),
+        _ => None,
+    }
+}
+
+fn stake_aggregate_signatures_from_state(
+    state: &StakeState,
+) -> Option<&StakeFunctor<schnorr::Signature>> {
+    match state {
+        StakeState::UnstakingSigned { signatures, .. } => Some(signatures.as_ref()),
+        StakeState::Confirmed { signatures, .. }
+        | StakeState::PreimageRevealed { signatures, .. } => signatures.as_ref().as_ref(),
+        _ => None,
+    }
+}

--- a/bin/strata-bridge/src/mode/rpc_server/mod.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/mod.rs
@@ -1,5 +1,6 @@
 //! RPC server initialization and monitoring response helpers.
 
+mod da;
 mod monitoring;
 mod server;
 

--- a/bin/strata-bridge/src/mode/rpc_server/server.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/server.rs
@@ -20,7 +20,7 @@ use strata_bridge_orchestrator::{
     persister::Persister,
     sm_registry::{SMConfig, SMRegistry},
 };
-use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
+use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
 use strata_bridge_rpc::{
     traits::{
         StrataBridgeControlApiServer, StrataBridgeDaApiServer, StrataBridgeMonitoringApiServer,
@@ -28,7 +28,7 @@ use strata_bridge_rpc::{
     types::{
         RpcAggregateSignatures, RpcBridgeDutyStatus, RpcDepositInfo, RpcDepositStatus,
         RpcGraphData, RpcOperatorStakeInfo, RpcOperatorStatus, RpcPendingWithdrawalInfo,
-        RpcReimbursementStatus, RpcWithdrawalStatus,
+        RpcReimbursementStatus, RpcStakeAggregateSignatures, RpcStakeData, RpcWithdrawalStatus,
     },
 };
 use strata_bridge_sm::deposit::state::DepositState;
@@ -48,7 +48,10 @@ use super::monitoring::{
 use crate::{
     config::{Config, RpcConfig},
     constants::DEFAULT_RPC_CACHE_REFRESH_INTERVAL,
-    mode::services::orchestrator::build_sm_config,
+    mode::{
+        rpc_server::da::{stake_aggregate_signatures_response, stake_data_response},
+        services::orchestrator::build_sm_config,
+    },
 };
 
 /// Starts an RPC server for a bridge operator.
@@ -481,6 +484,26 @@ impl StrataBridgeDaApiServer for BridgeRpc {
         Ok(cached_registry
             .get_graph(&graph_idx)
             .and_then(|gsm| aggregate_signatures_response(graph_idx, gsm.state())))
+    }
+
+    async fn get_stake_data(&self, operator_idx: OperatorIdx) -> RpcResult<Option<RpcStakeData>> {
+        let cached_registry = self.cached_registry.read().await;
+        let stake_cfg = cached_registry.cfg().stake.clone();
+
+        Ok(cached_registry
+            .get_stake(&operator_idx)
+            .and_then(|ssm| stake_data_response(ssm.context(), ssm.state(), &stake_cfg)))
+    }
+
+    async fn get_stake_aggregate_signatures(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> RpcResult<Option<RpcStakeAggregateSignatures>> {
+        let cached_registry = self.cached_registry.read().await;
+
+        Ok(cached_registry
+            .get_stake(&operator_idx)
+            .and_then(|ssm| stake_aggregate_signatures_response(operator_idx, ssm.state())))
     }
 }
 

--- a/bin/strata-bridge/src/mode/rpc_server/tests/da.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/tests/da.rs
@@ -1,0 +1,130 @@
+use std::collections::BTreeMap;
+
+use bitcoin::{
+    Amount, Network, OutPoint,
+    hashes::{Hash, sha256},
+    relative,
+    secp256k1::schnorr,
+};
+use strata_bridge_primitives::types::OperatorIdx;
+use strata_bridge_sm::stake::{
+    config::StakeSMCfg,
+    context::{MinimumStakeData, StakeSMCtx},
+    state::StakeState,
+};
+use strata_bridge_test_utils::{
+    bridge_fixtures::{TEST_MAGIC_BYTES, TEST_POV_IDX, random_p2tr_desc, test_operator_table},
+    prelude::generate_txid,
+};
+use strata_bridge_tx_graph::{
+    musig_functor::StakeFunctor,
+    stake_graph::{ProtocolParams, StakeGraphSummary},
+};
+
+use crate::mode::rpc_server::da::{stake_aggregate_signatures_response, stake_data_response};
+
+const OPERATOR_IDX: OperatorIdx = 1;
+
+fn test_stake_ctx() -> StakeSMCtx {
+    StakeSMCtx::new(OPERATOR_IDX, test_operator_table(3, TEST_POV_IDX))
+}
+
+fn test_stake_cfg() -> StakeSMCfg {
+    StakeSMCfg {
+        protocol_params: ProtocolParams {
+            network: Network::Regtest,
+            magic_bytes: TEST_MAGIC_BYTES.into(),
+            unstaking_timelock: relative::Height::from_height(10),
+            stake_amount: Amount::from_sat(20_000),
+        },
+    }
+}
+
+fn test_minimum_stake_data() -> MinimumStakeData {
+    MinimumStakeData {
+        stake_funds: OutPoint::new(generate_txid(), 0),
+        unstaking_image: sha256::Hash::hash(b"test-unstaking-preimage"),
+        unstaking_operator_desc: random_p2tr_desc(),
+    }
+}
+
+fn test_stake_summary() -> StakeGraphSummary {
+    StakeGraphSummary {
+        stake: generate_txid(),
+        unstaking_intent: generate_txid(),
+        unstaking: generate_txid(),
+    }
+}
+
+fn test_stake_signatures() -> StakeFunctor<schnorr::Signature> {
+    StakeFunctor {
+        unstaking_intent: [schnorr::Signature::from_slice(&[0x0a; 64]).expect("valid signature")],
+        unstaking: [
+            schnorr::Signature::from_slice(&[0x0b; 64]).expect("valid signature"),
+            schnorr::Signature::from_slice(&[0x0c; 64]).expect("valid signature"),
+        ],
+    }
+}
+#[test]
+fn stake_data_response_returns_stake_data_after_generation() {
+    let stake_ctx = test_stake_ctx();
+    let stake_cfg = test_stake_cfg();
+    let stake_data = test_minimum_stake_data();
+    let expected_setup = stake_data.expand(stake_cfg, &stake_ctx).setup;
+    let state = StakeState::StakeGraphGenerated {
+        last_block_height: 100,
+        stake_data,
+        summary: test_stake_summary(),
+        pub_nonces: BTreeMap::new(),
+    };
+
+    let response =
+        stake_data_response(&stake_ctx, &state, &stake_cfg).expect("stake data should be returned");
+
+    assert_eq!(response.context, stake_ctx);
+    assert_eq!(response.protocol, stake_cfg.protocol_params);
+    assert_eq!(response.setup, expected_setup);
+}
+
+#[test]
+fn stake_data_response_returns_none_before_stake_data_arrives() {
+    let state = StakeState::Created {
+        last_block_height: 100,
+    };
+
+    let response = stake_data_response(&test_stake_ctx(), &state, &test_stake_cfg());
+
+    assert!(response.is_none());
+}
+
+#[test]
+fn stake_aggregate_signatures_response_returns_packed_signatures() {
+    let signatures = test_stake_signatures();
+    let expected_signatures = signatures.pack().to_vec();
+    let state = StakeState::UnstakingSigned {
+        last_block_height: 100,
+        stake_data: test_minimum_stake_data(),
+        summary: test_stake_summary(),
+        signatures: Box::new(signatures),
+    };
+
+    let response = stake_aggregate_signatures_response(OPERATOR_IDX, &state)
+        .expect("stake signatures should be returned");
+
+    assert_eq!(response.operator_idx, OPERATOR_IDX);
+    assert_eq!(response.signatures, expected_signatures);
+}
+
+#[test]
+fn stake_aggregate_signatures_response_returns_none_before_signing() {
+    let state = StakeState::StakeGraphGenerated {
+        last_block_height: 100,
+        stake_data: test_minimum_stake_data(),
+        summary: test_stake_summary(),
+        pub_nonces: BTreeMap::new(),
+    };
+
+    let response = stake_aggregate_signatures_response(OPERATOR_IDX, &state);
+
+    assert!(response.is_none());
+}

--- a/bin/strata-bridge/src/mode/rpc_server/tests/mod.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/tests/mod.rs
@@ -1,3 +1,4 @@
 //! RPC server module tests.
 
+mod da;
 mod monitoring;

--- a/crates/bridge-exec/Cargo.toml
+++ b/crates/bridge-exec/Cargo.toml
@@ -49,4 +49,5 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+bdk_bitcoind_rpc.workspace = true
 corepc-node.workspace = true

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -114,6 +114,7 @@ pub async fn execute_graph_duty(
         GraphDuty::PublishUncontestedPayout {
             signed_uncontested_payout_tx,
         } => publish_uncontested_payout(&output_handles, signed_uncontested_payout_tx).await,
+        GraphDuty::PublishUnstakingBurn { .. } => todo!("PublishUnstakingBurn executor"),
         GraphDuty::PublishContest {
             contest_tx,
             n_of_n_signature,

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -7,6 +7,7 @@ mod contested;
 mod counterproof;
 mod counterproof_nack;
 mod uncontested;
+mod unstaking_burn;
 mod utils;
 
 use std::sync::Arc;
@@ -28,6 +29,7 @@ use crate::{
         counterproof::generate_and_publish_counterproof,
         counterproof_nack::publish_counterproof_nack,
         uncontested::publish_uncontested_payout,
+        unstaking_burn::publish_unstaking_burn,
     },
     output_handles::OutputHandles,
 };
@@ -114,7 +116,20 @@ pub async fn execute_graph_duty(
         GraphDuty::PublishUncontestedPayout {
             signed_uncontested_payout_tx,
         } => publish_uncontested_payout(&output_handles, signed_uncontested_payout_tx).await,
-        GraphDuty::PublishUnstakingBurn { .. } => todo!("PublishUnstakingBurn executor"),
+        GraphDuty::PublishUnstakingBurn {
+            graph_idx,
+            unstaking_burn_tx,
+            unstaking_preimage,
+        } => {
+            publish_unstaking_burn(
+                &cfg,
+                &output_handles,
+                *graph_idx,
+                unstaking_burn_tx.clone(),
+                *unstaking_preimage,
+            )
+            .await
+        }
         GraphDuty::PublishContest {
             contest_tx,
             n_of_n_signature,

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -1,0 +1,702 @@
+//! Executor for the unstaking burn transaction.
+
+use bitcoin::{
+    Amount, FeeRate, OutPoint, ScriptBuf, TapSighashType, Transaction, TxIn, TxOut,
+    hashes::Hash,
+    sighash::{Prevouts, SighashCache},
+    taproot,
+};
+use bitcoind_async_client::traits::Reader;
+use btc_tracker::event::TxStatus;
+use operator_wallet::OperatorWallet;
+use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
+use strata_bridge_primitives::types::GraphIdx;
+use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnTx;
+use tracing::{debug, info, warn};
+
+use crate::{
+    chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
+    output_handles::OutputHandles,
+};
+
+/// Index of the payout connector input in the unfunded burn template.
+const CONNECTOR_INPUT_INDEX: usize = 0;
+
+/// Index of the general-wallet funding input after [`attach_wallet_funding`] extends the template.
+const WALLET_INPUT_INDEX: usize = 1;
+
+/// General-wallet input selected for a single unstaking burn transaction.
+#[derive(Debug)]
+struct WalletFunding {
+    /// General-wallet outpoint leased for this burn attempt.
+    outpoint: OutPoint,
+    /// Previous output data for the leased input.
+    prevout: TxOut,
+}
+
+/// Fixed transaction construction parameters derived before selecting a funding UTXO.
+#[derive(Debug)]
+struct BurnTxPlan {
+    /// Value contributed by the payout connector input.
+    payout_connector_value: Amount,
+    /// Fee rate used to compute [`Self::fee`].
+    fee_rate: FeeRate,
+    /// Fee paid by the final burn transaction.
+    fee: Amount,
+    /// Virtual size used to compute [`Self::fee`].
+    estimated_vsize: u64,
+    /// Script that receives the remaining value after the burn fee is paid.
+    wallet_output_script: ScriptBuf,
+}
+
+/// Finalizes and publishes an unstaking burn transaction.
+pub(super) async fn publish_unstaking_burn(
+    cfg: &ExecutionConfig,
+    output_handles: &OutputHandles,
+    graph_idx: GraphIdx,
+    unstaking_burn_tx: UnstakingBurnTx,
+    unstaking_preimage: [u8; 32],
+) -> Result<(), ExecutorError> {
+    info!(%graph_idx, "preparing unstaking burn transaction");
+
+    let fee_rate = burn_fee_rate(output_handles).await?;
+    debug!(%graph_idx, %fee_rate, "selected fee rate for unstaking burn transaction");
+    if fee_rate > cfg.maximum_fee_rate {
+        warn!(
+            %graph_idx,
+            %fee_rate,
+            maximum_fee_rate = %cfg.maximum_fee_rate,
+            "fee rate exceeds maximum, skipping unstaking burn"
+        );
+        return Ok(());
+    }
+
+    let (funding, plan) = {
+        let mut wallet = output_handles.wallet.write().await;
+        select_funding(
+            &mut wallet,
+            graph_idx,
+            &unstaking_burn_tx,
+            unstaking_preimage,
+            fee_rate,
+        )
+        .await?
+    };
+
+    let sign_result = build_and_sign_tx(
+        output_handles,
+        graph_idx,
+        unstaking_burn_tx,
+        unstaking_preimage,
+        &funding,
+        &plan,
+    )
+    .await;
+
+    let signed_tx = match sign_result {
+        Ok(tx) => tx,
+        Err(e) => {
+            warn!(
+                %graph_idx,
+                funding_outpoint = %funding.outpoint,
+                %e,
+                "failed to sign unstaking burn transaction; releasing wallet funding outpoint"
+            );
+            output_handles
+                .wallet
+                .write()
+                .await
+                .release_outpoints(&[funding.outpoint]);
+            return Err(e);
+        }
+    };
+
+    info!(%graph_idx, txid = %signed_tx.compute_txid(), "publishing unstaking burn transaction");
+    let publish_result = publish_signed_transaction(
+        &output_handles.tx_driver,
+        &signed_tx,
+        "unstaking burn",
+        TxStatus::is_buried,
+    )
+    .await;
+
+    if let Err(ref e) = publish_result {
+        warn!(
+            %graph_idx,
+            funding_outpoint = %funding.outpoint,
+            %e,
+            "failed to publish unstaking burn transaction; releasing wallet funding outpoint"
+        );
+        output_handles
+            .wallet
+            .write()
+            .await
+            .release_outpoints(&[funding.outpoint]);
+    }
+
+    publish_result
+}
+
+/// Returns the fee rate used for an unstaking burn attempt.
+///
+/// The executor asks Bitcoin Core for a one-block estimate and floors missing or low estimates at
+/// the network broadcast minimum so the constructed transaction remains relayable.
+async fn burn_fee_rate(output_handles: &OutputHandles) -> Result<FeeRate, ExecutorError> {
+    let fee_rate = output_handles
+        .bitcoind_rpc_client
+        .estimate_smart_fee(1)
+        .await
+        .map_err(|e| {
+            warn!(
+                ?e,
+                "failed to estimate fee rate for unstaking burn transaction"
+            );
+            ExecutorError::WalletErr(format!("failed to estimate fee: {e}"))
+        })?;
+
+    let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
+        .unwrap_or(FeeRate::BROADCAST_MIN)
+        .max(FeeRate::BROADCAST_MIN);
+
+    debug!(%fee_rate, "computed unstaking burn fee rate");
+
+    Ok(fee_rate)
+}
+
+/// Selects and leases a general-wallet UTXO that can pay for the burn transaction.
+///
+/// The payout connector contributes value but does not necessarily cover relay fees. This helper
+/// computes the fixed fee once, filters wallet UTXOs against that fee, and returns both the
+/// selected UTXO and the plan used to construct the final transaction.
+///
+/// The burn transaction constructed by this executor is:
+///
+/// ```text
+/// +----------+-------------------------------------------+-------------------------------------------------+
+/// | Inputs   |                                           | Outputs                                         |
+/// +----------+-------------------------------------------+-------------------------------------------------+
+/// | input 0  | claim payout connector                    | output 0: general-wallet output                 |
+/// |          | value: BurnTxPlan::payout_connector_value | value: inputs - BurnTxPlan::fee                 |
+/// |          | witness: unstaking_preimage               | script_pubkey: BurnTxPlan::wallet_output_script |
+/// +----------+-------------------------------------------+-------------------------------------------------+
+/// | input 1  | general-wallet funding UTXO               |                                                 |
+/// |          | outpoint: WalletFunding::outpoint         |                                                 |
+/// |          | prevout: WalletFunding::prevout           |                                                 |
+/// +----------+-------------------------------------------+-------------------------------------------------+
+/// ```
+///
+/// The fee is the difference between total inputs and explicit outputs:
+///
+/// ```text
+/// BurnTxPlan::fee =
+///     BurnTxPlan::payout_connector_value
+///   + WalletFunding::prevout.value
+///   - general_wallet_output_value
+/// ```
+async fn select_funding(
+    wallet: &mut OperatorWallet,
+    graph_idx: GraphIdx,
+    unstaking_burn_tx: &UnstakingBurnTx,
+    unstaking_preimage: [u8; 32],
+    fee_rate: FeeRate,
+) -> Result<(WalletFunding, BurnTxPlan), ExecutorError> {
+    let payout_connector_value = unstaking_burn_tx.prevouts()[CONNECTOR_INPUT_INDEX].value;
+
+    info!(%graph_idx, "syncing wallet before funding unstaking burn transaction");
+    if let Err(e) = wallet.sync().await {
+        warn!(%graph_idx, ?e, "could not sync wallet before funding unstaking burn");
+    }
+
+    let wallet_output_script = wallet.general_script_buf().clone();
+    let min_output_value = wallet_output_script.minimal_non_dust();
+    let fee = estimate_unstaking_burn_fee(
+        unstaking_burn_tx,
+        unstaking_preimage,
+        &wallet_output_script,
+        fee_rate,
+    )?;
+    let plan = BurnTxPlan {
+        payout_connector_value,
+        fee_rate,
+        fee: fee.amount,
+        estimated_vsize: fee.vsize,
+        wallet_output_script,
+    };
+
+    debug!(
+        %graph_idx,
+        %payout_connector_value,
+        fee = %plan.fee,
+        %fee_rate,
+        estimated_vsize = plan.estimated_vsize,
+        %min_output_value,
+        "selecting wallet funding UTXO for unstaking burn"
+    );
+
+    let funding = wallet.select_and_lease_general_utxo(|utxo| {
+        let output_value = match payout_connector_value
+            .checked_add(utxo.txout.value)
+            .and_then(|input_value| input_value.checked_sub(plan.fee))
+        {
+            Some(output_value) => output_value,
+            None => {
+                debug!(
+                    %graph_idx,
+                    outpoint = %utxo.outpoint,
+                    utxo_value = %utxo.txout.value,
+                    fee = %plan.fee,
+                    "wallet UTXO cannot cover unstaking burn fee"
+                );
+                return false;
+            }
+        };
+
+        if output_value < min_output_value {
+            debug!(
+                %graph_idx,
+                outpoint = %utxo.outpoint,
+                utxo_value = %utxo.txout.value,
+                %output_value,
+                %min_output_value,
+                fee = %plan.fee,
+                "wallet UTXO cannot fund non-dust unstaking burn output"
+            );
+            return false;
+        }
+
+        true
+    });
+
+    let Some(funding) = funding else {
+        warn!(
+            %graph_idx,
+            %payout_connector_value,
+            fee = %plan.fee,
+            %min_output_value,
+            %fee_rate,
+            "no general wallet UTXO available to fund unstaking burn"
+        );
+        return Err(ExecutorError::WalletErr(format!(
+            "no general wallet UTXO available to fund unstaking burn for graph {graph_idx}; \
+             payout connector value {payout_connector_value}, fee {}, minimum output value {}",
+            plan.fee, min_output_value
+        )));
+    };
+
+    let wallet_output_value = payout_connector_value
+        .checked_add(funding.txout.value)
+        .and_then(|input_value| input_value.checked_sub(plan.fee))
+        .ok_or_else(|| {
+            ExecutorError::WalletErr(format!(
+                "selected unstaking burn funding UTXO {} cannot cover fee {}",
+                funding.outpoint, plan.fee
+            ))
+        })?;
+
+    info!(
+        %graph_idx,
+        funding_outpoint = %funding.outpoint,
+        funding_value = %funding.txout.value,
+        %wallet_output_value,
+        fee = %plan.fee,
+        fee_rate = %plan.fee_rate,
+        estimated_vsize = plan.estimated_vsize,
+        "leased wallet funding UTXO for unstaking burn"
+    );
+
+    Ok((
+        WalletFunding {
+            outpoint: funding.outpoint,
+            prevout: funding.txout,
+        },
+        plan,
+    ))
+}
+
+/// Builds the funded burn transaction and signs the general-wallet input.
+///
+/// `finalize_partial` spends the payout connector with the unstaking preimage. The executor then
+/// signs the wallet funding input that was appended by [`attach_wallet_funding`].
+async fn build_and_sign_tx(
+    output_handles: &OutputHandles,
+    graph_idx: GraphIdx,
+    unstaking_burn_tx: UnstakingBurnTx,
+    unstaking_preimage: [u8; 32],
+    funding: &WalletFunding,
+    plan: &BurnTxPlan,
+) -> Result<Transaction, ExecutorError> {
+    let wallet_output_value = plan
+        .payout_connector_value
+        .checked_add(funding.prevout.value)
+        .and_then(|input_value| input_value.checked_sub(plan.fee))
+        .ok_or_else(|| {
+            ExecutorError::WalletErr(format!(
+                "selected unstaking burn funding UTXO {} cannot cover fee {}",
+                funding.outpoint, plan.fee
+            ))
+        })?;
+
+    debug!(
+        %graph_idx,
+        funding_outpoint = %funding.outpoint,
+        funding_value = %funding.prevout.value,
+        %wallet_output_value,
+        fee = %plan.fee,
+        "building funded unstaking burn transaction"
+    );
+
+    let mut funded_burn = unstaking_burn_tx;
+    attach_wallet_funding(
+        &mut funded_burn,
+        funding.outpoint,
+        funding.prevout.clone(),
+        TxOut {
+            value: wallet_output_value,
+            script_pubkey: plan.wallet_output_script.clone(),
+        },
+    );
+
+    let prevouts = funded_burn.prevouts().to_vec();
+    let mut signed_tx = funded_burn.finalize_partial(unstaking_preimage);
+    let wallet_signature = sign_wallet_input(output_handles, &signed_tx, &prevouts).await?;
+    signed_tx.input[WALLET_INPUT_INDEX]
+        .witness
+        .push(wallet_signature.to_vec());
+
+    let final_vsize = signed_tx.vsize() as u64;
+    let final_fee = plan
+        .payout_connector_value
+        .checked_add(funding.prevout.value)
+        .and_then(|input_value| input_value.checked_sub(wallet_output_value))
+        .ok_or_else(|| {
+            ExecutorError::WalletErr("final unstaking burn fee calculation underflowed".to_string())
+        })?;
+    let effective_fee_rate_sat_vb = final_fee.to_sat() as f64 / final_vsize as f64;
+    if final_vsize != plan.estimated_vsize {
+        warn!(
+            %graph_idx,
+            txid = %signed_tx.compute_txid(),
+            estimated_vsize = plan.estimated_vsize,
+            final_vsize,
+            fee = %final_fee,
+            fee_rate = %plan.fee_rate,
+            effective_fee_rate_sat_vb,
+            "unstaking burn transaction size differed from fee estimate"
+        );
+    }
+
+    info!(
+        %graph_idx,
+        txid = %signed_tx.compute_txid(),
+        fee = %final_fee,
+        expected_fee = %plan.fee,
+        fee_rate = %plan.fee_rate,
+        effective_fee_rate_sat_vb = effective_fee_rate_sat_vb,
+        final_vsize,
+        estimated_vsize = plan.estimated_vsize,
+        "finalized unstaking burn transaction fee"
+    );
+
+    Ok(signed_tx)
+}
+
+/// Estimated fee data for the fixed unstaking burn transaction shape.
+#[derive(Debug)]
+struct FeeEstimate {
+    /// Fee amount at the selected fee rate.
+    amount: Amount,
+    /// Virtual size of the transaction shape used for fee calculation.
+    vsize: u64,
+}
+
+/// Estimates the fee for the concrete funded burn transaction.
+///
+/// The estimate is derived from the actual transaction template: one payout connector input, one
+/// general-wallet input, and one output back to the general wallet. The connector witness is
+/// populated by `finalize_partial`; the wallet witness is modeled with a 64-byte Schnorr signature.
+fn estimate_unstaking_burn_fee(
+    unstaking_burn_tx: &UnstakingBurnTx,
+    unstaking_preimage: [u8; 32],
+    payout_script: &ScriptBuf,
+    fee_rate: FeeRate,
+) -> Result<FeeEstimate, ExecutorError> {
+    let mut unstaking_burn_tx = unstaking_burn_tx.clone();
+    let min_output_value = payout_script.minimal_non_dust();
+    attach_wallet_funding(
+        &mut unstaking_burn_tx,
+        OutPoint::null(),
+        TxOut {
+            value: Amount::ZERO,
+            script_pubkey: payout_script.clone(),
+        },
+        TxOut {
+            value: min_output_value,
+            script_pubkey: payout_script.clone(),
+        },
+    );
+
+    // The connector witness is exact after `finalize_partial`; the general wallet witness is a
+    // fixed-size Schnorr signature, so a 64-byte dummy witness gives an exact vsize.
+    let mut estimated_tx = unstaking_burn_tx.finalize_partial(unstaking_preimage);
+    estimated_tx.input[WALLET_INPUT_INDEX]
+        .witness
+        .push([0u8; 64]);
+
+    let vsize = estimated_tx.vsize() as u64;
+    let fee = fee_rate
+        .fee_vb(vsize)
+        .ok_or_else(|| ExecutorError::WalletErr("unstaking burn fee overflow".into()))?;
+
+    info!(%fee_rate, %vsize, fee = %fee, "estimated unstaking burn transaction fee");
+
+    Ok(FeeEstimate { amount: fee, vsize })
+}
+
+/// Appends the general-wallet input and output to the burn template.
+///
+/// After this runs, input index `0` remains the payout connector and input index `1` is the wallet
+/// funding input signed by [`sign_wallet_input`].
+fn attach_wallet_funding(
+    tx: &mut UnstakingBurnTx,
+    funding_outpoint: OutPoint,
+    funding_prevout: TxOut,
+    output: TxOut,
+) {
+    tx.push_input(
+        TxIn {
+            previous_output: funding_outpoint,
+            ..Default::default()
+        },
+        funding_prevout,
+    );
+    tx.push_output(output);
+}
+
+/// Signs the appended general-wallet funding input using the secret service.
+///
+/// The general wallet uses a taproot key-spend path, so the signature commits to all prevouts and
+/// uses the default taproot sighash type.
+async fn sign_wallet_input(
+    output_handles: &OutputHandles,
+    tx: &Transaction,
+    prevouts: &[TxOut],
+) -> Result<taproot::Signature, ExecutorError> {
+    let prevouts = Prevouts::All(prevouts);
+    let mut sighash_cache = SighashCache::new(tx);
+    let s2_signer = output_handles.s2_client.general_wallet_signer();
+
+    let sighash = sighash_cache
+        .taproot_key_spend_signature_hash(WALLET_INPUT_INDEX, &prevouts, TapSighashType::Default)
+        .map_err(|e| {
+            warn!(%e, "failed to compute unstaking burn wallet-input sighash");
+            ExecutorError::WalletErr(format!("unstaking burn sighash error: {e}"))
+        })?;
+    let signature = s2_signer
+        .sign(&sighash.to_byte_array(), None)
+        .await
+        .map_err(|e| {
+            warn!(?e, "failed to sign unstaking burn wallet input");
+            ExecutorError::SecretServiceErr(e)
+        })?;
+
+    Ok(taproot::Signature {
+        signature,
+        sighash_type: TapSighashType::Default,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, sync::Arc};
+
+    use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client as CoreRpcClient};
+    use bitcoin::{
+        Address, Network, Txid, XOnlyPublicKey,
+        hashes::{Hash, sha256},
+        secp256k1::{Keypair, SECP256K1, SecretKey},
+    };
+    use corepc_node::{Conf, Node};
+    use operator_wallet::{OperatorWalletConfig, sync::Backend};
+    use strata_bridge_connectors::prelude::ClaimPayoutConnector;
+    use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnData;
+
+    use super::*;
+
+    const TEST_GRAPH_IDX: GraphIdx = GraphIdx {
+        deposit: 0,
+        operator: 0,
+    };
+
+    fn setup_bitcoind() -> Node {
+        let mut conf = Conf::default();
+        conf.args.push("-txindex=1");
+
+        Node::with_conf("bitcoind", &conf).expect("bitcoind should start")
+    }
+
+    fn core_rpc_client(bitcoind: &Node) -> CoreRpcClient {
+        let cookie = bitcoind
+            .params
+            .get_cookie_values()
+            .expect("cookie file should be readable")
+            .expect("cookie file should contain credentials");
+        let auth = Auth::UserPass(cookie.user, cookie.password);
+
+        CoreRpcClient::new(bitcoind.rpc_url().as_str(), auth)
+            .expect("core rpc client should initialize")
+    }
+
+    fn xonly_pubkey(byte: u8) -> XOnlyPublicKey {
+        let secret_key = SecretKey::from_slice(&[byte; 32]).expect("secret key should be valid");
+        let keypair = Keypair::from_secret_key(SECP256K1, &secret_key);
+
+        keypair.x_only_public_key().0
+    }
+
+    fn wallet(bitcoind: &Node) -> OperatorWallet {
+        OperatorWallet::new(
+            xonly_pubkey(1),
+            xonly_pubkey(2),
+            OperatorWalletConfig::new(
+                Amount::from_sat(20_000),
+                Amount::from_sat(1_000),
+                Network::Regtest,
+            ),
+            Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
+            BTreeSet::new(),
+        )
+    }
+
+    fn fund_general_wallet(bitcoind: &Node, wallet: &OperatorWallet, amount: Amount) {
+        let mining_address = bitcoind
+            .client
+            .new_address()
+            .expect("mining address should be generated");
+        bitcoind
+            .client
+            .generate_to_address(101, &mining_address)
+            .expect("coinbase outputs should mature");
+
+        let general_address = Address::from_script(wallet.general_script_buf(), Network::Regtest)
+            .expect("general wallet script should be addressable");
+        bitcoind
+            .client
+            .send_to_address(&general_address, amount)
+            .expect("general wallet should be funded");
+        bitcoind
+            .client
+            .generate_to_address(1, &mining_address)
+            .expect("general wallet funding should confirm");
+    }
+
+    fn unstaking_burn_tx(unstaking_preimage: [u8; 32]) -> UnstakingBurnTx {
+        let connector = ClaimPayoutConnector::new(
+            Network::Regtest,
+            xonly_pubkey(3),
+            xonly_pubkey(4),
+            sha256::Hash::hash(&unstaking_preimage),
+        );
+        let data = UnstakingBurnData {
+            claim_txid: Txid::from_slice(&[5; 32]).expect("txid should be valid"),
+        };
+
+        UnstakingBurnTx::new(data, connector)
+    }
+
+    fn wallet_script() -> ScriptBuf {
+        Address::p2tr(SECP256K1, xonly_pubkey(6), None, Network::Regtest).script_pubkey()
+    }
+
+    #[test]
+    fn fee_estimate_matches_final_transaction_shape() {
+        let unstaking_preimage = [7; 32];
+        let unstaking_burn_tx = unstaking_burn_tx(unstaking_preimage);
+        let payout_script = wallet_script();
+        let fee_rate = FeeRate::from_sat_per_vb(2).expect("fee rate should be valid");
+
+        let fee = estimate_unstaking_burn_fee(
+            &unstaking_burn_tx,
+            unstaking_preimage,
+            &payout_script,
+            fee_rate,
+        )
+        .expect("fee should be estimated");
+
+        let funding_prevout = TxOut {
+            value: Amount::from_sat(25_000),
+            script_pubkey: payout_script.clone(),
+        };
+        let output_value = unstaking_burn_tx.prevouts()[CONNECTOR_INPUT_INDEX].value
+            + funding_prevout.value
+            - fee.amount;
+        let mut funded_burn = unstaking_burn_tx;
+        attach_wallet_funding(
+            &mut funded_burn,
+            OutPoint::null(),
+            funding_prevout,
+            TxOut {
+                value: output_value,
+                script_pubkey: payout_script,
+            },
+        );
+
+        let mut tx = funded_burn.finalize_partial(unstaking_preimage);
+        tx.input[WALLET_INPUT_INDEX].witness.push([0; 64]);
+
+        assert_eq!(
+            tx.vsize() as u64,
+            fee.vsize,
+            "estimated vsize should match the finalized transaction shape"
+        );
+        assert_eq!(
+            fee.amount,
+            fee_rate
+                .fee_vb(tx.vsize() as u64)
+                .expect("fee should not overflow"),
+            "estimated fee should be derived from the selected fee rate and final vsize"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_funding_leases_utxo_that_can_fund_non_dust_output() {
+        let bitcoind = setup_bitcoind();
+        let mut wallet = wallet(&bitcoind);
+        fund_general_wallet(&bitcoind, &wallet, Amount::from_sat(25_000));
+
+        let unstaking_preimage = [8; 32];
+        let unstaking_burn_tx = unstaking_burn_tx(unstaking_preimage);
+        let fee_rate = FeeRate::from_sat_per_vb(2).expect("fee rate should be valid");
+        let min_output_value = wallet.general_script_buf().minimal_non_dust();
+
+        let (funding, plan) = select_funding(
+            &mut wallet,
+            TEST_GRAPH_IDX,
+            &unstaking_burn_tx,
+            unstaking_preimage,
+            fee_rate,
+        )
+        .await
+        .expect("wallet should have a suitable funding UTXO");
+        let wallet_output_value = plan.payout_connector_value + funding.prevout.value - plan.fee;
+
+        assert_eq!(
+            plan.fee_rate, fee_rate,
+            "funding plan should retain the selected fee rate"
+        );
+        assert!(
+            wallet_output_value >= min_output_value,
+            "selected funding should leave a non-dust wallet output"
+        );
+        assert_eq!(
+            plan.payout_connector_value,
+            unstaking_burn_tx.prevouts()[CONNECTOR_INPUT_INDEX].value,
+            "funding plan should retain the payout connector input value"
+        );
+        assert!(
+            wallet
+                .leased_outpoints()
+                .any(|outpoint| outpoint == funding.outpoint),
+            "selected funding outpoint should be leased"
+        );
+    }
+}

--- a/crates/bridge-sm/src/cross_sm_context.rs
+++ b/crates/bridge-sm/src/cross_sm_context.rs
@@ -1,0 +1,28 @@
+//! Auxiliary context resolved from sibling state machines.
+//!
+//! This data is destination-scoped: it is not a signal that should causally
+//! persist another state machine, but context that the receiving state machine
+//! may use while processing its own event.
+
+use serde::{Deserialize, Serialize};
+
+/// Cross-state-machine context available to a state transition.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CrossSmContext {
+    /// Revealed unstaking preimage for the graph owner, if known.
+    unstaking_preimage: Option<[u8; 32]>,
+}
+
+impl CrossSmContext {
+    /// Constructs a context with a revealed unstaking preimage.
+    pub const fn with_unstaking_preimage(unstaking_preimage: [u8; 32]) -> Self {
+        Self {
+            unstaking_preimage: Some(unstaking_preimage),
+        }
+    }
+
+    /// Returns the revealed unstaking preimage, if known.
+    pub const fn unstaking_preimage(&self) -> Option<[u8; 32]> {
+        self.unstaking_preimage
+    }
+}

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -16,7 +16,7 @@ use strata_bridge_primitives::{
 use strata_bridge_tx_graph::transactions::{
     claim::ClaimTx,
     counterproof::CounterproofTx,
-    prelude::{ContestTx, CounterproofNackTx},
+    prelude::{ContestTx, CounterproofNackTx, UnstakingBurnTx},
 };
 use strata_mosaic_client_api::types::CompletedSignatures;
 use zkaleido::ProofReceipt;
@@ -184,6 +184,19 @@ pub enum GraphDuty {
         signed_uncontested_payout_tx: Transaction,
     },
 
+    /// Publish an unstaking burn transaction to spend the claim-payout connector after the graph
+    /// owner's unstaking preimage is revealed.
+    PublishUnstakingBurn {
+        /// The index of the graph this duty is associated with.
+        graph_idx: GraphIdx,
+
+        /// The unsigned unstaking burn transaction.
+        unstaking_burn_tx: UnstakingBurnTx,
+
+        /// The graph owner's revealed unstaking preimage.
+        unstaking_preimage: [u8; 32],
+    },
+
     /// Publish the contest transaction on-chain in response to a faulty claim.
     PublishContest {
         /// The unsigned contest transaction.
@@ -295,6 +308,7 @@ impl std::fmt::Display for GraphDuty {
             GraphDuty::PublishGraphPartials { .. } => "PublishGraphPartials".to_string(),
             GraphDuty::PublishClaim { .. } => "PublishClaim".to_string(),
             GraphDuty::PublishUncontestedPayout { .. } => "PublishUncontestedPayout".to_string(),
+            GraphDuty::PublishUnstakingBurn { .. } => "PublishUnstakingBurn".to_string(),
             GraphDuty::PublishContest { .. } => "PublishContest".to_string(),
             GraphDuty::GenerateAndPublishBridgeProof { .. } => {
                 "GenerateAndPublishBridgeProof".to_string()

--- a/crates/bridge-sm/src/graph/machine.rs
+++ b/crates/bridge-sm/src/graph/machine.rs
@@ -11,6 +11,7 @@ use strata_bridge_tx_graph::{
 };
 
 use crate::{
+    cross_sm_context::CrossSmContext,
     error_policy::soften_peer_event_error,
     graph::{
         config::GraphSMCfg,
@@ -97,6 +98,14 @@ impl StateMachine for GraphSM {
                     .map_err(|err| soften_peer_event_error(sm_event, err))
             }
         }
+    }
+
+    fn run_post_stf_hook(
+        &self,
+        cfg: &Self::Config,
+        cross_sm_context: &CrossSmContext,
+    ) -> Vec<Self::Duty> {
+        self.run_graph_post_stf_hook(cfg, cross_sm_context)
     }
 }
 

--- a/crates/bridge-sm/src/graph/mod.rs
+++ b/crates/bridge-sm/src/graph/mod.rs
@@ -6,6 +6,7 @@ pub mod errors;
 pub mod events;
 mod handlers;
 pub mod machine;
+mod post_processor;
 pub mod state;
 pub mod transitions;
 mod tx_classifier;

--- a/crates/bridge-sm/src/graph/post_processor.rs
+++ b/crates/bridge-sm/src/graph/post_processor.rs
@@ -1,0 +1,155 @@
+//! Post-STF duty derivation for the Graph State Machine.
+
+use bitcoin::hashes::{Hash, sha256};
+use strata_bridge_tx_graph::{
+    game_graph::{DepositParams, GameConnectors},
+    transactions::prelude::{UnstakingBurnData, UnstakingBurnTx},
+};
+use tracing::warn;
+
+use crate::{
+    cross_sm_context::CrossSmContext,
+    graph::{config::GraphSMCfg, duties::GraphDuty, machine::GraphSM, state::GraphState},
+};
+
+impl GraphSM {
+    pub(crate) fn run_graph_post_stf_hook(
+        &self,
+        cfg: &GraphSMCfg,
+        cross_sm_context: &CrossSmContext,
+    ) -> Vec<GraphDuty> {
+        self.derive_unstaking_burn_duty(cfg, cross_sm_context)
+            .into_iter()
+            .collect()
+    }
+
+    fn derive_unstaking_burn_duty(
+        &self,
+        cfg: &GraphSMCfg,
+        cross_sm_context: &CrossSmContext,
+    ) -> Option<GraphDuty> {
+        let unstaking_preimage = cross_sm_context.unstaking_preimage()?;
+
+        if self.context().operator_idx() == self.context().operator_table().pov_idx() {
+            return None;
+        }
+
+        let preimage_hash = sha256::Hash::hash(&unstaking_preimage);
+        if preimage_hash != self.context().unstaking_image() {
+            warn!(
+                graph_idx = %self.context().graph_idx(),
+                expected = %self.context().unstaking_image(),
+                actual = %preimage_hash,
+                "cross-SM unstaking preimage does not match graph image"
+            );
+            return None;
+        }
+
+        let candidate = BurnCandidate::from_state(self.state())?;
+        let setup_params = self
+            .context()
+            .generate_setup_params(cfg, candidate.graph_data);
+        let connectors = GameConnectors::new(
+            candidate.graph_data.game_index,
+            &cfg.game_graph_params,
+            &setup_params,
+        );
+        let unstaking_burn_tx = UnstakingBurnTx::new(
+            UnstakingBurnData {
+                claim_txid: candidate.claim_txid,
+            },
+            connectors.claim_payout,
+        );
+
+        Some(GraphDuty::PublishUnstakingBurn {
+            graph_idx: self.context().graph_idx(),
+            unstaking_burn_tx,
+            unstaking_preimage,
+        })
+    }
+}
+
+struct BurnCandidate<'a> {
+    graph_data: &'a DepositParams,
+    claim_txid: bitcoin::Txid,
+}
+
+impl<'a> BurnCandidate<'a> {
+    const fn from_state(state: &'a GraphState) -> Option<Self> {
+        match state {
+            GraphState::Claimed {
+                graph_data,
+                graph_summary,
+                payout_connector_spent: None,
+                ..
+            }
+            | GraphState::Contested {
+                graph_data,
+                graph_summary,
+                payout_connector_spent: None,
+                ..
+            }
+            | GraphState::BridgeProofPosted {
+                graph_data,
+                graph_summary,
+                payout_connector_spent: None,
+                ..
+            }
+            | GraphState::CounterProofPosted {
+                graph_data,
+                graph_summary,
+                payout_connector_spent: None,
+                ..
+            } => Some(Self {
+                graph_data,
+                claim_txid: graph_summary.claim,
+            }),
+
+            GraphState::BridgeProofTimedout {
+                graph_data,
+                claim_txid,
+                ..
+            }
+            | GraphState::Acked {
+                graph_data,
+                claim_txid,
+                ..
+            }
+            | GraphState::AllNackd {
+                graph_data,
+                claim_txid,
+                ..
+            } => Some(Self {
+                graph_data,
+                claim_txid: *claim_txid,
+            }),
+
+            GraphState::Created { .. }
+            | GraphState::GraphGenerated { .. }
+            | GraphState::AdaptorsVerified { .. }
+            | GraphState::NoncesCollected { .. }
+            | GraphState::GraphSigned { .. }
+            | GraphState::Assigned { .. }
+            | GraphState::Fulfilled { .. }
+            | GraphState::Claimed {
+                payout_connector_spent: Some(_),
+                ..
+            }
+            | GraphState::Contested {
+                payout_connector_spent: Some(_),
+                ..
+            }
+            | GraphState::BridgeProofPosted {
+                payout_connector_spent: Some(_),
+                ..
+            }
+            | GraphState::CounterProofPosted {
+                payout_connector_spent: Some(_),
+                ..
+            }
+            | GraphState::Withdrawn { .. }
+            | GraphState::Slashed { .. }
+            | GraphState::Aborted { .. } => None,
+        }
+    }
+}

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -7,6 +7,7 @@ pub(super) mod utils;
 
 mod deposit_signal;
 mod notify_new_block;
+mod post_processor;
 mod process_payout;
 mod process_payout_connector_spent;
 mod tx_classifier;

--- a/crates/bridge-sm/src/graph/tests/post_processor.rs
+++ b/crates/bridge-sm/src/graph/tests/post_processor.rs
@@ -1,0 +1,262 @@
+//! Unit tests for GraphSM post-STF duty derivation.
+//!
+//! Coverage strategy: a single table-driven test iterates every [`GraphState`]
+//! variant returned by [`all_state_variants`] and asserts post-processor output
+//! against a per-state [`expected_outcomes`] mapping function. The mapping uses
+//! an exhaustive `match` over [`GraphState`], so adding a new variant is a
+//! compile error until the post-processing behavior is classified.
+
+use bitcoin::{
+    OutPoint,
+    hashes::{Hash, sha256},
+};
+use strata_bridge_primitives::types::GraphIdx;
+use strata_bridge_test_utils::prelude::generate_txid;
+use strata_bridge_tx_graph::transactions::prelude::ClaimTx;
+
+use crate::{
+    cross_sm_context::CrossSmContext,
+    graph::{
+        duties::GraphDuty,
+        state::GraphState,
+        tests::{create_nonpov_sm, create_sm, mock_states::all_state_variants, test_graph_sm_cfg},
+    },
+    state_machine::StateMachine,
+};
+
+const UNSTAKING_PREIMAGE: [u8; 32] = [0x42; 32];
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Outcome {
+    EmitsUnstakingBurn,
+    NoDuties,
+}
+
+#[derive(Debug, Clone)]
+struct StateClassification {
+    /// Non-owner watchtower, matching preimage present in cross-SM context.
+    matching_non_owner: Outcome,
+    /// Graph owner, matching preimage present in cross-SM context.
+    graph_owner: Outcome,
+    /// Non-owner watchtower, no preimage present in cross-SM context.
+    missing_preimage: Outcome,
+    /// Non-owner watchtower, preimage present but mismatched against graph context.
+    mismatched_preimage: Outcome,
+    /// `Some(_)` if the state carries `payout_connector_spent`. The contained
+    /// outcome describes what happens when that field is pre-set and a matching
+    /// preimage arrives.
+    with_connector_pre_set: Option<Outcome>,
+}
+
+/// Exhaustive over [`GraphState`] — adding a new variant is a compile error.
+fn expected_outcomes(state: &GraphState) -> StateClassification {
+    match state {
+        // Pre-claim states have no claim payout connector to burn.
+        GraphState::Created { .. }
+        | GraphState::GraphGenerated { .. }
+        | GraphState::AdaptorsVerified { .. }
+        | GraphState::NoncesCollected { .. }
+        | GraphState::GraphSigned { .. }
+        | GraphState::Assigned { .. }
+        | GraphState::Fulfilled { .. } => StateClassification {
+            matching_non_owner: Outcome::NoDuties,
+            graph_owner: Outcome::NoDuties,
+            missing_preimage: Outcome::NoDuties,
+            mismatched_preimage: Outcome::NoDuties,
+            with_connector_pre_set: None,
+        },
+
+        // Post-claim two-fact states can burn the payout connector unless a
+        // connector spend has already been recorded.
+        GraphState::Claimed { .. }
+        | GraphState::Contested { .. }
+        | GraphState::BridgeProofPosted { .. }
+        | GraphState::CounterProofPosted { .. } => StateClassification {
+            matching_non_owner: Outcome::EmitsUnstakingBurn,
+            graph_owner: Outcome::NoDuties,
+            missing_preimage: Outcome::NoDuties,
+            mismatched_preimage: Outcome::NoDuties,
+            with_connector_pre_set: Some(Outcome::NoDuties),
+        },
+
+        // Slash-path states no longer carry the connector-spend fact, but the
+        // payout connector still exists until a spend is observed on-chain.
+        GraphState::BridgeProofTimedout { .. }
+        | GraphState::Acked { .. }
+        | GraphState::AllNackd { .. } => StateClassification {
+            matching_non_owner: Outcome::EmitsUnstakingBurn,
+            graph_owner: Outcome::NoDuties,
+            missing_preimage: Outcome::NoDuties,
+            mismatched_preimage: Outcome::NoDuties,
+            with_connector_pre_set: None,
+        },
+
+        // Terminal states must not derive new duties.
+        GraphState::Withdrawn { .. } | GraphState::Slashed { .. } | GraphState::Aborted { .. } => {
+            StateClassification {
+                matching_non_owner: Outcome::NoDuties,
+                graph_owner: Outcome::NoDuties,
+                missing_preimage: Outcome::NoDuties,
+                mismatched_preimage: Outcome::NoDuties,
+                with_connector_pre_set: None,
+            }
+        }
+    }
+}
+
+#[test]
+fn post_stf_hook_dispatch_table_for_unstaking_burn_is_exhaustive() {
+    let matching_context = CrossSmContext::with_unstaking_preimage(UNSTAKING_PREIMAGE);
+    let missing_context = CrossSmContext::default();
+
+    // Every variant is exercised below. `all_state_variants()` returns one
+    // representative per variant; if a new variant is added the
+    // `expected_outcomes` match above fails to compile.
+    for variant in all_state_variants() {
+        let classification = expected_outcomes(&variant);
+
+        let (graph_idx, duties) = run_non_owner(
+            variant.clone(),
+            matching_unstaking_image(),
+            &matching_context,
+        );
+        let observed_matching = outcome_of(graph_idx, duties, &variant);
+        assert_eq!(
+            observed_matching, classification.matching_non_owner,
+            "matching non-owner outcome mismatch in state {variant}"
+        );
+
+        let (graph_idx, duties) = run_owner(
+            variant.clone(),
+            matching_unstaking_image(),
+            &matching_context,
+        );
+        let observed_owner = outcome_of(graph_idx, duties, &variant);
+        assert_eq!(
+            observed_owner, classification.graph_owner,
+            "graph-owner outcome mismatch in state {variant}"
+        );
+
+        let (graph_idx, duties) = run_non_owner(
+            variant.clone(),
+            matching_unstaking_image(),
+            &missing_context,
+        );
+        let observed_missing_preimage = outcome_of(graph_idx, duties, &variant);
+        assert_eq!(
+            observed_missing_preimage, classification.missing_preimage,
+            "missing-preimage outcome mismatch in state {variant}"
+        );
+
+        let (graph_idx, duties) = run_non_owner(
+            variant.clone(),
+            mismatched_unstaking_image(),
+            &matching_context,
+        );
+        let observed_mismatched_preimage = outcome_of(graph_idx, duties, &variant);
+        assert_eq!(
+            observed_mismatched_preimage, classification.mismatched_preimage,
+            "mismatched-preimage outcome mismatch in state {variant}"
+        );
+
+        if let Some(expected) = classification.with_connector_pre_set {
+            let mut state = variant.clone();
+            assert!(
+                state.set_payout_connector_spent(generate_txid()),
+                "with_connector_pre_set is `Some` but state does not carry the field: {variant}"
+            );
+
+            let (graph_idx, duties) =
+                run_non_owner(state, matching_unstaking_image(), &matching_context);
+            let observed = outcome_of(graph_idx, duties, &variant);
+            assert_eq!(
+                observed, expected,
+                "connector-pre-set outcome mismatch in state {variant}"
+            );
+        }
+    }
+}
+
+fn run_non_owner(
+    initial: GraphState,
+    unstaking_image: sha256::Hash,
+    cross_sm_context: &CrossSmContext,
+) -> (GraphIdx, Vec<GraphDuty>) {
+    let cfg = test_graph_sm_cfg();
+    let mut sm = create_nonpov_sm(initial);
+    sm.context.unstaking_image = unstaking_image;
+    let graph_idx = sm.context.graph_idx();
+    let duties = sm.run_post_stf_hook(&cfg, cross_sm_context);
+    (graph_idx, duties)
+}
+
+fn run_owner(
+    initial: GraphState,
+    unstaking_image: sha256::Hash,
+    cross_sm_context: &CrossSmContext,
+) -> (GraphIdx, Vec<GraphDuty>) {
+    let cfg = test_graph_sm_cfg();
+    let mut sm = create_sm(initial);
+    sm.context.unstaking_image = unstaking_image;
+    let graph_idx = sm.context.graph_idx();
+    let duties = sm.run_post_stf_hook(&cfg, cross_sm_context);
+    (graph_idx, duties)
+}
+
+fn outcome_of(
+    expected_graph_idx: GraphIdx,
+    duties: Vec<GraphDuty>,
+    initial: &GraphState,
+) -> Outcome {
+    if duties.is_empty() {
+        return Outcome::NoDuties;
+    }
+
+    let [
+        GraphDuty::PublishUnstakingBurn {
+            graph_idx,
+            unstaking_burn_tx,
+            unstaking_preimage,
+        },
+    ] = duties.as_slice()
+    else {
+        panic!("unexpected post-STF duties: {duties:?}");
+    };
+
+    assert_eq!(*graph_idx, expected_graph_idx);
+    assert_eq!(*unstaking_preimage, UNSTAKING_PREIMAGE);
+    assert_eq!(
+        unstaking_burn_tx.as_ref().input[0].previous_output,
+        expected_burn_outpoint(initial),
+        "unexpected burn outpoint in state {initial}"
+    );
+    Outcome::EmitsUnstakingBurn
+}
+
+fn expected_burn_outpoint(initial: &GraphState) -> OutPoint {
+    let txid = match initial {
+        GraphState::Claimed { graph_summary, .. }
+        | GraphState::Contested { graph_summary, .. }
+        | GraphState::BridgeProofPosted { graph_summary, .. }
+        | GraphState::CounterProofPosted { graph_summary, .. } => graph_summary.claim,
+        GraphState::BridgeProofTimedout { claim_txid, .. }
+        | GraphState::Acked { claim_txid, .. }
+        | GraphState::AllNackd { claim_txid, .. } => *claim_txid,
+        other => panic!("state should not emit PublishUnstakingBurn: {other}"),
+    };
+
+    OutPoint {
+        txid,
+        vout: ClaimTx::PAYOUT_VOUT,
+    }
+}
+
+fn matching_unstaking_image() -> sha256::Hash {
+    sha256::Hash::hash(&UNSTAKING_PREIMAGE)
+}
+
+fn mismatched_unstaking_image() -> sha256::Hash {
+    let mut image = matching_unstaking_image().to_byte_array();
+    image[0] ^= 1;
+    sha256::Hash::from_byte_array(image)
+}

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -635,10 +635,7 @@ impl GraphSM {
         // abort.
         if let Some(payout_connector_spending_txid) = self.state.payout_connector_spent_txid() {
             self.state = GraphState::Aborted {
-                claim_txid: self
-                    .state
-                    .claim_txid()
-                    .expect("claim txid must be in state if aborting due to stake spend"),
+                claim_txid: self.state.claim_txid().unwrap_or(Txid::all_zeros()),
                 reason: AbortReason::Both {
                     stake_spending_txid: spend_txid,
                     payout_connector_spending_txid,

--- a/crates/bridge-sm/src/lib.rs
+++ b/crates/bridge-sm/src/lib.rs
@@ -6,6 +6,7 @@
 //! other, and each state machine can also emit duties that need to be executed externally to
 //! effect the desired operations.
 
+pub mod cross_sm_context;
 pub mod deposit;
 pub(crate) mod error_policy;
 pub mod errors;

--- a/crates/bridge-sm/src/state_machine.rs
+++ b/crates/bridge-sm/src/state_machine.rs
@@ -3,7 +3,7 @@
 //! This module provides the core abstractions for all state machines in the bridge system,
 //! including the generic output type and the trait that all state machines implement.
 
-use crate::signals::Signal;
+use crate::{cross_sm_context::CrossSmContext, signals::Signal};
 
 /// Generic output from any state machine after processing an event.
 ///
@@ -92,7 +92,7 @@ where
 ///     type Event = DepositEvent;
 ///     type Error = DSMError;
 ///
-///     fn process_event(&mut self, event: Self::Event)
+///     fn process_event(&mut self, cfg: Self::Config, event: Self::Event)
 ///         -> Result<SMOutput<Self::Duty, Self::OutgoingSignal>, Self::Error>
 ///     {
 ///         // Implementation
@@ -128,4 +128,17 @@ pub trait StateMachine {
         cfg: Self::Config,
         event: Self::Event,
     ) -> Result<SMOutput<Self::Duty, Self::OutgoingSignal>, Self::Error>;
+
+    /// Runs after a successful state transition and derives append-only duties from the settled
+    /// state plus destination-scoped cross-SM context.
+    ///
+    /// This hook intentionally receives `&self` and returns a fresh duty list: it is not part of
+    /// the STF, must not mutate state, and must not emit signals.
+    fn run_post_stf_hook(
+        &self,
+        _cfg: &Self::Config,
+        _cross_sm_context: &CrossSmContext,
+    ) -> Vec<Self::Duty> {
+        Vec::new()
+    }
 }

--- a/crates/key-deriv/Cargo.toml
+++ b/crates/key-deriv/Cargo.toml
@@ -8,9 +8,14 @@ description = "Key derivation utilities for Strata Bridge"
 workspace = true
 
 [dependencies]
+strata-bridge-primitives.workspace = true
+
+make_buf = { git = "https://github.com/alpenlabs/make_buf", version = "1.0.0" }
+
 bitcoin.workspace = true
 ed25519-dalek.workspace = true
+hkdf.workspace = true
 secp256k1.workspace = true
-strata-bridge-primitives.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 zeroize.workspace = true

--- a/crates/key-deriv/src/derive.rs
+++ b/crates/key-deriv/src/derive.rs
@@ -21,11 +21,15 @@
 use std::ops::Deref;
 
 use bitcoin::{
-    XOnlyPublicKey,
+    Txid, XOnlyPublicKey,
     bip32::{self, Xpriv},
+    hashes::Hash,
     key::Keypair,
 };
+use hkdf::Hkdf;
+use make_buf::make_buf;
 use secp256k1::SECP256K1;
+use sha2::Sha256;
 use strata_bridge_primitives::secp::EvenSecretKey;
 
 use crate::paths::{
@@ -258,5 +262,64 @@ impl PreimageIkm {
         let child = base.derive_priv(SECP256K1, &PREIMG_IKM_PATH)?;
         let ikm = child.private_key.secret_bytes();
         Ok(Self(ikm))
+    }
+
+    /// Derive the deterministic stakechain preimage for a stake funding outpoint.
+    pub fn derive_preimage(
+        &self,
+        prestake_txid: Txid,
+        prestake_vout: u32,
+        stake_index: u32,
+    ) -> [u8; 32] {
+        let hk = Hkdf::<Sha256>::new(None, &self.0);
+        let mut okm = [0u8; 32];
+        let info = make_buf! {
+            (prestake_txid.as_raw_hash().as_byte_array(), 32),
+            (&prestake_vout.to_le_bytes(), 4),
+            (&stake_index.to_le_bytes(), 4)
+        };
+        hk.expand(&info, &mut okm)
+            .expect("32 is a valid length for Sha256 to output");
+        okm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{Txid, hashes::Hash};
+
+    use super::PreimageIkm;
+
+    #[test]
+    fn stakechain_preimage_derivation_is_deterministic() {
+        let ikm = PreimageIkm([1; 32]);
+        let txid = Txid::from_byte_array([2; 32]);
+
+        let first = ikm.derive_preimage(txid, 3, 0);
+        let second = ikm.derive_preimage(txid, 3, 0);
+
+        assert_eq!(
+            first, second,
+            "preimage derivation must be deterministic for the same stake funding outpoint"
+        );
+    }
+
+    #[test]
+    fn stakechain_preimage_derivation_binds_to_funding_outpoint() {
+        let ikm = PreimageIkm([1; 32]);
+        let txid = Txid::from_byte_array([2; 32]);
+
+        let base = ikm.derive_preimage(txid, 3, 0);
+        let different_vout = ikm.derive_preimage(txid, 4, 0);
+        let different_stake_index = ikm.derive_preimage(txid, 3, 1);
+
+        assert_ne!(
+            base, different_vout,
+            "changing the stake funding vout must change the derived preimage"
+        );
+        assert_ne!(
+            base, different_stake_index,
+            "changing the stake index must change the derived preimage"
+        );
     }
 }

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -524,14 +524,22 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::key::rand;
+    use std::num::NonZero;
+
+    use bitcoin::{OutPoint, hashes::Hash, key::rand};
     use strata_bridge_p2p_types::NagRequestPayload;
     use strata_bridge_primitives::types::{GraphIdx, P2POperatorPubKey};
     use strata_bridge_sm::{
         deposit::events::{DepositEvent, NagReceivedEvent, NewBlockEvent as DepositNewBlock},
-        graph::events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+        graph::{
+            duties::GraphDuty,
+            events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+            machine::generate_game_graph,
+            state::GraphState,
+        },
     };
-    use strata_bridge_test_utils::prelude::generate_txid;
+    use strata_bridge_test_utils::{bitcoin::generate_xonly_pubkey, prelude::generate_txid};
+    use strata_bridge_tx_graph::game_graph::DepositParams;
 
     use super::*;
     use crate::{
@@ -809,6 +817,53 @@ mod tests {
     }
 
     #[test]
+    fn process_event_appends_graph_post_stf_duties_from_cross_sm_context() {
+        let mut registry = test_populated_registry(1);
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let graph_idx = GraphIdx {
+            deposit: 0,
+            operator: 1,
+        };
+        let preimage = [0x42; 32];
+
+        registry
+            .insert_stake(
+                graph_idx.operator,
+                preimage_revealed_stake_sm(graph_idx.operator, table, preimage),
+            )
+            .unwrap();
+        set_graph_claimed_with_unstaking_image(&mut registry, graph_idx, preimage);
+
+        let outcome = registry
+            .process_event(
+                &SMId::Graph(graph_idx),
+                GraphEvent::NewBlock(GraphNewBlock {
+                    block_height: INITIAL_BLOCK_HEIGHT + 1,
+                })
+                .into(),
+            )
+            .unwrap();
+
+        let ProcessOutcome::Applied(output) = outcome else {
+            panic!("expected applied outcome, got {outcome:?}");
+        };
+        assert!(
+            output.duties.iter().any(|duty| {
+                matches!(
+                    duty,
+                    UnifiedDuty::Graph(GraphDuty::PublishUnstakingBurn {
+                        graph_idx: duty_graph_idx,
+                        unstaking_preimage,
+                        ..
+                    }) if *duty_graph_idx == graph_idx && *unstaking_preimage == preimage
+                )
+            }),
+            "expected PublishUnstakingBurn duty, got {:?}",
+            output.duties
+        );
+    }
+
+    #[test]
     fn sm_error_duplicate_maps_to_ignored_outcome() {
         let id = SMId::Deposit(7);
         let event = SMEvent::Deposit(Box::new(DepositEvent::NewBlock(DepositNewBlock {
@@ -916,6 +971,44 @@ mod tests {
                 signatures,
             },
         }
+    }
+
+    fn set_graph_claimed_with_unstaking_image(
+        registry: &mut SMRegistry,
+        graph_idx: GraphIdx,
+        preimage: [u8; 32],
+    ) {
+        let cfg = registry.cfg.graph.clone();
+        let graph = registry
+            .graphs
+            .get_mut(&graph_idx)
+            .expect("test registry must contain graph");
+        graph.context.unstaking_image = sha256::Hash::hash(&preimage);
+
+        let graph_data = DepositParams {
+            game_index: NonZero::new(graph_idx.deposit + 1).expect("deposit index + 1 is non-zero"),
+            claim_funds: OutPoint::default(),
+            deposit_outpoint: graph.context.deposit_outpoint(),
+            adaptor_pubkeys: (0..N_TEST_OPERATORS - 1)
+                .map(|_| generate_xonly_pubkey())
+                .collect(),
+            fault_pubkeys: (0..N_TEST_OPERATORS - 1)
+                .map(|_| generate_xonly_pubkey())
+                .collect(),
+        };
+        let graph_summary = generate_game_graph(&cfg, graph.context(), &graph_data).summarize();
+
+        graph.state = GraphState::Claimed {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            graph_data,
+            graph_summary,
+            signatures: Default::default(),
+            fulfillment_txid: Some(generate_txid()),
+            fulfillment_block_height: Some(INITIAL_BLOCK_HEIGHT),
+            claim_block_height: INITIAL_BLOCK_HEIGHT,
+            stake_spent: None,
+            payout_connector_spent: None,
+        };
     }
 
     // ===== Stake SM gating / snapshot tests =====

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -12,6 +12,7 @@ use strata_bridge_primitives::{
     types::{DepositIdx, GraphIdx, OperatorIdx},
 };
 use strata_bridge_sm::{
+    cross_sm_context::CrossSmContext,
     deposit::{config::DepositSMCfg, machine::DepositSM},
     errors::BridgeSMError,
     graph::{config::GraphSMCfg, machine::GraphSM},
@@ -404,6 +405,8 @@ impl SMRegistry {
         id: &SMId,
         event: SMEvent,
     ) -> Result<ProcessOutcome, ProcessError> {
+        let cross_sm_context = CrossSmContext::default();
+
         match (id, event) {
             (SMId::Deposit(idx), SMEvent::Deposit(deposit_event)) => {
                 let sm = self
@@ -413,8 +416,10 @@ impl SMRegistry {
                 let event = SMEvent::Deposit(deposit_event.clone());
                 sm.process_event(self.cfg.deposit.clone(), *deposit_event)
                     .map(|out| {
+                        let mut duties = out.duties;
+                        duties.extend(sm.run_post_stf_hook(&self.cfg.deposit, &cross_sm_context));
                         ProcessOutcome::Applied(SMOutput {
-                            duties: out.duties.into_iter().map(UnifiedDuty::Deposit).collect(),
+                            duties: duties.into_iter().map(UnifiedDuty::Deposit).collect(),
                             signals: out.signals.into_iter().map(Into::into).collect(),
                         })
                     })
@@ -429,8 +434,10 @@ impl SMRegistry {
                 let event = SMEvent::Graph(graph_event.clone());
                 sm.process_event(self.cfg.graph.clone(), *graph_event)
                     .map(|out| {
+                        let mut duties = out.duties;
+                        duties.extend(sm.run_post_stf_hook(&self.cfg.graph, &cross_sm_context));
                         ProcessOutcome::Applied(SMOutput {
-                            duties: out.duties.into_iter().map(UnifiedDuty::Graph).collect(),
+                            duties: duties.into_iter().map(UnifiedDuty::Graph).collect(),
                             signals: out.signals.into_iter().map(Into::into).collect(),
                         })
                     })
@@ -445,8 +452,10 @@ impl SMRegistry {
                 let event = SMEvent::Stake(stake_event.clone());
                 sm.process_event(self.cfg.stake.clone(), *stake_event)
                     .map(|out| {
+                        let mut duties = out.duties;
+                        duties.extend(sm.run_post_stf_hook(&self.cfg.stake, &cross_sm_context));
                         ProcessOutcome::Applied(SMOutput {
-                            duties: out.duties.into_iter().map(UnifiedDuty::Stake).collect(),
+                            duties: duties.into_iter().map(UnifiedDuty::Stake).collect(),
                             signals: out.signals,
                         })
                     })

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -405,7 +405,7 @@ impl SMRegistry {
         id: &SMId,
         event: SMEvent,
     ) -> Result<ProcessOutcome, ProcessError> {
-        let cross_sm_context = CrossSmContext::default();
+        let cross_sm_context = self.resolve_cross_sm_context(id);
 
         match (id, event) {
             (SMId::Deposit(idx), SMEvent::Deposit(deposit_event)) => {
@@ -465,6 +465,32 @@ impl SMRegistry {
             (id, event) => Err(ProcessError::InvalidInvocation(*id, event)),
         }
     }
+
+    /// Resolves auxiliary state from sibling state machines for the destination `id`.
+    ///
+    /// This context is intentionally not routed as a signal: resolving it does not create a
+    /// causal persistence edge from the source SM to the destination SM.
+    fn resolve_cross_sm_context(&self, id: &SMId) -> CrossSmContext {
+        match id {
+            SMId::Graph(graph_idx) => self.resolve_graph_cross_sm_context(graph_idx),
+            SMId::Deposit(_) | SMId::Stake(_) => CrossSmContext::default(),
+        }
+    }
+
+    /// Resolves context needed by a graph state machine from its owner's stake state machine.
+    fn resolve_graph_cross_sm_context(&self, graph_idx: &GraphIdx) -> CrossSmContext {
+        let Some(graph_sm) = self.graphs.get(graph_idx) else {
+            return CrossSmContext::default();
+        };
+
+        self.stakes
+            .get(&graph_sm.context().operator_idx())
+            .and_then(|stake_sm| stake_sm.state().preimage())
+            .map_or_else(
+                CrossSmContext::default,
+                CrossSmContext::with_unstaking_preimage,
+            )
+    }
 }
 
 fn sm_to_process_result<S, E>(
@@ -511,9 +537,10 @@ mod tests {
     use crate::{
         sm_types::OperatorKey,
         testing::{
-            N_TEST_OPERATORS, TEST_POV_IDX, insert_confirmed_stake, insert_created_stake,
-            insert_deposit_with_graphs, insert_stakes_for_all_operators, test_empty_registry,
-            test_operator_table, test_populated_registry,
+            INITIAL_BLOCK_HEIGHT, N_TEST_OPERATORS, TEST_POV_IDX, insert_confirmed_stake,
+            insert_created_stake, insert_deposit_with_graphs, insert_stakes_for_all_operators,
+            make_confirmed_stake_sm, test_empty_registry, test_operator_table,
+            test_populated_registry,
         },
     };
 
@@ -690,6 +717,46 @@ mod tests {
         assert!(op_idx.is_none());
     }
 
+    // ===== cross-SM context tests =====
+
+    #[test]
+    fn graph_cross_sm_context_includes_owner_unstaking_preimage() {
+        let mut registry = test_populated_registry(1);
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let graph_idx = GraphIdx {
+            deposit: 0,
+            operator: 1,
+        };
+        let preimage = [0x42; 32];
+
+        registry
+            .insert_stake(
+                graph_idx.operator,
+                preimage_revealed_stake_sm(graph_idx.operator, table, preimage),
+            )
+            .unwrap();
+
+        let context = registry.resolve_cross_sm_context(&SMId::Graph(graph_idx));
+        assert_eq!(context.unstaking_preimage(), Some(preimage));
+    }
+
+    #[test]
+    fn graph_cross_sm_context_does_not_use_different_operator_preimage() {
+        let mut registry = test_populated_registry(1);
+        let table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let graph_idx = GraphIdx {
+            deposit: 0,
+            operator: 1,
+        };
+
+        registry
+            .insert_stake(2, preimage_revealed_stake_sm(2, table, [0x24; 32]))
+            .unwrap();
+
+        let context = registry.resolve_cross_sm_context(&SMId::Graph(graph_idx));
+        assert_eq!(context.unstaking_preimage(), None);
+    }
+
     // ===== process_event error tests =====
 
     #[test]
@@ -819,6 +886,36 @@ mod tests {
             Err(ProcessError::InvariantViolation(dep_id, dep_event, state, err_reason))
                 if err_reason == reason && state == state_str && dep_id == id && dep_event == event
         ));
+    }
+
+    fn preimage_revealed_stake_sm(
+        operator_idx: OperatorIdx,
+        operator_table: OperatorTable,
+        preimage: [u8; 32],
+    ) -> StakeSM {
+        let sm = make_confirmed_stake_sm(operator_idx, operator_table, generate_txid());
+        let context = sm.context;
+        let StakeState::Confirmed {
+            stake_data,
+            summary,
+            signatures,
+            ..
+        } = sm.state
+        else {
+            unreachable!("test helper constructs Confirmed state");
+        };
+
+        StakeSM {
+            context,
+            state: StakeState::PreimageRevealed {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                stake_data,
+                summary,
+                preimage,
+                unstaking_intent_block_height: INITIAL_BLOCK_HEIGHT,
+                signatures,
+            },
+        }
     }
 
     // ===== Stake SM gating / snapshot tests =====

--- a/crates/rpc/src/traits.rs
+++ b/crates/rpc/src/traits.rs
@@ -2,12 +2,12 @@
 
 use bitcoin::PublicKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
+use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
 
 use crate::types::{
     RpcAggregateSignatures, RpcBridgeDutyStatus, RpcDepositInfo, RpcGraphData,
     RpcOperatorStakeInfo, RpcOperatorStatus, RpcPendingWithdrawalInfo, RpcReimbursementStatus,
-    RpcWithdrawalStatus,
+    RpcStakeAggregateSignatures, RpcStakeData, RpcWithdrawalStatus,
 };
 
 /// RPCs related to information about the client itself.
@@ -104,4 +104,15 @@ pub trait StrataBridgeDaApi {
         &self,
         graph_idx: GraphIdx,
     ) -> RpcResult<Option<RpcAggregateSignatures>>;
+
+    /// Query for the setup data required to reconstruct an operator's stake graph.
+    #[method(name = "stakeData")]
+    async fn get_stake_data(&self, operator_idx: OperatorIdx) -> RpcResult<Option<RpcStakeData>>;
+
+    /// Query for the aggregate stake signatures for a particular operator.
+    #[method(name = "stakeAggregateSignatures")]
+    async fn get_stake_aggregate_signatures(
+        &self,
+        operator_idx: OperatorIdx,
+    ) -> RpcResult<Option<RpcStakeAggregateSignatures>>;
 }

--- a/crates/rpc/src/types.rs
+++ b/crates/rpc/src/types.rs
@@ -4,8 +4,11 @@ use bitcoin::Txid;
 use secp256k1::schnorr::Signature;
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::types::{DepositIdx, GraphIdx, OperatorIdx};
-use strata_bridge_sm::graph::context::GraphSMCtx;
-use strata_bridge_tx_graph::game_graph::{DepositParams, SetupParams};
+use strata_bridge_sm::{graph::context::GraphSMCtx, stake::context::StakeSMCtx};
+use strata_bridge_tx_graph::{
+    game_graph::{DepositParams, SetupParams},
+    stake_graph::{ProtocolParams as StakeProtocolParams, SetupParams as StakeSetupParams},
+};
 
 /// Enum representing the status of a bridge operator
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -204,6 +207,29 @@ pub struct RpcAggregateSignatures {
     pub graph_idx: GraphIdx,
 
     /// Aggregate Schnorr signatures for the graph.
+    pub signatures: Vec<Signature>,
+}
+
+/// Stake data needed to reconstruct an operator's stake graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcStakeData {
+    /// Stake state machine context used for stake graph construction.
+    pub context: StakeSMCtx,
+
+    /// Protocol parameters used to construct the stake graph.
+    pub protocol: StakeProtocolParams,
+
+    /// Setup parameters required to construct the stake graph.
+    pub setup: StakeSetupParams,
+}
+
+/// Aggregate signatures needed to finalize presigned transactions in the stake graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcStakeAggregateSignatures {
+    /// Operator whose stake graph the signatures belong to.
+    pub operator_idx: OperatorIdx,
+
+    /// Aggregate Schnorr signatures for the stake graph.
     pub signatures: Vec<Signature>,
 }
 

--- a/functional-tests/constants.py
+++ b/functional-tests/constants.py
@@ -14,6 +14,7 @@ DT_DEPOSIT_VOUT = 1  # Deposit funds locked in N/N taproot
 # Game-graph tx output indices, mirrored from the Rust tx-graph crate.
 # Naming follows `<SOURCE_TX>_<OUTPUT>_VOUT`.
 CLAIM_CONTEST_VOUT = 0
+CLAIM_PAYOUT_VOUT = 1
 CONTEST_PROOF_VOUT = 0
 CONTEST_PAYOUT_VOUT = 1
 CONTEST_WATCHTOWER_0_VOUT = 3

--- a/functional-tests/tests/unstaking/fn_unstaking_burn.py
+++ b/functional-tests/tests/unstaking/fn_unstaking_burn.py
@@ -1,0 +1,149 @@
+import flexitest
+
+from constants import CLAIM_CONTEST_VOUT, CLAIM_PAYOUT_VOUT, MAX_BRIDGE_TIMEOUT
+from envs import BridgeNetworkEnv
+from envs.base_test import StrataTestBase
+from factory.bridge_operator.config_cfg import BridgeConfigParams
+from factory.bridge_operator.params_cfg import BridgeProtocolParams
+from rpc.types import RpcDepositStatusComplete
+from utils.bridge import get_bridge_nodes_and_rpcs
+from utils.deposit import (
+    wait_until_deposit_status,
+    wait_until_drt_recognized,
+    wait_until_utxo_spent,
+)
+from utils.dev_cli import DevCli
+from utils.utils import (
+    find_utxo_spender_txid,
+    read_operator_key,
+    wait_for_tx_confirmation,
+    wait_until,
+)
+from utils.withdrawal import wait_until_active_valid_claim
+
+
+@flexitest.register
+class UnstakingBurnTest(StrataTestBase):
+    """
+    Test that an operator unstaking intent lets a watchtower burn the claim payout connector.
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        self.bridge_protocol_params = BridgeProtocolParams(contest_timelock=MAX_BRIDGE_TIMEOUT)
+        ctx.set_env(
+            BridgeNetworkEnv(
+                bridge_protocol_params=self.bridge_protocol_params,
+                bridge_config_params=BridgeConfigParams(
+                    cooperative_payout_timeout=0,
+                ),
+            )
+        )
+
+    def main(self, ctx: flexitest.RunContext):
+        bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
+        bitcoind_service = ctx.get_service("bitcoin")
+        bitcoin_rpc = bitcoind_service.create_rpc()
+
+        num_operators = len(bridge_nodes)
+        operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
+
+        asm_service = ctx.get_service("asm_rpc")
+        asm_rpc = asm_service.create_rpc()
+
+        dev_cli = DevCli(
+            bitcoind_service.props,
+            operator_key_infos,
+            bridge_protocol_params=self.bridge_protocol_params,
+        )
+
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
+        deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
+        self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
+
+        deposit_info = wait_until_deposit_status(bridge_rpc, deposit_id, RpcDepositStatusComplete)
+        assert deposit_info is not None, "Deposit did not complete"
+        self.logger.info("Deposit completed")
+
+        recent_block_hash = bitcoin_rpc.proxy.getblockhash(bitcoin_rpc.proxy.getblockcount())
+        ckp_l1_txn = dev_cli.send_mock_checkpoint_from_tip(
+            asm_rpc,
+            recent_block_hash,
+            num_ol_slots=1,
+        )
+        ckp_block_hash = wait_for_tx_confirmation(bitcoin_rpc, ckp_l1_txn)
+        self.logger.info(f"Checkpoint tx {ckp_l1_txn} included in block {ckp_block_hash}")
+
+        wait_until(
+            lambda: len(asm_rpc.strata_asm_getAssignments(ckp_block_hash)) > 0,
+            timeout=300,
+            error_msg="ASM did not produce assignment",
+        )
+
+        active_claim = wait_until_active_valid_claim(bridge_rpc)
+        self.logger.info(
+            "Active claim %s for deposit %s assigned to operator %s",
+            active_claim.claim_txid,
+            active_claim.deposit_idx,
+            active_claim.assigned_operator,
+        )
+
+        claim_block_hash = wait_for_tx_confirmation(
+            bitcoin_rpc,
+            active_claim.claim_txid,
+            timeout=300,
+        )
+        self.logger.info(
+            f"Claim tx {active_claim.claim_txid} confirmed in block {claim_block_hash}"
+        )
+
+        owner_idx = active_claim.assigned_operator
+        owner_rpc_url = f"http://127.0.0.1:{bridge_nodes[owner_idx].props['rpc_port']}"
+        unstaking_intent_txid = dev_cli.send_unstaking_intent(
+            operator_idx=owner_idx,
+            bridge_node_url=owner_rpc_url,
+            seed=operator_key_infos[owner_idx].SEED,
+        )
+        self.logger.info(f"Broadcasted unstaking intent tx: {unstaking_intent_txid}")
+
+        unstaking_intent_block_hash = wait_for_tx_confirmation(
+            bitcoin_rpc,
+            unstaking_intent_txid,
+            timeout=300,
+        )
+        self.logger.info(
+            "Unstaking intent tx %s confirmed in block %s",
+            unstaking_intent_txid,
+            unstaking_intent_block_hash,
+        )
+
+        wait_until_utxo_spent(
+            bitcoin_rpc,
+            active_claim.claim_txid,
+            CLAIM_PAYOUT_VOUT,
+            timeout=450,
+        )
+        burn_txid = find_utxo_spender_txid(
+            bitcoin_rpc,
+            active_claim.claim_txid,
+            CLAIM_PAYOUT_VOUT,
+        )
+        burn_block_hash = wait_for_tx_confirmation(bitcoin_rpc, burn_txid, timeout=300)
+        self.logger.info(f"Unstaking burn tx {burn_txid} confirmed in block {burn_block_hash}")
+
+        burn_tx = bitcoin_rpc.proxy.getrawtransaction(burn_txid, True)
+        burn_inputs = [(vin["txid"], vin["vout"]) for vin in burn_tx.get("vin", [])]
+        assert len(burn_inputs) == 2, "Unstaking burn should have connector and wallet inputs"
+        assert burn_inputs[0] == (
+            active_claim.claim_txid,
+            CLAIM_PAYOUT_VOUT,
+        ), "Unstaking burn first input should spend the claim payout connector"
+        assert (
+            active_claim.claim_txid,
+            CLAIM_CONTEST_VOUT,
+        ) not in burn_inputs, "Unstaking burn should not spend the claim contest connector"
+        assert len(burn_tx.get("vout", [])) == 1, "Unstaking burn should have one wallet output"
+
+        return True

--- a/functional-tests/utils/dev_cli.py
+++ b/functional-tests/utils/dev_cli.py
@@ -234,3 +234,35 @@ class DevCli:
         # HACK: (@Rajil1213) parse raw stdout to extract txid
         txid = res.splitlines()[-1].split("=")[-1].strip()
         return txid
+
+    def send_unstaking_intent(
+        self,
+        operator_idx: int,
+        bridge_node_url: str,
+        seed: str,
+    ):
+        rpc_port = self.bitcoind_props["rpc_port"]  # fail fast if missing
+        wallet = self.bitcoind_props.get("walletname", "testwallet")
+
+        args = [
+            "unstaking-intent",
+            "--btc-url",
+            f"http://127.0.0.1:{rpc_port}/wallet/{wallet}",
+            "--btc-user",
+            self.bitcoind_props.get("rpc_user", "user"),
+            "--btc-pass",
+            self.bitcoind_props.get("rpc_password", "password"),
+            "--params",
+            self.params_path,
+            "--operator-idx",
+            str(operator_idx),
+            "--bridge-node-url",
+            bridge_node_url,
+            "--seed",
+            seed,
+        ]
+
+        res = self._run_command(args)
+        # HACK: (@Rajil1213) parse raw stdout to extract txid
+        txid = res.splitlines()[-1].split("=")[-1].strip()
+        return txid


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR handles the availability of the unstaking preimage when an operator posts the `UnstakingIntent` transaction. Once this transaction is posted, the preimage can be used to short-circuit any ongoing claims by burning the `claim-payout` connector. And so, this PR also implements the executor to post the `UnstakingBurn` transaction. The way the confirmation of `UnstakingIntent` transaction is handled is that:

* The preimage becomes available in the Stake SM.
* A new `post_stf_hook` has been added as part of the `StateMachine` trait which accepts a cross-state-machine context.
* This `cross-state-machine context` optionally holds the revealed preimage.
* In the implementation of this trait on the `GSM`, a `PublishUnstakingBurn` duty is emitted if the preimage is available in the `cross-state-machine context`.
* This duty gets appended to the duties queue from the normal STF.

A functional test group has been added (`unstaking`) that demonstrates the `UnstakingBurn` transaction being posted. This required adding an RPC to retrieve `StakeData` and a new command to the `dev-cli` to post the `UnstakingIntent` transaction.

Note that this PR depends on #526 (as `PublishUnstakingBurn` is unconditionally produced and so the abort path must be correctly handled).

Claude and Codex were used to plan this PR, and Codex to implement it.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor (`preimage` derivatio is now part of the `key-deriv` crate and not the `secret-service`)
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

This PR builds on #526 and should be reviewed and merged after that one.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3114