### PR TITLE
fix(orchestrator): skip no-op db writes on nag and retry ticks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,8 +202,8 @@ libp2p = { version = "0.56.0", features = [
   "identify",
 ] }
 libp2p-identity = { version = "0.2.12", features = ["ed25519"] }
-miniscript = "12.3.0"
 metrics = "0.24"
+miniscript = "12.3.0"
 # NOTE: (@Rajil1213) Using an alpenlabs fork that bumps serdect 0.2 → 0.3 to fix a
 # serialize/deserialize mismatch in non-human-readable binary formats (e.g.
 # postcard). Upstream musig2 ≥0.3.0 ships serdect 0.3 natively, but requires

--- a/crates/bridge-sm/src/deposit/handlers/nag.rs
+++ b/crates/bridge-sm/src/deposit/handlers/nag.rs
@@ -115,7 +115,7 @@ impl DepositSM {
             _ => Vec::new(),
         };
 
-        Ok(DSMOutput::with_duties(duties))
+        Ok(DSMOutput::with_duties(duties).mark_unchanged())
     }
 
     /// Processes an incoming nag from another operator.
@@ -140,7 +140,7 @@ impl DepositSM {
             )),
         }?;
 
-        Ok(DSMOutput::with_duties(duties))
+        Ok(DSMOutput::with_duties(duties).mark_unchanged())
     }
 
     fn reject_nag(&self, event: &NagReceivedEvent, detail: impl Into<String>) -> DSMError {

--- a/crates/bridge-sm/src/deposit/handlers/retry.rs
+++ b/crates/bridge-sm/src/deposit/handlers/retry.rs
@@ -73,6 +73,6 @@ impl DepositSM {
             _ => Vec::new(),
         };
 
-        Ok(DSMOutput::with_duties(duties))
+        Ok(DSMOutput::with_duties(duties).mark_unchanged())
     }
 }

--- a/crates/bridge-sm/src/deposit/transitions/common.rs
+++ b/crates/bridge-sm/src/deposit/transitions/common.rs
@@ -8,7 +8,7 @@ use crate::{
         state::DepositState,
     },
     signals::{DepositSignal, DepositToGraph},
-    state_machine::SMOutput,
+    state_machine::{SMOutput, StateMutation},
 };
 
 impl DepositSM {
@@ -44,6 +44,7 @@ impl DepositSM {
                 Ok(SMOutput {
                     duties: vec![],
                     signals: vec![],
+                    state_mutation: StateMutation::Mutated,
                 })
             }
 
@@ -64,6 +65,7 @@ impl DepositSM {
                 Ok(SMOutput {
                     duties: vec![],
                     signals: vec![],
+                    state_mutation: StateMutation::Mutated,
                 })
             }
 
@@ -116,6 +118,7 @@ impl DepositSM {
                                 },
                             },
                         )],
+                        state_mutation: StateMutation::Mutated,
                     });
                 }
 
@@ -124,6 +127,7 @@ impl DepositSM {
                 Ok(SMOutput {
                     duties: vec![],
                     signals: vec![],
+                    state_mutation: StateMutation::Mutated,
                 })
             }
 

--- a/crates/bridge-sm/src/deposit/transitions/deposit.rs
+++ b/crates/bridge-sm/src/deposit/transitions/deposit.rs
@@ -18,7 +18,7 @@ use crate::{
         state::DepositState,
     },
     signals::{DepositSignal, GraphToDeposit},
-    state_machine::SMOutput,
+    state_machine::{SMOutput, StateMutation},
 };
 
 impl DepositSM {
@@ -56,6 +56,7 @@ impl DepositSM {
             return Ok(SMOutput {
                 duties: vec![],
                 signals: vec![],
+                state_mutation: StateMutation::Mutated,
             });
         }
 

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -18,7 +18,7 @@ use crate::{
         machine::{DSMOutput, DepositSM},
         state::DepositState,
     },
-    state_machine::SMOutput,
+    state_machine::{SMOutput, StateMutation},
 };
 
 impl DepositSM {
@@ -604,6 +604,7 @@ impl DepositSM {
         Ok(SMOutput {
             duties: vec![],
             signals: vec![],
+            state_mutation: StateMutation::Mutated,
         })
     }
 }

--- a/crates/bridge-sm/src/graph/handlers/nag.rs
+++ b/crates/bridge-sm/src/graph/handlers/nag.rs
@@ -78,7 +78,7 @@ impl GraphSM {
             _ => Vec::new(),
         };
 
-        Ok(GSMOutput::with_duties(duties))
+        Ok(GSMOutput::with_duties(duties).mark_unchanged())
     }
 
     /// Processes an incoming nag from another operator.
