### PR TITLE
fix: harden DRT parsing and allow absurd fee rate on DT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11363,6 +11363,7 @@ dependencies = [
  "strata-bridge-test-utils",
  "strata-l1-txfmt",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11153,6 +11153,7 @@ dependencies = [
  "strata-bridge-sm",
  "strata-bridge-test-utils",
  "strata-bridge-tx-graph",
+ "strata-l1-txfmt",
  "strata-mosaic-client-api",
  "strata-p2p",
  "strata-predicate",

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -19,6 +19,7 @@ strata-bridge-tx-graph.workspace = true
 
 strata-asm-proto-bridge-v1.workspace = true
 strata-asm-proto-bridge-v1-txs.workspace = true
+strata-l1-txfmt.workspace = true
 strata-mosaic-client-api.workspace = true
 strata-p2p.workspace = true
 

--- a/crates/orchestrator/src/events_classifier/drt.rs
+++ b/crates/orchestrator/src/events_classifier/drt.rs
@@ -23,15 +23,9 @@ pub(super) struct Valid {
     pub(super) drt_output_amount: Amount,
 }
 
-/// Reason [`validate`] rejected a transaction.
+/// Reason [`validate_candidate`] rejected a transaction.
 #[derive(Debug, Error)]
 pub(super) enum ValidationError {
-    /// Transaction is not addressed to this bridge: missing SPS-50 OP_RETURN, or the magic /
-    /// subprotocol id / tx type do not identify it as a Bridge-v1 DRT for `cfg.magic_bytes`.
-    /// Expected for the vast majority of block transactions and not worth surfacing as an
-    /// error to the operator.
-    #[error("transaction is not a DRT for this bridge")]
-    NotOurEnvelope,
     /// SPS-50 envelope identified the tx as our DRT, but the structural parse failed.
     #[error("DRT is structurally invalid: {0}")]
     Structure(#[source] TxStructureError),
@@ -49,25 +43,27 @@ pub(super) enum ValidationError {
     LockingScriptMismatch,
 }
 
-/// Validates that `tx` is a well-formed DRT for the bridge with the given `cfg` and active
-/// operator set, and returns the parts a `DepositSM` needs.
+/// Returns `true` iff `tx`'s SPS-50 envelope identifies it as a Bridge-v1 deposit request for
+/// the bridge configured by `cfg`.
+pub(super) fn is_our_drt_envelope(tx: &Transaction, cfg: &DepositSMCfg) -> bool {
+    let Ok((magic, tag)) = extract_tx_magic_and_tag(tx) else {
+        return false;
+    };
+    magic == cfg.magic_bytes
+        && tag.subproto_id() == BRIDGE_V1_SUBPROTOCOL_ID
+        && tag.tx_type() == BridgeTxType::DepositRequest as u8
+}
+
+/// Validates a candidate DRT against the bridge configuration and active operator set, and
+/// returns the parts a `DepositSM` needs.
 ///
-/// Pure: no registry or applicator access.
-pub(super) fn validate(
+/// The caller must have already verified the SPS-50 envelope via [`is_our_drt_envelope`];
+/// passing a tx that fails the envelope check yields [`ValidationError::Structure`].
+pub(super) fn validate_candidate(
     tx: &Transaction,
     cfg: &DepositSMCfg,
     active_operator_table: &OperatorTable,
 ) -> Result<Valid, ValidationError> {
-    let Ok((magic, tag)) = extract_tx_magic_and_tag(tx) else {
-        return Err(ValidationError::NotOurEnvelope);
-    };
-    if magic != cfg.magic_bytes
-        || tag.subproto_id() != BRIDGE_V1_SUBPROTOCOL_ID
-        || tag.tx_type() != BridgeTxType::DepositRequest as u8
-    {
-        return Err(ValidationError::NotOurEnvelope);
-    }
-
     let drt_info = parse_drt(tx).map_err(ValidationError::Structure)?;
 
     let recovery_pk_bytes = drt_info.header_aux().recovery_pk();
@@ -116,24 +112,22 @@ mod tests {
         DrtBuilder, N_TEST_OPERATORS, TEST_POV_IDX, test_deposit_sm_cfg, test_operator_table,
     };
 
+    // ===== is_our_drt_envelope tests =====
+
     #[test]
-    fn accepts_aligned_drt() {
+    fn envelope_accepts_aligned_drt() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
-        let builder = DrtBuilder::aligned(&operator_table, &cfg);
-        let expected_pk = XOnlyPublicKey::from_slice(&builder.recovery_pk_in_aux).unwrap();
-        let expected_value = builder.output_value;
+        let tx = DrtBuilder::aligned(&operator_table, &cfg).build();
 
-        let valid =
-            validate(&builder.build(), &cfg, &operator_table).expect("aligned DRT must validate");
-
-        assert_eq!(valid.depositor_pubkey, expected_pk);
-        assert_eq!(valid.drt_output_amount, expected_value);
+        assert!(
+            is_our_drt_envelope(&tx, &cfg),
+            "aligned DRT envelope must classify as ours",
+        );
     }
 
     #[test]
-    fn rejects_tx_without_sps50_envelope() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+    fn envelope_rejects_tx_without_sps50() {
         let cfg = test_deposit_sm_cfg();
         let tx = Transaction {
             version: transaction::Version::TWO,
@@ -142,15 +136,14 @@ mod tests {
             output: vec![],
         };
 
-        assert!(matches!(
-            validate(&tx, &cfg, &operator_table),
-            Err(ValidationError::NotOurEnvelope)
-        ));
+        assert!(
+            !is_our_drt_envelope(&tx, &cfg),
+            "tx without an OP_RETURN must not classify as ours",
+        );
     }
 
     #[test]
-    fn rejects_non_op_return_first_output() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+    fn envelope_rejects_non_op_return_first_output() {
         let cfg = test_deposit_sm_cfg();
         let tx = Transaction {
             version: transaction::Version::TWO,
@@ -162,53 +155,76 @@ mod tests {
             }],
         };
 
-        assert!(matches!(
-            validate(&tx, &cfg, &operator_table),
-            Err(ValidationError::NotOurEnvelope)
-        ));
+        assert!(
+            !is_our_drt_envelope(&tx, &cfg),
+            "tx whose output 0 is not OP_RETURN must not classify as ours",
+        );
     }
 
     #[test]
-    fn rejects_wrong_magic() {
+    fn envelope_rejects_wrong_magic() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.magic = MagicBytes::new(*b"XXXX");
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::NotOurEnvelope)
-        ));
+        assert!(
+            !is_our_drt_envelope(&builder.build(), &cfg),
+            "tx with mismatched magic bytes must not classify as ours",
+        );
     }
 
     #[test]
-    fn rejects_wrong_subproto() {
+    fn envelope_rejects_wrong_subproto() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.subproto_id = BRIDGE_V1_SUBPROTOCOL_ID.wrapping_add(1);
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::NotOurEnvelope)
-        ));
+        assert!(
+            !is_our_drt_envelope(&builder.build(), &cfg),
+            "tx with a non-Bridge-v1 subprotocol id must not classify as ours",
+        );
     }
 
     #[test]
-    fn rejects_wrong_tx_type() {
+    fn envelope_rejects_wrong_tx_type() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.tx_type = BridgeTxType::Deposit as u8;
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::NotOurEnvelope)
-        ));
+        assert!(
+            !is_our_drt_envelope(&builder.build(), &cfg),
+            "non-DepositRequest Bridge-v1 tx type must not classify as our DRT",
+        );
+    }
+
+    // ===== validate_candidate tests =====
+
+    #[test]
+    fn candidate_accepts_aligned_drt() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let builder = DrtBuilder::aligned(&operator_table, &cfg);
+        let expected_pk = XOnlyPublicKey::from_slice(&builder.recovery_pk_in_aux).unwrap();
+        let expected_value = builder.output_value;
+
+        let valid = validate_candidate(&builder.build(), &cfg, &operator_table)
+            .expect("aligned DRT must validate");
+
+        assert_eq!(
+            valid.depositor_pubkey, expected_pk,
+            "validator must return the recovery pubkey from aux",
+        );
+        assert_eq!(
+            valid.drt_output_amount, expected_value,
+            "validator must return the output-1 amount",
+        );
     }
 
     #[test]
-    fn rejects_malformed_aux() {
+    fn candidate_rejects_malformed_aux() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
 
@@ -233,14 +249,17 @@ mod tests {
             }],
         };
 
-        assert!(matches!(
-            validate(&tx, &cfg, &operator_table),
-            Err(ValidationError::Structure(_))
-        ));
+        assert!(
+            matches!(
+                validate_candidate(&tx, &cfg, &operator_table),
+                Err(ValidationError::Structure(_)),
+            ),
+            "under-32-byte aux must surface as Structure error",
+        );
     }
 
     #[test]
-    fn rejects_invalid_recovery_pubkey() {
+    fn candidate_rejects_invalid_recovery_pubkey() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
@@ -248,14 +267,17 @@ mod tests {
         builder.recovery_pk_in_aux = [0u8; 32];
         builder.recovery_pk_in_script = [0u8; 32];
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::InvalidRecoveryPubkey(_))
-        ));
+        assert!(
+            matches!(
+                validate_candidate(&builder.build(), &cfg, &operator_table),
+                Err(ValidationError::InvalidRecoveryPubkey(_)),
+            ),
+            "32 zero bytes must surface as InvalidRecoveryPubkey",
+        );
     }
 
     #[test]
