### PR TITLE
fix(fntests,docker): use difficulty adjustment epoch timestamp instead of genesis

### DIFF
--- a/docker/asm-runner/gen_asm_params.py
+++ b/docker/asm-runner/gen_asm_params.py
@@ -3,13 +3,13 @@
 import argparse
 import base64
 import json
+import logging
 import time
 import tomllib
 import urllib.error
 import urllib.request
 from dataclasses import asdict
 from pathlib import Path
-import logging
 
 from asm_params import build_l1_anchor
 
@@ -89,23 +89,21 @@ def wait_for_genesis_height(
     )
 
 
-def fetch_chain_context(bitcoin_cfg: dict, genesis_height: int) -> tuple[str, dict]:
+def fetch_block_header(bitcoin_cfg: dict, height: int) -> dict:
     block_hash = rpc_call(
         bitcoin_cfg["rpc_url"],
         bitcoin_cfg["rpc_user"],
         bitcoin_cfg["rpc_password"],
         "getblockhash",
-        [genesis_height],
+        [height],
     )
-    header = rpc_call(
+    return rpc_call(
         bitcoin_cfg["rpc_url"],
         bitcoin_cfg["rpc_user"],
         bitcoin_cfg["rpc_password"],
         "getblockheader",
         [block_hash],
     )
-
-    return block_hash, header
 
 
 def validate_params(asm_params: dict, bridge_params: dict) -> None:
@@ -176,12 +174,15 @@ def main() -> None:
     logging.info(f"Waiting for bitcoind to reach genesis height {genesis_height}")
     wait_for_genesis_height(config["bitcoin"], genesis_height, args.timeout_secs)
 
-    logging.info("Fetching chain context for genesis height")
-    block_hash, header = fetch_chain_context(config["bitcoin"], genesis_height)
-
     network = params["anchor"]["network"]
     logging.info(f"Updating ASM params with chain context for {network} network")
-    params["anchor"] = asdict(build_l1_anchor(genesis_height, block_hash, header, network))
+    params["anchor"] = asdict(
+        build_l1_anchor(
+            genesis_height,
+            lambda h: fetch_block_header(config["bitcoin"], h),
+            network,
+        )
+    )
 
     logging.info(f"Writing updated ASM params to {params_path}")
     params_path.write_text(json.dumps(params, indent=4) + "\n")

--- a/functional-tests/factory/bridge_operator/asm_cfg.py
+++ b/functional-tests/factory/bridge_operator/asm_cfg.py
@@ -18,13 +18,15 @@ def build_asm_params(
     """Create AsmParams aligned with the current regtest chain."""
     cfg = asm_config or AsmEnvConfig()
     musig2_keys = [key.MUSIG2_KEY for key in operator_key_infos]
-    block_hash = bitcoind_rpc.proxy.getblockhash(genesis_height)
-    header = bitcoind_rpc.proxy.getblockheader(block_hash)
+
+    def get_block_header(height: int) -> dict[str, Any]:
+        block_hash = bitcoind_rpc.proxy.getblockhash(height)
+        return bitcoind_rpc.proxy.getblockheader(block_hash)
+
     return build_asm_params_common(
         musig2_keys=musig2_keys,
         genesis_height=genesis_height,
-        block_hash=block_hash,
-        header=header,
+        get_block_header=get_block_header,
         magic=cfg.magic,
         denomination=cfg.denomination,
         assignment_duration=cfg.assignment_duration,

--- a/functional-tests/factory/common/asm_params.py
+++ b/functional-tests/factory/common/asm_params.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
 from constants import ASM_MAGIC_BYTES
+
+# Bitcoin's difficulty adjustment interval, in blocks. Identical across all networks
+# (mainnet, testnet, signet, regtest) per Bitcoin Core's consensus params.
+DIFFICULTY_ADJUSTMENT_INTERVAL = 2016
+
+# A callable that returns the verbose ``getblockheader`` response (a dict with at least
+# ``hash``, ``bits``, and ``time`` fields) for the block at a given height.
+BlockHeaderFetcher = Callable[[int], dict[str, Any]]
 
 
 @dataclass
@@ -74,23 +83,32 @@ def parse_bits_to_target(bits: int | str) -> int:
     return int(bits)
 
 
-# NOTE: (@Rajil1213) This function is also used by the `gen_asm_params.py` script
-# in the `docker/asm-runner` directory, so it should be kept generic
-# and not rely on any test-specific logic.
+# NOTE: (@Rajil1213) This function is also used by the `gen_asm_params.py` script in the
+# `docker/asm-runner` directory, so it should be kept generic and not rely on any
+# test-specific logic.
 def build_l1_anchor(
     genesis_height: int,
-    block_hash: str,
-    header: dict[str, Any],
+    get_block_header: BlockHeaderFetcher,
     network: str = "regtest",
 ) -> L1Anchor:
-    """Constructs the L1 anchor for the ASM parameters based on the provided block information."""
-    header_time = int(header["time"])
-    next_target = parse_bits_to_target(header["bits"])
+    """Constructs the L1 anchor for the ASM parameters by sourcing the chain context for
+    ``genesis_height`` through ``get_block_header``.
+
+    The callable is invoked twice: once for ``genesis_height`` (whose hash and ``bits`` are
+    recorded on the anchor) and once for the block at the start of the containing difficulty
+    epoch (whose ``time`` is recorded as ``epoch_start_timestamp``, matching how the ASM
+    recomputes the next difficulty target).
+    """
+    epoch_start_height = (
+        genesis_height // DIFFICULTY_ADJUSTMENT_INTERVAL
+    ) * DIFFICULTY_ADJUSTMENT_INTERVAL
+    epoch_start_header = get_block_header(epoch_start_height)
+    genesis_header = get_block_header(genesis_height)
 
     return L1Anchor(
-        block=Block(height=genesis_height, blkid=block_hash),
-        next_target=next_target,
-        epoch_start_timestamp=header_time,
+        block=Block(height=genesis_height, blkid=genesis_header["hash"]),
+        next_target=parse_bits_to_target(genesis_header["bits"]),
+        epoch_start_timestamp=int(epoch_start_header["time"]),
         network=network,
     )
 
@@ -146,15 +164,14 @@ def build_subprotocols(
 def build_asm_params(
     musig2_keys: list[str],
     genesis_height: int,
-    block_hash: str,
-    header: dict[str, Any],
+    get_block_header: BlockHeaderFetcher,
     magic: str = ASM_MAGIC_BYTES,
     denomination: int = 1_000_000_000,
     assignment_duration: int = 10_000,
     operator_fee: int = 100_000_000,
     recovery_delay: int = 1_008,
 ) -> AsmParams:
-    anchor = build_l1_anchor(genesis_height, block_hash, header)
+    anchor = build_l1_anchor(genesis_height, get_block_header)
     subprotocols = build_subprotocols(
         musig2_keys,
         genesis_height,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This fixes an issue where the `asm-params` generation script in the functional tests and the docker entrypoint for `asm-runner` were using the timestamp from the genesis block's header instead of the last difficulty adjustment block as the `epoch_start_timestamp`.

Claude was used to make these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->