### PR TITLE
perf: sync operator wallet in background at startup

### DIFF
--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -16,7 +16,7 @@ use crate::{
         btc_client::init_btc_rpc_client,
         mosaic_client::{init_mosaic_client, run_mosaic_setup, spawn_mosaic_poller},
         operator_table::init_operator_table,
-        operator_wallet::init_operator_wallet,
+        operator_wallet::{init_operator_wallet, spawn_initial_operator_wallet_sync},
         orchestrator::init_orchestrator,
         p2p_handles::{P2PHandles, init_p2p_handles},
         rpc_server::init_rpc_server,
@@ -53,6 +53,13 @@ pub(crate) async fn bootstrap(
     let operator_wallet = init_operator_wallet(&config, &params, &s2_client, &db).await?;
     let operator_wallet = Arc::new(RwLock::new(operator_wallet));
     info!("operator wallet initialized");
+
+    debug!("spawning initial operator wallet sync");
+    let sync_wallet = operator_wallet.clone();
+    // Sync the wallet on a best-effort basis in the background.
+    // This is just to speed up syncing when we actually need to use the funds.
+    tokio::spawn(async move { spawn_initial_operator_wallet_sync(sync_wallet).await });
+    info!("initial operator wallet sync task spawned");
 
     debug!("initializing bitcoin client");
     let btc_rpc_client = init_btc_rpc_client(&config)?;

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -6,6 +6,7 @@ use bitcoind_async_client::traits::Reader;
 use strata_bridge_common::params::Params;
 use strata_bridge_db::fdb::client::FdbClient;
 use strata_tasks::TaskExecutor;
+use tokio::sync::RwLock;
 use tracing::{debug, info};
 
 use crate::{
@@ -50,6 +51,7 @@ pub(crate) async fn bootstrap(
 
     debug!("initializing operator wallet");
     let operator_wallet = init_operator_wallet(&config, &params, &s2_client, &db).await?;
+    let operator_wallet = Arc::new(RwLock::new(operator_wallet));
     info!("operator wallet initialized");
 
     debug!("initializing bitcoin client");

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -1,6 +1,6 @@
 //! Provides operator wallet initialization.
 
-use std::{num::NonZero, sync::Arc};
+use std::{num::NonZero, sync::Arc, time::Instant};
 
 use anyhow::anyhow;
 use bdk_bitcoind_rpc::bitcoincore_rpc;
@@ -17,7 +17,8 @@ use strata_bridge_connectors::prelude::{ClaimContestConnector, ClaimPayoutConnec
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb};
 use strata_bridge_primitives::constants::SEGWIT_MIN_AMOUNT;
 use strata_bridge_tx_graph::{fee, transactions::prelude::ClaimTx};
-use tracing::{debug, info};
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
 
 use crate::config::Config;
 
@@ -68,6 +69,24 @@ pub(in crate::mode) async fn init_operator_wallet(
     debug!("operator wallet initialized");
 
     Ok(operator_wallet)
+}
+
+/// Performs a one-shot sync of the operator wallet against its backend.
+///
+/// Intended to run as a background task at startup so the wallet has a head start before its
+/// first on-demand use. A sync failure is logged and swallowed: callers must still sync the wallet
+/// before use, so a failed initial sync must not crash the node.
+pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(
+    wallet: Arc<RwLock<OperatorWallet>>,
+) {
+    info!("starting initial operator wallet sync");
+    let start = Instant::now();
+    match wallet.write().await.sync().await {
+        Ok(()) => info!(time_spent=?start.elapsed(), "initial operator wallet sync complete"),
+        Err(e) => {
+            warn!(?e, time_spent=?start.elapsed(), "initial operator wallet sync failed, first use might be slow")
+        }
+    }
 }
 
 /// Computes the funding amount for the transaction graph based on the nature of the graph being

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -50,7 +50,7 @@ pub(crate) async fn init_orchestrator<M>(
     gossip_handle: GossipHandle,
     req_resp_handle: ReqRespHandle,
     p2p_keypair: Keypair,
-    wallet: OperatorWallet,
+    wallet: Arc<RwLock<OperatorWallet>>,
     btc_rpc_client: BitcoinClient,
     asm_rpc_client: HttpClient,
     fdb_client: Arc<FdbClient>,
@@ -115,7 +115,7 @@ where
     let exec_cfg = build_exec_config(params, config, &sm_config);
     let tx_driver = TxDriver::new(zmq_client, btc_rpc_client.clone()).await;
     let output_handles = OutputHandles {
-        wallet: RwLock::new(wallet),
+        wallet,
         msg_handler: RwLock::new(message_handler),
         db: fdb_client.clone(),
         bitcoind_rpc_client: btc_rpc_client,

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -21,7 +21,7 @@ use tokio::sync::RwLock;
 /// [`Arc`].
 pub struct OutputHandles {
     /// Handle for accessing operator funds.
-    pub wallet: RwLock<OperatorWallet>,
+    pub wallet: Arc<RwLock<OperatorWallet>>,
 
     /// Handle for accessing the database.
     // TODO: <https://alpenlabs.atlassian.net/browse/STR-2670>


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR spawns the wallet sync task in the background at startup so that the first use of the wallet is faster. Before this PR, this sync was only performed when we actually needed to access the funds. On public bitcoin networks with many blocks and transactions, this slows down the duty execution significantly (30-40 minutes). This change is meant to speed this up.

Claude was used to implement the changes. Codex was used to review.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3487