### PR TITLE
feat: reconnect logic in secret-service-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9219,6 +9219,7 @@ dependencies = [
  "secret-service-proto",
  "terrors",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/secret-service-client/Cargo.toml
+++ b/crates/secret-service-client/Cargo.toml
@@ -16,3 +16,4 @@ quinn.workspace = true
 rkyv.workspace = true
 terrors.workspace = true
 tokio.workspace = true
+tracing.workspace = true

--- a/crates/secret-service-client/src/lib.rs
+++ b/crates/secret-service-client/src/lib.rs
@@ -21,7 +21,8 @@ use preimage::PreimgClient;
 pub use quinn::rustls;
 use quinn::{
     crypto::rustls::{NoInitialCipherSuite, QuicClientConfig},
-    ClientConfig, ConnectError, Connection, ConnectionError, Endpoint, TransportConfig,
+    ClientConfig, ConnectError, Connection, ConnectionError, Endpoint, ReadExactError,
+    TransportConfig, WriteError,
 };
 use rkyv::{deserialize, rancor, util::AlignedVec};
 use secret_service_proto::{
@@ -35,10 +36,15 @@ use secret_service_proto::{
     },
 };
 use terrors::OneOf;
-use tokio::time::timeout;
+use tokio::{sync::RwLock, time::timeout};
+use tracing::{info, warn};
 use wallet::{GeneralWalletClient, ReservedWalletClient};
 
 const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(25);
+
+/// Maximum number of times a request is retried inside [`v2_req`] when the server responds with
+/// [`ServerMessage::TryAgain`].
+const MAX_RETRIES: usize = 10;
 
 /// Configuration for the Secret Service client.
 #[derive(Clone, Debug)]
@@ -63,14 +69,155 @@ pub struct Config {
     pub timeout: Duration,
 }
 
+/// Shared connection handle held by all per-signer clients.
+///
+/// Owns the live QUIC [`Connection`] plus the [`Endpoint`] and dial parameters needed to
+/// re-establish the connection if it dies mid-session. Reconnect is lazy: a failed request whose
+/// error signals the connection is dead triggers a single reconnect attempt and one retry inside
+/// [`ConnHandle::make_v2_req`]; if the retry also fails the error is propagated.
+///
+/// Clones are cheap — the inner state lives behind an [`Arc`].
+#[derive(Debug, Clone)]
+pub(crate) struct ConnHandle {
+    inner: Arc<ConnHandleInner>,
+}
+
+#[derive(Debug)]
+struct ConnHandleInner {
+    /// Current QUIC connection. Swapped out on reconnect.
+    conn: RwLock<Connection>,
+    /// Reusable QUIC endpoint — survives across reconnects.
+    endpoint: Endpoint,
+    /// Cloned per `connect_with` call (quinn consumes it by value).
+    client_config: ClientConfig,
+    /// Server address.
+    server_addr: SocketAddr,
+    /// Server TLS hostname.
+    server_hostname: String,
+    /// Per-request timeout.
+    timeout: Duration,
+}
+
+impl ConnHandle {
+    /// Snapshot the current connection. Cheap — [`Connection`] is Arc internally.
+    async fn current(&self) -> Connection {
+        self.inner.conn.read().await.clone()
+    }
+
+    /// Reconnect to the server, but only if the caller's snapshot is still the live connection.
+    /// Returns the freshly-installed connection (which may be the one another caller already
+    /// reconnected to if we lost the race).
+    async fn reconnect_if_stale(&self, stale: &Connection) -> Result<Connection, ClientError> {
+        let mut guard = self.inner.conn.write().await;
+        // Another caller may have reconnected while we were waiting for the write lock; bail with
+        // their fresh connection rather than churning.
+        if guard.stable_id() != stale.stable_id() {
+            return Ok(guard.clone());
+        }
+        info!(
+            server = %self.inner.server_addr,
+            "secret-service connection lost; reconnecting",
+        );
+        let connecting = self
+            .inner
+            .endpoint
+            .connect_with(
+                self.inner.client_config.clone(),
+                self.inner.server_addr,
+                &self.inner.server_hostname,
+            )
+            // `connect_with` fails for malformed config; we used the same config successfully at
+            // construction time, so a failure here means the system is in a degenerate state.
+            // Surface it as a generic reset.
+            .map_err(|e| {
+                warn!(?e, "secret-service reconnect dial failed");
+                ClientError::ConnectionError(ConnectionError::Reset)
+            })?;
+        // Bound the handshake by the same per-request timeout so a hung dial does not block
+        // every other signer call waiting on this write lock.
+        let new_conn = timeout(self.inner.timeout, connecting)
+            .await
+            .map_err(|_| {
+                warn!("secret-service reconnect handshake timed out");
+                ClientError::Timeout
+            })?
+            .map_err(|e| {
+                warn!(?e, "secret-service reconnect handshake failed");
+                ClientError::ConnectionError(e)
+            })?;
+        info!(
+            server = %self.inner.server_addr,
+            "secret-service reconnect succeeded",
+        );
+        *guard = new_conn.clone();
+        Ok(new_conn)
+    }
+
+    /// Makes a v2 secret service request via QUIC, transparently reconnecting on dead-connection
+    /// errors and per-request timeouts. Application-level errors (`TryAgain` exhaustion,
+    /// deserialization failures, etc.) are propagated to the caller without reconnecting.
+    pub(crate) async fn make_v2_req(
+        &self,
+        msg: ClientMessage,
+    ) -> Result<ServerMessage, ClientError> {
+        let conn = self.current().await;
+        // Try once on the current connection. On dead-connection errors only, reconnect and retry
+        // once more with the fresh connection. Note: we clone `msg` only on the retry path so the
+        // happy path pays just one clone (inside `v2_req` for serialization).
+        match v2_req(&conn, msg.clone(), self.inner.timeout, MAX_RETRIES).await {
+            Ok(m) => Ok(m),
+            Err(e) if should_reconnect(&e) => {
+                let new_conn = self.reconnect_if_stale(&conn).await?;
+                v2_req(&new_conn, msg, self.inner.timeout, MAX_RETRIES).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// Returns true if `err` warrants a reconnect attempt.
+///
+/// Reconnect on:
+/// - explicit dead-connection signals from quinn (closed, reset, locally-closed, etc.)
+/// - per-request `Timeout` — a slow server costs at most one wasted reconnect, but a server that
+///   has died without yet tripping the QUIC idle-timeout / keep-alive would otherwise keep timing
+///   out indefinitely.
+///
+/// Application-level errors (retry exhaustion, malformed payloads, serialization failures)
+/// are propagated.
+const fn should_reconnect(err: &ClientError) -> bool {
+    match err {
+        ClientError::ConnectionError(ce) => matches!(
+            ce,
+            ConnectionError::ApplicationClosed(_)
+                | ConnectionError::ConnectionClosed(_)
+                | ConnectionError::Reset
+                | ConnectionError::TimedOut
+                | ConnectionError::LocallyClosed
+        ),
+        ClientError::WriteError(we) => matches!(we, WriteError::ConnectionLost(_)),
+        ClientError::ReadError(re) => matches!(
+            re,
+            ReadExactError::ReadError(quinn::ReadError::ConnectionLost(_))
+        ),
+        ClientError::Timeout => true,
+        // Per-request errors that do not indicate a dead connection. Listed exhaustively rather
+        // than caught by a wildcard so any new `ClientError` variant forces a deliberate
+        // classification decision here at compile time.
+        ClientError::SerializationError(_)
+        | ClientError::DeserializationError(_)
+        | ClientError::BadData
+        | ClientError::NoMoreRetries
+        | ClientError::WrongMessage(_)
+        | ClientError::WrongVersion => false,
+    }
+}
+
 /// A client that connects to a remote secret service via QUIC.
 #[derive(Clone, Debug)]
 pub struct SecretServiceClient {
-    /// Client configuration.
-    config: Arc<Config>,
-
-    /// QUIC connection to the server.
-    conn: Connection,
+    /// Shared connection handle. Reconnects on transport failure are transparent to callers.
+    conn: ConnHandle,
 }
 
 impl SecretServiceClient {
@@ -103,14 +250,26 @@ impl SecretServiceClient {
         client_config.transport_config(transport_config.into());
 
         let connecting = endpoint
-            .connect_with(client_config, config.server_addr, &config.server_hostname)
+            .connect_with(
+                client_config.clone(),
+                config.server_addr,
+                &config.server_hostname,
+            )
             .map_err(OneOf::new)?;
         let conn = connecting.await.map_err(OneOf::new)?;
 
-        Ok(SecretServiceClient {
-            config: Arc::new(config),
-            conn,
-        })
+        let conn = ConnHandle {
+            inner: Arc::new(ConnHandleInner {
+                conn: RwLock::new(conn),
+                endpoint,
+                client_config,
+                server_addr: config.server_addr,
+                server_hostname: config.server_hostname.clone(),
+                timeout: config.timeout,
+            }),
+        };
+
+        Ok(SecretServiceClient { conn })
     }
 }
 
@@ -125,82 +284,103 @@ impl SecretService<Client> for SecretServiceClient {
     type Preimages = PreimgClient;
 
     fn general_wallet_signer(&self) -> Self::GeneralWalletSigner {
-        GeneralWalletClient::new(self.conn.clone(), self.config.clone())
+        GeneralWalletClient::new(self.conn.clone())
     }
 
     fn reserved_wallet_signer(&self) -> Self::ReservedWalletSigner {
-        ReservedWalletClient::new(self.conn.clone(), self.config.clone())
+        ReservedWalletClient::new(self.conn.clone())
     }
 
     fn p2p_signer(&self) -> Self::P2PSigner {
-        P2PClient::new(self.conn.clone(), self.config.clone())
+        P2PClient::new(self.conn.clone())
     }
 
     fn musig2_signer(&self) -> Self::Musig2Signer {
-        Musig2Client::new(self.conn.clone(), self.config.clone())
+        Musig2Client::new(self.conn.clone())
     }
 
     fn preimages(&self) -> Self::Preimages {
-        PreimgClient::new(self.conn.clone(), self.config.clone())
+        PreimgClient::new(self.conn.clone())
     }
 }
 
-/// Makes a v2 secret service request via QUIC.
-pub async fn make_v2_req(
+/// Issues a single v2 request over the given connection. Caller is responsible for retry on
+/// transport failure — see [`ConnHandle::make_v2_req`].
+async fn v2_req(
     conn: &Connection,
     msg: ClientMessage,
     timeout_dur: Duration,
+    retries: usize,
 ) -> Result<ServerMessage, ClientError> {
-    async fn v2_req(
-        conn: &Connection,
-        msg: ClientMessage,
-        timeout_dur: Duration,
-        retries: usize,
-    ) -> Result<ServerMessage, ClientError> {
-        let (mut tx, mut rx) = conn.open_bi().await.map_err(ClientError::ConnectionError)?;
-        let (len_bytes, msg_bytes) = VersionedClientMessage::V2(msg.clone())
-            .serialize()
-            .map_err(ClientError::SerializationError)?;
-        timeout(timeout_dur, tx.write_all(&len_bytes))
-            .await
-            .map_err(|_| ClientError::Timeout)?
-            .map_err(ClientError::WriteError)?;
-        timeout(timeout_dur, tx.write_all(&msg_bytes))
-            .await
-            .map_err(|_| ClientError::Timeout)?
-            .map_err(ClientError::WriteError)?;
+    let (mut tx, mut rx) = conn.open_bi().await.map_err(ClientError::ConnectionError)?;
+    let (len_bytes, msg_bytes) = VersionedClientMessage::V2(msg.clone())
+        .serialize()
+        .map_err(ClientError::SerializationError)?;
+    timeout(timeout_dur, tx.write_all(&len_bytes))
+        .await
+        .map_err(|_| ClientError::Timeout)?
+        .map_err(ClientError::WriteError)?;
+    timeout(timeout_dur, tx.write_all(&msg_bytes))
+        .await
+        .map_err(|_| ClientError::Timeout)?
+        .map_err(ClientError::WriteError)?;
 
-        let len_to_read = {
-            let mut buf = [0; size_of::<LengthUint>()];
-            timeout(timeout_dur, rx.read_exact(&mut buf))
-                .await
-                .map_err(|_| ClientError::Timeout)?
-                .map_err(ClientError::ReadError)?;
-            LengthUint::from_le_bytes(buf)
-        };
-
-        let mut buf: AlignedVec<16> = AlignedVec::with_capacity(len_to_read as usize);
-        buf.resize(len_to_read as usize, 0);
+    let len_to_read = {
+        let mut buf = [0; size_of::<LengthUint>()];
         timeout(timeout_dur, rx.read_exact(&mut buf))
             .await
             .map_err(|_| ClientError::Timeout)?
             .map_err(ClientError::ReadError)?;
+        LengthUint::from_le_bytes(buf)
+    };
 
-        let archived = rkyv::access::<ArchivedVersionedServerMessage, rancor::Error>(&buf)
-            .map_err(ClientError::DeserializationError)?;
+    let mut buf: AlignedVec<16> = AlignedVec::with_capacity(len_to_read as usize);
+    buf.resize(len_to_read as usize, 0);
+    timeout(timeout_dur, rx.read_exact(&mut buf))
+        .await
+        .map_err(|_| ClientError::Timeout)?
+        .map_err(ClientError::ReadError)?;
 
-        let VersionedServerMessage::V2(srv_msg) =
-            deserialize(archived).map_err(ClientError::DeserializationError)?;
+    let archived = rkyv::access::<ArchivedVersionedServerMessage, rancor::Error>(&buf)
+        .map_err(ClientError::DeserializationError)?;
 
-        if let ServerMessage::TryAgain = srv_msg {
-            if retries == 0 {
-                return Err(ClientError::NoMoreRetries);
-            } else {
-                return Box::pin(v2_req(conn, msg, timeout_dur, retries - 1)).await;
-            }
+    let VersionedServerMessage::V2(srv_msg) =
+        deserialize(archived).map_err(ClientError::DeserializationError)?;
+
+    if let ServerMessage::TryAgain = srv_msg {
+        if retries == 0 {
+            return Err(ClientError::NoMoreRetries);
+        } else {
+            return Box::pin(v2_req(conn, msg, timeout_dur, retries - 1)).await;
         }
-
-        Ok(srv_msg)
     }
-    return v2_req(conn, msg, timeout_dur, 10).await;
+
+    Ok(srv_msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_reconnect_classifies_errors() {
+        // Connection-level errors that mean "the connection is dead" -> reconnect.
+        assert!(should_reconnect(&ClientError::ConnectionError(
+            ConnectionError::Reset,
+        )));
+        assert!(should_reconnect(&ClientError::ConnectionError(
+            ConnectionError::TimedOut,
+        )));
+        assert!(should_reconnect(&ClientError::ConnectionError(
+            ConnectionError::LocallyClosed,
+        )));
+
+        // Per-request `Timeout` also triggers reconnect — a server that has died without yet
+        // tripping QUIC's idle-timeout would otherwise keep timing out forever.
+        assert!(should_reconnect(&ClientError::Timeout));
+
+        // Application-level errors -> propagate, do not reconnect.
+        assert!(!should_reconnect(&ClientError::NoMoreRetries));
+        assert!(!should_reconnect(&ClientError::BadData));
+    }
 }

--- a/crates/secret-service-client/src/musig2.rs
+++ b/crates/secret-service-client/src/musig2.rs
@@ -1,10 +1,7 @@
 //! MuSig2 signer client
 
-use std::sync::Arc;
-
 use bitcoin::{hashes::Hash, TapNodeHash, XOnlyPublicKey};
 use musig2::{secp256k1::schnorr::Signature, AggNonce, PartialSignature, PubNonce};
-use quinn::Connection;
 use secret_service_proto::v2::{
     traits::{
         Client, ClientError, Musig2Params, Musig2Signer, Origin, OurPubKeyIsNotInParams,
@@ -13,22 +10,19 @@ use secret_service_proto::v2::{
     wire::{ClientMessage, ServerMessage, SignerTarget},
 };
 
-use crate::{make_v2_req, Config};
+use crate::ConnHandle;
 
 /// MuSig2 client.
 #[derive(Debug, Clone)]
 pub struct Musig2Client {
-    /// QUIC connection to the server.
-    conn: Connection,
-
-    /// Configuration for the client.
-    config: Arc<Config>,
+    /// Shared QUIC connection handle (transparently reconnects on dead-connection errors).
+    conn: ConnHandle,
 }
 
 impl Musig2Client {
-    /// Creates a new MuSig2 client with an existing QUIC connection and configuration.
-    pub const fn new(conn: Connection, config: Arc<Config>) -> Self {
-        Self { conn, config }
+    /// Creates a new MuSig2 client with the given shared connection handle.
+    pub(crate) const fn new(conn: ConnHandle) -> Self {
+        Self { conn }
     }
 }
 
@@ -40,7 +34,7 @@ impl Musig2Signer<Client> for Musig2Client {
         let msg = ClientMessage::Musig2GetPubNonce {
             params: params.into(),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         if let ServerMessage::Musig2GetPubNonce(res) = res {
             Ok(match res {
                 Ok(bs) => Ok(PubNonce::from_bytes(&bs).map_err(|_| ClientError::BadData)?),
@@ -64,7 +58,7 @@ impl Musig2Signer<Client> for Musig2Client {
             aggnonce: aggnonce.serialize(),
             message,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         if let ServerMessage::Musig2GetOurPartialSig(res) = res {
             Ok(match res {
                 Ok(bs) => Ok(PartialSignature::from_slice(&bs).map_err(|_| ClientError::BadData)?),
@@ -87,7 +81,7 @@ impl SchnorrSigner<Client> for Musig2Client {
             digest: *digest,
             tweak: tweak.map(|t| t.to_raw_hash().to_byte_array()),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -108,7 +102,7 @@ impl SchnorrSigner<Client> for Musig2Client {
             key_tweak: *key_tweak,
             tap_tweak: tap_tweak.map(|t| t.to_raw_hash().to_byte_array()),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -122,7 +116,7 @@ impl SchnorrSigner<Client> for Musig2Client {
             target: SignerTarget::Musig2,
             digest: *digest,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -135,7 +129,7 @@ impl SchnorrSigner<Client> for Musig2Client {
         let msg = ClientMessage::SchnorrSignerPubkey {
             target: SignerTarget::Musig2,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         let ServerMessage::SchnorrSignerPubkey { pubkey } = res else {
             return Err(ClientError::WrongMessage(res.into()));
         };

--- a/crates/secret-service-client/src/p2p.rs
+++ b/crates/secret-service-client/src/p2p.rs
@@ -1,37 +1,31 @@
 //! P2P signer client
 
-use std::sync::Arc;
-
 use libp2p_identity::ed25519::SecretKey;
-use quinn::Connection;
 use secret_service_proto::v2::{
     traits::{Client, ClientError, Origin, P2PSigner},
     wire::{ClientMessage, ServerMessage},
 };
 
-use crate::{make_v2_req, Config};
+use crate::ConnHandle;
 
 /// P2P signer client.
 #[derive(Debug, Clone)]
 pub struct P2PClient {
-    /// QUIC connection to the server.
-    conn: Connection,
-
-    /// Configuration for the client.
-    config: Arc<Config>,
+    /// Shared QUIC connection handle (transparently reconnects on dead-connection errors).
+    conn: ConnHandle,
 }
 
 impl P2PClient {
-    /// Creates a new P2P client with an existing QUIC connection and configuration.
-    pub const fn new(conn: Connection, config: Arc<Config>) -> Self {
-        Self { conn, config }
+    /// Creates a new P2P client with the given shared connection handle.
+    pub(crate) const fn new(conn: ConnHandle) -> Self {
+        Self { conn }
     }
 }
 
 impl P2PSigner<Client> for P2PClient {
     async fn secret_key(&self) -> <Client as Origin>::Container<SecretKey> {
         let msg = ClientMessage::P2PSecretKey;
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         let ServerMessage::P2PSecretKey { mut key } = res else {
             return Err(ClientError::WrongMessage(res.into()));
         };

--- a/crates/secret-service-client/src/preimage.rs
+++ b/crates/secret-service-client/src/preimage.rs
@@ -1,31 +1,24 @@
 //! Preimages client
 
-use std::sync::Arc;
-
 use bitcoin::{hashes::Hash, Txid};
-use quinn::Connection;
 use secret_service_proto::v2::{
     traits::{Client, ClientError, Origin, Preimages},
     wire::{ClientMessage, ServerMessage},
 };
 
-use crate::{make_v2_req, Config};
+use crate::ConnHandle;
 
 /// Preimages client.
 #[derive(Debug, Clone)]
 pub struct PreimgClient {
-    /// QUIC connection to the server.
-    conn: Connection,
-
-    /// Configuration for the client.
-    config: Arc<Config>,
+    /// Shared QUIC connection handle (transparently reconnects on dead-connection errors).
+    conn: ConnHandle,
 }
 
 impl PreimgClient {
-    /// Creates a new preimages client with an existing QUIC connection and
-    /// configuration.
-    pub const fn new(conn: Connection, config: Arc<Config>) -> Self {
-        Self { conn, config }
+    /// Creates a new preimages client with the given shared connection handle.
+    pub(crate) const fn new(conn: ConnHandle) -> Self {
+        Self { conn }
     }
 }
 
@@ -41,7 +34,7 @@ impl Preimages<Client> for PreimgClient {
             prestake_vout,
             stake_index,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         let ServerMessage::GetPreimage { preimg } = res else {
             return Err(ClientError::WrongMessage(res.into()));
         };

--- a/crates/secret-service-client/src/wallet.rs
+++ b/crates/secret-service-client/src/wallet.rs
@@ -1,31 +1,25 @@
 //! Operator signer client
 
-use std::sync::Arc;
-
 use bitcoin::{hashes::Hash, TapNodeHash, XOnlyPublicKey};
 use musig2::secp256k1::schnorr::Signature;
-use quinn::Connection;
 use secret_service_proto::v2::{
     traits::{Client, ClientError, Origin, SchnorrSigner},
     wire::{ClientMessage, ServerMessage, SignerTarget},
 };
 
-use crate::{make_v2_req, Config};
+use crate::ConnHandle;
 
 /// General wallet signer client.
 #[derive(Debug, Clone)]
 pub struct GeneralWalletClient {
-    /// QUIC connection to the server.
-    conn: Connection,
-
-    /// Configuration for the client.
-    config: Arc<Config>,
+    /// Shared QUIC connection handle (transparently reconnects on dead-connection errors).
+    conn: ConnHandle,
 }
 
 impl GeneralWalletClient {
-    /// Creates a new operator client with an existing QUIC connection and configuration.
-    pub const fn new(conn: Connection, config: Arc<Config>) -> Self {
-        Self { conn, config }
+    /// Creates a new general wallet signer client with the given shared connection handle.
+    pub(crate) const fn new(conn: ConnHandle) -> Self {
+        Self { conn }
     }
 }
 
@@ -40,7 +34,7 @@ impl SchnorrSigner<Client> for GeneralWalletClient {
             digest: *digest,
             tweak: tweak.map(|t| t.to_raw_hash().to_byte_array()),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -61,7 +55,7 @@ impl SchnorrSigner<Client> for GeneralWalletClient {
             key_tweak: *key_tweak,
             tap_tweak: tap_tweak.map(|t| t.to_raw_hash().to_byte_array()),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -75,7 +69,7 @@ impl SchnorrSigner<Client> for GeneralWalletClient {
             target: SignerTarget::General,
             digest: *digest,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -88,7 +82,7 @@ impl SchnorrSigner<Client> for GeneralWalletClient {
         let msg = ClientMessage::SchnorrSignerPubkey {
             target: SignerTarget::General,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerPubkey { pubkey } => {
                 XOnlyPublicKey::from_slice(&pubkey).map_err(|_| ClientError::BadData)
@@ -101,17 +95,14 @@ impl SchnorrSigner<Client> for GeneralWalletClient {
 /// Reserved wallet signer client.
 #[derive(Debug, Clone)]
 pub struct ReservedWalletClient {
-    /// QUIC connection to the server.
-    conn: Connection,
-
-    /// Configuration for the client.
-    config: Arc<Config>,
+    /// Shared QUIC connection handle (transparently reconnects on dead-connection errors).
+    conn: ConnHandle,
 }
 
 impl ReservedWalletClient {
-    /// Creates a new operator client with an existing QUIC connection and configuration.
-    pub const fn new(conn: Connection, config: Arc<Config>) -> Self {
-        Self { conn, config }
+    /// Creates a new reserved wallet signer client with the given shared connection handle.
+    pub(crate) const fn new(conn: ConnHandle) -> Self {
+        Self { conn }
     }
 }
 
@@ -126,7 +117,7 @@ impl SchnorrSigner<Client> for ReservedWalletClient {
             digest: *digest,
             tweak: tweak.map(|t| t.to_raw_hash().to_byte_array()),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -147,7 +138,7 @@ impl SchnorrSigner<Client> for ReservedWalletClient {
             key_tweak: *key_tweak,
             tap_tweak: tap_tweak.map(|t| t.to_raw_hash().to_byte_array()),
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -161,7 +152,7 @@ impl SchnorrSigner<Client> for ReservedWalletClient {
             target: SignerTarget::Reserved,
             digest: *digest,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerSign { sig } => {
                 Signature::from_slice(&sig).map_err(|_| ClientError::BadData)
@@ -174,7 +165,7 @@ impl SchnorrSigner<Client> for ReservedWalletClient {
         let msg = ClientMessage::SchnorrSignerPubkey {
             target: SignerTarget::Reserved,
         };
-        let res = make_v2_req(&self.conn, msg, self.config.timeout).await?;
+        let res = self.conn.make_v2_req(msg).await?;
         match res {
             ServerMessage::SchnorrSignerPubkey { pubkey } => {
                 XOnlyPublicKey::from_slice(&pubkey).map_err(|_| ClientError::BadData)

--- a/functional-tests/tests/deposit/fn_deposit_s2_restart_test.py
+++ b/functional-tests/tests/deposit/fn_deposit_s2_restart_test.py
@@ -1,0 +1,90 @@
+"""
+Secret-Service Restart Resilience Test
+
+Verifies that a bridge node tolerates its secret-service (s2) process being
+stopped and restarted mid-deposit. The bridge node's `secret-service-client`
+holds a long-lived QUIC connection to the per-operator s2 server. Before
+STR-3305, dropping that connection (e.g. s2 process restart) caused every
+subsequent signing request to fail until the bridge node itself was
+restarted. STR-3305 adds lazy on-failure reconnect; this test exercises
+that path end-to-end.
+
+Test flow:
+1. Submit a DRT and wait until the deposit SM reaches `InProgress` (signing
+   requests are flowing through s2).
+2. Stop every s2 process. The bridge nodes' existing QUIC connections become
+   stale.
+3. Restart every s2 process on the same port (their on-disk config is
+   unchanged).
+4. The deposit must complete — proving the bridge nodes' `make_v2_req`
+   reconnect path successfully re-established each connection without
+   requiring a bridge-node restart.
+"""
+
+import flexitest
+
+from envs import BridgeNetworkEnv
+from envs.base_test import StrataTestBase
+from rpc.types import RpcDepositStatusComplete, RpcDepositStatusInProgress
+from utils.bridge import get_bridge_nodes_and_rpcs
+from utils.deposit import wait_until_deposit_status, wait_until_drt_recognized
+from utils.dev_cli import DevCli
+from utils.utils import read_operator_key
+
+
+@flexitest.register
+class DepositTolerantOfS2RestartTest(StrataTestBase):
+    """The bridge must complete a deposit across an s2 restart without a bridge-node restart."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(BridgeNetworkEnv())
+
+    def main(self, ctx: flexitest.RunContext):
+        bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+        num_operators = len(bridge_nodes)
+
+        # `Service` is the static type returned by `get_service`; the concrete s2 services are
+        # `ProcService`s with `.stop()`/`.start()`.
+        s2_services = [ctx.get_service(f"s2_{i}") for i in range(num_operators)]
+
+        bitcoind_service = ctx.get_service("bitcoin")
+        bitcoind_props = bitcoind_service.props
+        operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
+        dev_cli = DevCli(bitcoind_props, operator_key_infos)
+
+        # --- Submit DRT and wait for the signing phase to begin ---
+        drt_txid = dev_cli.send_deposit_request()
+        self.logger.info(f"Broadcasted DRT: {drt_txid}")
+        deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
+        wait_until_deposit_status(
+            bridge_rpc,
+            deposit_id,
+            RpcDepositStatusInProgress,
+            timeout=180,
+        )
+
+        # --- Stop every s2: the bridge nodes' QUIC connections are now stale ---
+        self.logger.info("Stopping all secret-service nodes mid-deposit")
+        for i, s2 in enumerate(s2_services):
+            self.logger.info(f"Stopping s2 node {i}")
+            s2.stop()  # ty: ignore[possibly-missing-attribute]
+
+        # --- Restart on the same port; the bridge clients must reconnect on demand ---
+        self.logger.info("Restarting all secret-service nodes")
+        for i, s2 in enumerate(s2_services):
+            self.logger.info(f"Starting s2 node {i}")
+            s2.start()  # ty: ignore[possibly-missing-attribute]
+
+        # --- The deposit must complete: any signing call on a stale connection should
+        #     trigger reconnect in `make_v2_req`, succeed on the second attempt against the
+        #     fresh s2, and the deposit drives to completion as normal ---
+        self.logger.info("Waiting for deposit to complete post-s2-restart")
+        wait_until_deposit_status(
+            bridge_rpc,
+            deposit_id,
+            RpcDepositStatusComplete,
+            timeout=300,
+        )
+
+        return True


### PR DESCRIPTION
## Summary
Adds transparent reconnect to the secret-service QUIC client. Previously a single connection drop forced a bridge-node restart to recover.

- New `ConnHandle` wraps `RwLock<Connection>` + reusable `Endpoint`/`ClientConfig`/dial params.
- `ConnHandle::make_v2_req` is the single hot path: snapshot conn → request → on dead-connection errors, redial under write lock + retry once. Race-safe via `Connection::stable_id()`.
- Per-signer clients (`GeneralWalletClient`, `StakechainWalletClient`, `Musig2Client`, `P2PClient`, `StakeChainPreimgClient`) all hold a `ConnHandle` clone — reconnects are transparent to callers.
- `tracing::info!`/`warn!` on reconnect path.
- Application errors (`Timeout`, `TryAgain` exhaustion, serialization) propagate without redialing.

## What's not in this PR
- Backoff/cooldown on consecutive reconnect failures — under high RPS against a crash-looping server, callers will each pay one redial. Worth a follow-up; not urgent for current bridge load.
- Integration test that kills a running server mid-test. Existing tests cover the happy path end-to-end (\`bin/secret-service/src/tests.rs\`); a kill-and-recover test would need server-stop plumbing. Unit test for \`should_reconnect\` classifier included.

## Test plan
- [x] \`just lint\` passes
- [x] \`cargo check --workspace --tests --all-features\` passes
- [x] Unit test \`should_reconnect_classifies_errors\`
- [ ] Functional test against a real bridge with server restart (manual)

Closes STR-3305.