-    fn rejects_output_value_below_required() {
+    fn candidate_rejects_output_value_below_required() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let required = DepositTx::drt_required(cfg.deposit_amount);
@@ -263,56 +285,74 @@ mod tests {
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.output_value = actual;
 
-        let err = validate(&builder.build(), &cfg, &operator_table).unwrap_err();
+        let err = validate_candidate(&builder.build(), &cfg, &operator_table).unwrap_err();
         match err {
             ValidationError::OutputValueBelowRequired {
                 actual: got_actual,
                 required: got_required,
             } => {
-                assert_eq!(got_actual, actual);
-                assert_eq!(got_required, required);
+                assert_eq!(
+                    got_actual, actual,
+                    "error must echo the actual DRT output value",
+                );
+                assert_eq!(
+                    got_required, required,
+                    "error must echo the required (deposit_amount + deposit_fee) value",
+                );
             }
             other => panic!("expected OutputValueBelowRequired, got {other:?}"),
         }
     }
 
     #[test]
-    fn rejects_mismatched_recovery_pk_in_script() {
+    fn candidate_rejects_mismatched_recovery_pk_in_script() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.recovery_pk_in_script = generate_xonly_pubkey().serialize();
-        assert_ne!(builder.recovery_pk_in_aux, builder.recovery_pk_in_script);
+        assert_ne!(
+            builder.recovery_pk_in_aux, builder.recovery_pk_in_script,
+            "test must mutate the script's recovery pk away from the aux's",
+        );
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::LockingScriptMismatch)
-        ));
+        assert!(
+            matches!(
+                validate_candidate(&builder.build(), &cfg, &operator_table),
+                Err(ValidationError::LockingScriptMismatch),
+            ),
+            "recovery pk encoded in the takeback tapscript must match aux",
+        );
     }
 
     #[test]
-    fn rejects_mismatched_internal_key() {
+    fn candidate_rejects_mismatched_internal_key() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.n_of_n_in_script = generate_xonly_pubkey();
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::LockingScriptMismatch)
-        ));
+        assert!(
+            matches!(
+                validate_candidate(&builder.build(), &cfg, &operator_table),
+                Err(ValidationError::LockingScriptMismatch),
+            ),
+            "P2TR internal key must match the active N-of-N aggregated key",
+        );
     }
 
     #[test]
-    fn rejects_mismatched_recovery_delay() {
+    fn candidate_rejects_mismatched_recovery_delay() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let cfg = test_deposit_sm_cfg();
         let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
         builder.recovery_delay_in_script = cfg.recovery_delay.wrapping_add(1);
 
-        assert!(matches!(
-            validate(&builder.build(), &cfg, &operator_table),
-            Err(ValidationError::LockingScriptMismatch)
-        ));
+        assert!(
+            matches!(
+                validate_candidate(&builder.build(), &cfg, &operator_table),
+                Err(ValidationError::LockingScriptMismatch),
+            ),
+            "tapscript CSV delay must match the bridge's configured recovery_delay",
+        );
     }
 }

--- a/crates/orchestrator/src/events_classifier/drt.rs
+++ b/crates/orchestrator/src/events_classifier/drt.rs
@@ -1,0 +1,318 @@
+//! Pure validation of deposit request transactions against a bridge configuration and active
+//! operator set.
+
+use bitcoin::{Amount, Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
+use strata_asm_proto_bridge_v1_txs::{
+    BRIDGE_V1_SUBPROTOCOL_ID,
+    constants::BridgeTxType,
+    deposit_request::{DRT_OUTPUT_INDEX, create_deposit_request_locking_script, parse_drt},
+    errors::TxStructureError,
+};
+use strata_bridge_primitives::operator_table::OperatorTable;
+use strata_bridge_sm::deposit::config::DepositSMCfg;
+use strata_bridge_tx_graph::transactions::deposit::DepositTx;
+use strata_l1_txfmt::extract_tx_magic_and_tag;
+use thiserror::Error;
+
+/// Successfully validated DRT data needed to construct a `DepositSM`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct Valid {
+    /// Depositor's x-only recovery pubkey parsed from the SPS-50 aux data.
+    pub(super) depositor_pubkey: XOnlyPublicKey,
+    /// Amount on the deposit-request output (output index 1).
+    pub(super) drt_output_amount: Amount,
+}
+
+/// Reason [`validate`] rejected a transaction.
+#[derive(Debug, Error)]
+pub(super) enum ValidationError {
+    /// Transaction is not addressed to this bridge: missing SPS-50 OP_RETURN, or the magic /
+    /// subprotocol id / tx type do not identify it as a Bridge-v1 DRT for `cfg.magic_bytes`.
+    /// Expected for the vast majority of block transactions and not worth surfacing as an
+    /// error to the operator.
+    #[error("transaction is not a DRT for this bridge")]
+    NotOurEnvelope,
+    /// SPS-50 envelope identified the tx as our DRT, but the structural parse failed.
+    #[error("DRT is structurally invalid: {0}")]
+    Structure(#[source] TxStructureError),
+    /// The 32-byte recovery pubkey in the SPS-50 aux data is not a valid x-only point.
+    #[error("DRT aux carries invalid recovery pubkey: {0}")]
+    InvalidRecoveryPubkey(String),
+    /// Output-1 carries less than `deposit_amount + deposit-tx fee` and so cannot fund a
+    /// relayable deposit transaction.
+    #[error("DRT output value {actual} is below required {required}")]
+    OutputValueBelowRequired { actual: Amount, required: Amount },
+    /// Output-1's P2TR script does not match the script reconstructed from the depositor's
+    /// recovery pubkey, the active N-of-N aggregated key, and the bridge's recovery delay.
+    /// The DRT is therefore not cooperatively spendable by the bridge.
+    #[error("DRT output script does not match expected P2TR locking script")]
+    LockingScriptMismatch,
+}
+
+/// Validates that `tx` is a well-formed DRT for the bridge with the given `cfg` and active
+/// operator set, and returns the parts a `DepositSM` needs.
+///
+/// Pure: no registry or applicator access.
+pub(super) fn validate(
+    tx: &Transaction,
+    cfg: &DepositSMCfg,
+    active_operator_table: &OperatorTable,
+) -> Result<Valid, ValidationError> {
+    let Ok((magic, tag)) = extract_tx_magic_and_tag(tx) else {
+        return Err(ValidationError::NotOurEnvelope);
+    };
+    if magic != cfg.magic_bytes
+        || tag.subproto_id() != BRIDGE_V1_SUBPROTOCOL_ID
+        || tag.tx_type() != BridgeTxType::DepositRequest as u8
+    {
+        return Err(ValidationError::NotOurEnvelope);
+    }
+
+    let drt_info = parse_drt(tx).map_err(ValidationError::Structure)?;
+
+    let recovery_pk_bytes = drt_info.header_aux().recovery_pk();
+    let depositor_pubkey = XOnlyPublicKey::from_slice(recovery_pk_bytes).map_err(|_| {
+        ValidationError::InvalidRecoveryPubkey(recovery_pk_bytes.to_lower_hex_string())
+    })?;
+
+    // `parse_drt` already ensures output at index 1 exists.
+    let drt_output = tx
+        .output
+        .get(DRT_OUTPUT_INDEX)
+        .expect("parse_drt guarantees output index 1 exists");
+
+    let required = DepositTx::drt_required(cfg.deposit_amount);
+    if drt_output.value < required {
+        return Err(ValidationError::OutputValueBelowRequired {
+            actual: drt_output.value,
+            required,
+        });
+    }
+
+    let n_of_n = active_operator_table
+        .aggregated_btc_key()
+        .x_only_public_key()
+        .0;
+    let expected_script =
+        create_deposit_request_locking_script(recovery_pk_bytes, n_of_n, cfg.recovery_delay);
+    if drt_output.script_pubkey != expected_script {
+        return Err(ValidationError::LockingScriptMismatch);
+    }
+
+    Ok(Valid {
+        depositor_pubkey,
+        drt_output_amount: drt_output.value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{ScriptBuf, TxIn, TxOut, absolute, secp256k1::SECP256K1, transaction};
+    use strata_bridge_test_utils::bitcoin::generate_xonly_pubkey;
+    use strata_l1_txfmt::{MagicBytes, ParseConfig, TagData};
+
+    use super::*;
+    use crate::testing::{
+        DrtBuilder, N_TEST_OPERATORS, TEST_POV_IDX, test_deposit_sm_cfg, test_operator_table,
+    };
+
+    #[test]
+    fn accepts_aligned_drt() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let builder = DrtBuilder::aligned(&operator_table, &cfg);
+        let expected_pk = XOnlyPublicKey::from_slice(&builder.recovery_pk_in_aux).unwrap();
+        let expected_value = builder.output_value;
+
+        let valid =
+            validate(&builder.build(), &cfg, &operator_table).expect("aligned DRT must validate");
+
+        assert_eq!(valid.depositor_pubkey, expected_pk);
+        assert_eq!(valid.drt_output_amount, expected_value);
+    }
+
+    #[test]
+    fn rejects_tx_without_sps50_envelope() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+
+        assert!(matches!(
+            validate(&tx, &cfg, &operator_table),
+            Err(ValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_op_return_first_output() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new_p2tr(SECP256K1, generate_xonly_pubkey(), None),
+            }],
+        };
+
+        assert!(matches!(
+            validate(&tx, &cfg, &operator_table),
+            Err(ValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.magic = MagicBytes::new(*b"XXXX");
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_subproto() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.subproto_id = BRIDGE_V1_SUBPROTOCOL_ID.wrapping_add(1);
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_tx_type() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.tx_type = BridgeTxType::Deposit as u8;
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_aux() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        // Aux below 32 bytes makes `parse_drt` fail with InvalidAuxiliaryData; envelope is
+        // otherwise aligned for our bridge.
+        let tag = TagData::new(
+            BRIDGE_V1_SUBPROTOCOL_ID,
+            BridgeTxType::DepositRequest as u8,
+            vec![0u8; 31],
+        )
+        .expect("aux must fit SPS-50 size limits");
+        let op_return = ParseConfig::new(cfg.magic_bytes)
+            .encode_script_buf(&tag.as_ref())
+            .expect("SPS-50 tag must encode");
+        let tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::ZERO,
+                script_pubkey: op_return,
+            }],
+        };
+
+        assert!(matches!(
+            validate(&tx, &cfg, &operator_table),
+            Err(ValidationError::Structure(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_recovery_pubkey() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        // 32 zero bytes are not a valid x-only point.
+        builder.recovery_pk_in_aux = [0u8; 32];
+        builder.recovery_pk_in_script = [0u8; 32];
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::InvalidRecoveryPubkey(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_output_value_below_required() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let required = DepositTx::drt_required(cfg.deposit_amount);
+        let actual = required - Amount::from_sat(1);
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.output_value = actual;
+
+        let err = validate(&builder.build(), &cfg, &operator_table).unwrap_err();
+        match err {
+            ValidationError::OutputValueBelowRequired {
+                actual: got_actual,
+                required: got_required,
+            } => {
+                assert_eq!(got_actual, actual);
+                assert_eq!(got_required, required);
+            }
+            other => panic!("expected OutputValueBelowRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_mismatched_recovery_pk_in_script() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.recovery_pk_in_script = generate_xonly_pubkey().serialize();
+        assert_ne!(builder.recovery_pk_in_aux, builder.recovery_pk_in_script);
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::LockingScriptMismatch)
+        ));
+    }
+
+    #[test]
+    fn rejects_mismatched_internal_key() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.n_of_n_in_script = generate_xonly_pubkey();
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::LockingScriptMismatch)
+        ));
+    }
+
+    #[test]
+    fn rejects_mismatched_recovery_delay() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.recovery_delay_in_script = cfg.recovery_delay.wrapping_add(1);
+
+        assert!(matches!(
+            validate(&builder.build(), &cfg, &operator_table),
+            Err(ValidationError::LockingScriptMismatch)
+        ));
+    }
+}