@@ -108,7 +108,7 @@ impl GraphSM {
             }
         }?;
 
-        Ok(GSMOutput::with_duties(duties))
+        Ok(GSMOutput::with_duties(duties).mark_unchanged())
     }
 
     fn reject_nag(&self, event: &NagReceivedEvent, detail: impl Into<String>) -> GSMError {

--- a/crates/bridge-sm/src/graph/handlers/retry.rs
+++ b/crates/bridge-sm/src/graph/handlers/retry.rs
@@ -218,7 +218,7 @@ impl GraphSM {
             _ => Vec::new(),
         };
 
-        Ok(GSMOutput::with_duties(duties))
+        Ok(GSMOutput::with_duties(duties).mark_unchanged())
     }
 
     fn generate_counterproof_duty(

--- a/crates/bridge-sm/src/stake/handlers/nag_received.rs
+++ b/crates/bridge-sm/src/stake/handlers/nag_received.rs
@@ -47,7 +47,7 @@ impl StakeSM {
             }
         }?;
 
-        Ok(SMOutput::with_duties(duties))
+        Ok(SMOutput::with_duties(duties).mark_unchanged())
     }
 
     fn reject_nag(&self, event: &NagReceivedEvent, detail: impl Into<String>) -> SSMError {

--- a/crates/bridge-sm/src/stake/handlers/nag_tick.rs
+++ b/crates/bridge-sm/src/stake/handlers/nag_tick.rs
@@ -83,6 +83,6 @@ impl StakeSM {
             _ => Vec::new(),
         };
 
-        Ok(SMOutput::with_duties(duties))
+        Ok(SMOutput::with_duties(duties).mark_unchanged())
     }
 }

--- a/crates/bridge-sm/src/stake/handlers/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/handlers/retry_tick.rs
@@ -29,6 +29,6 @@ impl StakeSM {
             _ => Vec::new(),
         };
 
-        Ok(SMOutput::with_duties(duties))
+        Ok(SMOutput::with_duties(duties).mark_unchanged())
     }
 }

--- a/crates/bridge-sm/src/state_machine.rs
+++ b/crates/bridge-sm/src/state_machine.rs
@@ -15,19 +15,12 @@ use crate::{cross_sm_context::CrossSmContext, signals::Signal};
 // Remove this enum once only true transitions exist in the `process_event` STF, and the rest (nags,
 // retries) are moved to separate handler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum StateMutation {
+pub(crate) enum StateMutation {
     /// The transition mutated state and must be persisted.
     #[default]
     Mutated,
     /// The transition left the state machine unchanged.
     Unchanged,
-}
-
-impl StateMutation {
-    /// Returns whether this transition mutated state.
-    pub const fn did_mutate(&self) -> bool {
-        matches!(self, Self::Mutated)
-    }
 }
 
 /// Generic output from any state machine after processing an event.
@@ -51,7 +44,7 @@ pub struct SMOutput<D, S: Into<Signal>> {
     /// The signals that need to be sent to other state machines.
     pub signals: Vec<S>,
     /// Whether the transition that produced this output mutated state machine state.
-    pub state_mutation: StateMutation,
+    pub(crate) state_mutation: StateMutation,
 }
 
 impl<D, S> Default for SMOutput<D, S>

--- a/crates/bridge-sm/src/state_machine.rs
+++ b/crates/bridge-sm/src/state_machine.rs
@@ -5,11 +5,30 @@
 
 use crate::{cross_sm_context::CrossSmContext, signals::Signal};
 
+/// Whether a state transition mutated the state machine's persistent state.
+///
+/// Every [`SMOutput`] constructor defaults to [`Mutated`](Self::Mutated); a transition that
+/// leaves state unchanged opts in to [`Unchanged`](Self::Unchanged) via
+/// [`SMOutput::mark_unchanged`]. The default fails safe: a handler that omits the marker is
+/// treated as mutating, so a state change is never silently dropped.
+// TODO: <https://alpenlabs.atlassian.net/browse/STR-3493>
+// Remove this enum once only true transitions exist in the `process_event` STF, and the rest (nags,
+// retries) are moved to separate handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StateMutation {
+    /// The transition mutated state and must be persisted.
+    #[default]
+    Mutated,
+    /// The transition left the state machine unchanged.
+    Unchanged,
+}
+
 /// Generic output from any state machine after processing an event.
 ///
 /// This struct is used by all state machines in the bridge system. It contains:
 /// - `duties`: Actions that need to be executed externally
 /// - `signals`: Messages to be sent to other state machines
