### PR TITLE
refactor: wire funds-table cleanup duties on terminal SM state (STR-3427)

### DIFF
--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -156,6 +156,9 @@ pub async fn execute_deposit_duty(
             )
             .await
         }
+        DepositDuty::DeleteWithdrawalFundingOutpoints { deposit_idx } => {
+            delete_withdrawal_funding_outpoints(&output_handles, *deposit_idx).await
+        }
         DepositDuty::Nag { duty } => {
             let (deposit_idx, operator_idx, nag_request) = match duty {
                 NagDuty::NagDepositNonce {
@@ -594,9 +597,17 @@ async fn fulfill_withdrawal(
 
     info!(%deposit_idx, %txid, "withdrawal fulfillment confirmed");
 
-    // The funding outpoints are now spent on-chain; drop the persisted row so the funds table
-    // doesn't grow unbounded. Failure to delete is non-fatal — `wallet.sync()` will observe the
-    // spend and unlease the outpoints regardless.
+    Ok(())
+}
+
+/// Deletes the persisted withdrawal-funding outpoints for `deposit_idx`. Emitted by the deposit
+/// state machine on `Assigned -> Fulfilled`, so at this point retry-tick can no longer re-issue
+/// `FulfillWithdrawalRequest` and the persisted row is safe to drop. Failure is non-fatal — the
+/// outpoints are already spent on-chain.
+async fn delete_withdrawal_funding_outpoints(
+    output_handles: &OutputHandles,
+    deposit_idx: DepositIdx,
+) -> Result<(), ExecutorError> {
     if let Err(e) = output_handles
         .db
         .delete_withdrawal_funding_outpoints(deposit_idx)
@@ -604,7 +615,6 @@ async fn fulfill_withdrawal(
     {
         warn!(%deposit_idx, ?e, "failed to delete persisted withdrawal funding outpoints");
     }
-
     Ok(())
 }
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -594,6 +594,17 @@ async fn fulfill_withdrawal(
 
     info!(%deposit_idx, %txid, "withdrawal fulfillment confirmed");
 
+    // The funding outpoints are now spent on-chain; drop the persisted row so the funds table
+    // doesn't grow unbounded. Failure to delete is non-fatal — `wallet.sync()` will observe the
+    // spend and unlease the outpoints regardless.
+    if let Err(e) = output_handles
+        .db
+        .delete_withdrawal_funding_outpoints(deposit_idx)
+        .await
+    {
+        warn!(%deposit_idx, ?e, "failed to delete persisted withdrawal funding outpoints");
+    }
+
     Ok(())
 }
 

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -126,6 +126,28 @@ fn invalid_mosaic_key(err: bitcoin::secp256k1::Error) -> ExecutorError {
     ExecutorError::MosaicErr(format!("invalid mosaic pubkey: {err:?}"))
 }
 
+/// Deletes the persisted claim-funding outpoint for `graph_idx`. Emitted by the graph state
+/// machine on transition past `AdaptorsVerified`, where nag-receive can no longer re-issue
+/// `GenerateGraphData`. Failure is non-fatal — the row would only be re-read by a
+/// `GenerateGraphData` invocation that the SM now refuses to dispatch.
+pub(super) async fn delete_claim_funding_outpoint(
+    output_handles: &OutputHandles,
+    graph_idx: GraphIdx,
+) -> Result<(), ExecutorError> {
+    if let Err(e) = output_handles
+        .db
+        .delete_claim_funding_outpoint(graph_idx)
+        .await
+    {
+        warn!(
+            ?graph_idx,
+            ?e,
+            "failed to delete persisted claim funding outpoint"
+        );
+    }
+    Ok(())
+}
+
 /// Returns the claim-funding outpoint for `graph_idx`, fetching it from the wallet (refilling
 /// if necessary) and caching to disk when not already saved.
 async fn ensure_claim_funding_outpoint(

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -189,6 +189,13 @@ pub async fn execute_graph_duty(
         GraphDuty::PublishContestedPayout {
             signed_contested_payout_tx,
         } => publish_contested_payout(&output_handles, signed_contested_payout_tx).await,
+        GraphDuty::DeleteClaimFundingOutpoint { graph_idx } => {
+            info!(
+                ?graph_idx,
+                "executing GraphDuty::DeleteClaimFundingOutpoint"
+            );
+            common::delete_claim_funding_outpoint(&output_handles, *graph_idx).await
+        }
         GraphDuty::Nag { duty } => {
             let (graph_idx, operator_idx, nag_request) = match duty {
                 strata_bridge_sm::graph::duties::NagDuty::NagGraphData {

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -83,6 +83,10 @@ pub async fn execute_stake_duty(
             info!(unstaking_txid=%signed_tx.compute_txid(), "executing StakeDuty::PublishUnstakingTx");
             unstaking::publish_unstaking_tx(&output_handles, signed_tx).await
         }
+        StakeDuty::DeleteStakeFundingReservation { operator_idx } => {
+            info!(%operator_idx, "executing StakeDuty::DeleteStakeFundingReservation");
+            staking::delete_stake_funding_reservation(&output_handles, *operator_idx).await
+        }
         StakeDuty::Nag(nag_duty) => {
             info!(?nag_duty, "executing StakeDuty::Nag");
             nag::execute_nag_duty(&output_handles, nag_duty).await

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -56,6 +56,17 @@ pub(crate) async fn publish_stake_data(
     )
     .await?;
 
+    // Funding tx is buried; the reservation has served its purpose. Wallet sync will pick up the
+    // new stake-funding output on its next pass. Failure to delete is non-fatal — the row will
+    // stay around but the inputs it referenced are already spent on-chain.
+    if let Err(e) = output_handles
+        .db
+        .delete_stake_funding_reservation(operator_idx)
+        .await
+    {
+        warn!(%operator_idx, ?e, "failed to delete persisted stake funding reservation");
+    }
+
     info!("fetching unstaking intent preimage from secret-service");
     let preimage = get_preimage(&output_handles.s2_client, stake_funds).await?;
     let unstaking_image = sha256::Hash::hash(&preimage);

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -56,17 +56,6 @@ pub(crate) async fn publish_stake_data(
     )
     .await?;
 
-    // Funding tx is buried; the reservation has served its purpose. Wallet sync will pick up the
-    // new stake-funding output on its next pass. Failure to delete is non-fatal — the row will
-    // stay around but the inputs it referenced are already spent on-chain.
-    if let Err(e) = output_handles
-        .db
-        .delete_stake_funding_reservation(operator_idx)
-        .await
-    {
-        warn!(%operator_idx, ?e, "failed to delete persisted stake funding reservation");
-    }
-
     info!("fetching unstaking intent preimage from secret-service");
     let preimage = get_preimage(&output_handles.s2_client, stake_funds).await?;
     let unstaking_image = sha256::Hash::hash(&preimage);
@@ -98,6 +87,24 @@ pub(crate) async fn publish_stake_data(
         .send_unstaking_input(operator_idx, unstaking_input, None)
         .await;
 
+    Ok(())
+}
+
+/// Deletes the persisted stake-funding reservation for `operator_idx`. Emitted by the stake state
+/// machine on transition to `Confirmed`, so peer nags can no longer re-issue `PublishStakeData`
+/// and the row is safe to drop. Failure is non-fatal — the reserved inputs are already spent
+/// on-chain by the buried funding tx.
+pub(crate) async fn delete_stake_funding_reservation(
+    output_handles: &OutputHandles,
+    operator_idx: OperatorIdx,
+) -> Result<(), ExecutorError> {
+    if let Err(e) = output_handles
+        .db
+        .delete_stake_funding_reservation(operator_idx)
+        .await
+    {
+        warn!(%operator_idx, ?e, "failed to delete persisted stake funding reservation");
+    }
     Ok(())
 }
 

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -192,6 +192,14 @@ pub enum DepositDuty {
         /// The index of the point-of-view operator (the assignee).
         pov_operator_idx: OperatorIdx,
     },
+    /// Delete the persisted withdrawal-funding outpoints for a deposit. Emitted by the assignee
+    /// once the deposit SM leaves `Assigned` (transitions to `Fulfilled`) — at which point
+    /// retry-tick can no longer re-emit [`DepositDuty::FulfillWithdrawalRequest`], so the
+    /// persisted row is no longer load-bearing for idempotency.
+    DeleteWithdrawalFundingOutpoints {
+        /// The index of the deposit.
+        deposit_idx: DepositIdx,
+    },
     /// Nag other operators for missing information.
     Nag {
         /// The specific nag duty to perform.
@@ -228,6 +236,12 @@ impl std::fmt::Display for DepositDuty {
             DepositDuty::PublishPayoutNonce { .. } => "PublishPayoutNonce".to_string(),
             DepositDuty::PublishPayoutPartial { .. } => "PublishPayoutPartial".to_string(),
             DepositDuty::PublishPayout { .. } => "PublishPayout".to_string(),
+            DepositDuty::DeleteWithdrawalFundingOutpoints { deposit_idx } => {
+                format!(
+                    "DeleteWithdrawalFundingOutpoints (deposit_idx: {})",
+                    deposit_idx
+                )
+            }
             DepositDuty::Nag { duty } => format!("Nag({})", duty),
         };
         write!(f, "{}", display_str)

--- a/crates/bridge-sm/src/deposit/tests/payout/process_fulfillment.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_fulfillment.rs
@@ -18,7 +18,8 @@ mod tests {
     };
 
     /// tests correct transition from Assigned to Fulfilled state when FulfillmentConfirmed event
-    /// is received and POV operator is the assignee (should emit RequestPayoutNonces duty)
+    /// is received and POV operator is the assignee (should emit cleanup +
+    /// RequestPayoutNonces duties)
     #[test]
     fn test_fulfillment_confirmed_from_assigned_pov_is_assignee() {
         let fulfillment_tx = generate_spending_tx(OutPoint::default(), &[]);
@@ -45,10 +46,15 @@ mod tests {
                 cooperative_payout_deadline: LATER_BLOCK_HEIGHT
                     + test_deposit_sm_cfg().cooperative_payout_timeout_blocks(),
             },
-            expected_duties: vec![DepositDuty::RequestPayoutNonces {
-                deposit_idx: TEST_DEPOSIT_IDX,
-                pov_operator_idx: TEST_POV_IDX,
-            }],
+            expected_duties: vec![
+                DepositDuty::DeleteWithdrawalFundingOutpoints {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                },
+                DepositDuty::RequestPayoutNonces {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    pov_operator_idx: TEST_POV_IDX,
+                },
+            ],
             expected_signals: vec![],
         });
     }
@@ -194,9 +200,10 @@ mod tests {
         }
     }
 
-    /// Tests that no RequestPayoutNonces duty is emitted when cooperative_payout_timeout = 0,
-    /// even when the POV operator is the assignee. This ensures the cooperative path is
-    /// skipped entirely when the timeout is set to zero.
+    /// Tests that no `RequestPayoutNonces` duty is emitted when `cooperative_payout_timeout = 0`,
+    /// even when the POV operator is the assignee. The cleanup duty still fires because the
+    /// assignee always persisted withdrawal-funding outpoints — they need cleaning up regardless
+    /// of whether the cooperative path runs.
     #[test]
     fn test_fulfillment_confirmed_no_duty_when_timeout_is_zero() {
         let fulfillment_tx = generate_spending_tx(OutPoint::default(), &[]);
@@ -228,8 +235,10 @@ mod tests {
                     // With timeout = 0, deadline equals fulfillment_height
                     cooperative_payout_deadline: LATER_BLOCK_HEIGHT,
                 },
-                // No duty should be emitted when timeout is 0
-                expected_duties: vec![],
+                // Cleanup still fires; cooperative path is skipped.
+                expected_duties: vec![DepositDuty::DeleteWithdrawalFundingOutpoints {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                }],
                 expected_signals: vec![],
             },
         );

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -125,20 +125,28 @@ impl DepositSM {
                     fulfillment_height: fulfillment.fulfillment_height,
                     cooperative_payout_deadline: cooperative_payment_deadline,
                 };
-                // Dispatch the duty to request the payout nonces if:
-                // 1. The assignee is the pov operator, AND
-                // 2. The cooperative payout timeout is non-zero (otherwise skip the cooperative
-                //    path)
+                // Dispatch any duties the new state requires. The assignee — and only the assignee
+                // — persisted withdrawal-funding outpoints under `deposit_idx` before broadcast,
+                // so only the assignee emits the cleanup duty here.
                 let pov_operator_idx = self.context.operator_table().pov_idx();
-                if pov_operator_idx == assignee && timeout > 0 {
-                    Ok(DSMOutput::with_duties(vec![
-                        DepositDuty::RequestPayoutNonces {
+                let mut duties = Vec::new();
+                if pov_operator_idx == assignee {
+                    duties.push(DepositDuty::DeleteWithdrawalFundingOutpoints {
+                        deposit_idx: self.context.deposit_idx(),
+                    });
+                    // Request payout nonces only if the cooperative payout timeout is non-zero
+                    // (otherwise skip the cooperative path entirely).
+                    if timeout > 0 {
+                        duties.push(DepositDuty::RequestPayoutNonces {
                             deposit_idx: self.context.deposit_idx(),
                             pov_operator_idx,
-                        },
-                    ]))
-                } else {
+                        });
+                    }
+                }
+                if duties.is_empty() {
                     Ok(DSMOutput::new())
+                } else {
+                    Ok(DSMOutput::with_duties(duties))
                 }
             }
 

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -275,6 +275,14 @@ pub enum GraphDuty {
         /// The signed contested payout transaction to be published.
         signed_contested_payout_tx: Transaction,
     },
+    /// Delete the persisted claim-funding outpoint for the graph. Emitted by the graph owner once
+    /// the SM leaves the `AdaptorsVerified` state (transitions to `NoncesCollected`) — at which
+    /// point nag-receive can no longer re-emit `GenerateGraphData`, so the persisted row is no
+    /// longer load-bearing for idempotency.
+    DeleteClaimFundingOutpoint {
+        /// The index of the graph this duty is associated with.
+        graph_idx: GraphIdx,
+    },
     /// Nag other operators for missing information.
     Nag {
         /// The specific nag duty to perform.
@@ -301,6 +309,9 @@ impl std::fmt::Display for GraphDuty {
             GraphDuty::PublishCounterProofNack { .. } => "PublishCounterProofNack".to_string(),
             GraphDuty::PublishSlash { .. } => "PublishSlash".to_string(),
             GraphDuty::PublishContestedPayout { .. } => "PublishContestedPayout".to_string(),
+            GraphDuty::DeleteClaimFundingOutpoint { graph_idx } => {
+                format!("DeleteClaimFundingOutpoint (graph_idx: {:?})", graph_idx)
+            }
             GraphDuty::Nag { duty } => format!("Nag({})", duty),
         };
         write!(f, "{s}")

--- a/crates/bridge-sm/src/graph/tests/uncontested/process_nonce_received.rs
+++ b/crates/bridge-sm/src/graph/tests/uncontested/process_nonce_received.rs
@@ -83,12 +83,19 @@ mod tests {
 
         seq.assert_no_errors();
         assert!(matches!(seq.state(), GraphState::NoncesCollected { .. }));
+        // Own-graph transition emits `PublishGraphPartials` AND the claim-funding cleanup duty
+        // (past `AdaptorsVerified`, nag-receive rejects `GenerateGraphData`, so the persisted
+        // claim-funding outpoint row is no longer load-bearing).
         assert!(
             matches!(
                 seq.all_duties().as_slice(),
-                [GraphDuty::PublishGraphPartials { .. }]
+                [
+                    GraphDuty::PublishGraphPartials { .. },
+                    GraphDuty::DeleteClaimFundingOutpoint { .. },
+                ]
             ),
-            "Expected exactly 1 PublishGraphPartials duty to be emitted"
+            "Expected PublishGraphPartials + DeleteClaimFundingOutpoint duties, got {:?}",
+            seq.all_duties()
         );
         assert!(seq.all_signals().is_empty());
     }

--- a/crates/bridge-sm/src/graph/transitions/uncontested.rs
+++ b/crates/bridge-sm/src/graph/transitions/uncontested.rs
@@ -355,17 +355,25 @@ impl GraphSM {
                         partial_signatures: BTreeMap::new(),
                     };
 
-                    return Ok(GSMOutput::with_duties(vec![
-                        GraphDuty::PublishGraphPartials {
-                            graph_idx: self.context().graph_idx(),
-                            agg_nonces,
-                            sighashes,
-                            graph_inpoints,
-                            graph_tweaks,
-                            claim_txid,
-                            ordered_pubkeys,
-                        },
-                    ]));
+                    let mut duties = vec![GraphDuty::PublishGraphPartials {
+                        graph_idx: self.context().graph_idx(),
+                        agg_nonces,
+                        sighashes,
+                        graph_inpoints,
+                        graph_tweaks,
+                        claim_txid,
+                        ordered_pubkeys,
+                    }];
+                    // Only the graph owner persisted a claim-funding outpoint for this graph,
+                    // so only the owner emits the cleanup duty. Past `AdaptorsVerified`, the
+                    // nag-receive handler rejects `GenerateGraphData`, so the persisted row is
+                    // no longer load-bearing.
+                    if graph_ctx.operator_idx() == graph_ctx.operator_table().pov_idx() {
+                        duties.push(GraphDuty::DeleteClaimFundingOutpoint {
+                            graph_idx: graph_ctx.graph_idx(),
+                        });
+                    }
+                    return Ok(GSMOutput::with_duties(duties));
                 }
 
                 Ok(GSMOutput::default())

--- a/crates/bridge-sm/src/stake/duties.rs
+++ b/crates/bridge-sm/src/stake/duties.rs
@@ -80,6 +80,14 @@ pub enum StakeDuty {
         /// The signed unstaking transaction.
         signed_tx: Transaction,
     },
+    /// Delete the persisted stake-funding reservation. Emitted once the stake transaction
+    /// confirms — i.e. the SM has reached the `Confirmed` state — at which point peer nags
+    /// can no longer re-emit [`StakeDuty::PublishStakeData`], so the persisted reservation is no
+    /// longer load-bearing for idempotency.
+    DeleteStakeFundingReservation {
+        /// The index of the operator that owns the stake.
+        operator_idx: OperatorIdx,
+    },
     /// Nag a given operator to provide missing data.
     Nag(NagDuty),
 }
@@ -134,6 +142,9 @@ impl std::fmt::Display for StakeDuty {
             Self::PublishUnstakingPartials { .. } => "PublishUnstakingPartials".to_string(),
             Self::PublishUnstakingIntent { .. } => "PublishUnstakingIntent".to_string(),
             Self::PublishUnstakingTx { .. } => "PublishUnstakingTx".to_string(),
+            Self::DeleteStakeFundingReservation { operator_idx } => {
+                format!("DeleteStakeFundingReservation (operator_idx: {operator_idx})")
+            }
             Self::Nag(duty) => format!("Nag ({duty})"),
         };
 

--- a/crates/bridge-sm/src/stake/tests/stake_confirmed.rs
+++ b/crates/bridge-sm/src/stake/tests/stake_confirmed.rs
@@ -1,7 +1,9 @@
 //! Unit tests for [`StakeSM::process_stake_confirmed`].
 
 use super::*;
-use crate::stake::{errors::SSMError, events::StakeConfirmedEvent, state::StakeState};
+use crate::stake::{
+    duties::StakeDuty, errors::SSMError, events::StakeConfirmedEvent, state::StakeState,
+};
 
 fn signed_state() -> StakeState {
     StakeState::UnstakingSigned {
@@ -56,6 +58,9 @@ fn invalid_states() -> [StakeState; 2] {
 
 #[test]
 fn accept_stake_tx_from_signed() {
+    // Own-stake happy path: emits the stake-funding-reservation cleanup duty so the persisted
+    // row no longer prevents idempotent re-broadcast (peer nags can no longer reach
+    // `PublishStakeData` past `Confirmed`).
     test_stake_transition(StakeTransition {
         from_state: signed_state(),
         event: StakeConfirmedEvent {
@@ -68,7 +73,9 @@ fn accept_stake_tx_from_signed() {
             summary: *TEST_GRAPH_SUMMARY,
             signatures: Some(*TEST_FINAL_SIGS).into(),
         },
-        expected_duties: vec![],
+        expected_duties: vec![StakeDuty::DeleteStakeFundingReservation {
+            operator_idx: TEST_POV_IDX,
+        }],
         expected_signals: vec![],
     });
 }

--- a/crates/bridge-sm/src/stake/transitions/stake_confirmed.rs
+++ b/crates/bridge-sm/src/stake/transitions/stake_confirmed.rs
@@ -1,5 +1,6 @@
 use crate::{
     stake::{
+        duties::StakeDuty,
         errors::{SSMError, SSMResult},
         events::StakeConfirmedEvent,
         machine::{SSMOutput, StakeSM},
@@ -74,7 +75,21 @@ impl StakeSM {
                     signatures: Box::new(Some(*signatures.clone())),
                 };
 
-                Ok(SMOutput::new())
+                // Only the operator that owns this stake graph persisted a stake-funding
+                // reservation, so only that operator emits the cleanup duty. Reaching
+                // `UnstakingSigned -> Confirmed` is the happy-path own-stake transition;
+                // before this point peer nags can re-emit `PublishStakeData`, so the
+                // reservation must remain persisted to keep that path idempotent.
+                let pov_idx = self.context.operator_table().pov_idx();
+                if self.context.operator_idx() == pov_idx {
+                    Ok(SMOutput::with_duties(vec![
+                        StakeDuty::DeleteStakeFundingReservation {
+                            operator_idx: pov_idx,
+                        },
+                    ]))
+                } else {
+                    Ok(SMOutput::new())
+                }
             }
             StakeState::Confirmed { .. } => {
                 Err(SSMError::duplicate(self.state.clone(), event.into()))

--- a/crates/db/src/fdb/bridge_db.rs
+++ b/crates/db/src/fdb/bridge_db.rs
@@ -290,12 +290,10 @@ impl BridgeDb for FdbClient {
 
     async fn delete_withdrawal_funding_outpoints(
         &self,
-        graph_idx: GraphIdx,
+        deposit_idx: DepositIdx,
     ) -> Result<(), Self::Error> {
-        self.basic_delete::<WithdrawalFundingRowSpec>(WithdrawalFundingKey {
-            deposit_idx: graph_idx.deposit,
-        })
-        .await
+        self.basic_delete::<WithdrawalFundingRowSpec>(WithdrawalFundingKey { deposit_idx })
+            .await
     }
 
     // ── Batch Persistence ─────────────────────────────────────────
@@ -1124,11 +1122,8 @@ mod tests {
         #[test]
         fn delete_withdrawal_funding_outpoints_roundtrip(
             deposit_idx in any::<DepositIdx>(),
-            operator_idx in any::<OperatorIdx>(),
             outpoints in arb_outpoints(),
         ) {
-            let graph_idx = GraphIdx { deposit: deposit_idx, operator: operator_idx };
-
             block_on(async {
                 let client = get_client();
 
@@ -1138,7 +1133,7 @@ mod tests {
                     .unwrap();
 
                 client
-                    .delete_withdrawal_funding_outpoints(graph_idx)
+                    .delete_withdrawal_funding_outpoints(deposit_idx)
                     .await
                     .unwrap();
 

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -174,10 +174,10 @@ pub trait BridgeDb {
         &self,
         graph_idx: GraphIdx,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
-    /// Deletes the reserved [`OutPoint`]s for the given graph and purpose.
+    /// Deletes the reserved [`OutPoint`]s used to fulfil the given deposit's withdrawal request.
     fn delete_withdrawal_funding_outpoints(
         &self,
-        graph_idx: GraphIdx,
+        deposit_idx: DepositIdx,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     // ── Batch Persistence ─────────────────────────────────────────────

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -147,25 +147,6 @@ impl OperatorWallet {
         self.leased_outpoints.remove(outpoint)
     }
 
-    /// Selects the first non-anchor, non-leased general-wallet UTXO that satisfies
-    /// `predicate`, leases it to prevent concurrent duties from re-selecting the same
-    /// outpoint, and returns its [`LocalOutput`].
-    ///
-    /// Returns `None` if no UTXO matches.
-    pub fn select_and_lease_general_utxo(
-        &mut self,
-        predicate: impl Fn(&LocalOutput) -> bool,
-    ) -> Option<LocalOutput> {
-        // Snapshot the leased set so we can mutably borrow `self` after the search.
-        let leased: BTreeSet<OutPoint> = self.leased_outpoints.iter().copied().collect();
-        let selected = self
-            .general_utxos()
-            .filter(|u| !leased.contains(&u.outpoint))
-            .find(predicate)?;
-        self.lease(selected.outpoint);
-        Some(selected)
-    }
-
     /// Funds an unfunded version 3 transaction by adding inputs and change.
     ///
     /// Takes a transaction with outputs only and adds inputs from the general wallet to cover the


### PR DESCRIPTION
Closes [STR-3427](https://alpenlabs.atlassian.net/browse/STR-3427).

## Summary

Cleanup bundle for the operator wallet adapter Phase A. Three changes in the same area:

1. **Wire funds-table row deletion on tx success.** Three persisted funds tables (`withdrawal_funding_outpoints`, `stake_funding_reservation`, `claim_funding_outpoint`) had delete trait methods but no callers; rows accumulated forever. This PR wires them via a new duty pattern (see *Design* below).
2. **Remove `OperatorWallet::select_and_lease_general_utxo`** — dead code, zero callers in the workspace.
3. **Stake-funding inputs persist-before-broadcast parity** (AC #3 of the ticket) — already satisfied by `set_stake_funding_reservation` running before broadcast in `read_or_create_stake_funding`; no change needed, documenting closure.

## Design

Each delete is gated on an SM terminal-state transition (the point past which the publishing duty cannot be re-emitted), not on tx burial. The naïve "delete when tx is buried" trigger was unsafe — the SMs stay in nag/retry-emitting states past burial in real edge cases, and a wiped row would cause the next re-emit to select fresh inputs and broadcast a second tx (deposit deadline-miss double-fund; stake nag-replay double-fund — the latter already failing `fn_stake_data_idempotency_test` in CI).

New duty variants:

| Funds table | Duty | Emitted on | Gate |
|---|---|---|---|
| Withdrawal-funding outpoints | \`DepositDuty::DeleteWithdrawalFundingOutpoints\` | \`Assigned → Fulfilled\` | \`pov_idx == assignee\` |
| Stake-funding reservation | \`StakeDuty::DeleteStakeFundingReservation\` | \`UnstakingSigned → Confirmed\` | own-stake (\`operator_idx == pov_idx\`) |
| Claim-funding outpoint | \`GraphDuty::DeleteClaimFundingOutpoint\` | \`AdaptorsVerified → NoncesCollected\` | own-graph (\`operator_idx == pov_idx\`) |

Each duty's executor handler calls the corresponding \`db.delete_*\` and warns-and-swallows on error (the persisted inputs are already spent on-chain by the buried publishing tx, so a failed delete is a hygiene issue, not a correctness one).

Cleanup duties are emitted only at the transition site, only when the state actually transitions, and only from the operator that persisted the row. Pov-gating is symmetric with the persist site — the only operator that persisted the row is the only one that emits the cleanup.

## Test plan

- [x] \`cargo nextest run -p strata-bridge-sm\` — 419/419 (3 transition tests updated to assert the new cleanup duties).
- [x] \`cargo doc -p strata-bridge-sm -p strata-bridge-exec --no-deps\` — clean.
- [ ] CI to re-run the previously-failing \`fn_stake_data_idempotency_test\` (the failure originated from this PR's earlier broken commit and is fixed in the duty-based design).
- [ ] CI green across the rest of the functional test suite.

## Follow-up

[STR-3542](https://alpenlabs.atlassian.net/browse/STR-3542) captures a P2 surfaced during review: if the orchestrator crashes between state-persist and duty-dispatch for a cleanup-emitting transition, the cleanup is lost (stale row, no correctness impact). Pre-existing pipeline behaviour, not introduced here.

[STR-3427]: https://alpenlabs.atlassian.net/browse/STR-3427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STR-3542]: https://alpenlabs.atlassian.net/browse/STR-3542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