### PR TITLE
fix(bridge-sm): emit PublishStake duty once all unstaking partials are collected

### DIFF
--- a/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
@@ -71,8 +71,34 @@ fn accept_partials() {
 }
 
 #[test]
-fn accept_partials_all_collected() {
+fn accept_partials_all_collected_pov() {
     test_stake_transition(StakeTransition {
+        from_state: nonces_collected_state(BTreeMap::from([
+            (0, operator_partial_sigs(0)),
+            (1, operator_partial_sigs(1)),
+        ])),
+        event: UnstakingPartialsReceivedEvent {
+            operator_idx: 2,
+            partial_signatures: operator_partial_sigs(2),
+        }
+        .into(),
+        expected_state: StakeState::UnstakingSigned {
+            last_block_height: STAKE_HEIGHT,
+            stake_data: TEST_STAKE_DATA.clone(),
+            summary: *TEST_GRAPH_SUMMARY,
+            signatures: Box::new(*TEST_FINAL_SIGS),
+        },
+        expected_duties: vec![StakeDuty::PublishStake {
+            operator_idx: 0,
+            tx: TEST_GRAPH.stake.as_ref().clone(),
+        }],
+        expected_signals: vec![],
+    });
+}
+
+#[test]
+fn accept_partials_all_collected_nonpov() {
+    test_nonpov_stake_transition(StakeTransition {
         from_state: nonces_collected_state(BTreeMap::from([
             (0, operator_partial_sigs(0)),
             (1, operator_partial_sigs(1)),

--- a/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
@@ -5,6 +5,7 @@ use strata_bridge_tx_graph::{musig_functor::StakeFunctor, stake_graph::StakeGrap
 use crate::{
     stake::{
         config::StakeSMCfg,
+        duties::StakeDuty,
         errors::{SSMError, SSMResult},
         events::UnstakingPartialsReceivedEvent,
         machine::{SSMOutput, StakeSM},
@@ -40,6 +41,7 @@ impl StakeSM {
             .idx_to_btc_key(&event.operator_idx)
             .expect("operator index has been validated above");
 
+        let mut duties = vec![];
         match self.state_mut() {
             StakeState::UnstakingNoncesCollected {
                 last_block_height,
@@ -133,6 +135,15 @@ impl StakeSM {
                     )
                     .boxed();
 
+                    if context.operator_idx() == context.operator_table().pov_idx() {
+                        let stake_graph = StakeGraph::new(stake_data.expand(*cfg, &context));
+                        let stake_tx = stake_graph.stake.as_ref().clone();
+                        duties.push(StakeDuty::PublishStake {
+                            operator_idx: context.operator_idx(),
+                            tx: stake_tx,
+                        });
+                    }
+
                     self.state = StakeState::UnstakingSigned {
                         last_block_height: *last_block_height,
                         stake_data: stake_data.clone(),
@@ -141,7 +152,7 @@ impl StakeSM {
                     };
                 }
 
-                Ok(SMOutput::new())
+                Ok(SMOutput::with_duties(duties))
             }
             StakeState::UnstakingSigned { .. } => Err(SSMError::duplicate(
                 self.state.clone(),


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR fixes a bug where the `PublishStake` duty was not being emitted even after all the unstaking partials had been collected. This was not caught in any of the functional tests as the retry logic correctly emits this duty from the `UnstakingSigned` state. So, if the retry interval is short enough, this issue will not be observed. This was observed in our signet deployment where the retry interval is 1 hr.

The corresponding design doc PR: https://github.com/alpenlabs/bridge-sm-design-docs/pull/27.

AI was not used.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
@uncomputable this needs your review.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->