+/// - `state_mutation`: Whether the transition changed persistent state
 ///
 /// The type parameters ensure that each state machine can only emit duties and signals
 /// that are appropriate for that state machine.
@@ -24,6 +43,8 @@ pub struct SMOutput<D, S: Into<Signal>> {
     pub duties: Vec<D>,
     /// The signals that need to be sent to other state machines.
     pub signals: Vec<S>,
+    /// Whether the transition that produced this output mutated state machine state.
+    pub state_mutation: StateMutation,
 }
 
 impl<D, S> Default for SMOutput<D, S>
@@ -34,6 +55,7 @@ where
         Self {
             duties: Vec::new(),
             signals: Vec::new(),
+            state_mutation: StateMutation::Mutated,
         }
     }
 }
@@ -52,6 +74,7 @@ where
         Self {
             duties,
             signals: Vec::new(),
+            state_mutation: StateMutation::Mutated,
         }
     }
 
@@ -60,12 +83,28 @@ where
         Self {
             duties: Vec::new(),
             signals,
+            state_mutation: StateMutation::Mutated,
         }
     }
 
     /// Creates an output with both duties and signals.
     pub const fn with_duties_and_signals(duties: Vec<D>, signals: Vec<S>) -> Self {
-        Self { duties, signals }
+        Self {
+            duties,
+            signals,
+            state_mutation: StateMutation::Mutated,
+        }
+    }
+
+    /// Marks this output as the result of a transition that left state unchanged.
+    pub const fn mark_unchanged(mut self) -> Self {
+        self.state_mutation = StateMutation::Unchanged;
+        self
+    }
+
+    /// Returns whether this output is the result of a transition that mutated state.
+    pub const fn did_mutate(&self) -> bool {
+        matches!(self.state_mutation, StateMutation::Mutated)
     }
 }
 

--- a/crates/bridge-sm/src/state_machine.rs
+++ b/crates/bridge-sm/src/state_machine.rs
@@ -23,6 +23,13 @@ pub enum StateMutation {
     Unchanged,
 }
 
+impl StateMutation {
+    /// Returns whether this transition mutated state.
+    pub const fn did_mutate(&self) -> bool {
+        matches!(self, Self::Mutated)
+    }
+}
+
 /// Generic output from any state machine after processing an event.
 ///
 /// This struct is used by all state machines in the bridge system. It contains:

--- a/crates/bridge-sm/src/testing/transition.rs
+++ b/crates/bridge-sm/src/testing/transition.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 
 use crate::{
     signals::Signal,
-    state_machine::{SMOutput, StateMachine},
+    state_machine::{SMOutput, StateMachine, StateMutation},
 };
 
 /// Describes a valid state transition for value-based testing.
@@ -47,13 +47,14 @@ pub fn test_transition<SM, S, E, D, Sig, Err, CreateFn, GetStateFn>(
     transition: Transition<S, E, D, Sig>,
 ) where
     SM: StateMachine<Event = E, Duty = D, OutgoingSignal = Sig, Error = Err>,
