### PR TITLE
refactor: remove bdk::Wallet leak from OperatorWallet public API

### DIFF
--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -167,7 +167,6 @@ async fn ensure_claim_funding_outpoint(
                 finalize_claim_funding_tx(
                     &output_handles.s2_client,
                     &output_handles.tx_driver,
-                    wallet.general_wallet(),
                     psbt,
                 )
                 .await?;

--- a/crates/bridge-exec/src/graph/utils.rs
+++ b/crates/bridge-exec/src/graph/utils.rs
@@ -1,7 +1,6 @@
 //! Shared helpers for graph executors.
 
 use algebra::predicate;
-use bdk_wallet::Wallet;
 use bitcoin::{
     Psbt, TapSighashType,
     hashes::Hash,
@@ -17,27 +16,27 @@ use crate::errors::ExecutorError;
 
 /// Finalizes and broadcasts a claim funding transaction.
 ///
-/// This function assumes that the [`Psbt`] has already been funded. It will finalize this [`Psbt`]
-/// by signing all inputs using the general wallet signer in the secret service, submit the
-/// finalized transaction to the tx driver for broadcasting and then wait for the transaction to
-/// appear in the mempool.
+/// This function assumes that the [`Psbt`] has already been funded with `witness_utxo` populated
+/// on every input (which `OperatorWallet::refill_claim_funding_utxos` guarantees). It signs all
+/// inputs using the general wallet signer in the secret service, submits the finalized
+/// transaction to the tx driver for broadcasting, and then waits for the transaction to appear
+/// in the mempool.
 pub(super) async fn finalize_claim_funding_tx(
     s2_client: &SecretServiceClient,
     tx_driver: &TxDriver,
-    general_wallet: &Wallet,
     psbt: Psbt,
 ) -> Result<(), ExecutorError> {
-    let mut tx = psbt.unsigned_tx;
-    let txins_as_outs = tx
-        .input
+    let txins_as_outs = psbt
+        .inputs
         .iter()
-        .map(|txin| {
-            general_wallet
-                .get_utxo(txin.previous_output)
-                .expect("always have this output because the wallet selected it in the first place")
-                .txout
+        .map(|input| {
+            input
+                .witness_utxo
+                .clone()
+                .expect("PSBT input from claim-funding refill always has witness_utxo")
         })
         .collect::<Vec<_>>();
+    let mut tx = psbt.unsigned_tx;
 
     let mut sighasher = SighashCache::new(&mut tx);
     let sighash_type = TapSighashType::Default;

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -404,16 +404,6 @@ impl OperatorWallet {
         &self.reserved_addr_script_buf
     }
 
-    /// Returns an immutable reference to the general wallet
-    pub const fn general_wallet(&self) -> &Wallet {
-        &self.general_wallet
-    }
-
-    /// Returns an immutable reference to the reserved wallet
-    pub const fn reserved_wallet(&self) -> &Wallet {
-        &self.reserved_wallet
-    }
-
     /// Syncs the wallet using the backend provided on construction.
     pub async fn sync(&mut self) -> Result<(), SyncError> {
         let mut attempt = 0;


### PR DESCRIPTION
**Stacked on #553** (\`azz/str-3425-rename-stakechain-to-reserved\`). Will rebase onto main when #553 merges.

## Summary

Drops the two \`pub\` accessors on \`OperatorWallet\` that returned \`&bdk::Wallet\`:

- \`reserved_wallet()\` had zero callers.
- \`general_wallet()\` had exactly one caller chain (\`graph/common.rs:170\` → \`graph/utils.rs:35-37\`) that used it to fetch prevout \`TxOut\`s for sighash construction.

Refactors \`finalize_claim_funding_tx\` to read prevouts from \`psbt.inputs[i].witness_utxo\` directly. BDK's \`TxBuilder::finish()\` populates \`witness_utxo\` for Taproot inputs (the general wallet uses a \`tr(...)\` descriptor), so this is sound.

## Why

This is the only \`&bdk::Wallet\` leak in \`OperatorWallet\`'s public API. Removing it unblocks the upcoming \`OperatorWalletBackend\` trait extraction (STR-3435), where a non-BDK backend (Fireblocks) cannot satisfy a \`&bdk::Wallet\` return type.

## Out of scope (deferred to STR-3435)

\`OperatorWallet\` still re-exposes BDK's \`LocalOutput\` via \`claim_funding_outputs() -> impl Iterator<Item = LocalOutput>\`. The trait extraction will need to abstract over this — out of scope for this PR's stated "drop \`&bdk::Wallet\` accessors" task.

## Test plan

- [x] \`just lint\` passes
- [x] \`cargo check --workspace --tests --all-features\` passes (verified locally before the diff was finalized)
- [ ] Functional tests (recommend running before merge given the executor signature change)

Closes STR-3426.