--- a/crates/orchestrator/src/events_classifier/mod.rs
+++ b/crates/orchestrator/src/events_classifier/mod.rs
@@ -3,5 +3,6 @@
 //! - [`offchain`]: P2P gossip, requests, and assignment classification
 //! - [`onchain`]: Block scanning, TxClassifier, and NewBlock cursor events
 
+mod drt;
 pub mod offchain;
 pub mod onchain;

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -10,12 +10,12 @@
 
 use std::sync::Arc;
 
-use bitcoin::{Amount, Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
+use bitcoin::{Amount, OutPoint, Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
 use btc_tracker::event::BlockEvent;
 use strata_asm_proto_bridge_v1_txs::{
     BRIDGE_V1_SUBPROTOCOL_ID,
     constants::BridgeTxType,
-    deposit_request::{create_deposit_request_locking_script, parse_drt},
+    deposit_request::{DRT_OUTPUT_INDEX, create_deposit_request_locking_script, parse_drt},
     errors::TxStructureError,
 };
 use strata_bridge_primitives::{
@@ -43,7 +43,7 @@ use strata_bridge_sm::{
 use strata_bridge_tx_graph::transactions::{deposit::DepositTx, prelude::DepositData};
 use strata_l1_txfmt::extract_tx_magic_and_tag;
 use thiserror::Error;
-use tracing::{Level, error, info, warn};
+use tracing::{Level, info, warn};
 
 use crate::{
     applicator::Applicator,
@@ -125,13 +125,6 @@ pub(crate) fn process_block(
 }
 
 /// Successfully validated DRT data needed to construct a [`DepositSM`].
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into try_register_deposit in the next commit"
-    )
-)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ValidDrt {
     /// Depositor's x-only recovery pubkey parsed from the SPS-50 aux data.
@@ -141,13 +134,6 @@ struct ValidDrt {
 }
 
 /// Reason [`validate_drt`] rejected a transaction.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into try_register_deposit in the next commit"
-    )
-)]
 #[derive(Debug, Error)]
 enum DrtValidationError {
     /// Transaction is not addressed to this bridge: missing SPS-50 OP_RETURN, or the magic /
@@ -179,13 +165,6 @@ enum DrtValidationError {
 /// Pure: no registry or applicator access. The caller is responsible for ensuring stake
 /// readiness and deriving `active_operator_table` from the active-operator snapshot before
 /// calling.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "wired into try_register_deposit in the next commit"
-    )
-)]
 fn validate_drt(
     tx: &Transaction,
     cfg: &DepositSMCfg,
@@ -242,9 +221,8 @@ fn validate_drt(
 /// [`GraphSM`]s into the registry.
 ///
 /// Returns initial duties emitted by [`GraphSM`] constructors (e.g., `GenerateGraphData`).
-/// Returns `Ok(Vec::new())` if the transaction is not a DRT or if the registry is not yet ready
-/// to accept deposits (either because not all operators have staked, or because this node's own
-/// operator is not active).
+/// Returns `Ok(Vec::new())` if the registry is not yet ready (no stakes confirmed, or this
+/// node's operator is not in the active set) or if [`validate_drt`] rejects the transaction.
 fn try_register_deposit(
     deposit_cfg: &Arc<DepositSMCfg>,
     full_operator_table: &OperatorTable,
@@ -252,22 +230,12 @@ fn try_register_deposit(
     tx: &Transaction,
     height: BitcoinBlockHeight,
 ) -> Result<Vec<UnifiedDuty>, ProcessError> {
-    let Ok(drt_info) = parse_drt(tx) else {
-        return Ok(Vec::new());
-    };
-
-    let drt_txid = tx.compute_txid();
-
-    let span = tracing::span!(Level::INFO, "registering new deposit", drt_txid=%drt_txid);
-    let _entered = span.entered();
-
     // Activation rule: before any DSM / GSM may become active, one stake state machine must exist
     // for every configured operator and all of them must have reached `Confirmed` or higher.
     if !applicator
         .registry()
         .all_operators_have_staked(full_operator_table)
     {
-        warn!("skipping DRT: not all operators have completed staking");
         return Ok(Vec::new());
     }
 
@@ -277,49 +245,9 @@ fn try_register_deposit(
     {
         Ok(snap) => snap,
         Err(err) => {
-            warn!(%err, "skipping DRT: could not derive active operator snapshot");
+            warn!(%err, "skipping DRT check: could not derive active operator snapshot");
             return Ok(Vec::new());
         }
-    };
-    info!(
-        active_operator_count = snapshot.operator_table.operator_idxs().len(),
-        "passed stake-readiness gate; registering DSM / GSMs from active operator snapshot"
-    );
-
-    let depositor_pubkey = drt_info.header_aux().recovery_pk();
-    let Ok(depositor_pubkey) = XOnlyPublicKey::from_slice(depositor_pubkey) else {
-        error!(pk=%depositor_pubkey.to_lower_hex_string(), "invalid depositor pubkey in DRT, ignoring");
-        return Ok(Vec::new());
-    };
-
-    let magic_bytes = deposit_cfg.magic_bytes;
-
-    let deposit_idx_offset = applicator.registry().next_deposit_idx()?;
-
-    // Always second output for now: output 0 is SPS-50 OP_RETURN and output 1 is DRT spend UTXO.
-    let Some(deposit_request_output) = tx.output.get(1) else {
-        error!("invalid DRT: expected spendable output at index 1, ignoring");
-        return Ok(Vec::new());
-    };
-
-    // The deposit-request UTXO must include the deposit amount plus the bridge's hardcoded
-    // deposit-tx fee — without that surplus the deposit transaction would have insufficient
-    // fee to relay.
-    let drt_required = DepositTx::drt_required(deposit_cfg.deposit_amount);
-    if deposit_request_output.value < drt_required {
-        error!(
-            drt_value = %deposit_request_output.value,
-            %drt_required,
-            "invalid DRT: spendable output value is less than deposit_amount + deposit_fee, ignoring"
-        );
-        return Ok(Vec::new());
-    }
-
-    let deposit_request_outpoint = bitcoin::OutPoint::new(drt_txid, 1);
-    let deposit_data = DepositData {
-        deposit_idx: deposit_idx_offset,
-        deposit_request_outpoint,
-        magic_bytes,
     };
 
     let ActiveOperatorSnapshot {
@@ -328,24 +256,49 @@ fn try_register_deposit(
         unstaking_images,
     } = snapshot;
 
+    let valid = match validate_drt(tx, deposit_cfg, &active_operator_table) {
+        Ok(valid) => valid,
+        Err(DrtValidationError::NotOurEnvelope) => return Ok(Vec::new()),
+        Err(err) => {
+            warn!(%err, txid=%tx.compute_txid(), "rejecting DRT candidate");
+            return Ok(Vec::new());
+        }
+    };
+
+    let drt_txid = tx.compute_txid();
+    let span = tracing::span!(Level::INFO, "registering new deposit", drt_txid=%drt_txid);
+    let _entered = span.entered();
+    info!(
+        active_operator_count = active_operator_table.operator_idxs().len(),
+        "passed validation; registering DSM / GSMs from active operator snapshot"
+    );
+
+    let deposit_idx = applicator.registry().next_deposit_idx()?;
+    let deposit_request_outpoint = OutPoint::new(drt_txid, DRT_OUTPUT_INDEX as u32);
+    let deposit_data = DepositData {
+        deposit_idx,
+        deposit_request_outpoint,
+        magic_bytes: deposit_cfg.magic_bytes,
+    };
+
     let dsm = DepositSM::new(
         deposit_cfg.clone(),
         active_operator_table.clone(),
         deposit_data,
-        depositor_pubkey,
-        deposit_request_output.value,
+        valid.depositor_pubkey,
+        valid.drt_output_amount,
         height,
     );
 
     let deposit_outpoint = dsm.context().deposit_outpoint();
-    info!(%deposit_outpoint, deposit_idx=deposit_idx_offset, "registering new DepositSM for detected DRT");
-    applicator.insert_deposit(deposit_idx_offset, dsm)?;
+    info!(%deposit_outpoint, %deposit_idx, "registering new DepositSM for detected DRT");
+    applicator.insert_deposit(deposit_idx, dsm)?;
 
     // Register one GraphSM per active operator, collecting initial duties.
     let mut duties = Vec::new();
     for &op_idx in active_operator_table.operator_idxs().iter() {
         let graph_idx = GraphIdx {
-            deposit: deposit_idx_offset,
+            deposit: deposit_idx,
             operator: op_idx,
         };
 
@@ -448,17 +401,17 @@ fn new_block_events(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{Amount, Network, ScriptBuf, TxIn, TxOut, absolute, transaction};
-    use strata_bridge_test_utils::{
-        bitcoin::generate_xonly_pubkey,
-        bridge_fixtures::{TEST_MAGIC_BYTES, TEST_RECOVERY_DELAY},
-    };
+    use bitcoin::{Amount, ScriptBuf, TxIn, TxOut, absolute, transaction};
+    use strata_bridge_test_utils::bitcoin::{generate_txid, generate_xonly_pubkey};
     use strata_l1_txfmt::{MagicBytes, ParseConfig, TagData};
 
     use super::*;
-    use crate::testing::{
-        N_TEST_OPERATORS, TEST_POV_IDX, test_deposit_sm_cfg, test_operator_table,
-        test_populated_registry,
+    use crate::{
+        sm_registry::SMRegistry,
+        testing::{
+            N_TEST_OPERATORS, TEST_POV_IDX, insert_confirmed_stake, test_deposit_sm_cfg,
+            test_operator_table, test_populated_registry,
+        },
     };
 
     const TEST_HEIGHT: BitcoinBlockHeight = 200;
@@ -644,21 +597,43 @@ mod tests {
 
     // ===== try_register_deposit tests =====
 
+    /// Pre-populates `registry` with one Confirmed stake per operator so that the
+    /// stake-readiness gate in [`try_register_deposit`] passes.
+    fn confirm_all_stakes(registry: &mut SMRegistry, operator_table: &OperatorTable) {
+        for op_idx in operator_table.operator_idxs() {
+            insert_confirmed_stake(registry, op_idx, operator_table.clone(), generate_txid());
+        }
+    }
+
     #[test]
-    fn try_register_deposit_non_drt() {
+    fn try_register_deposit_silent_when_stakes_not_ready() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let deposit_cfg = Arc::new(DepositSMCfg {
-            network: Network::Regtest,
-            cooperative_payout_timeout_blocks: 144,
-            deposit_amount: Amount::from_sat(10_000_000),
-            operator_fee: Amount::from_sat(10_000),
-            magic_bytes: TEST_MAGIC_BYTES.into(),
-            recovery_delay: TEST_RECOVERY_DELAY,
-        });
+        let cfg = test_deposit_sm_cfg();
+        let mut registry = test_populated_registry(0); // no stakes
 
+        let tx = DrtBuilder::aligned(&operator_table, &cfg).build();
+
+        let mut applicator = Applicator::new(&mut registry);
+        let duties =
+            try_register_deposit(&cfg, &operator_table, &mut applicator, &tx, TEST_HEIGHT).unwrap();
+        let (_, tracker) = applicator.finish();
+
+        assert!(duties.is_empty());
+        assert_eq!(registry.num_deposits(), 0);
+        assert!(
+            tracker.into_batches().is_empty(),
+            "stake-readiness gate must not record any SMs"
+        );
+    }
+
+    #[test]
+    fn try_register_deposit_silent_on_validate_rejection() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
         let mut registry = test_populated_registry(0);
+        confirm_all_stakes(&mut registry, &operator_table);
 
-        // A random transaction that is not a DRT
+        // A random transaction makes `validate_drt` return `NotOurEnvelope`.
         let random_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
@@ -668,20 +643,47 @@ mod tests {
 
         let mut applicator = Applicator::new(&mut registry);
         let duties = try_register_deposit(
-            &deposit_cfg,
+            &cfg,
             &operator_table,
             &mut applicator,
             &random_tx,
-            100,
+            TEST_HEIGHT,
         )
-        .expect("non-DRT path should not fail");
-        let (_, tracker) = applicator.finish();
+        .unwrap();
+        let _ = applicator.finish();
 
         assert!(duties.is_empty());
         assert_eq!(registry.num_deposits(), 0);
-        assert!(
-            tracker.into_batches().is_empty(),
-            "non-DRT path must not record any SMs in the persistence tracker"
+    }
+
+    #[test]
+    fn try_register_deposit_registers_dsm_for_aligned_drt() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let mut registry = test_populated_registry(0);
+        confirm_all_stakes(&mut registry, &operator_table);
+
+        let tx = DrtBuilder::aligned(&operator_table, &cfg).build();
+
+        let mut applicator = Applicator::new(&mut registry);
+        let duties =
+            try_register_deposit(&cfg, &operator_table, &mut applicator, &tx, TEST_HEIGHT).unwrap();
+        let _ = applicator.finish();
+
+        assert_eq!(
+            registry.num_deposits(),
+            1,
+            "aligned DRT must register exactly one DSM"
+        );
+        assert_eq!(
+            registry.get_graph_ids().len(),
+            N_TEST_OPERATORS,
+            "one GraphSM per active operator is expected"
+        );
+        assert_eq!(
+            duties.len(),
+            1,
+            "exactly one GenerateGraphData duty is emitted, for the POV operator only"
         );
     }
 

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -131,6 +131,13 @@ fn try_register_deposit(
     tx: &Transaction,
     height: BitcoinBlockHeight,
 ) -> Result<Vec<UnifiedDuty>, ProcessError> {
+    // Cheapest filter first: skip the ~99% of block transactions that don't carry our SPS-50
+    // envelope. Subsequent gates allocate (snapshot) or parse the full DRT, so we want to
+    // avoid them on non-DRT traffic.
+    if !drt::is_our_drt_envelope(tx, deposit_cfg) {
+        return Ok(Vec::new());
+    }
+
     // Activation rule: before any DSM / GSM may become active, one stake state machine must exist
     // for every configured operator and all of them must have reached `Confirmed` or higher.
     if !applicator
@@ -157,9 +164,8 @@ fn try_register_deposit(
         unstaking_images,
     } = snapshot;
 
-    let valid = match drt::validate(tx, deposit_cfg, &active_operator_table) {
+    let valid = match drt::validate_candidate(tx, deposit_cfg, &active_operator_table) {
         Ok(valid) => valid,
-        Err(drt::ValidationError::NotOurEnvelope) => return Ok(Vec::new()),
         Err(err) => {
             warn!(%err, txid=%tx.compute_txid(), "rejecting DRT candidate");
             return Ok(Vec::new());
@@ -440,11 +446,18 @@ mod tests {
             try_register_deposit(&cfg, &operator_table, &mut applicator, &tx, TEST_HEIGHT).unwrap();
         let (_, tracker) = applicator.finish();
 
-        assert!(duties.is_empty());
-        assert_eq!(registry.num_deposits(), 0);
+        assert!(
+            duties.is_empty(),
+            "stake-readiness gate must not emit duties",
+        );
+        assert_eq!(
+            registry.num_deposits(),
+            0,
+            "stake-readiness gate must not register a DSM",
+        );
         assert!(
             tracker.into_batches().is_empty(),
-            "stake-readiness gate must not record any SMs"
+            "stake-readiness gate must not record any SMs",
         );
     }
 
@@ -455,7 +468,7 @@ mod tests {
         let mut registry = test_populated_registry(0);
         confirm_all_stakes(&mut registry, &operator_table);
 
-        // A random transaction makes `validate_drt` return `NotOurEnvelope`.
+        // A random transaction fails the envelope pre-filter inside try_register_deposit.
         let random_tx = Transaction {
             version: transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
@@ -474,8 +487,15 @@ mod tests {
         .unwrap();
         let _ = applicator.finish();
 
-        assert!(duties.is_empty());
-        assert_eq!(registry.num_deposits(), 0);
+        assert!(
+            duties.is_empty(),
+            "validate-rejected DRT must not emit duties",
+        );
+        assert_eq!(
+            registry.num_deposits(),
+            0,
+            "validate-rejected DRT must not register a DSM",
+        );
     }
 
     #[test]

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -10,9 +10,14 @@
 
 use std::sync::Arc;
 
-use bitcoin::{Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
+use bitcoin::{Amount, Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
 use btc_tracker::event::BlockEvent;
-use strata_asm_proto_bridge_v1_txs::deposit_request::parse_drt;
+use strata_asm_proto_bridge_v1_txs::{
+    BRIDGE_V1_SUBPROTOCOL_ID,
+    constants::BridgeTxType,
+    deposit_request::{create_deposit_request_locking_script, parse_drt},
+    errors::TxStructureError,
+};
 use strata_bridge_primitives::{
     operator_table::OperatorTable,
     types::{BitcoinBlockHeight, DepositIdx, GraphIdx, OperatorIdx},
@@ -36,6 +41,8 @@ use strata_bridge_sm::{
     tx_classifier::TxClassifier,
 };
 use strata_bridge_tx_graph::transactions::{deposit::DepositTx, prelude::DepositData};
+use strata_l1_txfmt::extract_tx_magic_and_tag;
+use thiserror::Error;
 use tracing::{Level, error, info, warn};
 
 use crate::{
@@ -115,6 +122,120 @@ pub(crate) fn process_block(
     applicator.apply_batch(new_block)?;
 
     Ok(())
+}
+
+/// Successfully validated DRT data needed to construct a [`DepositSM`].
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into try_register_deposit in the next commit"
+    )
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ValidDrt {
+    /// Depositor's x-only recovery pubkey parsed from the SPS-50 aux data.
+    depositor_pubkey: XOnlyPublicKey,
+    /// Amount on the deposit-request output (output index 1).
+    drt_output_amount: Amount,
+}
+
+/// Reason [`validate_drt`] rejected a transaction.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into try_register_deposit in the next commit"
+    )
+)]
+#[derive(Debug, Error)]
+enum DrtValidationError {
+    /// Transaction is not addressed to this bridge: missing SPS-50 OP_RETURN, or the magic /
+    /// subprotocol id / tx type do not identify it as a Bridge-v1 DRT for `cfg.magic_bytes`.
+    /// Expected for the vast majority of block transactions and not worth surfacing as an
+    /// error to the operator.
+    #[error("transaction is not a DRT for this bridge")]
+    NotOurEnvelope,
+    /// SPS-50 envelope identified the tx as our DRT, but the structural parse failed.
+    #[error("DRT is structurally invalid: {0}")]
+    Structure(#[source] TxStructureError),
+    /// The 32-byte recovery pubkey in the SPS-50 aux data is not a valid x-only point.
+    #[error("DRT aux carries invalid recovery pubkey: {0}")]
+    InvalidRecoveryPubkey(String),
+    /// Output-1 carries less than `deposit_amount + deposit-tx fee` and so cannot fund a
+    /// relayable deposit transaction.
+    #[error("DRT output value {actual} is below required {required}")]
+    OutputValueBelowRequired { actual: Amount, required: Amount },
+    /// Output-1's P2TR script does not match the script reconstructed from the depositor's
+    /// recovery pubkey, the active N-of-N aggregated key, and the bridge's recovery delay.
+    /// The DRT is therefore not cooperatively spendable by the bridge.
+    #[error("DRT output script does not match expected P2TR locking script")]
+    LockingScriptMismatch,
+}
+
+/// Validates that `tx` is a well-formed DRT for the bridge with the given `cfg` and the given
+/// active operator set, and returns the parts a [`DepositSM`] needs.
+///
+/// Pure: no registry or applicator access. The caller is responsible for ensuring stake
+/// readiness and deriving `active_operator_table` from the active-operator snapshot before
+/// calling.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into try_register_deposit in the next commit"
+    )
+)]
+fn validate_drt(
+    tx: &Transaction,
+    cfg: &DepositSMCfg,
+    active_operator_table: &OperatorTable,
+) -> Result<ValidDrt, DrtValidationError> {
+    let Ok((magic, tag)) = extract_tx_magic_and_tag(tx) else {
+        return Err(DrtValidationError::NotOurEnvelope);
+    };
+    if magic != cfg.magic_bytes
+        || tag.subproto_id() != BRIDGE_V1_SUBPROTOCOL_ID
+        || tag.tx_type() != BridgeTxType::DepositRequest as u8
+    {
+        return Err(DrtValidationError::NotOurEnvelope);
+    }
+
+    let drt_info = parse_drt(tx).map_err(DrtValidationError::Structure)?;
+
+    let recovery_pk_bytes = drt_info.header_aux().recovery_pk();
+    let depositor_pubkey = XOnlyPublicKey::from_slice(recovery_pk_bytes).map_err(|_| {
+        DrtValidationError::InvalidRecoveryPubkey(recovery_pk_bytes.to_lower_hex_string())
+    })?;
+
+    // `parse_drt` already ensures output at index 1 exists.
+    let drt_output = tx
+        .output
+        .get(1)
+        .expect("parse_drt guarantees output index 1 exists");
+
+    let required = DepositTx::drt_required(cfg.deposit_amount);
+    if drt_output.value < required {
+        return Err(DrtValidationError::OutputValueBelowRequired {
+            actual: drt_output.value,
+            required,
+        });
+    }
+
+    let n_of_n = active_operator_table
+        .aggregated_btc_key()
+        .x_only_public_key()
+        .0;
+    let expected_script =
+        create_deposit_request_locking_script(recovery_pk_bytes, n_of_n, cfg.recovery_delay);
+    if drt_output.script_pubkey != expected_script {
+        return Err(DrtValidationError::LockingScriptMismatch);
+    }
+
+    Ok(ValidDrt {
+        depositor_pubkey,
+        drt_output_amount: drt_output.value,
+    })
 }
 
 /// If `tx` is a valid deposit request transaction, registers a [`DepositSM`] and per-operator
@@ -327,15 +448,98 @@ fn new_block_events(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{Amount, Network, absolute, transaction};
-    use strata_bridge_test_utils::bridge_fixtures::{TEST_MAGIC_BYTES, TEST_RECOVERY_DELAY};
+    use bitcoin::{Amount, Network, ScriptBuf, TxIn, TxOut, absolute, transaction};
+    use strata_bridge_test_utils::{
+        bitcoin::generate_xonly_pubkey,
+        bridge_fixtures::{TEST_MAGIC_BYTES, TEST_RECOVERY_DELAY},
+    };
+    use strata_l1_txfmt::{MagicBytes, ParseConfig, TagData};
 
     use super::*;
     use crate::testing::{
-        N_TEST_OPERATORS, TEST_POV_IDX, test_operator_table, test_populated_registry,
+        N_TEST_OPERATORS, TEST_POV_IDX, test_deposit_sm_cfg, test_operator_table,
+        test_populated_registry,
     };
 
     const TEST_HEIGHT: BitcoinBlockHeight = 200;
+
+    // ===== Test fixture builders =====
+
+    /// Configurable builder for synthetic DRTs. Defaults produce a structurally valid DRT for
+    /// the bridge whose `operator_table` and `cfg` are passed to [`Self::aligned`]; individual
+    /// fields can then be overridden to drive each gate in [`validate_drt`].
+    struct DrtBuilder {
+        magic: MagicBytes,
+        subproto_id: u8,
+        tx_type: u8,
+        /// Recovery pubkey bytes placed in the SPS-50 aux data.
+        recovery_pk_in_aux: [u8; 32],
+        /// N-of-N internal key used when building the output-1 P2TR script.
+        n_of_n_in_script: XOnlyPublicKey,
+        /// Recovery pubkey bytes used inside the output-1 takeback tapscript.
+        recovery_pk_in_script: [u8; 32],
+        /// CSV delay encoded inside the output-1 takeback tapscript.
+        recovery_delay_in_script: u16,
+        /// Amount placed on output 1.
+        output_value: Amount,
+        /// Optional destination bytes appended after the 32-byte recovery_pk in aux.
+        destination: Vec<u8>,
+    }
+
+    impl DrtBuilder {
+        /// Returns a builder whose every field is aligned with a valid DRT for the given
+        /// operator table and configuration.
+        fn aligned(operator_table: &OperatorTable, cfg: &DepositSMCfg) -> Self {
+            let recovery_pk = generate_xonly_pubkey().serialize();
+            let n_of_n = operator_table.aggregated_btc_key().x_only_public_key().0;
+            Self {
+                magic: cfg.magic_bytes,
+                subproto_id: BRIDGE_V1_SUBPROTOCOL_ID,
+                tx_type: BridgeTxType::DepositRequest as u8,
+                recovery_pk_in_aux: recovery_pk,
+                n_of_n_in_script: n_of_n,
+                recovery_pk_in_script: recovery_pk,
+                recovery_delay_in_script: cfg.recovery_delay,
+                output_value: DepositTx::drt_required(cfg.deposit_amount),
+                destination: Vec::new(),
+            }
+        }
+
+        /// Build the synthetic transaction.
+        fn build(&self) -> Transaction {
+            let mut aux = Vec::with_capacity(32 + self.destination.len());
+            aux.extend_from_slice(&self.recovery_pk_in_aux);
+            aux.extend_from_slice(&self.destination);
+
+            let tag = TagData::new(self.subproto_id, self.tx_type, aux)
+                .expect("aux must fit SPS-50 size limits");
+            let op_return = ParseConfig::new(self.magic)
+                .encode_script_buf(&tag.as_ref())
+                .expect("SPS-50 tag must encode");
+
+            let lock = create_deposit_request_locking_script(
+                &self.recovery_pk_in_script,
+                self.n_of_n_in_script,
+                self.recovery_delay_in_script,
+            );
+
+            Transaction {
+                version: transaction::Version::TWO,
+                lock_time: absolute::LockTime::ZERO,
+                input: vec![TxIn::default()],
+                output: vec![
+                    TxOut {
+                        value: Amount::ZERO,
+                        script_pubkey: op_return,
+                    },
+                    TxOut {
+                        value: self.output_value,
+                        script_pubkey: lock,
+                    },
+                ],
+            }
+        }
+    }
 
     // ===== new_block_events tests =====
 
@@ -479,5 +683,222 @@ mod tests {
             tracker.into_batches().is_empty(),
             "non-DRT path must not record any SMs in the persistence tracker"
         );
+    }
+
+    // ===== validate_drt tests =====
+
+    #[test]
+    fn validate_drt_accepts_aligned_drt() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let builder = DrtBuilder::aligned(&operator_table, &cfg);
+        let expected_pk = XOnlyPublicKey::from_slice(&builder.recovery_pk_in_aux).unwrap();
+        let expected_value = builder.output_value;
+
+        let valid = validate_drt(&builder.build(), &cfg, &operator_table)
+            .expect("aligned DRT must validate");
+
+        assert_eq!(valid.depositor_pubkey, expected_pk);
+        assert_eq!(valid.drt_output_amount, expected_value);
+    }
+
+    #[test]
+    fn validate_drt_rejects_tx_without_sps50_envelope() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+
+        assert!(matches!(
+            validate_drt(&tx, &cfg, &operator_table),
+            Err(DrtValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_non_op_return_first_output() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+        let tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new_p2tr(
+                    bitcoin::secp256k1::SECP256K1,
+                    generate_xonly_pubkey(),
+                    None,
+                ),
+            }],
+        };
+
+        assert!(matches!(
+            validate_drt(&tx, &cfg, &operator_table),
+            Err(DrtValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_wrong_magic() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.magic = MagicBytes::new(*b"XXXX");
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_wrong_subproto() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.subproto_id = BRIDGE_V1_SUBPROTOCOL_ID.wrapping_add(1);
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_wrong_tx_type() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.tx_type = BridgeTxType::Deposit as u8;
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::NotOurEnvelope)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_malformed_aux() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        // Aux below 32 bytes makes `parse_drt` fail with InvalidAuxiliaryData; envelope is
+        // otherwise aligned for our bridge.
+        let tag = TagData::new(
+            BRIDGE_V1_SUBPROTOCOL_ID,
+            BridgeTxType::DepositRequest as u8,
+            vec![0u8; 31],
+        )
+        .expect("aux must fit SPS-50 size limits");
+        let op_return = ParseConfig::new(cfg.magic_bytes)
+            .encode_script_buf(&tag.as_ref())
+            .expect("SPS-50 tag must encode");
+        let tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::ZERO,
+                script_pubkey: op_return,
+            }],
+        };
+
+        assert!(matches!(
+            validate_drt(&tx, &cfg, &operator_table),
+            Err(DrtValidationError::Structure(_))
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_invalid_recovery_pubkey() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        // 32 zero bytes are not a valid x-only point.
+        builder.recovery_pk_in_aux = [0u8; 32];
+        builder.recovery_pk_in_script = [0u8; 32];
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::InvalidRecoveryPubkey(_))
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_output_value_below_required() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let required = DepositTx::drt_required(cfg.deposit_amount);
+        let actual = required - Amount::from_sat(1);
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.output_value = actual;
+
+        let err = validate_drt(&builder.build(), &cfg, &operator_table).unwrap_err();
+        match err {
+            DrtValidationError::OutputValueBelowRequired {
+                actual: got_actual,
+                required: got_required,
+            } => {
+                assert_eq!(got_actual, actual);
+                assert_eq!(got_required, required);
+            }
+            other => panic!("expected OutputValueBelowRequired, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_drt_rejects_mismatched_recovery_pk_in_script() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        // Aux carries one recovery pk, but the takeback tapscript commits to a different one.
+        builder.recovery_pk_in_script = generate_xonly_pubkey().serialize();
+        assert_ne!(builder.recovery_pk_in_aux, builder.recovery_pk_in_script);
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::LockingScriptMismatch)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_mismatched_internal_key() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        // Pin the output to a P2TR with a non-bridge internal key.
+        builder.n_of_n_in_script = generate_xonly_pubkey();
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::LockingScriptMismatch)
+        ));
+    }
+
+    #[test]
+    fn validate_drt_rejects_mismatched_recovery_delay() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let cfg = test_deposit_sm_cfg();
+
+        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
+        builder.recovery_delay_in_script = cfg.recovery_delay.wrapping_add(1);
+
+        assert!(matches!(
+            validate_drt(&builder.build(), &cfg, &operator_table),
+            Err(DrtValidationError::LockingScriptMismatch)
+        ));
     }
 }

--- a/crates/orchestrator/src/events_classifier/onchain.rs
+++ b/crates/orchestrator/src/events_classifier/onchain.rs
@@ -10,14 +10,9 @@
 
 use std::sync::Arc;
 
-use bitcoin::{Amount, OutPoint, Transaction, hex::DisplayHex, secp256k1::XOnlyPublicKey};
+use bitcoin::{OutPoint, Transaction};
 use btc_tracker::event::BlockEvent;
-use strata_asm_proto_bridge_v1_txs::{
-    BRIDGE_V1_SUBPROTOCOL_ID,
-    constants::BridgeTxType,
-    deposit_request::{DRT_OUTPUT_INDEX, create_deposit_request_locking_script, parse_drt},
-    errors::TxStructureError,
-};
+use strata_asm_proto_bridge_v1_txs::deposit_request::DRT_OUTPUT_INDEX;
 use strata_bridge_primitives::{
     operator_table::OperatorTable,
     types::{BitcoinBlockHeight, DepositIdx, GraphIdx, OperatorIdx},
@@ -40,11 +35,10 @@ use strata_bridge_sm::{
     },
     tx_classifier::TxClassifier,
 };
-use strata_bridge_tx_graph::transactions::{deposit::DepositTx, prelude::DepositData};
-use strata_l1_txfmt::extract_tx_magic_and_tag;
-use thiserror::Error;
+use strata_bridge_tx_graph::transactions::prelude::DepositData;
 use tracing::{Level, info, warn};
 
+use super::drt;
 use crate::{
     applicator::Applicator,
     errors::{PipelineError, ProcessError},
@@ -124,105 +118,12 @@ pub(crate) fn process_block(
     Ok(())
 }
 
-/// Successfully validated DRT data needed to construct a [`DepositSM`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ValidDrt {
-    /// Depositor's x-only recovery pubkey parsed from the SPS-50 aux data.
-    depositor_pubkey: XOnlyPublicKey,
-    /// Amount on the deposit-request output (output index 1).
-    drt_output_amount: Amount,
-}
-
-/// Reason [`validate_drt`] rejected a transaction.
-#[derive(Debug, Error)]
-enum DrtValidationError {
-    /// Transaction is not addressed to this bridge: missing SPS-50 OP_RETURN, or the magic /
-    /// subprotocol id / tx type do not identify it as a Bridge-v1 DRT for `cfg.magic_bytes`.
-    /// Expected for the vast majority of block transactions and not worth surfacing as an
-    /// error to the operator.
-    #[error("transaction is not a DRT for this bridge")]
-    NotOurEnvelope,
-    /// SPS-50 envelope identified the tx as our DRT, but the structural parse failed.
-    #[error("DRT is structurally invalid: {0}")]
-    Structure(#[source] TxStructureError),
-    /// The 32-byte recovery pubkey in the SPS-50 aux data is not a valid x-only point.
-    #[error("DRT aux carries invalid recovery pubkey: {0}")]
-    InvalidRecoveryPubkey(String),
-    /// Output-1 carries less than `deposit_amount + deposit-tx fee` and so cannot fund a
-    /// relayable deposit transaction.
-    #[error("DRT output value {actual} is below required {required}")]
-    OutputValueBelowRequired { actual: Amount, required: Amount },
-    /// Output-1's P2TR script does not match the script reconstructed from the depositor's
-    /// recovery pubkey, the active N-of-N aggregated key, and the bridge's recovery delay.
-    /// The DRT is therefore not cooperatively spendable by the bridge.
-    #[error("DRT output script does not match expected P2TR locking script")]
-    LockingScriptMismatch,
-}
-
-/// Validates that `tx` is a well-formed DRT for the bridge with the given `cfg` and the given
-/// active operator set, and returns the parts a [`DepositSM`] needs.
-///
-/// Pure: no registry or applicator access. The caller is responsible for ensuring stake
-/// readiness and deriving `active_operator_table` from the active-operator snapshot before
-/// calling.
-fn validate_drt(
-    tx: &Transaction,
-    cfg: &DepositSMCfg,
-    active_operator_table: &OperatorTable,
-) -> Result<ValidDrt, DrtValidationError> {
-    let Ok((magic, tag)) = extract_tx_magic_and_tag(tx) else {
-        return Err(DrtValidationError::NotOurEnvelope);
-    };
-    if magic != cfg.magic_bytes
-        || tag.subproto_id() != BRIDGE_V1_SUBPROTOCOL_ID
-        || tag.tx_type() != BridgeTxType::DepositRequest as u8
-    {
-        return Err(DrtValidationError::NotOurEnvelope);
-    }
-
-    let drt_info = parse_drt(tx).map_err(DrtValidationError::Structure)?;
-
-    let recovery_pk_bytes = drt_info.header_aux().recovery_pk();
-    let depositor_pubkey = XOnlyPublicKey::from_slice(recovery_pk_bytes).map_err(|_| {
-        DrtValidationError::InvalidRecoveryPubkey(recovery_pk_bytes.to_lower_hex_string())
-    })?;
-
-    // `parse_drt` already ensures output at index 1 exists.
-    let drt_output = tx
-        .output
-        .get(1)
-        .expect("parse_drt guarantees output index 1 exists");
-
-    let required = DepositTx::drt_required(cfg.deposit_amount);
-    if drt_output.value < required {
-        return Err(DrtValidationError::OutputValueBelowRequired {
-            actual: drt_output.value,
-            required,
-        });
-    }
-
-    let n_of_n = active_operator_table
-        .aggregated_btc_key()
-        .x_only_public_key()
-        .0;
-    let expected_script =
-        create_deposit_request_locking_script(recovery_pk_bytes, n_of_n, cfg.recovery_delay);
-    if drt_output.script_pubkey != expected_script {
-        return Err(DrtValidationError::LockingScriptMismatch);
-    }
-
-    Ok(ValidDrt {
-        depositor_pubkey,
-        drt_output_amount: drt_output.value,
-    })
-}
-
 /// If `tx` is a valid deposit request transaction, registers a [`DepositSM`] and per-operator
 /// [`GraphSM`]s into the registry.
 ///
 /// Returns initial duties emitted by [`GraphSM`] constructors (e.g., `GenerateGraphData`).
 /// Returns `Ok(Vec::new())` if the registry is not yet ready (no stakes confirmed, or this
-/// node's operator is not in the active set) or if [`validate_drt`] rejects the transaction.
+/// node's operator is not in the active set) or if the transaction fails DRT validation.
 fn try_register_deposit(
     deposit_cfg: &Arc<DepositSMCfg>,
     full_operator_table: &OperatorTable,
@@ -256,9 +157,9 @@ fn try_register_deposit(
         unstaking_images,
     } = snapshot;
 
-    let valid = match validate_drt(tx, deposit_cfg, &active_operator_table) {
+    let valid = match drt::validate(tx, deposit_cfg, &active_operator_table) {
         Ok(valid) => valid,
-        Err(DrtValidationError::NotOurEnvelope) => return Ok(Vec::new()),
+        Err(drt::ValidationError::NotOurEnvelope) => return Ok(Vec::new()),
         Err(err) => {
             warn!(%err, txid=%tx.compute_txid(), "rejecting DRT candidate");
             return Ok(Vec::new());
@@ -401,98 +302,19 @@ fn new_block_events(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{Amount, ScriptBuf, TxIn, TxOut, absolute, transaction};
-    use strata_bridge_test_utils::bitcoin::{generate_txid, generate_xonly_pubkey};
-    use strata_l1_txfmt::{MagicBytes, ParseConfig, TagData};
+    use bitcoin::{absolute, transaction};
+    use strata_bridge_test_utils::bitcoin::generate_txid;
 
     use super::*;
     use crate::{
         sm_registry::SMRegistry,
         testing::{
-            N_TEST_OPERATORS, TEST_POV_IDX, insert_confirmed_stake, test_deposit_sm_cfg,
-            test_operator_table, test_populated_registry,
+            DrtBuilder, N_TEST_OPERATORS, TEST_POV_IDX, insert_confirmed_stake,
+            test_deposit_sm_cfg, test_operator_table, test_populated_registry,
         },
     };
 
     const TEST_HEIGHT: BitcoinBlockHeight = 200;
-
-    // ===== Test fixture builders =====
-
-    /// Configurable builder for synthetic DRTs. Defaults produce a structurally valid DRT for
-    /// the bridge whose `operator_table` and `cfg` are passed to [`Self::aligned`]; individual
-    /// fields can then be overridden to drive each gate in [`validate_drt`].
-    struct DrtBuilder {
-        magic: MagicBytes,
-        subproto_id: u8,
-        tx_type: u8,
-        /// Recovery pubkey bytes placed in the SPS-50 aux data.
-        recovery_pk_in_aux: [u8; 32],
-        /// N-of-N internal key used when building the output-1 P2TR script.
-        n_of_n_in_script: XOnlyPublicKey,
-        /// Recovery pubkey bytes used inside the output-1 takeback tapscript.
-        recovery_pk_in_script: [u8; 32],
-        /// CSV delay encoded inside the output-1 takeback tapscript.
-        recovery_delay_in_script: u16,
-        /// Amount placed on output 1.
-        output_value: Amount,
-        /// Optional destination bytes appended after the 32-byte recovery_pk in aux.
-        destination: Vec<u8>,
-    }
-
-    impl DrtBuilder {
-        /// Returns a builder whose every field is aligned with a valid DRT for the given
-        /// operator table and configuration.
-        fn aligned(operator_table: &OperatorTable, cfg: &DepositSMCfg) -> Self {
-            let recovery_pk = generate_xonly_pubkey().serialize();
-            let n_of_n = operator_table.aggregated_btc_key().x_only_public_key().0;
-            Self {
-                magic: cfg.magic_bytes,
-                subproto_id: BRIDGE_V1_SUBPROTOCOL_ID,
-                tx_type: BridgeTxType::DepositRequest as u8,
-                recovery_pk_in_aux: recovery_pk,
-                n_of_n_in_script: n_of_n,
-                recovery_pk_in_script: recovery_pk,
-                recovery_delay_in_script: cfg.recovery_delay,
-                output_value: DepositTx::drt_required(cfg.deposit_amount),
-                destination: Vec::new(),
-            }
-        }
-
-        /// Build the synthetic transaction.
-        fn build(&self) -> Transaction {
-            let mut aux = Vec::with_capacity(32 + self.destination.len());
-            aux.extend_from_slice(&self.recovery_pk_in_aux);
-            aux.extend_from_slice(&self.destination);
-
-            let tag = TagData::new(self.subproto_id, self.tx_type, aux)
-                .expect("aux must fit SPS-50 size limits");
-            let op_return = ParseConfig::new(self.magic)
-                .encode_script_buf(&tag.as_ref())
-                .expect("SPS-50 tag must encode");
-
-            let lock = create_deposit_request_locking_script(
-                &self.recovery_pk_in_script,
-                self.n_of_n_in_script,
-                self.recovery_delay_in_script,
-            );
-
-            Transaction {
-                version: transaction::Version::TWO,
-                lock_time: absolute::LockTime::ZERO,
-                input: vec![TxIn::default()],
-                output: vec![
-                    TxOut {
-                        value: Amount::ZERO,
-                        script_pubkey: op_return,
-                    },
-                    TxOut {
-                        value: self.output_value,
-                        script_pubkey: lock,
-                    },
-                ],
-            }
-        }
-    }
 
     // ===== new_block_events tests =====
 
@@ -685,222 +507,5 @@ mod tests {
             1,
             "exactly one GenerateGraphData duty is emitted, for the POV operator only"
         );
-    }
-
-    // ===== validate_drt tests =====
-
-    #[test]
-    fn validate_drt_accepts_aligned_drt() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-        let builder = DrtBuilder::aligned(&operator_table, &cfg);
-        let expected_pk = XOnlyPublicKey::from_slice(&builder.recovery_pk_in_aux).unwrap();
-        let expected_value = builder.output_value;
-
-        let valid = validate_drt(&builder.build(), &cfg, &operator_table)
-            .expect("aligned DRT must validate");
-
-        assert_eq!(valid.depositor_pubkey, expected_pk);
-        assert_eq!(valid.drt_output_amount, expected_value);
-    }
-
-    #[test]
-    fn validate_drt_rejects_tx_without_sps50_envelope() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let tx = Transaction {
-            version: transaction::Version::TWO,
-            lock_time: absolute::LockTime::ZERO,
-            input: vec![],
-            output: vec![],
-        };
-
-        assert!(matches!(
-            validate_drt(&tx, &cfg, &operator_table),
-            Err(DrtValidationError::NotOurEnvelope)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_non_op_return_first_output() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-        let tx = Transaction {
-            version: transaction::Version::TWO,
-            lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::default()],
-            output: vec![TxOut {
-                value: Amount::from_sat(1_000),
-                script_pubkey: ScriptBuf::new_p2tr(
-                    bitcoin::secp256k1::SECP256K1,
-                    generate_xonly_pubkey(),
-                    None,
-                ),
-            }],
-        };
-
-        assert!(matches!(
-            validate_drt(&tx, &cfg, &operator_table),
-            Err(DrtValidationError::NotOurEnvelope)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_wrong_magic() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        builder.magic = MagicBytes::new(*b"XXXX");
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::NotOurEnvelope)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_wrong_subproto() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        builder.subproto_id = BRIDGE_V1_SUBPROTOCOL_ID.wrapping_add(1);
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::NotOurEnvelope)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_wrong_tx_type() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        builder.tx_type = BridgeTxType::Deposit as u8;
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::NotOurEnvelope)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_malformed_aux() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        // Aux below 32 bytes makes `parse_drt` fail with InvalidAuxiliaryData; envelope is
-        // otherwise aligned for our bridge.
-        let tag = TagData::new(
-            BRIDGE_V1_SUBPROTOCOL_ID,
-            BridgeTxType::DepositRequest as u8,
-            vec![0u8; 31],
-        )
-        .expect("aux must fit SPS-50 size limits");
-        let op_return = ParseConfig::new(cfg.magic_bytes)
-            .encode_script_buf(&tag.as_ref())
-            .expect("SPS-50 tag must encode");
-        let tx = Transaction {
-            version: transaction::Version::TWO,
-            lock_time: absolute::LockTime::ZERO,
-            input: vec![TxIn::default()],
-            output: vec![TxOut {
-                value: Amount::ZERO,
-                script_pubkey: op_return,
-            }],
-        };
-
-        assert!(matches!(
-            validate_drt(&tx, &cfg, &operator_table),
-            Err(DrtValidationError::Structure(_))
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_invalid_recovery_pubkey() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        // 32 zero bytes are not a valid x-only point.
-        builder.recovery_pk_in_aux = [0u8; 32];
-        builder.recovery_pk_in_script = [0u8; 32];
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::InvalidRecoveryPubkey(_))
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_output_value_below_required() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let required = DepositTx::drt_required(cfg.deposit_amount);
-        let actual = required - Amount::from_sat(1);
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        builder.output_value = actual;
-
-        let err = validate_drt(&builder.build(), &cfg, &operator_table).unwrap_err();
-        match err {
-            DrtValidationError::OutputValueBelowRequired {
-                actual: got_actual,
-                required: got_required,
-            } => {
-                assert_eq!(got_actual, actual);
-                assert_eq!(got_required, required);
-            }
-            other => panic!("expected OutputValueBelowRequired, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn validate_drt_rejects_mismatched_recovery_pk_in_script() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        // Aux carries one recovery pk, but the takeback tapscript commits to a different one.
-        builder.recovery_pk_in_script = generate_xonly_pubkey().serialize();
-        assert_ne!(builder.recovery_pk_in_aux, builder.recovery_pk_in_script);
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::LockingScriptMismatch)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_mismatched_internal_key() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        // Pin the output to a P2TR with a non-bridge internal key.
-        builder.n_of_n_in_script = generate_xonly_pubkey();
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::LockingScriptMismatch)
-        ));
-    }
-
-    #[test]
-    fn validate_drt_rejects_mismatched_recovery_delay() {
-        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
-        let cfg = test_deposit_sm_cfg();
-
-        let mut builder = DrtBuilder::aligned(&operator_table, &cfg);
-        builder.recovery_delay_in_script = cfg.recovery_delay.wrapping_add(1);
-
-        assert!(matches!(
-            validate_drt(&builder.build(), &cfg, &operator_table),
-            Err(DrtValidationError::LockingScriptMismatch)
-        ));
     }
 }

--- a/crates/orchestrator/src/testing.rs
+++ b/crates/orchestrator/src/testing.rs
@@ -7,9 +7,15 @@
 use std::{num::NonZero, sync::Arc};
 
 use bitcoin::{
-    Amount, Network, OutPoint, Txid,
+    Amount, Network, OutPoint, Transaction, TxIn, TxOut, Txid, absolute,
     hashes::{Hash, sha256},
     relative,
+    secp256k1::XOnlyPublicKey,
+    transaction,
+};
+use strata_asm_proto_bridge_v1_txs::{
+    BRIDGE_V1_SUBPROTOCOL_ID, constants::BridgeTxType,
+    deposit_request::create_deposit_request_locking_script,
 };
 use strata_bridge_primitives::{
     operator_table::OperatorTable,
@@ -36,8 +42,9 @@ use strata_bridge_test_utils::{
 use strata_bridge_tx_graph::{
     game_graph::ProtocolParams as GameProtocolParams,
     stake_graph::{ProtocolParams as StakeProtocolParams, StakeGraphSummary},
-    transactions::prelude::DepositData,
+    transactions::{deposit::DepositTx, prelude::DepositData},
 };
+use strata_l1_txfmt::{MagicBytes, ParseConfig, TagData};
 use strata_predicate::PredicateKey;
 
 use crate::sm_registry::{SMConfig, SMRegistry};
@@ -243,4 +250,82 @@ pub(crate) fn test_populated_registry(n_deposits: usize) -> SMRegistry {
         insert_deposit_with_graphs(&mut registry, i as DepositIdx);
     }
     registry
+}
+
+// ===== DRT fixture =====
+
+/// Configurable builder for synthetic deposit request transactions. Defaults from
+/// [`Self::aligned`] produce a structurally valid DRT for the given bridge config and operator
+/// set; tests override individual fields to drive each gate in the validator.
+pub(crate) struct DrtBuilder {
+    pub(crate) magic: MagicBytes,
+    pub(crate) subproto_id: u8,
+    pub(crate) tx_type: u8,
+    /// Recovery pubkey bytes placed in the SPS-50 aux data.
+    pub(crate) recovery_pk_in_aux: [u8; 32],
+    /// N-of-N internal key used when building the output-1 P2TR script.
+    pub(crate) n_of_n_in_script: XOnlyPublicKey,
+    /// Recovery pubkey bytes used inside the output-1 takeback tapscript.
+    pub(crate) recovery_pk_in_script: [u8; 32],
+    /// CSV delay encoded inside the output-1 takeback tapscript.
+    pub(crate) recovery_delay_in_script: u16,
+    /// Amount placed on output 1.
+    pub(crate) output_value: Amount,
+    /// Optional destination bytes appended after the 32-byte recovery_pk in aux.
+    pub(crate) destination: Vec<u8>,
+}
+
+impl DrtBuilder {
+    /// Returns a builder whose fields are aligned with a valid DRT for the given operator
+    /// table and configuration.
+    pub(crate) fn aligned(operator_table: &OperatorTable, cfg: &DepositSMCfg) -> Self {
+        let recovery_pk = generate_xonly_pubkey().serialize();
+        let n_of_n = operator_table.aggregated_btc_key().x_only_public_key().0;
+        Self {
+            magic: cfg.magic_bytes,
+            subproto_id: BRIDGE_V1_SUBPROTOCOL_ID,
+            tx_type: BridgeTxType::DepositRequest as u8,
+            recovery_pk_in_aux: recovery_pk,
+            n_of_n_in_script: n_of_n,
+            recovery_pk_in_script: recovery_pk,
+            recovery_delay_in_script: cfg.recovery_delay,
+            output_value: DepositTx::drt_required(cfg.deposit_amount),
+            destination: Vec::new(),
+        }
+    }
+
+    /// Build the synthetic transaction.
+    pub(crate) fn build(&self) -> Transaction {
+        let mut aux = Vec::with_capacity(32 + self.destination.len());
+        aux.extend_from_slice(&self.recovery_pk_in_aux);
+        aux.extend_from_slice(&self.destination);
+
+        let tag = TagData::new(self.subproto_id, self.tx_type, aux)
+            .expect("aux must fit SPS-50 size limits");
+        let op_return = ParseConfig::new(self.magic)
+            .encode_script_buf(&tag.as_ref())
+            .expect("SPS-50 tag must encode");
+
+        let lock = create_deposit_request_locking_script(
+            &self.recovery_pk_in_script,
+            self.n_of_n_in_script,
+            self.recovery_delay_in_script,
+        );
+
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: op_return,
+                },
+                TxOut {
+                    value: self.output_value,
+                    script_pubkey: lock,
+                },
+            ],
+        }
+    }
 }

--- a/crates/tx-graph/Cargo.toml
+++ b/crates/tx-graph/Cargo.toml
@@ -18,6 +18,7 @@ bitcoin-bosd = { workspace = true, features = ["address"] }
 futures.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std"] }
 serde.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 strata-bridge-test-utils.workspace = true

--- a/crates/tx-graph/src/transactions/deposit.rs
+++ b/crates/tx-graph/src/transactions/deposit.rs
@@ -2,6 +2,7 @@
 
 use bitcoin::{
     absolute,
+    psbt::ExtractTxError,
     sighash::{Prevouts, SighashCache},
     transaction::Version,
     Amount, OutPoint, Psbt, ScriptBuf, Transaction, TxIn, TxOut,
@@ -14,6 +15,7 @@ use strata_bridge_connectors::{
     Connector, SigningInfo,
 };
 use strata_l1_txfmt::{MagicBytes, ParseConfig};
+use tracing::warn;
 
 use crate::transactions::PresignedTx;
 
@@ -128,7 +130,34 @@ impl DepositTx {
         self.deposit_request_connector
             .finalize_input(&mut psbt.inputs[0], &deposit_request_witness);
 
-        psbt.extract_tx().expect("should be able to extract tx")
+        // `Psbt::extract_tx` rejects fee rates above `DEFAULT_MAX_FEE_RATE` (25 ksat/vb). The
+        // depositor controls the DRT amount, so an "absurd" fee rate is external input — not an
+        // invariant violation. Log a warning and proceed with the recovered tx; the surplus goes to
+        // the miner. The other variants are invariant violations given
+        // how `DepositTx::new` is constructed and the upstream DRT validation, so they panic.
+        match psbt.extract_tx() {
+            Ok(tx) => tx,
+            Err(ExtractTxError::AbsurdFeeRate { fee_rate, tx }) => {
+                warn!(
+                    %fee_rate,
+                    txid = %tx.compute_txid(),
+                    "DRT overpaid; finalizing deposit tx anyway",
+                );
+                tx
+            }
+            // `DepositTx::new` always populates `witness_utxo` on the input.
+            Err(err @ ExtractTxError::MissingInputValue { .. }) => {
+                panic!("deposit tx PSBT missing input value: {err}")
+            }
+            // Upstream DRT validation must guarantee `drt_value >= deposit_amount + deposit_fee`.
+            Err(err @ ExtractTxError::SendingTooMuch { .. }) => {
+                panic!("deposit tx outputs exceed inputs: {err}")
+            }
+            // `ExtractTxError` is `#[non_exhaustive]`; this catch-all fires only if a future
+            // `bitcoin` release adds a new variant, in which case we want to fail loudly until
+            // this match is updated.
+            Err(err) => panic!("unhandled ExtractTxError variant: {err}"),
+        }
     }
 }
 
@@ -188,15 +217,21 @@ mod tests {
         DepositTx::new(data, deposit_connector, deposit_request)
     }
 
-    // Regression test for STR-3430: a depositor-controlled DRT amount large enough to push the
-    // deposit-tx fee rate above `Psbt::DEFAULT_MAX_FEE_RATE` (25 ksat/vb) currently crashes
-    // `finalize` via the `expect` on `Psbt::extract_tx`. The `should_panic` arm locks in that
-    // buggy behavior; removing it (and the panic) is the actual fix.
     #[test]
-    #[should_panic(expected = "should be able to extract tx")]
-    fn finalize_panics_on_absurd_fee_rate() {
+    fn finalize_does_not_panic_on_absurd_fee_rate() {
         // 0.034 BTC = 3,400,000 sats => ~25k sat/vbyte fee rate on a 132 vbyte tx
-        let drt_value = DEPOSIT_AMOUNT + Amount::from_int_btc(10);
-        let _ = make_deposit_tx(drt_value).finalize(dummy_sig());
+        let drt_value = DEPOSIT_AMOUNT + Amount::from_sat(3_400_000);
+        let tx = make_deposit_tx(drt_value).finalize(dummy_sig());
+
+        assert_eq!(
+            tx.input.len(),
+            DepositTx::N_INPUTS,
+            "finalized deposit tx must carry exactly one input",
+        );
+        assert_eq!(
+            tx.output[DepositTx::DEPOSIT_VOUT as usize].value,
+            DEPOSIT_AMOUNT,
+            "finalized deposit tx's connector output must carry deposit_amount",
+        );
     }
 }

--- a/crates/tx-graph/src/transactions/deposit.rs
+++ b/crates/tx-graph/src/transactions/deposit.rs
@@ -149,3 +149,54 @@ impl AsRef<Transaction> for DepositTx {
         &self.psbt.unsigned_tx
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{relative, Network};
+    use secp256k1::Keypair;
+    use strata_bridge_test_utils::bitcoin::generate_keypair;
+
+    use super::*;
+
+    const DEPOSIT_AMOUNT: Amount = Amount::from_int_btc(10);
+    const RECOVERY_DELAY: u16 = 1_008;
+
+    fn dummy_sig() -> schnorr::Signature {
+        schnorr::Signature::from_slice(&[0xAA; 64]).expect("64 bytes is a valid sig length")
+    }
+
+    fn make_deposit_tx(drt_value: Amount) -> DepositTx {
+        let n_of_n: Keypair = generate_keypair();
+        let depositor: Keypair = generate_keypair();
+        let deposit_request = DepositRequestConnector::new(
+            Network::Regtest,
+            n_of_n.x_only_public_key().0,
+            depositor.x_only_public_key().0,
+            relative::Height::from_height(RECOVERY_DELAY),
+            drt_value,
+        );
+        let deposit_connector = NOfNConnector::new(
+            Network::Regtest,
+            n_of_n.x_only_public_key().0,
+            DEPOSIT_AMOUNT,
+        );
+        let data = DepositData {
+            deposit_idx: 0,
+            deposit_request_outpoint: OutPoint::null(),
+            magic_bytes: (*b"ALPN").into(),
+        };
+        DepositTx::new(data, deposit_connector, deposit_request)
+    }
+
+    // Regression test for STR-3430: a depositor-controlled DRT amount large enough to push the
+    // deposit-tx fee rate above `Psbt::DEFAULT_MAX_FEE_RATE` (25 ksat/vb) currently crashes
+    // `finalize` via the `expect` on `Psbt::extract_tx`. The `should_panic` arm locks in that
+    // buggy behavior; removing it (and the panic) is the actual fix.
+    #[test]
+    #[should_panic(expected = "should be able to extract tx")]
+    fn finalize_panics_on_absurd_fee_rate() {
+        // 0.034 BTC = 3,400,000 sats => ~25k sat/vbyte fee rate on a 132 vbyte tx
+        let drt_value = DEPOSIT_AMOUNT + Amount::from_int_btc(10);
+        let _ = make_deposit_tx(drt_value).finalize(dummy_sig());
+    }
+}


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR hardens the DRT parsing logic in the bridge. Previously, we relied solely on the parsing logic (`parse_drt`) from the `asm` repo. This function only checks for structural soundness of a DRT and not its crptographic soundness. Now, we check both the shape of the transaction (number of outputs, magic bytes, etc.) _and_ whether the DRT output is locked to the right script pubkey. These checks still use the helpers from the `asm` repo. (STR-3429)

Another issue is that if a user is to send a valid DRT with a large amount (> `deposit_amount` + 0.034 BTC), deposit transaction cannot be created causing the bridge node to crash. This happens because the call to `Psbt::finalize` errors if the fee rate of the finalized transaction exceeds 25k sat/vb. Now, we just log a warning. (STR-3430)

Claude was used to implement most of the code changes in this PR.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
@uncomputable please review the last two commits (that touch the `tx-graph` crate).

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3429
Closes STR-3430