-    S: PartialEq + Debug,
+    S: PartialEq + Debug + Clone,
     D: PartialEq + Debug,
     Sig: PartialEq + Debug + Into<Signal>,
     Err: Debug,
     CreateFn: Fn(S) -> SM,
     GetStateFn: Fn(&SM) -> &S,
 {
+    let from_state = transition.from_state.clone();
     let mut sm = create_sm(transition.from_state);
 
     let result = sm.process_event(config, transition.event);
@@ -77,6 +78,19 @@ pub fn test_transition<SM, S, E, D, Sig, Err, CreateFn, GetStateFn>(
     assert_eq!(
         output.signals, transition.expected_signals,
         "Signals mismatch"
+    );
+
+    // The reported `state_mutation` must agree with whether the state value actually
+    // changed: a transition that leaves state byte-identical must report `Unchanged`,
+    // and one that advances it must report `Mutated`.
+    let expected_mutation = if get_state(&sm) == &from_state {
+        StateMutation::Unchanged
+    } else {
+        StateMutation::Mutated
+    };
+    assert_eq!(
+        output.state_mutation, expected_mutation,
+        "state_mutation must reflect whether the transition changed state"
     );
 }
 

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -133,17 +133,27 @@ impl<'a> Applicator<'a> {
     ///
     /// On success, accumulates duties and enqueues any signal-derived events. Ignored outcomes
     /// (duplicates, rejections) are non-fatal and logged. Fatal errors are propagated.
+    ///
+    /// Persistence tracking follows the state machine's own report: a transition that leaves state
+    /// unchanged (e.g. a nag or retry tick) still has its duties accumulated and its signals
+    /// enqueued, but the source SM is neither recorded for persistence nor linked into a batch.
     fn apply_one(&mut self, sm_id: SMId, sm_event: SMEvent) -> Result<(), PipelineError> {
         match self.registry.process_event(&sm_id, sm_event) {
             Ok(ProcessOutcome::Applied(output)) => {
+                let mutated = output.did_mutate();
+                if mutated {
+                    self.tracker.record(sm_id);
+                }
+
                 self.duties.extend(output.duties);
-                self.tracker.record(sm_id);
 
                 for signal in output.signals {
                     for (target_id, target_event) in
                         signals_router::route_signal(self.registry, signal)
                     {
-                        self.tracker.link(sm_id, target_id);
+                        if mutated {
+                            self.tracker.link(sm_id, target_id);
+                        }
                         self.signal_queue.push_back((target_id, target_event));
                     }
                 }

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{BTreeMap, btree_map::Entry},
+    fmt::{Debug, Display},
     sync::Arc,
 };
 
@@ -16,6 +17,7 @@ use strata_bridge_sm::{
     deposit::{config::DepositSMCfg, machine::DepositSM},
     errors::BridgeSMError,
     graph::{config::GraphSMCfg, machine::GraphSM},
+    signals,
     stake::{config::StakeSMCfg, machine::StakeSM, state::StakeState},
     state_machine::{SMOutput, StateMachine},
 };
@@ -416,15 +418,12 @@ impl SMRegistry {
                 let event = SMEvent::Deposit(deposit_event.clone());
                 sm.process_event(self.cfg.deposit.clone(), *deposit_event)
                     .map(|out| {
-                        let mut duties = out.duties;
-                        duties.extend(sm.run_post_stf_hook(&self.cfg.deposit, &cross_sm_context));
-                        ProcessOutcome::Applied(SMOutput {
-                            duties: duties.into_iter().map(UnifiedDuty::Deposit).collect(),
-                            signals: out.signals.into_iter().map(Into::into).collect(),
-                            state_mutation: out.state_mutation,
-                        })
+                        let mut out = out;
+                        out.duties
+                            .extend(sm.run_post_stf_hook(&self.cfg.deposit, &cross_sm_context));
+                        applied_process_outcome(out, UnifiedDuty::Deposit)
                     })
-                    .or_else(|err| sm_to_process_result(id, event, err))
+                    .or_else(|err| process_result_from_sm_error(id, event, err))
             }
 
             (SMId::Graph(idx), SMEvent::Graph(graph_event)) => {
@@ -435,15 +434,12 @@ impl SMRegistry {
                 let event = SMEvent::Graph(graph_event.clone());
                 sm.process_event(self.cfg.graph.clone(), *graph_event)
                     .map(|out| {
-                        let mut duties = out.duties;
-                        duties.extend(sm.run_post_stf_hook(&self.cfg.graph, &cross_sm_context));
-                        ProcessOutcome::Applied(SMOutput {
-                            duties: duties.into_iter().map(UnifiedDuty::Graph).collect(),
-                            signals: out.signals.into_iter().map(Into::into).collect(),
-                            state_mutation: out.state_mutation,
-                        })
+                        let mut out = out;
+                        out.duties
+                            .extend(sm.run_post_stf_hook(&self.cfg.graph, &cross_sm_context));
+                        applied_process_outcome(out, UnifiedDuty::Graph)
                     })
-                    .or_else(|err| sm_to_process_result(id, event, err))
+                    .or_else(|err| process_result_from_sm_error(id, event, err))
             }
 
             (SMId::Stake(idx), SMEvent::Stake(stake_event)) => {
@@ -454,15 +450,12 @@ impl SMRegistry {
                 let event = SMEvent::Stake(stake_event.clone());
                 sm.process_event(self.cfg.stake.clone(), *stake_event)
                     .map(|out| {
-                        let mut duties = out.duties;
-                        duties.extend(sm.run_post_stf_hook(&self.cfg.stake, &cross_sm_context));
-                        ProcessOutcome::Applied(SMOutput {
-                            duties: duties.into_iter().map(UnifiedDuty::Stake).collect(),
-                            signals: out.signals,
-                            state_mutation: out.state_mutation,
-                        })
+                        let mut out = out;
+                        out.duties
+                            .extend(sm.run_post_stf_hook(&self.cfg.stake, &cross_sm_context));
+                        applied_process_outcome(out, UnifiedDuty::Stake)
                     })
-                    .or_else(|err| sm_to_process_result(id, event, err))
+                    .or_else(|err| process_result_from_sm_error(id, event, err))
             }
 
             (id, event) => Err(ProcessError::InvalidInvocation(*id, event)),
@@ -496,14 +489,34 @@ impl SMRegistry {
     }
 }
 
-fn sm_to_process_result<S, E>(
+fn applied_process_outcome<D, S, MapDuty>(out: SMOutput<D, S>, map_duty: MapDuty) -> ProcessOutcome
+where
+    S: Into<signals::Signal>,
+    MapDuty: FnMut(D) -> UnifiedDuty,
+{
+    let did_mutate = out.did_mutate();
+    let output: ProcessOutput = SMOutput::with_duties_and_signals(
+        out.duties.into_iter().map(map_duty).collect(),
+        out.signals.into_iter().map(Into::into).collect(),
+    );
+
+    let output = if did_mutate {
+        output
+    } else {
+        output.mark_unchanged()
+    };
+
+    ProcessOutcome::Applied(output)
+}
+
+fn process_result_from_sm_error<S, E>(
     id: &SMId,
     event: SMEvent,
     err: BridgeSMError<S, E>,
 ) -> Result<ProcessOutcome, ProcessError>
 where
-    S: std::fmt::Display + std::fmt::Debug,
-    E: std::fmt::Display + std::fmt::Debug,
+    S: Display + Debug,
+    E: Display + Debug,
 {
     match err {
         BridgeSMError::InvalidEvent { reason, state, .. } => Err(ProcessError::InvariantViolation(
@@ -873,7 +886,7 @@ mod tests {
             block_height: 200,
         })));
 
-        let result = sm_to_process_result(
+        let result = process_result_from_sm_error(
             &id,
             event,
             BridgeSMError::Duplicate {
@@ -900,7 +913,7 @@ mod tests {
         })));
         let reason = "stale event".to_string();
 
-        let result = sm_to_process_result(
+        let result = process_result_from_sm_error(
             &id,
             event,
             BridgeSMError::Rejected {
@@ -929,7 +942,7 @@ mod tests {
         let reason = "invalid transition".to_string();
 
         let state_str = "state".to_string();
-        let result = sm_to_process_result(
+        let result = process_result_from_sm_error(
             &id,
             event.clone(),
             BridgeSMError::InvalidEvent {

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -421,6 +421,7 @@ impl SMRegistry {
                         ProcessOutcome::Applied(SMOutput {
                             duties: duties.into_iter().map(UnifiedDuty::Deposit).collect(),
                             signals: out.signals.into_iter().map(Into::into).collect(),
+                            state_mutation: out.state_mutation,
                         })
                     })
                     .or_else(|err| sm_to_process_result(id, event, err))
@@ -439,6 +440,7 @@ impl SMRegistry {
                         ProcessOutcome::Applied(SMOutput {
                             duties: duties.into_iter().map(UnifiedDuty::Graph).collect(),
                             signals: out.signals.into_iter().map(Into::into).collect(),
+                            state_mutation: out.state_mutation,
                         })
                     })
                     .or_else(|err| sm_to_process_result(id, event, err))
@@ -457,6 +459,7 @@ impl SMRegistry {
                         ProcessOutcome::Applied(SMOutput {
                             duties: duties.into_iter().map(UnifiedDuty::Stake).collect(),
                             signals: out.signals,
+                            state_mutation: out.state_mutation,
                         })
                     })
                     .or_else(|err| sm_to_process_result(id, event, err))


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
In our current design, the orchestrator feeds events to the state machines, collects the IDs of all state machines where their STF returned an `Ok(())` and then persists these state machines in the database. Each state machine maintains a property where they return an `Ok(())` only if the state mutates. However, this is not true for non-transitions/handlers (namely, the nag and retry handlers) which _always_ produce an `Ok(())` but do not mutate the state. This leads to unnecessary writes to the database and as nag and retry intervals are regular, this can degrade the node/db performance over prolonged runs. The right way to fix this is to add another top-level handler that deals with nags and retries, separate from the `process_event` STF. However, this introduces a substantial code churn. So for now, a separate [ticket](https://alpenlabs.atlassian.net/browse/STR-3493) has been created to handle this.

Instead, this PR introduces a new field `state_mutation` to `SMOutput` that indicates whether the state has changed. By default, this is true so at worst, we end up making more db calls than strictly necessary but never miss out on any changes. Outputs from retry and nag handlers are explicitly marked as `Unchanged` via `.mark_unchanged()`.

Claude was used to implement the changes. Codex was used to review.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3488