### PR TITLE
feat: extract GeneralWallet trait + native impl + migrate bridge-exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7401,6 +7401,8 @@ version = "0.1.0"
 dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
+ "corepc-node",
+ "serial_test",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7399,9 +7399,9 @@ dependencies = [
 name = "operator-wallet"
 version = "0.1.0"
 dependencies = [
- "algebra",
  "bdk_bitcoind_rpc",
  "bdk_wallet",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -52,9 +52,10 @@ pub(crate) async fn bootstrap(
     info!(%pov_idx, %pov_p2p_key, %pov_btc_key, %agg_key, "operator table initialized");
 
     debug!("initializing operator wallet");
-    let operator_wallet = init_operator_wallet(&config, &params, &s2_client, &db).await?;
-    let operator_wallet = Arc::new(RwLock::new(operator_wallet));
-    info!("operator wallet initialized");
+    let initialized_wallet = init_operator_wallet(&config, &params, &s2_client, &db).await?;
+    let claim_funding_utxo_value = initialized_wallet.claim_funding_utxo_value;
+    let operator_wallet = Arc::new(RwLock::new(initialized_wallet.wallet));
+    info!(%claim_funding_utxo_value, "operator wallet initialized");
 
     debug!("spawning initial operator wallet sync");
     let sync_wallet = operator_wallet.clone();
@@ -109,6 +110,7 @@ pub(crate) async fn bootstrap(
         req_resp_handle,
         keypair,
         operator_wallet,
+        claim_funding_utxo_value,
         btc_rpc_client,
         asm_rpc_client,
         db.clone(),

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -26,14 +26,14 @@ use crate::config::Config;
 /// Result of [`init_operator_wallet`] — the constructed wallet plus the per-UTXO
 /// denomination of the claim-funding pool. The latter is no longer stored on
 /// `OperatorWalletConfig` (the composer is now agnostic of caller denominations); the
-/// orchestrator forwards it into `ExecutionConfig` so duty executors can reference the
-/// pool by value.
+/// orchestrator forwards it into `strata_bridge_exec::config::ExecutionConfig` so duty
+/// executors can reference the pool by value.
 pub(in crate::mode) struct InitializedOperatorWallet {
     /// The composed operator wallet, ready to lease + sign against.
     pub wallet: NativeWallet,
     /// Per-UTXO denomination of the claim-funding pool. The composer is denomination-
-    /// agnostic; this value is propagated into [`ExecutionConfig`] so duty executors can
-    /// reference the pool by value.
+    /// agnostic; this value is propagated into `strata_bridge_exec::config::ExecutionConfig`
+    /// so duty executors can reference the pool by value.
     pub claim_funding_utxo_value: Amount,
 }
 

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -23,12 +23,26 @@ use tracing::{debug, info, warn};
 
 use crate::config::Config;
 
+/// Result of [`init_operator_wallet`] — the constructed wallet plus the per-UTXO
+/// denomination of the claim-funding pool. The latter is no longer stored on
+/// `OperatorWalletConfig` (the composer is now agnostic of caller denominations); the
+/// orchestrator forwards it into `ExecutionConfig` so duty executors can reference the
+/// pool by value.
+pub(in crate::mode) struct InitializedOperatorWallet {
+    /// The composed operator wallet, ready to lease + sign against.
+    pub wallet: NativeWallet,
+    /// Per-UTXO denomination of the claim-funding pool. The composer is denomination-
+    /// agnostic; this value is propagated into [`ExecutionConfig`] so duty executors can
+    /// reference the pool by value.
+    pub claim_funding_utxo_value: Amount,
+}
+
 pub(in crate::mode) async fn init_operator_wallet(
     config: &Config,
     params: &Params,
     s2_client: &SecretServiceClient,
     db_client: &FdbClient,
-) -> anyhow::Result<NativeWallet> {
+) -> anyhow::Result<InitializedOperatorWallet> {
     info!("fetching leased utxos from database");
     let leased_outpoints = db_client
         .get_all_funds()
@@ -53,17 +67,16 @@ pub(in crate::mode) async fn init_operator_wallet(
     let reserved_key = s2_client.reserved_wallet_signer().pubkey().await?;
     info!(%reserved_key, "operator wallet reserved key");
     let own_musig2_key = s2_client.musig2_signer().pubkey().await?;
-    let operator_funds = compute_funding_amount(params, own_musig2_key);
-    let operator_wallet_config =
-        OperatorWalletConfig::new(operator_funds, SEGWIT_MIN_AMOUNT, params.network);
-    debug!(?operator_wallet_config, "operator wallet config");
+    let claim_funding_utxo_value = compute_claim_funding_utxo_value(params, own_musig2_key);
+    let operator_wallet_config = OperatorWalletConfig::new(SEGWIT_MIN_AMOUNT, params.network);
+    debug!(?operator_wallet_config, %claim_funding_utxo_value, "operator wallet config");
 
     let general_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
     let reserved_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
     debug!(?general_sync_backend, "operator wallet sync backend");
     let general_wallet =
         NativeGeneralWallet::new(general_key, params.network, general_sync_backend);
-    let operator_wallet = OperatorWallet::new(
+    let wallet = OperatorWallet::new(
         general_wallet,
         reserved_key,
         operator_wallet_config,
@@ -72,7 +85,10 @@ pub(in crate::mode) async fn init_operator_wallet(
     );
     debug!("operator wallet initialized");
 
-    Ok(operator_wallet)
+    Ok(InitializedOperatorWallet {
+        wallet,
+        claim_funding_utxo_value,
+    })
 }
 
 /// Performs a one-shot sync of the operator wallet against its backend.
@@ -91,12 +107,12 @@ pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(wallet: Arc<RwLo
     }
 }
 
-/// Computes the funding amount for the transaction graph based on the nature of the graph being
-/// constructed.
+/// Computes the per-UTXO denomination for the claim-funding pool. Each claim transaction
+/// consumes one UTXO of this size from the reserved wallet, so the value is derived from
+/// the connectors that the claim tx must pay for (which depend on the watchtower set size).
 ///
-/// This amount is not a constant since it depends upon the number of watchtowers that are allowed
-/// to contest a claim.
-fn compute_funding_amount(params: &Params, own_musig2_key: XOnlyPublicKey) -> Amount {
+/// Not a constant since it depends on the number of watchtowers allowed to contest a claim.
+fn compute_claim_funding_utxo_value(params: &Params, own_musig2_key: XOnlyPublicKey) -> Amount {
     // Must match the value used in `orchestrator.rs::COUNTERPROOF_N_DATA`. Hardcoded here too
     // because `Params` does not currently expose it.
     const COUNTERPROOF_N_DATA: NonZero<usize> =

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -9,12 +9,13 @@ use bitcoin::{
     hashes::{Hash, sha256},
     relative,
 };
-use operator_wallet::{OperatorWallet, OperatorWalletConfig, sync::Backend};
+use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_common::params::Params;
 use strata_bridge_connectors::prelude::{ClaimContestConnector, ClaimPayoutConnector};
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb};
+use strata_bridge_exec::output_handles::NativeWallet;
 use strata_bridge_primitives::constants::SEGWIT_MIN_AMOUNT;
 use strata_bridge_tx_graph::{fee, transactions::prelude::ClaimTx};
 use tokio::sync::RwLock;
@@ -27,7 +28,7 @@ pub(in crate::mode) async fn init_operator_wallet(
     params: &Params,
     s2_client: &SecretServiceClient,
     db_client: &FdbClient,
-) -> anyhow::Result<OperatorWallet> {
+) -> anyhow::Result<NativeWallet> {
     info!("fetching leased utxos from database");
     let leased_outpoints = db_client
         .get_all_funds()
@@ -57,13 +58,16 @@ pub(in crate::mode) async fn init_operator_wallet(
         OperatorWalletConfig::new(operator_funds, SEGWIT_MIN_AMOUNT, params.network);
     debug!(?operator_wallet_config, "operator wallet config");
 
-    let sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
-    debug!(?sync_backend, "operator wallet sync backend");
+    let general_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
+    let reserved_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
+    debug!(?general_sync_backend, "operator wallet sync backend");
+    let general_wallet =
+        NativeGeneralWallet::new(general_key, params.network, general_sync_backend);
     let operator_wallet = OperatorWallet::new(
-        general_key,
+        general_wallet,
         reserved_key,
         operator_wallet_config,
-        sync_backend,
+        reserved_sync_backend,
         leased_outpoints,
     );
     debug!("operator wallet initialized");
@@ -76,9 +80,7 @@ pub(in crate::mode) async fn init_operator_wallet(
 /// Intended to run as a background task at startup so the wallet has a head start before its
 /// first on-demand use. A sync failure is logged and swallowed: callers must still sync the wallet
 /// before use, so a failed initial sync must not crash the node.
-pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(
-    wallet: Arc<RwLock<OperatorWallet>>,
-) {
+pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(wallet: Arc<RwLock<NativeWallet>>) {
     info!("starting initial operator wallet sync");
     let start = Instant::now();
     match wallet.write().await.sync().await {

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -53,6 +53,7 @@ pub(crate) async fn init_orchestrator<M>(
     req_resp_handle: ReqRespHandle,
     p2p_keypair: Keypair,
     wallet: Arc<RwLock<NativeWallet>>,
+    claim_funding_utxo_value: bitcoin::Amount,
     btc_rpc_client: BitcoinClient,
     asm_rpc_client: HttpClient,
     fdb_client: Arc<FdbClient>,
@@ -114,7 +115,7 @@ where
         retry_tick,
     };
 
-    let exec_cfg = build_exec_config(params, config, &sm_config);
+    let exec_cfg = build_exec_config(params, config, &sm_config, claim_funding_utxo_value);
     let tx_driver = TxDriver::new(zmq_client, btc_rpc_client.clone()).await;
     let ProofBackend { bridge_proof_host } = ProofBackend::new(&config.bridge_proof).await?;
     let output_handles = OutputHandles {
@@ -242,7 +243,12 @@ pub(in crate::mode) fn build_sm_config(config: &Config, params: &Params) -> SMCo
     }
 }
 
-fn build_exec_config(params: &Params, config: &Config, sm_config: &SMConfig) -> ExecutionConfig {
+fn build_exec_config(
+    params: &Params,
+    config: &Config,
+    sm_config: &SMConfig,
+    claim_funding_utxo_value: bitcoin::Amount,
+) -> ExecutionConfig {
     ExecutionConfig {
         network: params.network,
         min_withdrawal_fulfillment_window: config.min_withdrawal_fulfillment_window,
@@ -250,6 +256,7 @@ fn build_exec_config(params: &Params, config: &Config, sm_config: &SMConfig) -> 
         maximum_fee_rate: FeeRate::from_sat_per_vb(config.max_fee_rate).unwrap(),
         operator_fee: params.protocol.operator_fee,
         stake_amount: params.protocol.stake_amount,
+        claim_funding_utxo_value,
         funding_uxto_pool_size: config.operator_wallet.claim_funding_pool_size,
         graph_sm_cfg: sm_config.graph.clone(),
     }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -8,13 +8,15 @@ use bitcoind_async_client::Client as BitcoinClient;
 use btc_tracker::tx_driver::TxDriver;
 use jsonrpsee::http_client::HttpClient;
 use libp2p_identity::ed25519::Keypair;
-use operator_wallet::OperatorWallet;
 use secret_service_client::SecretServiceClient;
 use strata_bridge_asm_events::client::AsmEventFeed;
 use strata_bridge_common::params::Params;
 use strata_bridge_counterproof::build_bridge_counterproof_host;
 use strata_bridge_db::fdb::client::FdbClient;
-use strata_bridge_exec::{config::ExecutionConfig, output_handles::OutputHandles};
+use strata_bridge_exec::{
+    config::ExecutionConfig,
+    output_handles::{NativeWallet, OutputHandles},
+};
 use strata_bridge_orchestrator::{
     duty_dispatcher::DutyDispatcher, events_mux::EventsMux, persister::Persister,
     pipeline::Pipeline, sm_registry::SMConfig,
@@ -50,7 +52,7 @@ pub(crate) async fn init_orchestrator<M>(
     gossip_handle: GossipHandle,
     req_resp_handle: ReqRespHandle,
     p2p_keypair: Keypair,
-    wallet: Arc<RwLock<OperatorWallet>>,
+    wallet: Arc<RwLock<NativeWallet>>,
     btc_rpc_client: BitcoinClient,
     asm_rpc_client: HttpClient,
     fdb_client: Arc<FdbClient>,

--- a/crates/bridge-exec/src/config.rs
+++ b/crates/bridge-exec/src/config.rs
@@ -30,7 +30,13 @@ pub struct ExecutionConfig {
     /// stake transaction must carry `stake_amount` plus any connector dust the stake tx produces.
     pub stake_amount: Amount,
 
-    /// The number of claim funding utxos to generate at any given time when the pool is exhausted.
+    /// The denomination of each UTXO in the claim-funding pool. The composer creates
+    /// reserved-wallet UTXOs of exactly this value when refilling the pool, and the duty
+    /// dispatcher selects them by exact value match.
+    pub claim_funding_utxo_value: Amount,
+
+    /// The target number of claim-funding UTXOs to keep available in the reserved wallet.
+    /// When the pool is exhausted, the duty dispatcher tops it back up to this size.
     pub funding_uxto_pool_size: usize,
 
     /// The graph state-machine configuration, shared with the GSM to keep protocol parameters

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -491,7 +491,7 @@ async fn fulfill_withdrawal(
             Ok(funded) => {
                 // Track which outpoints were newly leased (only in None path)
                 let newly_leased = if persisted_funding_outpoints.is_none() {
-                    Some(funded.spent.clone())
+                    Some(funded.spent())
                 } else {
                     None
                 };

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -477,29 +477,25 @@ async fn fulfill_withdrawal(
         let funding_result = match persisted_funding_outpoints.as_deref() {
             Some(outpoints) => {
                 info!(%deposit_idx, "reusing persisted funding outpoints");
-                wallet.fund_v3_transaction_with_outpoints(outpoints, unfunded_tx, fee_rate)
+                wallet
+                    .fund_v3_transaction_with_inputs(unfunded_tx, outpoints, fee_rate)
+                    .await
             }
             None => {
                 info!(%deposit_idx, "selecting new funding outpoints");
-                wallet.fund_v3_transaction(unfunded_tx, fee_rate)
+                wallet.fund_v3_transaction(unfunded_tx, fee_rate).await
             }
         };
 
         match funding_result {
-            Ok(psbt) => {
+            Ok(funded) => {
                 // Track which outpoints were newly leased (only in None path)
                 let newly_leased = if persisted_funding_outpoints.is_none() {
-                    Some(
-                        psbt.unsigned_tx
-                            .input
-                            .iter()
-                            .map(|input| input.previous_output)
-                            .collect::<Vec<_>>(),
-                    )
+                    Some(funded.spent.clone())
                 } else {
                     None
                 };
-                (psbt, newly_leased)
+                (funded.psbt, newly_leased)
             }
             Err(err) => {
                 error!(%deposit_idx, %err, "could not fund withdrawal");
@@ -553,11 +549,7 @@ async fn fulfill_withdrawal(
             // Release newly leased outpoints so they can be reused on retry.
             // Nothing was persisted, so retry will select fresh UTXOs.
             if let Some(ref outpoints) = newly_leased_outpoints {
-                output_handles
-                    .wallet
-                    .write()
-                    .await
-                    .release_outpoints(outpoints);
+                output_handles.wallet.write().await.release(outpoints);
             }
             return Err(e);
         }
@@ -579,11 +571,7 @@ async fn fulfill_withdrawal(
     {
         error!(%deposit_idx, ?e, "failed to persist withdrawal funding outpoints");
         if let Some(ref outpoints) = newly_leased_outpoints {
-            output_handles
-                .wallet
-                .write()
-                .await
-                .release_outpoints(outpoints);
+            output_handles.wallet.write().await.release(outpoints);
         }
         return Err(e.into());
     }

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -4,7 +4,7 @@ use std::num::NonZero;
 
 use algebra::predicate;
 use bitcoin::{
-    OutPoint, TapSighashType, Txid, XOnlyPublicKey,
+    OutPoint, TapSighashType, TxOut, Txid, XOnlyPublicKey,
     hashes::sha256,
     sighash::{Prevouts, SighashCache},
 };
@@ -159,12 +159,23 @@ async fn ensure_claim_funding_outpoint(
             ),
         }
 
-        match wallet.claim_funding_utxo(predicate::never::<UtxoInfo>).0 {
+        match wallet
+            .reserve_utxo_with_value(cfg.claim_funding_utxo_value, predicate::never::<UtxoInfo>)
+            .0
+        {
             Some(outpoint) => outpoint,
             None => {
                 warn!("could not acquire claim funding utxo. attempting refill...");
+                // How many we need to top the pool back up to the configured target. The
+                // existing pool count is read by `reserve_utxo_with_value`'s peer
+                // `reserved_utxos_with_value` — we use the current size to compute the
+                // batch ourselves so the wallet stays denomination-agnostic.
+                let current_pool_size = wallet
+                    .reserved_utxos_with_value(cfg.claim_funding_utxo_value)
+                    .len();
+                let batch_size = cfg.funding_uxto_pool_size.saturating_sub(current_pool_size);
                 let funded = wallet
-                    .refill_claim_funding_utxos(fee::FEE_RATE, cfg.funding_uxto_pool_size)
+                    .create_reserved_utxos(fee::FEE_RATE, cfg.claim_funding_utxo_value, batch_size)
                     .await
                     .map_err(|e| ExecutorError::WalletErr(format!("refill failed: {e}")))?;
                 finalize_claim_funding_tx(
@@ -178,7 +189,10 @@ async fn ensure_claim_funding_outpoint(
                     ExecutorError::WalletErr(format!("wallet sync failed after refill: {e:?}"))
                 })?;
                 wallet
-                    .claim_funding_utxo(predicate::never::<UtxoInfo>)
+                    .reserve_utxo_with_value(
+                        cfg.claim_funding_utxo_value,
+                        predicate::never::<UtxoInfo>,
+                    )
                     .0
                     .expect("funding utxos must be available after refill")
             }
@@ -528,6 +542,7 @@ pub(super) async fn publish_graph_partials(
 
 /// Publishes the claim transaction to Bitcoin.
 pub(super) async fn publish_claim(
+    cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
     claim_tx: &ClaimTx,
 ) -> Result<(), ExecutorError> {
@@ -538,14 +553,14 @@ pub(super) async fn publish_claim(
         "signing claim transaction"
     );
 
-    let claim_prevout = {
+    let claim_prevout: TxOut = {
         let wallet = output_handles.wallet.read().await;
         wallet
-            .claim_funding_outputs()
+            .reserved_utxos_with_value(cfg.claim_funding_utxo_value)
             .into_iter()
             .find(|utxo| utxo.outpoint == claim_tx.as_ref().input[0].previous_output)
             .expect("claim funding outpoint not found in wallet")
-            .as_txout()
+            .into()
     };
 
     let prevouts = Prevouts::All(&[claim_prevout]);

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -166,13 +166,21 @@ async fn ensure_claim_funding_outpoint(
             Some(outpoint) => outpoint,
             None => {
                 warn!("could not acquire claim funding utxo. attempting refill...");
-                // How many we need to top the pool back up to the configured target. The
-                // existing pool count is read by `reserve_utxo_with_value`'s peer
-                // `reserved_utxos_with_value` — we use the current size to compute the
-                // batch ourselves so the wallet stays denomination-agnostic.
-                let current_pool_size = wallet
-                    .reserved_utxos_with_value(cfg.claim_funding_utxo_value)
-                    .len();
+                // How many we need to top the pool back up to the configured target. We
+                // compute the batch ourselves (the wallet stays denomination-agnostic),
+                // counting only *unleased* pool members: `reserved_utxos_with_value`
+                // returns every matching UTXO including leased ones, but a leased UTXO is
+                // already committed to another graph and can't satisfy this reservation.
+                // Counting them would understate the deficit and could yield a zero-size
+                // batch, after which the post-refill `reserve_utxo_with_value` below would
+                // panic with nothing to hand out.
+                let current_pool_size = {
+                    let pool = wallet.reserved_utxos_with_value(cfg.claim_funding_utxo_value);
+                    let leased = wallet.leased_outpoints();
+                    pool.iter()
+                        .filter(|u| !leased.contains(&u.outpoint))
+                        .count()
+                };
                 let batch_size = cfg.funding_uxto_pool_size.saturating_sub(current_pool_size);
                 let funded = wallet
                     .create_reserved_utxos(fee::FEE_RATE, cfg.claim_funding_utxo_value, batch_size)

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -11,6 +11,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
+use operator_wallet::UtxoInfo;
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_db::traits::BridgeDb;
 use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
@@ -158,16 +159,18 @@ async fn ensure_claim_funding_outpoint(
             ),
         }
 
-        match wallet.claim_funding_utxo(predicate::never).0 {
+        match wallet.claim_funding_utxo(predicate::never::<UtxoInfo>).0 {
             Some(outpoint) => outpoint,
             None => {
                 warn!("could not acquire claim funding utxo. attempting refill...");
-                let psbt =
-                    wallet.refill_claim_funding_utxos(fee::FEE_RATE, cfg.funding_uxto_pool_size)?;
+                let funded = wallet
+                    .refill_claim_funding_utxos(fee::FEE_RATE, cfg.funding_uxto_pool_size)
+                    .await
+                    .map_err(|e| ExecutorError::WalletErr(format!("refill failed: {e}")))?;
                 finalize_claim_funding_tx(
                     &output_handles.s2_client,
                     &output_handles.tx_driver,
-                    psbt,
+                    funded.psbt,
                 )
                 .await?;
                 wallet.sync().await.map_err(|e| {
@@ -175,7 +178,7 @@ async fn ensure_claim_funding_outpoint(
                     ExecutorError::WalletErr(format!("wallet sync failed after refill: {e:?}"))
                 })?;
                 wallet
-                    .claim_funding_utxo(predicate::never)
+                    .claim_funding_utxo(predicate::never::<UtxoInfo>)
                     .0
                     .expect("funding utxos must be available after refill")
             }
@@ -539,9 +542,10 @@ pub(super) async fn publish_claim(
         let wallet = output_handles.wallet.read().await;
         wallet
             .claim_funding_outputs()
+            .into_iter()
             .find(|utxo| utxo.outpoint == claim_tx.as_ref().input[0].previous_output)
             .expect("claim funding outpoint not found in wallet")
-            .txout
+            .as_txout()
     };
 
     let prevouts = Prevouts::All(&[claim_prevout]);

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -32,12 +32,7 @@ pub(super) async fn publish_counterproof_nack(
     // subtraction.
     let connector_value = counterproof_nack_tx.prevouts()[0].value;
     let payout_value = connector_value - fee::counterproof_nack_fee();
-    let payout_script = output_handles
-        .wallet
-        .read()
-        .await
-        .general_script_buf()
-        .clone();
+    let payout_script = output_handles.wallet.read().await.general_script_pubkey();
     counterproof_nack_tx.push_output(TxOut {
         value: payout_value,
         script_pubkey: payout_script,

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -114,7 +114,9 @@ pub async fn execute_graph_duty(
             )
             .await
         }
-        GraphDuty::PublishClaim { claim_tx } => publish_claim(&output_handles, claim_tx).await,
+        GraphDuty::PublishClaim { claim_tx } => {
+            publish_claim(&cfg, &output_handles, claim_tx).await
+        }
         GraphDuty::PublishUncontestedPayout {
             signed_uncontested_payout_tx,
         } => publish_uncontested_payout(&output_handles, signed_uncontested_payout_tx).await,

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -8,15 +8,16 @@ use bitcoin::{
 };
 use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
-use operator_wallet::OperatorWallet;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_primitives::types::GraphIdx;
 use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnTx;
 use tracing::{debug, info, warn};
 
 use crate::{
-    chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
-    output_handles::OutputHandles,
+    chain::publish_signed_transaction,
+    config::ExecutionConfig,
+    errors::ExecutorError,
+    output_handles::{NativeWallet, OutputHandles},
 };
 
 /// Index of the payout connector input in the unfunded burn template.
@@ -106,7 +107,7 @@ pub(super) async fn publish_unstaking_burn(
                 .wallet
                 .write()
                 .await
-                .release_outpoints(&[funding.outpoint]);
+                .release(&[funding.outpoint]);
             return Err(e);
         }
     };
@@ -131,7 +132,7 @@ pub(super) async fn publish_unstaking_burn(
             .wallet
             .write()
             .await
-            .release_outpoints(&[funding.outpoint]);
+            .release(&[funding.outpoint]);
     }
 
     publish_result
@@ -194,7 +195,7 @@ async fn burn_fee_rate(output_handles: &OutputHandles) -> Result<FeeRate, Execut
 ///   - general_wallet_output_value
 /// ```
 async fn select_funding(
-    wallet: &mut OperatorWallet,
+    wallet: &mut NativeWallet,
     graph_idx: GraphIdx,
     unstaking_burn_tx: &UnstakingBurnTx,
     unstaking_preimage: [u8; 32],
@@ -207,7 +208,7 @@ async fn select_funding(
         warn!(%graph_idx, ?e, "could not sync wallet before funding unstaking burn");
     }
 
-    let wallet_output_script = wallet.general_script_buf().clone();
+    let wallet_output_script = wallet.general_script_pubkey();
     let min_output_value = wallet_output_script.minimal_non_dust();
     let fee = estimate_unstaking_burn_fee(
         unstaking_burn_tx,
@@ -235,7 +236,7 @@ async fn select_funding(
 
     let funding = wallet.select_and_lease_general_utxo(|utxo| {
         let output_value = match payout_connector_value
-            .checked_add(utxo.txout.value)
+            .checked_add(utxo.amount)
             .and_then(|input_value| input_value.checked_sub(plan.fee))
         {
             Some(output_value) => output_value,
@@ -243,7 +244,7 @@ async fn select_funding(
                 debug!(
                     %graph_idx,
                     outpoint = %utxo.outpoint,
-                    utxo_value = %utxo.txout.value,
+                    utxo_value = %utxo.amount,
                     fee = %plan.fee,
                     "wallet UTXO cannot cover unstaking burn fee"
                 );
@@ -255,7 +256,7 @@ async fn select_funding(
             debug!(
                 %graph_idx,
                 outpoint = %utxo.outpoint,
-                utxo_value = %utxo.txout.value,
+                utxo_value = %utxo.amount,
                 %output_value,
                 %min_output_value,
                 fee = %plan.fee,
@@ -284,7 +285,7 @@ async fn select_funding(
     };
 
     let wallet_output_value = payout_connector_value
-        .checked_add(funding.txout.value)
+        .checked_add(funding.amount)
         .and_then(|input_value| input_value.checked_sub(plan.fee))
         .ok_or_else(|| {
             ExecutorError::WalletErr(format!(
@@ -296,7 +297,7 @@ async fn select_funding(
     info!(
         %graph_idx,
         funding_outpoint = %funding.outpoint,
-        funding_value = %funding.txout.value,
+        funding_value = %funding.amount,
         %wallet_output_value,
         fee = %plan.fee,
         fee_rate = %plan.fee_rate,
@@ -307,7 +308,7 @@ async fn select_funding(
     Ok((
         WalletFunding {
             outpoint: funding.outpoint,
-            prevout: funding.txout,
+            prevout: funding.into(),
         },
         plan,
     ))
@@ -516,7 +517,7 @@ mod tests {
         secp256k1::{Keypair, SECP256K1, SecretKey},
     };
     use corepc_node::{Conf, Node};
-    use operator_wallet::{OperatorWalletConfig, sync::Backend};
+    use operator_wallet::{NativeGeneralWallet, OperatorWalletConfig, sync::Backend};
     use strata_bridge_connectors::prelude::ClaimPayoutConnector;
     use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnData;
 
@@ -553,21 +554,22 @@ mod tests {
         keypair.x_only_public_key().0
     }
 
-    fn wallet(bitcoind: &Node) -> OperatorWallet {
-        OperatorWallet::new(
+    fn wallet(bitcoind: &Node) -> NativeWallet {
+        let general = NativeGeneralWallet::new(
             xonly_pubkey(1),
+            Network::Regtest,
+            Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
+        );
+        NativeWallet::new(
+            general,
             xonly_pubkey(2),
-            OperatorWalletConfig::new(
-                Amount::from_sat(20_000),
-                Amount::from_sat(1_000),
-                Network::Regtest,
-            ),
+            OperatorWalletConfig::new(Amount::from_sat(20_000), Network::Regtest),
             Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
             BTreeSet::new(),
         )
     }
 
-    fn fund_general_wallet(bitcoind: &Node, wallet: &OperatorWallet, amount: Amount) {
+    fn fund_general_wallet(bitcoind: &Node, wallet: &NativeWallet, amount: Amount) {
         let mining_address = bitcoind
             .client
             .new_address()
@@ -577,8 +579,9 @@ mod tests {
             .generate_to_address(101, &mining_address)
             .expect("coinbase outputs should mature");
 
-        let general_address = Address::from_script(wallet.general_script_buf(), Network::Regtest)
-            .expect("general wallet script should be addressable");
+        let general_address =
+            Address::from_script(&wallet.general_script_pubkey(), Network::Regtest)
+                .expect("general wallet script should be addressable");
         bitcoind
             .client
             .send_to_address(&general_address, amount)
@@ -666,7 +669,7 @@ mod tests {
         let unstaking_preimage = [8; 32];
         let unstaking_burn_tx = unstaking_burn_tx(unstaking_preimage);
         let fee_rate = FeeRate::from_sat_per_vb(2).expect("fee rate should be valid");
-        let min_output_value = wallet.general_script_buf().minimal_non_dust();
+        let min_output_value = wallet.general_script_pubkey().minimal_non_dust();
 
         let (funding, plan) = select_funding(
             &mut wallet,
@@ -693,9 +696,7 @@ mod tests {
             "funding plan should retain the payout connector input value"
         );
         assert!(
-            wallet
-                .leased_outpoints()
-                .any(|outpoint| outpoint == funding.outpoint),
+            wallet.leased_outpoints().contains(&funding.outpoint),
             "selected funding outpoint should be leased"
         );
     }

--- a/crates/bridge-exec/src/graph/utils.rs
+++ b/crates/bridge-exec/src/graph/utils.rs
@@ -16,11 +16,11 @@ use crate::errors::ExecutorError;
 
 /// Finalizes and broadcasts a claim funding transaction.
 ///
-/// This function assumes that the [`Psbt`] has already been funded with `witness_utxo` populated
-/// on every input (which `OperatorWallet::refill_claim_funding_utxos` guarantees). It signs all
-/// inputs using the general wallet signer in the secret service, submits the finalized
-/// transaction to the tx driver for broadcasting, and then waits for the transaction to appear
-/// in the mempool.
+/// This function assumes that the [`Psbt`] has already been funded with `witness_utxo`
+/// populated on every input (which `OperatorWallet::create_reserved_utxos` guarantees by
+/// returning a [`crate::Psbt`] whose inputs all carry the wallet's `witness_utxo`). It signs
+/// all inputs via the caller-provided signer, submits the finalized transaction to the tx
+/// driver for broadcasting, and waits for it to appear in the mempool.
 pub(super) async fn finalize_claim_funding_tx(
     s2_client: &SecretServiceClient,
     tx_driver: &TxDriver,

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -5,7 +5,7 @@ use std::{fmt, sync::Arc};
 use bitcoind_async_client::Client as BitcoinClient;
 use btc_tracker::tx_driver::TxDriver;
 use jsonrpsee::http_client::HttpClient;
-use operator_wallet::OperatorWallet;
+use operator_wallet::{NativeGeneralWallet, OperatorWallet};
 use secret_service_client::SecretServiceClient;
 use strata_bridge_counterproof::BridgeCounterproofHost;
 use strata_bridge_db::fdb::client::FdbClient;
@@ -15,13 +15,22 @@ use strata_bridge_proof::BridgeProofHost;
 use strata_mosaic_client_api::MosaicClientApi;
 use tokio::sync::RwLock;
 
+/// Concrete operator-wallet type used by bridge-exec. Today the only general-wallet backend in
+/// use is [`NativeGeneralWallet`]; Fireblocks support (STR-3437) will add a sibling impl and
+/// the binary will pick between them at startup.
+pub type NativeWallet = OperatorWallet<NativeGeneralWallet>;
+
 /// The handles for external services that need to be accessed by the executors.
 ///
 /// If this needs to be shared across multiple executors, it should be wrapped in an
 /// [`Arc`].
 pub struct OutputHandles {
     /// Handle for accessing operator funds.
-    pub wallet: Arc<RwLock<OperatorWallet>>,
+    ///
+    /// Methods on [`OperatorWallet`] take `&mut self`. The outer `RwLock` also lets executors
+    /// span multi-step critical sections (e.g. DB-lookup-then-fund-then-persist) without
+    /// races between concurrent duties.
+    pub wallet: Arc<RwLock<NativeWallet>>,
 
     /// Handle for accessing the database.
     // TODO: <https://alpenlabs.atlassian.net/browse/STR-2670>

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -113,14 +113,18 @@ async fn read_or_create_stake_funding(
         .await?
     {
         info!(%operator_idx, "reusing persisted stake funding reservation");
-        validate_reservation(&reservation, wallet.reserved_script_buf(), funding_amount)?;
-        wallet.lease_outpoints(
-            reservation
-                .unsigned_tx
-                .input
-                .iter()
-                .map(|txin| txin.previous_output),
-        );
+        validate_reservation(
+            &reservation,
+            &wallet.reserved_script_pubkey(),
+            funding_amount,
+        )?;
+        let inputs: Vec<OutPoint> = reservation
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|txin| txin.previous_output)
+            .collect();
+        wallet.lease(&inputs);
         return Ok(reservation);
     }
 
@@ -128,10 +132,11 @@ async fn read_or_create_stake_funding(
     let fee_rate = estimate_funding_fee_rate(cfg, output_handles).await?;
 
     info!(%fee_rate, %funding_amount, "creating stake funding transaction");
-    let psbt = wallet
+    let funded = wallet
         .create_stake_funding_tx(fee_rate, funding_amount)
+        .await
         .expect("must be able to create stake funding transaction");
-    let reservation = reservation_from_psbt(&psbt);
+    let reservation = reservation_from_psbt(&funded.psbt);
 
     info!(%operator_idx, "persisting stake funding reservation");
     if let Err(err) = output_handles
@@ -148,7 +153,7 @@ async fn read_or_create_stake_funding(
 
         // If we fail to persist the reservation, we must release the leased outpoints so they can
         // be used
-        wallet.release_outpoints(&new_inputs);
+        wallet.release(&new_inputs);
         return Err(err.into());
     }
 
@@ -392,10 +397,7 @@ pub(crate) async fn publish_stake(
     // the covenant, so key-path sign it with the reserved wallet signer before broadcasting.
     // Reconstruct the prevout from known values: the funding UTXO is always at the reserved
     // address with value `stake_amount + unstaking_intent_output.value() + stake_fee`.
-    let reserved_script = {
-        let wallet = output_handles.wallet.read().await;
-        wallet.reserved_script_buf().clone()
-    };
+    let reserved_script = output_handles.wallet.read().await.reserved_script_pubkey();
     let funding_amount = stake_funding_amount(cfg.network, cfg.stake_amount);
     let prevout = TxOut {
         script_pubkey: reserved_script,

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -132,8 +132,11 @@ async fn read_or_create_stake_funding(
     let fee_rate = estimate_funding_fee_rate(cfg, output_handles).await?;
 
     info!(%fee_rate, %funding_amount, "creating stake funding transaction");
+    // Stake funding is one reserved-wallet UTXO of `funding_amount`. The reserved-utxo API
+    // takes denomination + quantity uniformly (claim-funding pool uses larger quantity
+    // with a smaller per-UTXO value); for the stake-funding case it's always quantity 1.
     let funded = wallet
-        .create_stake_funding_tx(fee_rate, funding_amount)
+        .create_reserved_utxos(fee_rate, funding_amount, 1)
         .await
         .expect("must be able to create stake funding transaction");
     let reservation = reservation_from_psbt(&funded.psbt);

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-algebra.workspace = true
-
 bdk_bitcoind_rpc.workspace = true
 bdk_wallet.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -12,3 +12,7 @@ bdk_wallet.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+
+[dev-dependencies]
+corepc-node.workspace = true
+serial_test.workspace = true

--- a/crates/operator-wallet/src/config.rs
+++ b/crates/operator-wallet/src/config.rs
@@ -1,0 +1,67 @@
+//! Configuration knobs for [`crate::OperatorWallet`].
+//!
+//! Holds runtime parameters that don't change after construction (network, anchor-identification
+//! value, sync retry policy). Per-call parameters like UTXO denominations are passed to the
+//! relevant methods directly; this struct intentionally does not bake them in so the same
+//! composer can serve multiple use cases (claim funding, stake funding, etc.) without
+//! conflating their denominations.
+
+use std::time::Duration;
+
+use bdk_wallet::bitcoin::{Amount, Network};
+
+/// How many times wallet sync is reattempted after an error before propagating.
+pub const DEFAULT_SYNC_RETRIES: u32 = 5;
+
+/// Exponential backoff base for sync retries: `delay = DEFAULT_SYNC_BASE_DELAY *
+/// DEFAULT_SYNC_BACKOFF.pow(attempt)`.
+pub const DEFAULT_SYNC_BACKOFF: u32 = 3;
+
+/// Initial delay between sync retry attempts (multiplied by the exponential backoff).
+pub const DEFAULT_SYNC_BASE_DELAY: Duration = Duration::from_millis(100);
+
+/// Configuration for [`crate::OperatorWallet`].
+#[derive(Debug, Clone)]
+pub struct OperatorWalletConfig {
+    /// Value that identifies a CPFP anchor output. Outputs with this exact value at zero
+    /// confirmations are excluded from input selection so a future CPFP child can spend them.
+    pub(crate) cpfp_value: Amount,
+    /// Bitcoin network the composed wallets operate on.
+    pub(crate) network: Network,
+    /// Number of times a wallet sync attempt is retried before propagating the error.
+    pub(crate) sync_retries: u32,
+    /// Exponential backoff base for sync retries: `delay = sync_base_delay * sync_backoff.pow(n)`.
+    pub(crate) sync_backoff: u32,
+    /// Initial delay before the first retry; multiplied by the exponential backoff on each
+    /// subsequent attempt.
+    pub(crate) sync_base_delay: Duration,
+}
+
+impl OperatorWalletConfig {
+    /// Creates a new config with the sync-retry knobs at their defaults
+    /// ([`DEFAULT_SYNC_RETRIES`] / [`DEFAULT_SYNC_BACKOFF`] / [`DEFAULT_SYNC_BASE_DELAY`]).
+    /// Use [`Self::with_sync_policy`] to override them.
+    pub const fn new(cpfp_value: Amount, network: Network) -> Self {
+        Self {
+            cpfp_value,
+            network,
+            sync_retries: DEFAULT_SYNC_RETRIES,
+            sync_backoff: DEFAULT_SYNC_BACKOFF,
+            sync_base_delay: DEFAULT_SYNC_BASE_DELAY,
+        }
+    }
+
+    /// Returns a copy with the sync-retry policy replaced. Useful for tests that want to
+    /// disable backoff entirely (`sync_retries = 0`).
+    pub const fn with_sync_policy(
+        mut self,
+        sync_retries: u32,
+        sync_backoff: u32,
+        sync_base_delay: Duration,
+    ) -> Self {
+        self.sync_retries = sync_retries;
+        self.sync_backoff = sync_backoff;
+        self.sync_base_delay = sync_base_delay;
+        self
+    }
+}

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -1,40 +1,37 @@
-//! The `GeneralWallet` trait — abstraction over the part of an operator's funds that pays for
-//! bridge operations (fronting withdrawals, CPFP, top-ups). The trait isolates the surface that
-//! genuinely differs between backends: today the native BDK-backed wallet, tomorrow a Fireblocks
-//! adapter.
+//! The [`GeneralWallet`] trait — abstraction over the operator's general-purpose funds
+//! (the wallet that fronts payments, pays CPFP fees, and tops up other internal pools).
+//! The trait isolates the surface that genuinely varies between backends; concrete
+//! implementations live in submodules.
 //!
 //! Everything that doesn't vary between backends — leasing, the reserved wallet, anchor
-//! filtering, cross-wallet transaction construction — lives on the concrete
-//! [`crate::OperatorWallet<G>`] composer that wraps a `GeneralWallet`.
+//! filtering, cross-wallet transaction construction — lives on the composer
+//! [`crate::OperatorWallet<G>`] that wraps a `GeneralWallet`.
 
 pub mod native;
 
 use std::error::Error as StdError;
 
-use bdk_wallet::bitcoin::{Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut};
+use bdk_wallet::{
+    bitcoin::{Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut},
+    chain::ChainPosition,
+};
 
 /// A backend that manages the operator's general-purpose Bitcoin funds.
 ///
-/// Concrete implementations:
-/// - [`native::NativeGeneralWallet`] — BDK-backed, descriptor-only (no key material). Signing is
-///   delegated to the secret-service by the caller.
-/// - Fireblocks adapter (forthcoming) — ECDSA signing via Fireblocks API.
-///
-/// The trait is intentionally narrow: it covers signing + UTXO discovery + transaction
+/// The trait is intentionally narrow: it covers UTXO discovery + signing + transaction
 /// construction for the general wallet only. Lease bookkeeping, the reserved wallet, and
 /// anchor handling live on the composer.
 ///
 /// # Signing contract
 ///
-/// A backend signs inputs it has key material for. Inputs it leaves unsigned must be populated
-/// with `witness_utxo` and `tap_internal_key` (or analogous fields) so the caller can sign
-/// downstream — typically by routing the sighash through the secret service.
+/// A backend signs the inputs it has key material for. Inputs it leaves unsigned must
+/// carry `witness_utxo` (and `tap_internal_key` for Taproot key-path) so the caller can
+/// sign them downstream by whatever means it sees fit.
 pub trait GeneralWallet: Send + Sync {
     /// Backend-specific error type.
     type Error: StdError + Send + Sync + 'static;
 
-    /// Refreshes internal state from the underlying source (chain RPC for native, vault API for
-    /// remote backends like Fireblocks). Idempotent.
+    /// Refreshes internal state from the underlying source. Idempotent.
     ///
     /// Takes `&mut self` because the typical native impl needs to mutate its BDK wallet
     /// state. Callers serialize via an outer lock; the trait doesn't impose interior
@@ -50,17 +47,18 @@ pub trait GeneralWallet: Send + Sync {
     /// exclusions before requesting funding.
     fn list_utxos(&self) -> Vec<UtxoInfo>;
 
-    /// Builds and (where possible) signs a v3 TRUC funding transaction.
+    /// Builds a v3 TRUC funding transaction and signs the inputs it has key material for.
     ///
     /// * `outputs` — recipient outputs to fund. Change (if any) is appended.
     /// * `explicit_inputs` — when `Some`, only these outpoints are used as inputs. When `None`, the
     ///   backend selects inputs from its spendable UTXO set, skipping `exclude`.
     /// * `fee_rate` — target sat-per-vbyte for the transaction itself.
     /// * `exclude` — outpoints the backend must not select (anchors, currently-leased outpoints,
-    ///   etc.). Ignored if `explicit_inputs` is `Some`.
+    ///   etc.). Ignored when `explicit_inputs` is `Some`.
     ///
-    /// Inputs the backend has key material for are signed. Anything left unsigned must have
-    /// `witness_utxo` (and `tap_internal_key` for Taproot inputs) populated.
+    /// Inputs the backend can sign are returned with their witnesses populated; the rest
+    /// carry `witness_utxo` and `tap_internal_key` (for Taproot) so the caller can sign
+    /// downstream.
     fn fund_v3_transaction(
         &mut self,
         outputs: Vec<TxOut>,
@@ -72,17 +70,13 @@ pub trait GeneralWallet: Send + Sync {
     /// Builds a v3 TRUC CPFP child for `parent`, spending the keyed-Taproot anchor at
     /// `parent.output[anchor_vout]` plus one fee-paying input drawn from this wallet.
     ///
-    /// The project uses a keyed-Taproot anchor at the segwit-dust minimum (`SEGWIT_MIN_AMOUNT`,
-    /// 330 sat) rather than a BIP-431 ephemeral P2A (value-0) output. Implementers must spend
-    /// the 330-sat anchor and account for its value when constructing the child.
-    ///
     /// * `target_pkg_fee_rate` — sat-per-vbyte target for the (parent, child) package as a whole.
     /// * `exclude` — fee-paying-input selection skips these outpoints. Used to avoid re-selecting
     ///   the funding input of a prior child being replaced via RBF.
     ///
-    /// **The anchor input is never signed** — backends populate its `witness_utxo` and
-    /// `tap_internal_key` and leave the caller to sign it via the secret service. The
-    /// funding input is signed iff the backend holds its key material.
+    /// Per the trait-level signing contract, the anchor input is left unsigned with
+    /// `witness_utxo` and `tap_internal_key` populated; the fee-paying input is signed iff
+    /// the backend holds its key material.
     fn build_cpfp_child(
         &mut self,
         parent: &Transaction,
@@ -95,34 +89,72 @@ pub trait GeneralWallet: Send + Sync {
 /// A funded PSBT returned by [`GeneralWallet`] funding operations.
 #[derive(Debug, Clone)]
 pub struct FundedPsbt {
-    /// The funded PSBT. Inputs the backend could sign are signed; the rest carry
-    /// `witness_utxo` (and `tap_internal_key` for Taproot) for downstream signing.
+    /// The funded PSBT. See the [`GeneralWallet`] signing contract for which inputs are
+    /// signed vs. left for downstream signing.
     pub psbt: Psbt,
-    /// Outpoints consumed as inputs to this PSBT. The caller leases these so they aren't
-    /// re-selected by concurrent duties.
-    pub spent: Vec<OutPoint>,
+}
+
+impl FundedPsbt {
+    /// Returns the outpoints consumed as inputs to this PSBT, derived from
+    /// `psbt.unsigned_tx`. Use this to lease the spent UTXOs against re-selection by
+    /// concurrent callers.
+    pub fn spent(&self) -> Vec<OutPoint> {
+        self.psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|txin| txin.previous_output)
+            .collect()
+    }
 }
 
 /// A snapshot of a single UTXO controlled by a [`GeneralWallet`] (or, by convention, the
 /// reserved wallet that the [`crate::OperatorWallet`] composer manages internally).
 #[derive(Debug, Clone)]
 pub struct UtxoInfo {
-    /// On-chain outpoint of the UTXO.
+    /// Outpoint identifying this UTXO.
     pub outpoint: OutPoint,
     /// Output amount.
     pub amount: Amount,
-    /// Confirmations as of the most recent sync. `0` if unconfirmed.
+    /// Confirmations as of the most recent sync. `0` if the UTXO is in the mempool only
+    /// (not yet on chain).
     pub confirmations: u32,
     /// Output script.
     pub script_pubkey: ScriptBuf,
 }
 
-impl UtxoInfo {
-    /// Reconstructs the [`TxOut`] this UTXO refers to.
-    pub fn as_txout(&self) -> TxOut {
-        TxOut {
-            value: self.amount,
-            script_pubkey: self.script_pubkey.clone(),
+impl From<UtxoInfo> for TxOut {
+    fn from(u: UtxoInfo) -> Self {
+        Self {
+            value: u.amount,
+            script_pubkey: u.script_pubkey,
         }
+    }
+}
+
+impl From<&UtxoInfo> for TxOut {
+    fn from(u: &UtxoInfo) -> Self {
+        Self {
+            value: u.amount,
+            script_pubkey: u.script_pubkey.clone(),
+        }
+    }
+}
+
+/// Converts a BDK [`bdk_wallet::LocalOutput`] into a backend-neutral [`UtxoInfo`], computing
+/// confirmations against `tip_height`. Shared between the native general-wallet backend and
+/// the composer's reserved-wallet lookup since both are BDK-backed.
+pub(crate) fn local_output_to_utxo_info(lo: &bdk_wallet::LocalOutput, tip_height: u32) -> UtxoInfo {
+    let confirmations = match &lo.chain_position {
+        ChainPosition::Confirmed { anchor, .. } => tip_height
+            .saturating_sub(anchor.block_id.height)
+            .saturating_add(1),
+        ChainPosition::Unconfirmed { .. } => 0,
+    };
+    UtxoInfo {
+        outpoint: lo.outpoint,
+        amount: lo.txout.value,
+        confirmations,
+        script_pubkey: lo.txout.script_pubkey.clone(),
     }
 }

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -69,8 +69,12 @@ pub trait GeneralWallet: Send + Sync {
         exclude: &[OutPoint],
     ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;
 
-    /// Builds a v3 TRUC CPFP child for `parent`, spending the BIP-431 ephemeral anchor at
+    /// Builds a v3 TRUC CPFP child for `parent`, spending the keyed-Taproot anchor at
     /// `parent.output[anchor_vout]` plus one fee-paying input drawn from this wallet.
+    ///
+    /// The project uses a keyed-Taproot anchor at the segwit-dust minimum (`SEGWIT_MIN_AMOUNT`,
+    /// 330 sat) rather than a BIP-431 ephemeral P2A (value-0) output. Implementers must spend
+    /// the 330-sat anchor and account for its value when constructing the child.
     ///
     /// * `target_pkg_fee_rate` — sat-per-vbyte target for the (parent, child) package as a whole.
     /// * `exclude` — fee-paying-input selection skips these outpoints. Used to avoid re-selecting

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -1,0 +1,124 @@
+//! The `GeneralWallet` trait — abstraction over the part of an operator's funds that pays for
+//! bridge operations (fronting withdrawals, CPFP, top-ups). The trait isolates the surface that
+//! genuinely differs between backends: today the native BDK-backed wallet, tomorrow a Fireblocks
+//! adapter.
+//!
+//! Everything that doesn't vary between backends — leasing, the reserved wallet, anchor
+//! filtering, cross-wallet transaction construction — lives on the concrete
+//! [`crate::OperatorWallet<G>`] composer that wraps a `GeneralWallet`.
+
+pub mod native;
+
+use std::error::Error as StdError;
+
+use bdk_wallet::bitcoin::{Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut};
+
+/// A backend that manages the operator's general-purpose Bitcoin funds.
+///
+/// Concrete implementations:
+/// - [`native::NativeGeneralWallet`] — BDK-backed, descriptor-only (no key material). Signing is
+///   delegated to the secret-service by the caller.
+/// - Fireblocks adapter (forthcoming) — ECDSA signing via Fireblocks API.
+///
+/// The trait is intentionally narrow: it covers signing + UTXO discovery + transaction
+/// construction for the general wallet only. Lease bookkeeping, the reserved wallet, and
+/// anchor handling live on the composer.
+///
+/// # Signing contract
+///
+/// A backend signs inputs it has key material for. Inputs it leaves unsigned must be populated
+/// with `witness_utxo` and `tap_internal_key` (or analogous fields) so the caller can sign
+/// downstream — typically by routing the sighash through the secret service.
+pub trait GeneralWallet: Send + Sync {
+    /// Backend-specific error type.
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Refreshes internal state from the underlying source (chain RPC for native, vault API for
+    /// remote backends like Fireblocks). Idempotent.
+    ///
+    /// Takes `&mut self` because the typical native impl needs to mutate its BDK wallet
+    /// state. Callers serialize via an outer lock; the trait doesn't impose interior
+    /// mutability.
+    fn sync(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Returns the receive script for this wallet. Stable across calls for native backends;
+    /// may rotate for backends that mint fresh deposit addresses per call.
+    fn script_pubkey(&self) -> ScriptBuf;
+
+    /// Returns every UTXO this wallet currently controls (confirmed and unconfirmed). The
+    /// caller is responsible for filtering anchors, leases, and other domain-specific
+    /// exclusions before requesting funding.
+    fn list_utxos(&self) -> Vec<UtxoInfo>;
+
+    /// Builds and (where possible) signs a v3 TRUC funding transaction.
+    ///
+    /// * `outputs` — recipient outputs to fund. Change (if any) is appended.
+    /// * `explicit_inputs` — when `Some`, only these outpoints are used as inputs. When `None`, the
+    ///   backend selects inputs from its spendable UTXO set, skipping `exclude`.
+    /// * `fee_rate` — target sat-per-vbyte for the transaction itself.
+    /// * `exclude` — outpoints the backend must not select (anchors, currently-leased outpoints,
+    ///   etc.). Ignored if `explicit_inputs` is `Some`.
+    ///
+    /// Inputs the backend has key material for are signed. Anything left unsigned must have
+    /// `witness_utxo` (and `tap_internal_key` for Taproot inputs) populated.
+    fn fund_v3_transaction(
+        &mut self,
+        outputs: Vec<TxOut>,
+        explicit_inputs: Option<&[OutPoint]>,
+        fee_rate: FeeRate,
+        exclude: &[OutPoint],
+    ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;
+
+    /// Builds a v3 TRUC CPFP child for `parent`, spending the BIP-431 ephemeral anchor at
+    /// `parent.output[anchor_vout]` plus one fee-paying input drawn from this wallet.
+    ///
+    /// * `target_pkg_fee_rate` — sat-per-vbyte target for the (parent, child) package as a whole.
+    /// * `exclude` — fee-paying-input selection skips these outpoints. Used to avoid re-selecting
+    ///   the funding input of a prior child being replaced via RBF.
+    ///
+    /// **The anchor input is never signed** — backends populate its `witness_utxo` and
+    /// `tap_internal_key` and leave the caller to sign it via the secret service. The
+    /// funding input is signed iff the backend holds its key material.
+    fn build_cpfp_child(
+        &mut self,
+        parent: &Transaction,
+        anchor_vout: u32,
+        target_pkg_fee_rate: FeeRate,
+        exclude: &[OutPoint],
+    ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;
+}
+
+/// A funded PSBT returned by [`GeneralWallet`] funding operations.
+#[derive(Debug, Clone)]
+pub struct FundedPsbt {
+    /// The funded PSBT. Inputs the backend could sign are signed; the rest carry
+    /// `witness_utxo` (and `tap_internal_key` for Taproot) for downstream signing.
+    pub psbt: Psbt,
+    /// Outpoints consumed as inputs to this PSBT. The caller leases these so they aren't
+    /// re-selected by concurrent duties.
+    pub spent: Vec<OutPoint>,
+}
+
+/// A snapshot of a single UTXO controlled by a [`GeneralWallet`] (or, by convention, the
+/// reserved wallet that the [`crate::OperatorWallet`] composer manages internally).
+#[derive(Debug, Clone)]
+pub struct UtxoInfo {
+    /// On-chain outpoint of the UTXO.
+    pub outpoint: OutPoint,
+    /// Output amount.
+    pub amount: Amount,
+    /// Confirmations as of the most recent sync. `0` if unconfirmed.
+    pub confirmations: u32,
+    /// Output script.
+    pub script_pubkey: ScriptBuf,
+}
+
+impl UtxoInfo {
+    /// Reconstructs the [`TxOut`] this UTXO refers to.
+    pub fn as_txout(&self) -> TxOut {
+        TxOut {
+            value: self.amount,
+            script_pubkey: self.script_pubkey.clone(),
+        }
+    }
+}

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -1,0 +1,177 @@
+//! Native BDK-backed implementation of [`GeneralWallet`].
+//!
+//! The native wallet holds the operator's general-funds descriptor (`tr(general_pubkey)`) but
+//! never holds private keys: signing is delegated to the secret-service by the caller. As a
+//! consequence every PSBT returned by this impl carries `witness_utxo` and `tap_internal_key`
+//! on its inputs but no signatures — the caller signs downstream.
+
+use std::collections::BTreeSet;
+
+use bdk_wallet::{
+    bitcoin::{FeeRate, Network, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    chain::ChainPosition,
+    descriptor,
+    error::CreateTxError,
+    KeychainKind, TxOrdering, Wallet,
+};
+use thiserror::Error;
+use tracing::info;
+
+use crate::{
+    general::{FundedPsbt, GeneralWallet, UtxoInfo},
+    sync::{Backend, SyncError},
+};
+
+/// Native BDK-backed general wallet.
+#[derive(Debug)]
+pub struct NativeGeneralWallet {
+    /// Cached at construction; the BDK descriptor doesn't change at runtime.
+    script_pubkey: ScriptBuf,
+    wallet: Wallet,
+    sync_backend: Backend,
+}
+
+impl NativeGeneralWallet {
+    /// Constructs a native general wallet from the operator's general x-only public key.
+    pub fn new(general_pubkey: XOnlyPublicKey, network: Network, sync_backend: Backend) -> Self {
+        let (desc, ..) = descriptor!(tr(general_pubkey)).expect("valid tr() descriptor");
+        let wallet = Wallet::create_single(desc)
+            .network(network)
+            .create_wallet_no_persist()
+            .expect("wallet creation must not fail");
+        let address = wallet.peek_address(KeychainKind::External, 0).address;
+        info!("general wallet address: {address}");
+        let script_pubkey = address.script_pubkey();
+        Self {
+            script_pubkey,
+            wallet,
+            sync_backend,
+        }
+    }
+}
+
+/// Error type for the native general wallet impl.
+#[derive(Debug, Error)]
+pub enum NativeGeneralError {
+    /// BDK failed to build a transaction (insufficient funds, no UTXOs, ...).
+    #[error("bdk create-tx: {0}")]
+    CreateTx(#[from] CreateTxError),
+    /// Chain sync (block / mempool fetch) failed.
+    #[error("wallet sync: {0:?}")]
+    Sync(SyncError),
+    /// CPFP-child building is intentionally unimplemented until STR-3439 lands.
+    #[error("native build_cpfp_child not yet implemented (STR-3439)")]
+    CpfpChildNotImplemented,
+}
+
+impl GeneralWallet for NativeGeneralWallet {
+    type Error = NativeGeneralError;
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        self.sync_backend
+            .sync_wallet(&mut self.wallet)
+            .await
+            .map_err(NativeGeneralError::Sync)
+    }
+
+    fn script_pubkey(&self) -> ScriptBuf {
+        self.script_pubkey.clone()
+    }
+
+    fn list_utxos(&self) -> Vec<UtxoInfo> {
+        let tip = self.wallet.latest_checkpoint().height();
+        self.wallet
+            .list_unspent()
+            .map(|lo| local_output_to_utxo_info(&lo, tip))
+            .collect()
+    }
+
+    async fn fund_v3_transaction(
+        &mut self,
+        outputs: Vec<TxOut>,
+        explicit_inputs: Option<&[OutPoint]>,
+        fee_rate: FeeRate,
+        exclude: &[OutPoint],
+    ) -> Result<FundedPsbt, Self::Error> {
+        let psbt = build_v3_psbt(
+            &mut self.wallet,
+            &outputs,
+            explicit_inputs,
+            fee_rate,
+            exclude,
+        )?;
+        let spent = psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|txin| txin.previous_output)
+            .collect();
+        Ok(FundedPsbt { psbt, spent })
+    }
+
+    async fn build_cpfp_child(
+        &mut self,
+        _parent: &Transaction,
+        _anchor_vout: u32,
+        _target_pkg_fee_rate: FeeRate,
+        _exclude: &[OutPoint],
+    ) -> Result<FundedPsbt, Self::Error> {
+        // TODO(STR-3439): wire up CPFP child construction during the tx-driver / RBF work.
+        Err(NativeGeneralError::CpfpChildNotImplemented)
+    }
+}
+
+/// Converts a BDK [`bdk_wallet::LocalOutput`] into a backend-neutral [`UtxoInfo`], computing
+/// confirmations against the wallet's current tip.
+fn local_output_to_utxo_info(lo: &bdk_wallet::LocalOutput, tip_height: u32) -> UtxoInfo {
+    let confirmations = match &lo.chain_position {
+        ChainPosition::Confirmed { anchor, .. } => tip_height
+            .saturating_sub(anchor.block_id.height)
+            .saturating_add(1),
+        ChainPosition::Unconfirmed { .. } => 0,
+    };
+    UtxoInfo {
+        outpoint: lo.outpoint,
+        amount: lo.txout.value,
+        confirmations,
+        script_pubkey: lo.txout.script_pubkey.clone(),
+    }
+}
+
+/// Builds a v3 (TRUC) PSBT using BDK's transaction builder, with `outputs` as recipients,
+/// optional explicit input selection, the given fee rate, and `exclude` skipped during
+/// auto-selection.
+fn build_v3_psbt(
+    wallet: &mut Wallet,
+    outputs: &[TxOut],
+    explicit_inputs: Option<&[OutPoint]>,
+    fee_rate: FeeRate,
+    exclude: &[OutPoint],
+) -> Result<Psbt, CreateTxError> {
+    let exclude_set: BTreeSet<OutPoint> = exclude.iter().copied().collect();
+
+    let mut tx_builder = wallet.build_tx();
+    tx_builder.version(3);
+    tx_builder.fee_rate(fee_rate);
+    tx_builder.ordering(TxOrdering::Untouched);
+
+    match explicit_inputs {
+        Some(inputs) => {
+            for outpoint in inputs {
+                tx_builder
+                    .add_utxo(*outpoint)
+                    .map_err(|_| CreateTxError::UnknownUtxo)?;
+            }
+            tx_builder.manually_selected_only();
+        }
+        None => {
+            tx_builder.unspendable(exclude_set.into_iter().collect());
+        }
+    }
+
+    for output in outputs {
+        tx_builder.add_recipient(output.script_pubkey.clone(), output.value);
+    }
+
+    tx_builder.finish()
+}

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -116,7 +116,8 @@ impl GeneralWallet for NativeGeneralWallet {
         _target_pkg_fee_rate: FeeRate,
         _exclude: &[OutPoint],
     ) -> Result<FundedPsbt, Self::Error> {
-        // TODO(STR-3439): wire up CPFP child construction during the tx-driver / RBF work.
+        // TODO: <https://alpenlabs.atlassian.net/browse/STR-3439>
+        // Wire up CPFP child construction during the tx-driver / RBF work.
         Err(NativeGeneralError::CpfpChildNotImplemented)
     }
 }

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -1,15 +1,14 @@
 //! Native BDK-backed implementation of [`GeneralWallet`].
 //!
 //! The native wallet holds the operator's general-funds descriptor (`tr(general_pubkey)`) but
-//! never holds private keys: signing is delegated to the secret-service by the caller. As a
-//! consequence every PSBT returned by this impl carries `witness_utxo` and `tap_internal_key`
-//! on its inputs but no signatures — the caller signs downstream.
+//! never holds private keys. Per the [`GeneralWallet`] signing contract, every PSBT this impl
+//! returns carries `witness_utxo` and `tap_internal_key` on its inputs but no signatures —
+//! the caller signs downstream.
 
 use std::collections::BTreeSet;
 
 use bdk_wallet::{
     bitcoin::{FeeRate, Network, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
-    chain::ChainPosition,
     descriptor,
     error::CreateTxError,
     KeychainKind, TxOrdering, Wallet,
@@ -18,7 +17,7 @@ use thiserror::Error;
 use tracing::info;
 
 use crate::{
-    general::{FundedPsbt, GeneralWallet, UtxoInfo},
+    general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
     sync::{Backend, SyncError},
 };
 
@@ -100,13 +99,7 @@ impl GeneralWallet for NativeGeneralWallet {
             fee_rate,
             exclude,
         )?;
-        let spent = psbt
-            .unsigned_tx
-            .input
-            .iter()
-            .map(|txin| txin.previous_output)
-            .collect();
-        Ok(FundedPsbt { psbt, spent })
+        Ok(FundedPsbt { psbt })
     }
 
     async fn build_cpfp_child(
@@ -119,23 +112,6 @@ impl GeneralWallet for NativeGeneralWallet {
         // TODO: <https://alpenlabs.atlassian.net/browse/STR-3439>
         // Wire up CPFP child construction during the tx-driver / RBF work.
         Err(NativeGeneralError::CpfpChildNotImplemented)
-    }
-}
-
-/// Converts a BDK [`bdk_wallet::LocalOutput`] into a backend-neutral [`UtxoInfo`], computing
-/// confirmations against the wallet's current tip.
-fn local_output_to_utxo_info(lo: &bdk_wallet::LocalOutput, tip_height: u32) -> UtxoInfo {
-    let confirmations = match &lo.chain_position {
-        ChainPosition::Confirmed { anchor, .. } => tip_height
-            .saturating_sub(anchor.block_id.height)
-            .saturating_add(1),
-        ChainPosition::Unconfirmed { .. } => 0,
-    };
-    UtxoInfo {
-        outpoint: lo.outpoint,
-        amount: lo.txout.value,
-        confirmations,
-        script_pubkey: lo.txout.script_pubkey.clone(),
     }
 }
 

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -1,34 +1,51 @@
-//! Operator wallet
+//! Operator wallet — composition over a swappable [`GeneralWallet`] backend.
+//!
+//! The bridge node holds an `OperatorWallet<G>` where `G: GeneralWallet`. The composer
+//! manages:
+//! - the always-native reserved wallet (BDK descriptor-only, signing via secret-service),
+//! - the in-memory lease set (shared bookkeeping that doesn't differ between backends),
+//! - anchor identification and exclusion,
+//! - cross-wallet transaction construction (refill claim-funding pool, create stake funding tx).
+//!
+//! The `general` backend handles only what genuinely varies between native and Fireblocks:
+//! its own UTXO discovery, its own signing, and its share of transaction building (funding,
+//! CPFP child).
+//!
+//! Methods on [`OperatorWallet`] are `&mut self`. Callers serialize via an outer lock (today
+//! `Arc<RwLock<OperatorWallet<_>>>` in `bridge-exec`) which also lets the executor span
+//! multi-step critical sections (e.g. DB-lookup-then-fund-then-persist).
+
+pub mod general;
 pub mod sync;
 
 use std::{collections::BTreeSet, time::Duration};
 
-use algebra::predicate;
 use bdk_wallet::{
-    bitcoin::{Amount, FeeRate, Network, OutPoint, Psbt, ScriptBuf, Transaction, XOnlyPublicKey},
-    descriptor,
-    error::CreateTxError,
-    KeychainKind, LocalOutput, TxOrdering, Wallet,
+    bitcoin::{Amount, FeeRate, Network, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    chain::ChainPosition,
+    descriptor, KeychainKind, Wallet,
 };
-use sync::{Backend, SyncError};
+use thiserror::Error;
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
-/// How many times we should reattempt after an error during a wallet sync
+pub use crate::general::{native::NativeGeneralWallet, FundedPsbt, GeneralWallet, UtxoInfo};
+use crate::sync::{Backend, SyncError};
+
+/// How many times we should reattempt after an error during a wallet sync.
 const SYNC_RETRIES: u32 = 5;
-/// The wallet will delay a retry by SYNC_BASE_DELAY*SYNC_BACKOFF^current_retry,
-/// exponential backoff
+/// The wallet will delay a retry by SYNC_BASE_DELAY * SYNC_BACKOFF.pow(current_retry).
 const SYNC_BACKOFF: u32 = 3;
 const SYNC_BASE_DELAY: Duration = Duration::from_millis(100);
 
-/// Config for [`OperatorWallet`]
-#[derive(Debug)]
+/// Config for [`OperatorWallet`].
+#[derive(Debug, Clone)]
 pub struct OperatorWalletConfig {
     /// Value of the funding UTXO for stakes. Not the `s` connector value.
     stake_funding_utxo_value: Amount,
-    /// Value of CPFP UTXOs to identify them
+    /// Value of CPFP UTXOs to identify them.
     cpfp_value: Amount,
-    /// Bitcoin network we're on
+    /// Bitcoin network we're on.
     network: Network,
 }
 
@@ -47,221 +64,108 @@ impl OperatorWalletConfig {
     }
 }
 
-/// The [`OperatorWallet`] is responsible for managing an operator's L1 funds, split into a general
-/// wallet and a dedicated reserved wallet.
+/// Errors returned by [`OperatorWallet`] methods. Backend errors are boxed so call sites don't
+/// have to be generic over `G::Error`.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The general wallet backend reported an error.
+    #[error("general wallet: {0}")]
+    General(Box<dyn std::error::Error + Send + Sync>),
+    /// BDK reported an error building a transaction on the reserved wallet.
+    #[error("reserved wallet create-tx: {0}")]
+    Reserved(#[from] bdk_wallet::error::CreateTxError),
+    /// Reserved-wallet sync against the chain failed.
+    #[error("reserved wallet sync: {0:?}")]
+    Sync(SyncError),
+}
+
+impl Error {
+    fn from_general<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
+        Self::General(Box::new(e))
+    }
+}
+
+/// The operator's wallet, composing a swappable general-wallet backend with the always-native
+/// reserved wallet, lease bookkeeping, and cross-wallet transaction construction.
 #[derive(Debug)]
-pub struct OperatorWallet {
-    general_wallet: Wallet,
-    reserved_wallet: Wallet,
+pub struct OperatorWallet<G: GeneralWallet> {
+    general: G,
+    reserved: Wallet,
+    reserved_sync_backend: Backend,
+    reserved_script_pubkey: ScriptBuf,
     config: OperatorWalletConfig,
-    reserved_addr_script_buf: ScriptBuf,
-    general_addr_script_buf: ScriptBuf,
-    sync_backend: Backend,
     leased_outpoints: BTreeSet<OutPoint>,
 }
 
-impl OperatorWallet {
-    /// Creates a new [`OperatorWallet`]
+impl<G: GeneralWallet> OperatorWallet<G> {
+    /// Constructs a new [`OperatorWallet`] from a [`GeneralWallet`] backend and a native
+    /// reserved-wallet pubkey. `initial_leases` is the set of outpoints to seed the lease
+    /// state with (typically rehydrated from FDB at startup).
     pub fn new(
-        general: XOnlyPublicKey,
-        reserved: XOnlyPublicKey,
+        general: G,
+        reserved_pubkey: XOnlyPublicKey,
         config: OperatorWalletConfig,
-        sync_backend: Backend,
-        leased_outpoints: BTreeSet<OutPoint>,
+        reserved_sync_backend: Backend,
+        initial_leases: BTreeSet<OutPoint>,
     ) -> Self {
-        let (general_desc, ..) = descriptor!(tr(general)).unwrap();
-        let (reserved_desc, ..) = descriptor!(tr(reserved)).unwrap();
-        let general_wallet = Wallet::create_single(general_desc)
-            .network(config.network)
-            .create_wallet_no_persist()
-            .unwrap();
-        let general_addr = general_wallet
-            .peek_address(KeychainKind::External, 0)
-            .address;
-        info!("general wallet address: {general_addr}");
+        let (reserved_desc, ..) =
+            descriptor!(tr(reserved_pubkey)).expect("valid tr() descriptor for reserved");
         let reserved_wallet = Wallet::create_single(reserved_desc)
             .network(config.network)
             .create_wallet_no_persist()
-            .unwrap();
+            .expect("reserved wallet creation must not fail");
         let reserved_addr = reserved_wallet
             .peek_address(KeychainKind::External, 0)
             .address;
         info!("reserved wallet address: {reserved_addr}");
+        let reserved_script_pubkey = reserved_addr.script_pubkey();
         Self {
+            general,
+            reserved: reserved_wallet,
+            reserved_sync_backend,
+            reserved_script_pubkey,
             config,
-            reserved_addr_script_buf: reserved_addr.script_pubkey(),
-            general_addr_script_buf: general_addr.script_pubkey(),
-            general_wallet,
-            reserved_wallet,
-            sync_backend,
-            leased_outpoints,
+            leased_outpoints: initial_leases,
         }
     }
 
-    /// Predicate for determining whether a utxo can be used as an anchor. This will only select
-    /// unconfirmed minimum value outputs.
-    fn is_anchor(&self, txout: &LocalOutput) -> bool {
-        txout.txout.value == self.config.cpfp_value && !txout.chain_position.is_confirmed()
+    /// Returns a reference to the underlying [`GeneralWallet`] for callers that need
+    /// backend-specific operations the composer doesn't wrap. Use sparingly.
+    pub const fn general(&self) -> &G {
+        &self.general
     }
 
-    fn is_claim_funding_output(&self, txout: &LocalOutput) -> bool {
-        txout.txout.value == self.config.stake_funding_utxo_value
+    // ── Script accessors ────────────────────────────────────────────────────
+
+    /// Returns the general wallet's receive script.
+    pub fn general_script_pubkey(&self) -> ScriptBuf {
+        self.general.script_pubkey()
     }
 
-    /// Returns the list of known anchor outputs that should only be spent when fee bumping.
-    pub fn anchor_outputs(&self) -> impl Iterator<Item = LocalOutput> + '_ {
-        self.general_wallet
-            .list_unspent()
-            .filter(|utxo| self.is_anchor(utxo))
+    /// Returns the reserved wallet's receive script.
+    pub fn reserved_script_pubkey(&self) -> ScriptBuf {
+        self.reserved_script_pubkey.clone()
     }
 
-    /// Returns the list of outputs that match the criteria for claim funding.
-    pub fn claim_funding_outputs(&self) -> impl Iterator<Item = LocalOutput> + '_ {
-        self.reserved_wallet
-            .list_unspent()
-            .filter(|txout| self.is_claim_funding_output(txout))
+    // ── Lease bookkeeping ───────────────────────────────────────────────────
+
+    /// Returns the currently-leased outpoints.
+    pub const fn leased_outpoints(&self) -> &BTreeSet<OutPoint> {
+        &self.leased_outpoints
     }
 
-    /// Returns the list of [`OutPoint`]s that are currently being leased by the system.
-    pub fn leased_outpoints(&self) -> impl Iterator<Item = OutPoint> + '_ {
-        self.leased_outpoints.iter().copied()
-    }
-
-    /// Returns a list of UTXOs from the general wallet that can be used for fronting withdrawals.
-    /// Excludes anchor outputs.
-    pub fn general_utxos(&self) -> impl Iterator<Item = LocalOutput> + '_ {
-        self.general_wallet
-            .list_unspent()
-            .filter(|utxo| !self.is_anchor(utxo))
-    }
-
-    fn lease(&mut self, outpoint: OutPoint) -> bool {
-        self.leased_outpoints.insert(outpoint)
-    }
-
-    fn is_leased_pred<'a>(&'a self) -> impl Fn(&OutPoint) -> bool + 'a {
-        |outpoint| self.leased_outpoints.contains(outpoint)
-    }
-
-    fn release(&mut self, outpoint: &OutPoint) -> bool {
-        self.leased_outpoints.remove(outpoint)
-    }
-
-    /// Selects the first non-anchor, non-leased general-wallet UTXO that satisfies
-    /// `predicate`, leases it to prevent concurrent duties from re-selecting the same
-    /// outpoint, and returns its [`LocalOutput`].
-    ///
-    /// Returns `None` if no UTXO matches.
-    pub fn select_and_lease_general_utxo(
-        &mut self,
-        predicate: impl Fn(&LocalOutput) -> bool,
-    ) -> Option<LocalOutput> {
-        // Snapshot the leased set so we can mutably borrow `self` after the search.
-        let leased: BTreeSet<OutPoint> = self.leased_outpoints.iter().copied().collect();
-        let selected = self
-            .general_utxos()
-            .filter(|u| !leased.contains(&u.outpoint))
-            .find(predicate)?;
-        self.lease(selected.outpoint);
-        Some(selected)
-    }
-
-    /// Funds an unfunded version 3 transaction by adding inputs and change.
-    ///
-    /// Takes a transaction with outputs only and adds inputs from the general wallet to cover the
-    /// outputs plus fees. Change, if any, is added at the end of vouts.
-    ///
-    /// The used input UTXOs are marked as leased so that two different executors do not end up
-    /// using the same UTXOs and failing due to double-spend.
-    ///
-    /// # Notes
-    ///
-    /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
-    /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
-    pub fn fund_v3_transaction(
-        &mut self,
-        unfunded_tx: Transaction,
-        fee_rate: FeeRate,
-    ) -> Result<Psbt, CreateTxError> {
-        let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint).collect();
-        // Outpoints already committed to other transactions - exclude to prevent double-spend
-        let leased: Vec<OutPoint> = self.leased_outpoints().collect();
-
-        let mut tx_builder = self.general_wallet.build_tx();
-        // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
-        tx_builder.version(3);
-        tx_builder.unspendable(anchor_outpoints);
-        tx_builder.unspendable(leased);
-        tx_builder.fee_rate(fee_rate);
-
-        // Add all outputs from the unfunded transaction
-        for output in &unfunded_tx.output {
-            tx_builder.add_recipient(output.script_pubkey.clone(), output.value);
-        }
-
-        tx_builder.ordering(TxOrdering::Untouched);
-
-        let psbt = tx_builder.finish()?;
-
-        // Mark the used input(s) as leased so they won't be reused
-        psbt.unsigned_tx.input.iter().for_each(|input| {
-            self.lease(input.previous_output);
-        });
-
-        Ok(psbt)
-    }
-
-    /// Creates a funded PSBT for a V3 transaction using explicit outpoints.
-    ///
-    /// This is used for idempotent transaction creation when the funding outpoints
-    /// have been persisted from a previous run.
-    ///
-    /// The specified outpoints are marked as leased to prevent concurrent duties from
-    /// selecting them via [`Self::fund_v3_transaction`].
-    pub fn fund_v3_transaction_with_outpoints(
-        &mut self,
-        outpoints: &[OutPoint],
-        unfunded_tx: Transaction,
-        fee_rate: FeeRate,
-    ) -> Result<Psbt, CreateTxError> {
-        let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint).collect();
-
-        let mut tx_builder = self.general_wallet.build_tx();
-        tx_builder.version(3);
-        tx_builder.unspendable(anchor_outpoints);
-
+    /// Marks each of `outpoints` as leased.
+    pub fn lease(&mut self, outpoints: &[OutPoint]) {
         for outpoint in outpoints {
-            tx_builder
-                .add_utxo(*outpoint)
-                .map_err(|_| CreateTxError::UnknownUtxo)?;
+            self.leased_outpoints.insert(*outpoint);
         }
-        tx_builder.manually_selected_only();
-        tx_builder.fee_rate(fee_rate);
-
-        for output in &unfunded_tx.output {
-            tx_builder.add_recipient(output.script_pubkey.clone(), output.value);
-        }
-        tx_builder.ordering(TxOrdering::Untouched);
-
-        let psbt = tx_builder.finish()?;
-
-        // Lease the outpoints to prevent concurrent duties from selecting them.
-        // This is necessary because sync may have removed leases when the previous
-        // transaction was in mempool, and if that transaction was later dropped,
-        // these outpoints would become available for selection again.
-        for outpoint in outpoints {
-            self.lease(*outpoint);
-        }
-
-        Ok(psbt)
     }
 
-    /// Releases the outpoints from leased_outpoints.
-    /// This is used to free up outpoints if the outpoints were not persisted due to issues
-    /// like failure to sign.
-    pub fn release_outpoints(&mut self, outpoints: &[OutPoint]) {
+    /// Removes each of `outpoints` from the lease set. Logs (at `warn`) but does not error
+    /// when a given outpoint wasn't leased — releases are idempotent.
+    pub fn release(&mut self, outpoints: &[OutPoint]) {
         for outpoint in outpoints {
-            if !self.release(outpoint) {
+            if !self.leased_outpoints.remove(outpoint) {
                 warn!(
                     ?outpoint,
                     "attempted to release outpoint that was not leased"
@@ -270,171 +174,230 @@ impl OperatorWallet {
         }
     }
 
-    /// Marks each of the given outpoints as leased.
-    pub fn lease_outpoints(&mut self, outpoints: impl IntoIterator<Item = OutPoint>) {
-        for outpoint in outpoints {
-            self.lease(outpoint);
-        }
+    // ── Reserved-wallet operations ─────────────────────────────────────────
+
+    /// Returns the reserved-wallet UTXOs that match the claim-funding value (i.e. the dust
+    /// pool used to fund claim transactions).
+    pub fn claim_funding_outputs(&self) -> Vec<UtxoInfo> {
+        let tip = self.reserved.latest_checkpoint().height();
+        self.reserved
+            .list_unspent()
+            .filter(|utxo| utxo.txout.value == self.config.stake_funding_utxo_value)
+            .map(|lo| UtxoInfo {
+                outpoint: lo.outpoint,
+                amount: lo.txout.value,
+                confirmations: match &lo.chain_position {
+                    ChainPosition::Confirmed { anchor, .. } => {
+                        tip.saturating_sub(anchor.block_id.height).saturating_add(1)
+                    }
+                    ChainPosition::Unconfirmed { .. } => 0,
+                },
+                script_pubkey: lo.txout.script_pubkey.clone(),
+            })
+            .collect()
     }
 
-    /// Creates a PSBT that refills the pool of claim funding UTXOs from the general wallet
-    /// (excluding anchor outputs). Needs signing by the general wallet.
+    /// Selects an unleased claim-funding UTXO that the `ignore` predicate doesn't reject,
+    /// leases it, and returns it along with the remaining count.
+    pub fn claim_funding_utxo(
+        &mut self,
+        ignore: impl Fn(&UtxoInfo) -> bool,
+    ) -> (Option<OutPoint>, u64) {
+        let available = self.claim_funding_outputs();
+        let leased = &self.leased_outpoints;
+        let mut considered = available
+            .into_iter()
+            .filter(|u| !leased.contains(&u.outpoint) && !ignore(u));
+        let selected = considered.next();
+        let remaining = considered.count() as u64;
+        if let Some(ref utxo) = selected {
+            self.leased_outpoints.insert(utxo.outpoint);
+        }
+        (selected.map(|u| u.outpoint), remaining)
+    }
+
+    // ── General-wallet pass-throughs with lease bookkeeping ────────────────
+
+    /// Funds an unsigned v3 transaction from the general wallet.
     ///
-    /// # Notes
+    /// Selects inputs from spendable general-wallet UTXOs (excluding anchors and currently-
+    /// leased outpoints), signs them where the backend has key material, and returns a
+    /// [`FundedPsbt`]. The consumed inputs are leased before return.
+    pub async fn fund_v3_transaction(
+        &mut self,
+        unsigned_tx: Transaction,
+        fee_rate: FeeRate,
+    ) -> Result<FundedPsbt, Error> {
+        let exclude = self.exclude_anchors_and_leases();
+        let funded = self
+            .general
+            .fund_v3_transaction(unsigned_tx.output, None, fee_rate, &exclude)
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent);
+        Ok(funded)
+    }
+
+    /// Funds an unsigned v3 transaction using `inputs` as the input set (typically a
+    /// previously-persisted funding plan being replayed on retry).
+    pub async fn fund_v3_transaction_with_inputs(
+        &mut self,
+        unsigned_tx: Transaction,
+        inputs: &[OutPoint],
+        fee_rate: FeeRate,
+    ) -> Result<FundedPsbt, Error> {
+        let funded = self
+            .general
+            .fund_v3_transaction(unsigned_tx.output, Some(inputs), fee_rate, &[])
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent);
+        Ok(funded)
+    }
+
+    /// Builds a CPFP child for `parent` spending the anchor at `anchor_vout`.
     ///
-    /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
-    /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
-    pub fn refill_claim_funding_utxos(
+    /// `replacing`, when `Some`, identifies the funding outpoints of a prior child being
+    /// replaced via RBF. Those outpoints are released from the lease set before
+    /// fee-paying-input selection so they can be re-selected.
+    pub async fn build_cpfp_child(
+        &mut self,
+        parent: &Transaction,
+        anchor_vout: u32,
+        target_pkg_fee_rate: FeeRate,
+        replacing: Option<&[OutPoint]>,
+    ) -> Result<FundedPsbt, Error> {
+        if let Some(prior) = replacing {
+            self.release(prior);
+        }
+        let exclude = self.exclude_anchors_and_leases();
+        let funded = self
+            .general
+            .build_cpfp_child(parent, anchor_vout, target_pkg_fee_rate, &exclude)
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent);
+        Ok(funded)
+    }
+
+    // ── Cross-wallet (general → reserved) ──────────────────────────────────
+
+    /// Creates a PSBT that refills the pool of claim-funding UTXOs in the reserved wallet by
+    /// sending `stake_funding_utxo_value`-sized outputs from the general wallet to the
+    /// reserved script. The returned PSBT still needs signing for any inputs the backend
+    /// couldn't sign.
+    pub async fn refill_claim_funding_utxos(
         &mut self,
         fee_rate: FeeRate,
         target_size: usize,
-    ) -> Result<Psbt, CreateTxError> {
-        let current_claim_funding_outpoints: Vec<OutPoint> = self
+    ) -> Result<FundedPsbt, Error> {
+        let claim_funding_outpoints: BTreeSet<OutPoint> = self
             .claim_funding_outputs()
-            .map(|o| o.outpoint)
-            .filter(predicate::not(self.is_leased_pred()))
+            .into_iter()
+            .map(|u| u.outpoint)
+            .collect();
+        let current_size = claim_funding_outpoints.len();
+        let batch_size = target_size.saturating_sub(current_size);
+
+        let outputs = (0..batch_size)
+            .map(|_| TxOut {
+                value: self.config.stake_funding_utxo_value,
+                script_pubkey: self.reserved_script_pubkey.clone(),
+            })
             .collect();
 
-        let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint);
-        let leased_outpoints = self.leased_outpoints();
+        let mut exclude = self.exclude_anchors_and_leases();
+        exclude.extend(claim_funding_outpoints);
 
-        // DON'T spend any of the anchor outputs or the existing claim funding utxos or
-        // anything leased.
-        let excluded = current_claim_funding_outpoints
-            .iter()
-            .copied()
-            .chain(anchor_outpoints)
-            .chain(leased_outpoints)
-            .collect();
-
-        let mut tx_builder = self.general_wallet.build_tx();
-        // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
-        tx_builder.version(3);
-        tx_builder.unspendable(excluded);
-
-        let current_size = current_claim_funding_outpoints.len();
-        let batch_size = target_size - current_size;
-        for _ in 0..batch_size {
-            tx_builder.add_recipient(
-                self.reserved_addr_script_buf.clone(),
-                self.config.stake_funding_utxo_value,
-            );
-        }
-
-        tx_builder.fee_rate(fee_rate);
-
-        tx_builder.finish()
+        let funded = self
+            .general
+            .fund_v3_transaction(outputs, None, fee_rate, &exclude)
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent);
+        Ok(funded)
     }
 
-    /// Attempts to find a funding UTXO for a stake, ignoring outpoints for which ignore returns
-    /// `true`. The first value returned is the assigned claim funding output if one is found. The
-    /// second value returned is the remaining number of claim funding outputs excluding the one
-    /// in the first return value.
-    pub fn claim_funding_utxo(
-        &mut self,
-        ignore: impl Fn(&OutPoint) -> bool,
-    ) -> (Option<OutPoint>, u64) {
-        let ignore_leased = |o: &OutPoint| self.leased_outpoints.contains(o);
-        let consider = predicate::contramap(
-            |o: &LocalOutput| o.outpoint,
-            predicate::nor(ignore, ignore_leased),
-        );
-
-        let mut considered = self.claim_funding_outputs().filter(consider);
-        let claim_funding_output = considered.next().map(|utxo| utxo.outpoint);
-        let remaining = considered.count() as u64;
-
-        let leased = claim_funding_output.and_then(predicate::guard_mut(|o| self.lease(*o)));
-
-        (leased, remaining)
-    }
-
-    /// Creates a new transaction by paying funds from the general wallet into the
-    /// reserved wallet (excludes anchor outputs and currently leased outpoints). The
-    /// resulting UTXO is the single input to the stake transaction.
-    ///
-    /// The `funding_amount` must equal the sum of the stake transaction's outputs — the stake
-    /// amount plus any connector dust the caller is
-    /// responsible for covering (for example, the unstaking-intent connector's minimum non-dust
-    /// value).
-    ///
-    /// The selected inputs are marked as leased so concurrent duties cannot re-select them. If
-    /// the caller fails to persist or sign the funding plan, the leases must be released via
-    /// [`Self::release_outpoints`].
-    ///
-    /// # Notes
-    ///
-    /// This transaction is a version 3 transaction that supports 1-parent-1-child (1P1C) package
-    /// relay mempool policies. The transaction maximum size is `10_000` virtual bytes.
-    pub fn create_stake_funding_tx(
+    /// Creates a PSBT that funds a stake-chain transaction by paying `funding_amount` from
+    /// the general wallet into the reserved script.
+    pub async fn create_stake_funding_tx(
         &mut self,
         fee_rate: FeeRate,
         funding_amount: Amount,
-    ) -> Result<Psbt, CreateTxError> {
-        let anchor_outpoints = self.anchor_outputs().map(|lo| lo.outpoint).collect();
-        let leased: Vec<OutPoint> = self.leased_outpoints().collect();
-
-        let mut tx_builder = self.general_wallet.build_tx();
-        // Set transaction version to 3 for CPFP 1P1C TRUC transactions.
-        tx_builder.version(3);
-        tx_builder.unspendable(anchor_outpoints);
-        tx_builder.unspendable(leased);
-        tx_builder.fee_rate(fee_rate);
-        tx_builder.add_recipient(self.reserved_addr_script_buf.clone(), funding_amount);
-        tx_builder.ordering(TxOrdering::Untouched);
-
-        let psbt = tx_builder.finish()?;
-
-        for input in &psbt.unsigned_tx.input {
-            self.lease(input.previous_output);
-        }
-
-        Ok(psbt)
+    ) -> Result<FundedPsbt, Error> {
+        let outputs = vec![TxOut {
+            value: funding_amount,
+            script_pubkey: self.reserved_script_pubkey.clone(),
+        }];
+        let exclude = self.exclude_anchors_and_leases();
+        let funded = self
+            .general
+            .fund_v3_transaction(outputs, None, fee_rate, &exclude)
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent);
+        Ok(funded)
     }
 
-    /// Returns the script buf of the general wallet address. External funds should be sent here.
-    pub const fn general_script_buf(&self) -> &ScriptBuf {
-        &self.general_addr_script_buf
-    }
+    // ── Sync ───────────────────────────────────────────────────────────────
 
-    /// Returns the script buf of the reserved wallet address.
-    ///
-    /// This is where the reserved funds for funding dust outputs reside.
-    pub const fn reserved_script_buf(&self) -> &ScriptBuf {
-        &self.reserved_addr_script_buf
-    }
-
-    /// Syncs the wallet using the backend provided on construction.
-    pub async fn sync(&mut self) -> Result<(), SyncError> {
-        let mut attempt = 0;
+    /// Syncs both wallets against their respective backends and then prunes the lease set:
+    /// any leased outpoint that is no longer in either wallet's spendable UTXO set is
+    /// dropped (it was observed spent on-chain).
+    pub async fn sync(&mut self) -> Result<(), Error> {
+        let mut attempt = 0u32;
         loop {
-            let mut err = None;
-            if let Err(e) = self
-                .sync_backend
-                .sync_wallet(&mut self.general_wallet, &mut self.leased_outpoints)
-                .await
-            {
-                err = Some(e);
+            let mut err: Option<Error> = None;
+            if let Err(e) = self.general.sync().await {
+                err = Some(Error::from_general(e));
             }
             if let Err(e) = self
-                .sync_backend
-                .sync_wallet(&mut self.reserved_wallet, &mut self.leased_outpoints)
+                .reserved_sync_backend
+                .sync_wallet(&mut self.reserved)
                 .await
             {
-                err = Some(e);
+                err = Some(Error::Sync(e));
             }
-
             match err {
                 Some(e) => {
                     error!(?e, "error syncing wallet");
                     if attempt >= SYNC_RETRIES {
-                        break Err(e);
+                        return Err(e);
                     }
                     sleep(SYNC_BASE_DELAY * SYNC_BACKOFF.pow(attempt)).await;
                     attempt += 1;
                 }
-                None => break Ok(()),
+                None => break,
             }
         }
+
+        // Prune stale leases. After a successful sync, drop any leased outpoint whose
+        // underlying UTXO is no longer in either wallet's spendable set — it was observed
+        // spent on-chain (the on-chain spend supersedes our local lease bookkeeping).
+        let live: BTreeSet<OutPoint> = self
+            .general
+            .list_utxos()
+            .into_iter()
+            .map(|u| u.outpoint)
+            .chain(self.reserved.list_unspent().map(|lo| lo.outpoint))
+            .collect();
+        self.leased_outpoints.retain(|o| live.contains(o));
+        Ok(())
+    }
+
+    // ── Internal helpers ───────────────────────────────────────────────────
+
+    /// Returns the set of general-wallet outpoints that should be excluded from input
+    /// selection: anchors (zero/dust-value unconfirmed outputs we keep around for fee
+    /// bumping) plus currently-leased outpoints.
+    fn exclude_anchors_and_leases(&self) -> Vec<OutPoint> {
+        let utxos = self.general.list_utxos();
+        let anchors = utxos
+            .iter()
+            .filter(|u| u.amount == self.config.cpfp_value && u.confirmations == 0)
+            .map(|u| u.outpoint);
+        anchors
+            .chain(self.leased_outpoints.iter().copied())
+            .collect()
     }
 }

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -1,68 +1,37 @@
 //! Operator wallet — composition over a swappable [`GeneralWallet`] backend.
 //!
-//! The bridge node holds an `OperatorWallet<G>` where `G: GeneralWallet`. The composer
-//! manages:
-//! - the always-native reserved wallet (BDK descriptor-only, signing via secret-service),
-//! - the in-memory lease set (shared bookkeeping that doesn't differ between backends),
-//! - anchor identification and exclusion,
-//! - cross-wallet transaction construction (refill claim-funding pool, create stake funding tx).
+//! Callers hold an `OperatorWallet<G>` where `G: GeneralWallet`. The composer owns:
+//! - a descriptor-only reserved wallet (BDK), signed downstream by the caller,
+//! - the in-memory lease set shared across both wallets,
+//! - CPFP-anchor identification and exclusion from input selection,
+//! - cross-wallet construction helpers that pay from the general wallet into reserved-wallet
+//!   outputs of a caller-specified denomination.
 //!
-//! The `general` backend handles only what genuinely varies between native and Fireblocks:
-//! its own UTXO discovery, its own signing, and its share of transaction building (funding,
-//! CPFP child).
+//! The [`GeneralWallet`] backend handles only what varies between implementations: its own
+//! UTXO discovery, its own signing, and the funding+CPFP construction primitives.
 //!
-//! Methods on [`OperatorWallet`] are `&mut self`. Callers serialize via an outer lock (today
-//! `Arc<RwLock<OperatorWallet<_>>>` in `bridge-exec`) which also lets the executor span
-//! multi-step critical sections (e.g. DB-lookup-then-fund-then-persist).
+//! Methods on [`OperatorWallet`] are `&mut self`. Callers serialize via an outer lock when
+//! they need a multi-step critical section (e.g. DB-lookup-then-fund-then-persist).
 
+pub mod config;
 pub mod general;
 pub mod sync;
+pub mod wallet;
 
-use std::{collections::BTreeSet, time::Duration};
-
-use bdk_wallet::{
-    bitcoin::{Amount, FeeRate, Network, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
-    chain::ChainPosition,
-    descriptor, KeychainKind, Wallet,
-};
+// Dev-deps only used by the `tests/` integration tests; silence the lib-test build's
+// unused-crate-dependencies warning.
+#[cfg(test)]
+use corepc_node as _;
+#[cfg(test)]
+use serial_test as _;
 use thiserror::Error;
-use tokio::time::sleep;
-use tracing::{error, info, warn};
 
-pub use crate::general::{native::NativeGeneralWallet, FundedPsbt, GeneralWallet, UtxoInfo};
-use crate::sync::{Backend, SyncError};
-
-/// How many times we should reattempt after an error during a wallet sync.
-const SYNC_RETRIES: u32 = 5;
-/// The wallet will delay a retry by SYNC_BASE_DELAY * SYNC_BACKOFF.pow(current_retry).
-const SYNC_BACKOFF: u32 = 3;
-const SYNC_BASE_DELAY: Duration = Duration::from_millis(100);
-
-/// Config for [`OperatorWallet`].
-#[derive(Debug, Clone)]
-pub struct OperatorWalletConfig {
-    /// Value of the funding UTXO for stakes. Not the `s` connector value.
-    stake_funding_utxo_value: Amount,
-    /// Value of CPFP UTXOs to identify them.
-    cpfp_value: Amount,
-    /// Bitcoin network we're on.
-    network: Network,
-}
-
-impl OperatorWalletConfig {
-    /// Creates a new [`OperatorWalletConfig`].
-    pub const fn new(
-        stake_funding_utxo_value: Amount,
-        cpfp_value: Amount,
-        network: Network,
-    ) -> Self {
-        Self {
-            stake_funding_utxo_value,
-            cpfp_value,
-            network,
-        }
-    }
-}
+pub use crate::{
+    config::OperatorWalletConfig,
+    general::{native::NativeGeneralWallet, FundedPsbt, GeneralWallet, UtxoInfo},
+    sync::SyncError,
+    wallet::OperatorWallet,
+};
 
 /// Errors returned by [`OperatorWallet`] methods. Backend errors are boxed so call sites don't
 /// have to be generic over `G::Error`.
@@ -80,336 +49,7 @@ pub enum Error {
 }
 
 impl Error {
-    fn from_general<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
+    pub(crate) fn from_general<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
         Self::General(Box::new(e))
-    }
-}
-
-/// The operator's wallet, composing a swappable general-wallet backend with the always-native
-/// reserved wallet, lease bookkeeping, and cross-wallet transaction construction.
-#[derive(Debug)]
-pub struct OperatorWallet<G: GeneralWallet> {
-    general: G,
-    reserved: Wallet,
-    reserved_sync_backend: Backend,
-    reserved_script_pubkey: ScriptBuf,
-    config: OperatorWalletConfig,
-    leased_outpoints: BTreeSet<OutPoint>,
-}
-
-impl<G: GeneralWallet> OperatorWallet<G> {
-    /// Constructs a new [`OperatorWallet`] from a [`GeneralWallet`] backend and a native
-    /// reserved-wallet pubkey. `initial_leases` is the set of outpoints to seed the lease
-    /// state with (typically rehydrated from FDB at startup).
-    pub fn new(
-        general: G,
-        reserved_pubkey: XOnlyPublicKey,
-        config: OperatorWalletConfig,
-        reserved_sync_backend: Backend,
-        initial_leases: BTreeSet<OutPoint>,
-    ) -> Self {
-        let (reserved_desc, ..) =
-            descriptor!(tr(reserved_pubkey)).expect("valid tr() descriptor for reserved");
-        let reserved_wallet = Wallet::create_single(reserved_desc)
-            .network(config.network)
-            .create_wallet_no_persist()
-            .expect("reserved wallet creation must not fail");
-        let reserved_addr = reserved_wallet
-            .peek_address(KeychainKind::External, 0)
-            .address;
-        info!("reserved wallet address: {reserved_addr}");
-        let reserved_script_pubkey = reserved_addr.script_pubkey();
-        Self {
-            general,
-            reserved: reserved_wallet,
-            reserved_sync_backend,
-            reserved_script_pubkey,
-            config,
-            leased_outpoints: initial_leases,
-        }
-    }
-
-    /// Returns a reference to the underlying [`GeneralWallet`] for callers that need
-    /// backend-specific operations the composer doesn't wrap. Use sparingly.
-    pub const fn general(&self) -> &G {
-        &self.general
-    }
-
-    // ── Script accessors ────────────────────────────────────────────────────
-
-    /// Returns the general wallet's receive script.
-    pub fn general_script_pubkey(&self) -> ScriptBuf {
-        self.general.script_pubkey()
-    }
-
-    /// Returns the reserved wallet's receive script.
-    pub fn reserved_script_pubkey(&self) -> ScriptBuf {
-        self.reserved_script_pubkey.clone()
-    }
-
-    // ── Lease bookkeeping ───────────────────────────────────────────────────
-
-    /// Returns the currently-leased outpoints.
-    pub const fn leased_outpoints(&self) -> &BTreeSet<OutPoint> {
-        &self.leased_outpoints
-    }
-
-    /// Marks each of `outpoints` as leased.
-    pub fn lease(&mut self, outpoints: &[OutPoint]) {
-        for outpoint in outpoints {
-            self.leased_outpoints.insert(*outpoint);
-        }
-    }
-
-    /// Removes each of `outpoints` from the lease set. Logs (at `warn`) but does not error
-    /// when a given outpoint wasn't leased — releases are idempotent.
-    pub fn release(&mut self, outpoints: &[OutPoint]) {
-        for outpoint in outpoints {
-            if !self.leased_outpoints.remove(outpoint) {
-                warn!(
-                    ?outpoint,
-                    "attempted to release outpoint that was not leased"
-                );
-            }
-        }
-    }
-
-    // ── Reserved-wallet operations ─────────────────────────────────────────
-
-    /// Returns the reserved-wallet UTXOs that match the claim-funding value (i.e. the dust
-    /// pool used to fund claim transactions).
-    pub fn claim_funding_outputs(&self) -> Vec<UtxoInfo> {
-        let tip = self.reserved.latest_checkpoint().height();
-        self.reserved
-            .list_unspent()
-            .filter(|utxo| utxo.txout.value == self.config.stake_funding_utxo_value)
-            .map(|lo| UtxoInfo {
-                outpoint: lo.outpoint,
-                amount: lo.txout.value,
-                confirmations: match &lo.chain_position {
-                    ChainPosition::Confirmed { anchor, .. } => {
-                        tip.saturating_sub(anchor.block_id.height).saturating_add(1)
-                    }
-                    ChainPosition::Unconfirmed { .. } => 0,
-                },
-                script_pubkey: lo.txout.script_pubkey.clone(),
-            })
-            .collect()
-    }
-
-    /// Selects an unleased claim-funding UTXO that the `ignore` predicate doesn't reject,
-    /// leases it, and returns it along with the remaining count.
-    pub fn claim_funding_utxo(
-        &mut self,
-        ignore: impl Fn(&UtxoInfo) -> bool,
-    ) -> (Option<OutPoint>, u64) {
-        let available = self.claim_funding_outputs();
-        let leased = &self.leased_outpoints;
-        let mut considered = available
-            .into_iter()
-            .filter(|u| !leased.contains(&u.outpoint) && !ignore(u));
-        let selected = considered.next();
-        let remaining = considered.count() as u64;
-        if let Some(ref utxo) = selected {
-            self.leased_outpoints.insert(utxo.outpoint);
-        }
-        (selected.map(|u| u.outpoint), remaining)
-    }
-
-    // ── General-wallet pass-throughs with lease bookkeeping ────────────────
-
-    /// Funds an unsigned v3 transaction from the general wallet.
-    ///
-    /// Selects inputs from spendable general-wallet UTXOs (excluding anchors and currently-
-    /// leased outpoints), signs them where the backend has key material, and returns a
-    /// [`FundedPsbt`]. The consumed inputs are leased before return.
-    pub async fn fund_v3_transaction(
-        &mut self,
-        unsigned_tx: Transaction,
-        fee_rate: FeeRate,
-    ) -> Result<FundedPsbt, Error> {
-        let exclude = self.exclude_anchors_and_leases();
-        let funded = self
-            .general
-            .fund_v3_transaction(unsigned_tx.output, None, fee_rate, &exclude)
-            .await
-            .map_err(Error::from_general)?;
-        self.lease(&funded.spent);
-        Ok(funded)
-    }
-
-    /// Funds an unsigned v3 transaction using `inputs` as the input set (typically a
-    /// previously-persisted funding plan being replayed on retry).
-    pub async fn fund_v3_transaction_with_inputs(
-        &mut self,
-        unsigned_tx: Transaction,
-        inputs: &[OutPoint],
-        fee_rate: FeeRate,
-    ) -> Result<FundedPsbt, Error> {
-        let funded = self
-            .general
-            .fund_v3_transaction(unsigned_tx.output, Some(inputs), fee_rate, &[])
-            .await
-            .map_err(Error::from_general)?;
-        self.lease(&funded.spent);
-        Ok(funded)
-    }
-
-    /// Builds a CPFP child for `parent` spending the anchor at `anchor_vout`.
-    ///
-    /// `replacing`, when `Some`, identifies the funding outpoints of a prior child being
-    /// replaced via RBF. Those outpoints are released from the lease set before
-    /// fee-paying-input selection so they can be re-selected.
-    pub async fn build_cpfp_child(
-        &mut self,
-        parent: &Transaction,
-        anchor_vout: u32,
-        target_pkg_fee_rate: FeeRate,
-        replacing: Option<&[OutPoint]>,
-    ) -> Result<FundedPsbt, Error> {
-        if let Some(prior) = replacing {
-            self.release(prior);
-        }
-        let exclude = self.exclude_anchors_and_leases();
-        match self
-            .general
-            .build_cpfp_child(parent, anchor_vout, target_pkg_fee_rate, &exclude)
-            .await
-        {
-            Ok(funded) => {
-                self.lease(&funded.spent);
-                Ok(funded)
-            }
-            Err(e) => {
-                // Restore the lease state torn down before selection so a retry observes the
-                // same world. Without this, a backend failure silently un-leases the prior
-                // child's funding inputs.
-                if let Some(prior) = replacing {
-                    self.lease(prior);
-                }
-                Err(Error::from_general(e))
-            }
-        }
-    }
-
-    // ── Cross-wallet (general → reserved) ──────────────────────────────────
-
-    /// Creates a PSBT that refills the pool of claim-funding UTXOs in the reserved wallet by
-    /// sending `stake_funding_utxo_value`-sized outputs from the general wallet to the
-    /// reserved script. The returned PSBT still needs signing for any inputs the backend
-    /// couldn't sign.
-    pub async fn refill_claim_funding_utxos(
-        &mut self,
-        fee_rate: FeeRate,
-        target_size: usize,
-    ) -> Result<FundedPsbt, Error> {
-        let claim_funding_outpoints: BTreeSet<OutPoint> = self
-            .claim_funding_outputs()
-            .into_iter()
-            .map(|u| u.outpoint)
-            .collect();
-        let current_size = claim_funding_outpoints.len();
-        let batch_size = target_size.saturating_sub(current_size);
-
-        let outputs = (0..batch_size)
-            .map(|_| TxOut {
-                value: self.config.stake_funding_utxo_value,
-                script_pubkey: self.reserved_script_pubkey.clone(),
-            })
-            .collect();
-
-        let mut exclude = self.exclude_anchors_and_leases();
-        exclude.extend(claim_funding_outpoints);
-
-        let funded = self
-            .general
-            .fund_v3_transaction(outputs, None, fee_rate, &exclude)
-            .await
-            .map_err(Error::from_general)?;
-        self.lease(&funded.spent);
-        Ok(funded)
-    }
-
-    /// Creates a PSBT that funds a stake-chain transaction by paying `funding_amount` from
-    /// the general wallet into the reserved script.
-    pub async fn create_stake_funding_tx(
-        &mut self,
-        fee_rate: FeeRate,
-        funding_amount: Amount,
-    ) -> Result<FundedPsbt, Error> {
-        let outputs = vec![TxOut {
-            value: funding_amount,
-            script_pubkey: self.reserved_script_pubkey.clone(),
-        }];
-        let exclude = self.exclude_anchors_and_leases();
-        let funded = self
-            .general
-            .fund_v3_transaction(outputs, None, fee_rate, &exclude)
-            .await
-            .map_err(Error::from_general)?;
-        self.lease(&funded.spent);
-        Ok(funded)
-    }
-
-    // ── Sync ───────────────────────────────────────────────────────────────
-
-    /// Syncs both wallets against their respective backends and then prunes the lease set:
-    /// any leased outpoint that is no longer in either wallet's spendable UTXO set is
-    /// dropped (it was observed spent on-chain).
-    pub async fn sync(&mut self) -> Result<(), Error> {
-        let mut attempt = 0u32;
-        loop {
-            let mut err: Option<Error> = None;
-            if let Err(e) = self.general.sync().await {
-                err = Some(Error::from_general(e));
-            }
-            if let Err(e) = self
-                .reserved_sync_backend
-                .sync_wallet(&mut self.reserved)
-                .await
-            {
-                err = Some(Error::Sync(e));
-            }
-            match err {
-                Some(e) => {
-                    error!(?e, "error syncing wallet");
-                    if attempt >= SYNC_RETRIES {
-                        return Err(e);
-                    }
-                    sleep(SYNC_BASE_DELAY * SYNC_BACKOFF.pow(attempt)).await;
-                    attempt += 1;
-                }
-                None => break,
-            }
-        }
-
-        // Prune stale leases. After a successful sync, drop any leased outpoint whose
-        // underlying UTXO is no longer in either wallet's spendable set — it was observed
-        // spent on-chain (the on-chain spend supersedes our local lease bookkeeping).
-        let live: BTreeSet<OutPoint> = self
-            .general
-            .list_utxos()
-            .into_iter()
-            .map(|u| u.outpoint)
-            .chain(self.reserved.list_unspent().map(|lo| lo.outpoint))
-            .collect();
-        self.leased_outpoints.retain(|o| live.contains(o));
-        Ok(())
-    }
-
-    // ── Internal helpers ───────────────────────────────────────────────────
-
-    /// Returns the set of general-wallet outpoints that should be excluded from input
-    /// selection: anchors (zero/dust-value unconfirmed outputs we keep around for fee
-    /// bumping) plus currently-leased outpoints.
-    fn exclude_anchors_and_leases(&self) -> Vec<OutPoint> {
-        let utxos = self.general.list_utxos();
-        let anchors = utxos
-            .iter()
-            .filter(|u| u.amount == self.config.cpfp_value && u.confirmations == 0)
-            .map(|u| u.outpoint);
-        anchors
-            .chain(self.leased_outpoints.iter().copied())
-            .collect()
     }
 }

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -271,13 +271,25 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             self.release(prior);
         }
         let exclude = self.exclude_anchors_and_leases();
-        let funded = self
+        match self
             .general
             .build_cpfp_child(parent, anchor_vout, target_pkg_fee_rate, &exclude)
             .await
-            .map_err(Error::from_general)?;
-        self.lease(&funded.spent);
-        Ok(funded)
+        {
+            Ok(funded) => {
+                self.lease(&funded.spent);
+                Ok(funded)
+            }
+            Err(e) => {
+                // Restore the lease state torn down before selection so a retry observes the
+                // same world. Without this, a backend failure silently un-leases the prior
+                // child's funding inputs.
+                if let Some(prior) = replacing {
+                    self.lease(prior);
+                }
+                Err(Error::from_general(e))
+            }
+        }
     }
 
     // ── Cross-wallet (general → reserved) ──────────────────────────────────

--- a/crates/operator-wallet/src/sync.rs
+++ b/crates/operator-wallet/src/sync.rs
@@ -1,17 +1,16 @@
 //! Operator wallet chain data sync module
-use std::{collections::BTreeSet, fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc};
 
 use bdk_bitcoind_rpc::{
     bitcoincore_rpc::{self},
     BlockEvent, Emitter,
 };
 use bdk_wallet::{
-    bitcoin::{Block, OutPoint, Transaction},
+    bitcoin::{Block, Transaction},
     chain::CheckPoint,
     Wallet,
 };
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
-use tracing::debug;
 
 /// A message sent from a sync task to the syncer
 #[derive(Debug)]
@@ -33,12 +32,13 @@ pub enum Backend {
 }
 
 impl Backend {
-    /// Syncs a wallet using the internal update
-    pub async fn sync_wallet(
-        &self,
-        wallet: &mut Wallet,
-        leases: &mut BTreeSet<OutPoint>,
-    ) -> Result<(), SyncError> {
+    /// Syncs a wallet using the configured backend.
+    ///
+    /// Pulls new blocks + mempool state and applies them to the wallet's view. Lease
+    /// cleanup (removing leases whose underlying outpoints have been observed spent) is the
+    /// caller's responsibility — after this call, the caller compares its lease set against
+    /// the wallet's `list_unspent()` and drops any lease whose outpoint is no longer present.
+    pub async fn sync_wallet(&self, wallet: &mut Wallet) -> Result<(), SyncError> {
         let last_cp = wallet.latest_checkpoint();
         let (tx, mut rx) = unbounded_channel();
 
@@ -57,33 +57,14 @@ impl Backend {
                     wallet
                         .apply_block_connected_to(&ev.block, height, connected_to)
                         .expect("block to be added");
-                    let spent_outpoints = ev
-                        .block
-                        .txdata
-                        .iter()
-                        .flat_map(|tx| tx.input.iter())
-                        .map(|txin| txin.previous_output);
-                    for outpoint in spent_outpoints {
-                        leases.remove(&outpoint);
-                    }
                 }
                 WalletUpdate::MempoolTxs(txs) => {
-                    let spent_outpoints = txs
-                        .iter()
-                        .flat_map(|a| a.0.input.iter())
-                        .map(|txin| txin.previous_output);
-                    for outpoint in spent_outpoints {
-                        leases.remove(&outpoint);
-                    }
                     wallet.apply_unconfirmed_txs(txs);
                 }
             }
         }
 
         handle.await.expect("thread to be fine")?;
-
-        debug!(utxo_leases=?leases, "finished operator wallet sync");
-
         Ok(())
     }
 }

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -1,0 +1,341 @@
+//! The [`OperatorWallet`] composer.
+//!
+//! Composes a swappable [`crate::GeneralWallet`] backend with an always-native reserved wallet
+//! and shared in-memory lease bookkeeping. The composer owns:
+//!
+//! - the BDK descriptor-only reserved wallet (signed downstream by the caller),
+//! - the lease set shared across both wallets,
+//! - anchor exclusion during input selection,
+//! - cross-wallet construction helpers that produce PSBTs paying from the general wallet into
+//!   reserved-wallet outputs of a caller-specified denomination.
+//!
+//! Methods on [`OperatorWallet`] take `&mut self`; callers serialize via an outer lock when
+//! they need a multi-step critical section (e.g. DB-lookup-then-fund-then-persist).
+
+use std::collections::BTreeSet;
+
+use bdk_wallet::{
+    bitcoin::{Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    descriptor, KeychainKind, Wallet,
+};
+use tokio::time::sleep;
+use tracing::{error, info, warn};
+
+use crate::{
+    config::OperatorWalletConfig,
+    general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    sync::Backend,
+    Error,
+};
+
+/// The operator's wallet: a [`GeneralWallet`] backend composed with the always-native reserved
+/// wallet, shared lease bookkeeping, and cross-wallet transaction construction helpers.
+#[derive(Debug)]
+pub struct OperatorWallet<G: GeneralWallet> {
+    general: G,
+    reserved: Wallet,
+    reserved_sync_backend: Backend,
+    reserved_script_pubkey: ScriptBuf,
+    config: OperatorWalletConfig,
+    leased_outpoints: BTreeSet<OutPoint>,
+}
+
+impl<G: GeneralWallet> OperatorWallet<G> {
+    /// Constructs an [`OperatorWallet`] from a [`GeneralWallet`] backend and a reserved-wallet
+    /// pubkey. `initial_leases` is the set of outpoints to seed the lease state with
+    /// (typically rehydrated from durable storage at startup).
+    pub fn new(
+        general: G,
+        reserved_pubkey: XOnlyPublicKey,
+        config: OperatorWalletConfig,
+        reserved_sync_backend: Backend,
+        initial_leases: BTreeSet<OutPoint>,
+    ) -> Self {
+        let (reserved_desc, ..) =
+            descriptor!(tr(reserved_pubkey)).expect("valid tr() descriptor for reserved");
+        let reserved_wallet = Wallet::create_single(reserved_desc)
+            .network(config.network)
+            .create_wallet_no_persist()
+            .expect("reserved wallet creation must not fail");
+        let reserved_addr = reserved_wallet
+            .peek_address(KeychainKind::External, 0)
+            .address;
+        info!("reserved wallet address: {reserved_addr}");
+        let reserved_script_pubkey = reserved_addr.script_pubkey();
+        Self {
+            general,
+            reserved: reserved_wallet,
+            reserved_sync_backend,
+            reserved_script_pubkey,
+            config,
+            leased_outpoints: initial_leases,
+        }
+    }
+
+    /// Returns a reference to the underlying [`GeneralWallet`] for callers that need
+    /// backend-specific operations the composer doesn't wrap. Use sparingly.
+    pub const fn general(&self) -> &G {
+        &self.general
+    }
+
+    // ── Script accessors ────────────────────────────────────────────────────
+
+    /// Returns the general wallet's receive script.
+    pub fn general_script_pubkey(&self) -> ScriptBuf {
+        self.general.script_pubkey()
+    }
+
+    /// Returns the reserved wallet's receive script.
+    pub fn reserved_script_pubkey(&self) -> ScriptBuf {
+        self.reserved_script_pubkey.clone()
+    }
+
+    // ── Lease bookkeeping ───────────────────────────────────────────────────
+
+    /// Returns the currently-leased outpoints.
+    pub const fn leased_outpoints(&self) -> &BTreeSet<OutPoint> {
+        &self.leased_outpoints
+    }
+
+    /// Marks each of `outpoints` as leased. Safe to call with already-leased outpoints
+    /// (the set is idempotent).
+    pub fn lease(&mut self, outpoints: &[OutPoint]) {
+        for outpoint in outpoints {
+            self.leased_outpoints.insert(*outpoint);
+        }
+    }
+
+    /// Removes each of `outpoints` from the lease set. Safe to call repeatedly or with
+    /// outpoints that were never leased.
+    pub fn release(&mut self, outpoints: &[OutPoint]) {
+        for outpoint in outpoints {
+            if !self.leased_outpoints.remove(outpoint) {
+                warn!(
+                    ?outpoint,
+                    "attempted to release outpoint that was not leased"
+                );
+            }
+        }
+    }
+
+    // ── Reserved-wallet UTXO lookup ─────────────────────────────────────────
+
+    /// Returns every reserved-wallet UTXO whose output value matches `value`.
+    ///
+    /// Used to look up the pool of equal-denomination reserved-wallet UTXOs maintained for
+    /// some downstream purpose (claim funding, etc.) — the composer doesn't know what the
+    /// caller's "purpose" is, only that they want UTXOs of a specific size.
+    pub fn reserved_utxos_with_value(&self, value: Amount) -> Vec<UtxoInfo> {
+        let tip = self.reserved.latest_checkpoint().height();
+        self.reserved
+            .list_unspent()
+            .filter(|utxo| utxo.txout.value == value)
+            .map(|lo| local_output_to_utxo_info(&lo, tip))
+            .collect()
+    }
+
+    /// Selects and leases one unleased reserved-wallet UTXO of value `value` that the
+    /// `ignore` predicate doesn't reject. Returns the selected outpoint (if any) and the
+    /// number of *additional* matching UTXOs left after the selection.
+    pub fn reserve_utxo_with_value(
+        &mut self,
+        value: Amount,
+        ignore: impl Fn(&UtxoInfo) -> bool,
+    ) -> (Option<OutPoint>, u64) {
+        let available = self.reserved_utxos_with_value(value);
+        let leased = &self.leased_outpoints;
+        let mut considered = available
+            .into_iter()
+            .filter(|u| !leased.contains(&u.outpoint) && !ignore(u));
+        let selected = considered.next();
+        let remaining = considered.count() as u64;
+        if let Some(ref utxo) = selected {
+            self.leased_outpoints.insert(utxo.outpoint);
+        }
+        (selected.map(|u| u.outpoint), remaining)
+    }
+
+    // ── General-wallet pass-throughs with lease bookkeeping ────────────────
+
+    /// Funds an unsigned v3 transaction from the general wallet.
+    ///
+    /// Selects inputs from spendable general-wallet UTXOs (excluding anchors and currently-
+    /// leased outpoints), signs them where the backend has key material, and returns a
+    /// [`FundedPsbt`]. The consumed inputs are leased before return.
+    pub async fn fund_v3_transaction(
+        &mut self,
+        unsigned_tx: Transaction,
+        fee_rate: FeeRate,
+    ) -> Result<FundedPsbt, Error> {
+        let exclude = self.exclude_anchors_and_leases();
+        let funded = self
+            .general
+            .fund_v3_transaction(unsigned_tx.output, None, fee_rate, &exclude)
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent());
+        Ok(funded)
+    }
+
+    /// Funds an unsigned v3 transaction using `inputs` as the explicit input set (typically
+    /// a previously-persisted funding plan being replayed on retry).
+    pub async fn fund_v3_transaction_with_inputs(
+        &mut self,
+        unsigned_tx: Transaction,
+        inputs: &[OutPoint],
+        fee_rate: FeeRate,
+    ) -> Result<FundedPsbt, Error> {
+        let funded = self
+            .general
+            .fund_v3_transaction(unsigned_tx.output, Some(inputs), fee_rate, &[])
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent());
+        Ok(funded)
+    }
+
+    /// Builds a CPFP child for `parent` spending the anchor at `anchor_vout`.
+    ///
+    /// `replacing`, when `Some`, identifies the funding outpoints of a prior child being
+    /// replaced via RBF. Those outpoints are released from the lease set before
+    /// fee-paying-input selection so they can be re-selected.
+    pub async fn build_cpfp_child(
+        &mut self,
+        parent: &Transaction,
+        anchor_vout: u32,
+        target_pkg_fee_rate: FeeRate,
+        replacing: Option<&[OutPoint]>,
+    ) -> Result<FundedPsbt, Error> {
+        if let Some(prior) = replacing {
+            self.release(prior);
+        }
+        let exclude = self.exclude_anchors_and_leases();
+        match self
+            .general
+            .build_cpfp_child(parent, anchor_vout, target_pkg_fee_rate, &exclude)
+            .await
+        {
+            Ok(funded) => {
+                self.lease(&funded.spent());
+                Ok(funded)
+            }
+            Err(e) => {
+                // Restore the lease state torn down before selection so a retry observes the
+                // same world. Without this, a backend failure silently un-leases the prior
+                // child's funding inputs.
+                if let Some(prior) = replacing {
+                    self.lease(prior);
+                }
+                Err(Error::from_general(e))
+            }
+        }
+    }
+
+    // ── Cross-wallet (general → reserved) ──────────────────────────────────
+
+    /// Creates a PSBT that funds `quantity` reserved-wallet UTXOs of `utxo_value` each,
+    /// paying from the general wallet. The outputs go to the reserved-wallet script.
+    ///
+    /// The composer is agnostic of what `utxo_value` means to the caller — it only
+    /// enforces that each output carries exactly that value and pays the reserved
+    /// script. Callers wanting to top up a pool of equal-denomination UTXOs should query
+    /// [`Self::reserved_utxos_with_value`] first and request only the delta they're
+    /// missing; existing reserved-wallet UTXOs of the same `utxo_value` are
+    /// automatically excluded from input selection so the composer doesn't re-spend pool
+    /// members back to themselves.
+    pub async fn create_reserved_utxos(
+        &mut self,
+        fee_rate: FeeRate,
+        utxo_value: Amount,
+        quantity: usize,
+    ) -> Result<FundedPsbt, Error> {
+        // Exclude already-existing reserved UTXOs of the same value from selection so the
+        // composer doesn't accidentally spend pool members back to itself.
+        let existing: BTreeSet<OutPoint> = self
+            .reserved_utxos_with_value(utxo_value)
+            .into_iter()
+            .map(|u| u.outpoint)
+            .collect();
+
+        let outputs = (0..quantity)
+            .map(|_| TxOut {
+                value: utxo_value,
+                script_pubkey: self.reserved_script_pubkey.clone(),
+            })
+            .collect();
+
+        let mut exclude = self.exclude_anchors_and_leases();
+        exclude.extend(existing);
+
+        let funded = self
+            .general
+            .fund_v3_transaction(outputs, None, fee_rate, &exclude)
+            .await
+            .map_err(Error::from_general)?;
+        self.lease(&funded.spent());
+        Ok(funded)
+    }
+
+    // ── Sync ───────────────────────────────────────────────────────────────
+
+    /// Syncs both wallets against their respective backends and then prunes the lease set:
+    /// any leased outpoint that is no longer in either wallet's spendable UTXO set is
+    /// dropped (it was observed spent on-chain).
+    pub async fn sync(&mut self) -> Result<(), Error> {
+        let mut attempt = 0u32;
+        loop {
+            let mut err: Option<Error> = None;
+            if let Err(e) = self.general.sync().await {
+                err = Some(Error::from_general(e));
+            }
+            if let Err(e) = self
+                .reserved_sync_backend
+                .sync_wallet(&mut self.reserved)
+                .await
+            {
+                err = Some(Error::Sync(e));
+            }
+            match err {
+                Some(e) => {
+                    error!(?e, "error syncing wallet");
+                    if attempt >= self.config.sync_retries {
+                        return Err(e);
+                    }
+                    sleep(self.config.sync_base_delay * self.config.sync_backoff.pow(attempt))
+                        .await;
+                    attempt += 1;
+                }
+                None => break,
+            }
+        }
+
+        // Prune stale leases. After a successful sync, drop any leased outpoint whose
+        // underlying UTXO is no longer in either wallet's spendable set — it was observed
+        // spent on-chain (the on-chain spend supersedes our local lease bookkeeping).
+        let live: BTreeSet<OutPoint> = self
+            .general
+            .list_utxos()
+            .into_iter()
+            .map(|u| u.outpoint)
+            .chain(self.reserved.list_unspent().map(|lo| lo.outpoint))
+            .collect();
+        self.leased_outpoints.retain(|o| live.contains(o));
+        Ok(())
+    }
+
+    // ── Internal helpers ───────────────────────────────────────────────────
+
+    /// Returns the set of general-wallet outpoints that should be excluded from input
+    /// selection: CPFP anchors (zero-confirmation outputs at the configured anchor value)
+    /// plus currently-leased outpoints.
+    fn exclude_anchors_and_leases(&self) -> Vec<OutPoint> {
+        let utxos = self.general.list_utxos();
+        let anchors = utxos
+            .iter()
+            .filter(|u| u.amount == self.config.cpfp_value && u.confirmations == 0)
+            .map(|u| u.outpoint);
+        anchors
+            .chain(self.leased_outpoints.iter().copied())
+            .collect()
+    }
+}

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -157,6 +157,28 @@ impl<G: GeneralWallet> OperatorWallet<G> {
 
     // ── General-wallet pass-throughs with lease bookkeeping ────────────────
 
+    /// Selects the first general-wallet UTXO that satisfies `predicate`, excluding CPFP
+    /// anchors and currently-leased outpoints, leases it so concurrent duties don't
+    /// re-select the same outpoint, and returns it. Returns `None` if nothing matches.
+    ///
+    /// Unlike [`Self::fund_v3_transaction`], this hands back a single chosen UTXO for callers
+    /// that build a bespoke transaction around it — e.g. the unstaking-burn executor, whose tx
+    /// has a fixed non-wallet first input that the generic outputs-only funding path can't
+    /// express.
+    pub fn select_and_lease_general_utxo(
+        &mut self,
+        predicate: impl Fn(&UtxoInfo) -> bool,
+    ) -> Option<UtxoInfo> {
+        let exclude: BTreeSet<OutPoint> = self.exclude_anchors_and_leases().into_iter().collect();
+        let selected = self
+            .general
+            .list_utxos()
+            .into_iter()
+            .find(|u| !exclude.contains(&u.outpoint) && predicate(u))?;
+        self.lease(&[selected.outpoint]);
+        Some(selected)
+    }
+
     /// Funds an unsigned v3 transaction from the general wallet.
     ///
     /// Selects inputs from spendable general-wallet UTXOs (excluding anchors and currently-

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -1,0 +1,483 @@
+#![allow(unused_crate_dependencies)]
+//! Crate-level integration tests for `operator-wallet` against a real `bitcoind` regtest
+//! node (via `corepc-node`).
+//!
+//! These tests cover the load-bearing surface of [`OperatorWallet`]:
+//!
+//! - **Lease bookkeeping** is idempotent and additive (lease + release semantics).
+//! - **Reserved-UTXO creation** funds the reserved wallet with the requested denomination +
+//!   quantity, and the resulting UTXOs are discoverable via `reserved_utxos_with_value`.
+//! - **Pool refill** semantics: caller computes batch size from current count, requests only the
+//!   delta, and the wallet doesn't re-spend existing pool members back to itself.
+//! - **Sync prunes stale leases** so a long-running operator doesn't accumulate leases for
+//!   outpoints that the chain has already spent.
+//!
+//! Tests are `#[serial]` because `bitcoind` binds a fixed RPC port — parallel runs would
+//! collide. Each test spins up a fresh `bitcoind` so state doesn't leak between cases.
+//!
+//! Signing of the funded PSBTs (the `create_reserved_utxos` happy path) is performed
+//! in-process with the test's known operator privkey: the native general wallet is
+//! descriptor-only, so production goes through secret-service. The test bypasses that by
+//! signing with the same keypair the descriptor was constructed from (BIP-341 key-path with
+//! the empty-merkle-root tap-tweak).
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use bdk_wallet::bitcoin::{
+    hashes::Hash,
+    key::{Keypair, Secp256k1, TapTweak},
+    secp256k1::{Message, SecretKey},
+    sighash::{Prevouts, SighashCache},
+    taproot, Address, Amount, FeeRate, Network, OutPoint, Psbt, TapSighashType, Transaction,
+    Witness, XOnlyPublicKey,
+};
+use corepc_node::{Conf, Node};
+use operator_wallet::{
+    sync::Backend, GeneralWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
+};
+use serial_test::serial;
+
+/// 1 sat — the smallest possible "anchor" value, used in tests where we don't actually
+/// want any UTXO to look like an anchor. `OperatorWallet`'s anchor exclusion filters on
+/// (value == cpfp_value) AND (confirmations == 0); none of the test outputs are that small
+/// AND unconfirmed-at-query-time, so the filter is a no-op in these tests.
+const SENTINEL_ANCHOR_VALUE: Amount = Amount::from_sat(330);
+
+/// Boots a fresh regtest `bitcoind`, mines coinbase maturity, and returns the node.
+fn setup_bitcoind() -> Node {
+    let bitcoind = Node::with_conf("bitcoind", &Conf::default()).expect("bitcoind must start");
+    let mining_address = bitcoind.client.new_address().expect("mining address");
+    bitcoind
+        .client
+        .generate_to_address(101, &mining_address)
+        .expect("mine coinbase maturity");
+    bitcoind
+}
+
+/// Spins up a sync `bitcoincore_rpc::Client` against the running node — needed by
+/// `Backend::BitcoinCore`.
+fn sync_rpc_client(bitcoind: &Node) -> bdk_bitcoind_rpc::bitcoincore_rpc::Client {
+    let cookie_path = bitcoind.params.cookie_file.clone();
+    let auth = bdk_bitcoind_rpc::bitcoincore_rpc::Auth::CookieFile(cookie_path);
+    bdk_bitcoind_rpc::bitcoincore_rpc::Client::new(&bitcoind.rpc_url(), auth)
+        .expect("sync rpc client")
+}
+
+/// Constructs a deterministic keypair from `seed`.
+fn keypair_from_seed(seed: u8) -> (Keypair, XOnlyPublicKey) {
+    let secret = SecretKey::from_slice(&[seed; 32]).expect("valid 32-byte scalar");
+    let kp = Keypair::from_secret_key(&Secp256k1::new(), &secret);
+    let (xonly, _) = kp.x_only_public_key();
+    (kp, xonly)
+}
+
+/// Builds a fully-wired `OperatorWallet<NativeGeneralWallet>` for tests. Funds the general
+/// wallet with `general_funding_utxos` UTXOs of `general_funding_value` each via bitcoind's
+/// own wallet, then syncs. The reserved wallet is created from a separate deterministic
+/// keypair and starts empty.
+async fn build_operator_wallet(
+    bitcoind: &Node,
+    general_seed: u8,
+    reserved_seed: u8,
+    general_funding_utxos: usize,
+    general_funding_value: Amount,
+) -> (
+    OperatorWallet<NativeGeneralWallet>,
+    Keypair, // general keypair, used by the test to sign funded PSBTs
+    XOnlyPublicKey,
+) {
+    let (general_kp, general_pubkey) = keypair_from_seed(general_seed);
+    let (_reserved_kp, reserved_pubkey) = keypair_from_seed(reserved_seed);
+
+    let general_backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
+    let reserved_backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
+    let general = NativeGeneralWallet::new(general_pubkey, Network::Regtest, general_backend);
+    let config = OperatorWalletConfig::new(SENTINEL_ANCHOR_VALUE, Network::Regtest);
+    let mut wallet = OperatorWallet::new(
+        general,
+        reserved_pubkey,
+        config,
+        reserved_backend,
+        BTreeSet::new(),
+    );
+
+    // Fund the general wallet's address from bitcoind's own wallet.
+    let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
+    for _ in 0..general_funding_utxos {
+        bitcoind
+            .client
+            .send_to_address(&general_address, general_funding_value)
+            .expect("send_to_address");
+    }
+    let miner_addr = bitcoind.client.new_address().expect("miner address");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine confirmation");
+
+    wallet.sync().await.expect("initial wallet sync");
+    (wallet, general_kp, general_pubkey)
+}
+
+/// Manually signs every input of `psbt` with `keypair` as a Taproot key-path spend
+/// (BIP-341 tap-tweak with empty merkle root). Used by the tests to finalize PSBTs that
+/// the descriptor-only `NativeGeneralWallet` returns unsigned. Returns the extracted
+/// signed transaction.
+fn sign_and_finalize(mut psbt: Psbt, keypair: Keypair) -> Transaction {
+    let secp = Secp256k1::new();
+    let tweaked = keypair.tap_tweak(&secp, None).to_keypair();
+    let prevouts: Vec<_> = psbt
+        .inputs
+        .iter()
+        .map(|i| i.witness_utxo.clone().expect("witness_utxo on every input"))
+        .collect();
+    let unsigned = psbt.unsigned_tx.clone();
+    let mut cache = SighashCache::new(&unsigned);
+    for i in 0..psbt.inputs.len() {
+        let sighash = cache
+            .taproot_key_spend_signature_hash(i, &Prevouts::All(&prevouts), TapSighashType::Default)
+            .expect("sighash");
+        let signature = secp.sign_schnorr_no_aux_rand(&Message::from(sighash), &tweaked);
+        psbt.inputs[i].tap_key_sig = Some(taproot::Signature {
+            signature,
+            sighash_type: TapSighashType::Default,
+        });
+    }
+    for input in &mut psbt.inputs {
+        if let Some(sig) = input.tap_key_sig.take() {
+            let mut witness = Witness::new();
+            witness.push(sig.to_vec());
+            input.final_script_witness = Some(witness);
+        }
+    }
+    psbt.extract_tx().expect("extract")
+}
+
+#[tokio::test]
+#[serial]
+async fn lease_release_are_idempotent_and_additive() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, _kp, _pk) =
+        build_operator_wallet(&bitcoind, 1, 2, 1, Amount::from_btc(0.5).unwrap()).await;
+
+    let op_a = OutPoint {
+        txid: bdk_wallet::bitcoin::Txid::from_slice(&[1u8; 32]).unwrap(),
+        vout: 0,
+    };
+    let op_b = OutPoint {
+        txid: bdk_wallet::bitcoin::Txid::from_slice(&[2u8; 32]).unwrap(),
+        vout: 1,
+    };
+
+    assert!(wallet.leased_outpoints().is_empty(), "starts empty");
+    wallet.lease(&[op_a, op_b]);
+    assert_eq!(wallet.leased_outpoints().len(), 2, "two leased");
+    // Idempotent: re-leasing the same outpoints doesn't grow the set.
+    wallet.lease(&[op_a]);
+    assert_eq!(
+        wallet.leased_outpoints().len(),
+        2,
+        "still two after re-lease"
+    );
+
+    wallet.release(&[op_a]);
+    assert_eq!(wallet.leased_outpoints().len(), 1, "one left after release");
+    // Release-of-unleased is safe (no panic; logs a warning we don't capture here).
+    wallet.release(&[op_a]);
+    assert_eq!(wallet.leased_outpoints().len(), 1, "still one");
+    wallet.release(&[op_b]);
+    assert!(wallet.leased_outpoints().is_empty(), "empty again");
+}
+
+#[tokio::test]
+#[serial]
+async fn create_reserved_utxos_funds_pool_and_leases_inputs() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, general_kp, _) =
+        build_operator_wallet(&bitcoind, 3, 4, 3, Amount::from_btc(0.5).unwrap()).await;
+
+    // Create 5 reserved UTXOs of 0.01 BTC each. Bridges the same shape as the claim-funding
+    // pool: caller picks the denomination, the composer constructs the funding tx.
+    let utxo_value = Amount::from_btc(0.01).unwrap();
+    let quantity = 5;
+    let fee_rate = FeeRate::from_sat_per_vb(5).unwrap();
+    let funded = wallet
+        .create_reserved_utxos(fee_rate, utxo_value, quantity)
+        .await
+        .expect("funding must succeed");
+
+    // The wallet should have leased the funding inputs (so concurrent duties don't double-
+    // pick them). The actual leased outpoints come from the funded PSBT's inputs.
+    let leased = wallet.leased_outpoints();
+    assert!(
+        !leased.is_empty(),
+        "wallet must have leased the funding inputs"
+    );
+    for spent in funded.spent() {
+        assert!(
+            leased.contains(&spent),
+            "every spent outpoint must be leased; missing {spent}"
+        );
+    }
+
+    // The PSBT must carry the requested quantity of reserved-wallet outputs.
+    let reserved_script = wallet.reserved_script_pubkey();
+    let reserved_output_count = funded
+        .psbt
+        .unsigned_tx
+        .output
+        .iter()
+        .filter(|o| o.value == utxo_value && o.script_pubkey == reserved_script)
+        .count();
+    assert_eq!(
+        reserved_output_count, quantity,
+        "PSBT must contain {quantity} reserved-wallet outputs of {utxo_value}"
+    );
+
+    // Sign + broadcast + confirm; resync; the reserved pool now contains the new UTXOs.
+    let signed = sign_and_finalize(funded.psbt, general_kp);
+    bitcoind
+        .client
+        .send_raw_transaction(&signed)
+        .expect("sendrawtransaction");
+    let miner_addr = bitcoind.client.new_address().expect("miner addr");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine");
+    wallet.sync().await.expect("post-broadcast sync");
+
+    let pool = wallet.reserved_utxos_with_value(utxo_value);
+    assert_eq!(
+        pool.len(),
+        quantity,
+        "reserved pool must have {quantity} matching UTXOs"
+    );
+    for utxo in &pool {
+        assert_eq!(utxo.amount, utxo_value);
+        assert_eq!(utxo.script_pubkey, reserved_script);
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn reserve_utxo_with_value_picks_and_leases_one() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, general_kp, _) =
+        build_operator_wallet(&bitcoind, 5, 6, 3, Amount::from_btc(0.5).unwrap()).await;
+
+    // Seed the reserved pool with 3 UTXOs of 0.01 BTC.
+    let utxo_value = Amount::from_btc(0.01).unwrap();
+    let funded = wallet
+        .create_reserved_utxos(FeeRate::from_sat_per_vb(5).unwrap(), utxo_value, 3)
+        .await
+        .expect("seed funding");
+    let signed = sign_and_finalize(funded.psbt, general_kp);
+    bitcoind
+        .client
+        .send_raw_transaction(&signed)
+        .expect("broadcast");
+    let miner_addr = bitcoind.client.new_address().expect("miner");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine");
+    wallet.sync().await.expect("sync");
+
+    // Reset wallet's lease state — the funding-tx inputs were leased; the new reserved
+    // UTXOs themselves haven't been. We're testing reserve_utxo_with_value on the pool.
+    let funding_inputs: Vec<OutPoint> = wallet.leased_outpoints().iter().copied().collect();
+    wallet.release(&funding_inputs);
+    assert!(wallet.leased_outpoints().is_empty(), "lease state cleared");
+
+    let (picked, remaining) = wallet.reserve_utxo_with_value(utxo_value, |_| false);
+    let picked = picked.expect("must return one outpoint");
+    assert_eq!(remaining, 2, "two more left in the pool");
+    assert!(
+        wallet.leased_outpoints().contains(&picked),
+        "picked outpoint must be leased"
+    );
+
+    // Picking again skips the leased one; we get a different outpoint.
+    let (picked_again, remaining_again) = wallet.reserve_utxo_with_value(utxo_value, |_| false);
+    let picked_again = picked_again.expect("must return another outpoint");
+    assert_ne!(picked_again, picked, "must pick a different unleased UTXO");
+    assert_eq!(remaining_again, 1, "one more left after second pick");
+}
+
+#[tokio::test]
+#[serial]
+async fn reserve_utxo_with_value_filters_by_value() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, general_kp, _) =
+        build_operator_wallet(&bitcoind, 7, 8, 3, Amount::from_btc(0.5).unwrap()).await;
+
+    // Seed two pools at different denominations.
+    let small_value = Amount::from_btc(0.01).unwrap();
+    let large_value = Amount::from_btc(0.05).unwrap();
+    for value in [small_value, large_value] {
+        let funded = wallet
+            .create_reserved_utxos(FeeRate::from_sat_per_vb(5).unwrap(), value, 2)
+            .await
+            .unwrap_or_else(|e| panic!("seed funding for {value} failed: {e}"));
+        let signed = sign_and_finalize(funded.psbt, general_kp);
+        bitcoind
+            .client
+            .send_raw_transaction(&signed)
+            .expect("broadcast");
+        let miner_addr = bitcoind.client.new_address().expect("miner");
+        bitcoind
+            .client
+            .generate_to_address(1, &miner_addr)
+            .expect("mine");
+        wallet.sync().await.expect("sync");
+    }
+
+    // Looking up by small value returns ONLY the small UTXOs.
+    let small_pool = wallet.reserved_utxos_with_value(small_value);
+    assert_eq!(small_pool.len(), 2, "expected 2 UTXOs of {small_value}");
+    for u in &small_pool {
+        assert_eq!(u.amount, small_value);
+    }
+    let large_pool = wallet.reserved_utxos_with_value(large_value);
+    assert_eq!(large_pool.len(), 2, "expected 2 UTXOs of {large_value}");
+    for u in &large_pool {
+        assert_eq!(u.amount, large_value);
+    }
+    // Mismatched value yields nothing.
+    let missing = wallet.reserved_utxos_with_value(Amount::from_btc(0.99).unwrap());
+    assert!(missing.is_empty(), "no UTXOs of unmatched value");
+}
+
+#[tokio::test]
+#[serial]
+async fn sync_prunes_leases_whose_outpoints_have_been_spent() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, general_kp, general_pk) =
+        build_operator_wallet(&bitcoind, 9, 10, 2, Amount::from_btc(0.5).unwrap()).await;
+
+    // Lease one of the general-wallet UTXOs (manually — represents some prior funding tx
+    // we built but haven't broadcast yet). After the chain spends it from elsewhere
+    // (simulated below by broadcasting a tx that consumes it), `sync` should drop the
+    // lease.
+    let general_utxos: Vec<OutPoint> = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .map(|u| u.outpoint)
+        .collect();
+    let target_outpoint = general_utxos[0];
+    wallet.lease(&[target_outpoint]);
+    assert!(wallet.leased_outpoints().contains(&target_outpoint));
+
+    // Spend `target_outpoint` directly via a manually-built tx, broadcast it, mine, sync.
+    let prevout = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .find(|u| u.outpoint == target_outpoint)
+        .expect("prevout found");
+    let fee = Amount::from_sat(2_000);
+    let drain_value = prevout.amount - fee;
+    let drain_script =
+        Address::p2tr(&Secp256k1::new(), general_pk, None, Network::Regtest).script_pubkey();
+    let unsigned_tx = Transaction {
+        version: bdk_wallet::bitcoin::transaction::Version(3),
+        lock_time: bdk_wallet::bitcoin::absolute::LockTime::ZERO,
+        input: vec![bdk_wallet::bitcoin::TxIn {
+            previous_output: target_outpoint,
+            ..Default::default()
+        }],
+        output: vec![bdk_wallet::bitcoin::TxOut {
+            value: drain_value,
+            script_pubkey: drain_script,
+        }],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("from_unsigned_tx");
+    psbt.inputs[0].witness_utxo = Some(bdk_wallet::bitcoin::TxOut {
+        value: prevout.amount,
+        script_pubkey: prevout.script_pubkey.clone(),
+    });
+    let signed = sign_and_finalize(psbt, general_kp);
+    bitcoind
+        .client
+        .send_raw_transaction(&signed)
+        .expect("broadcast");
+    let miner_addr = bitcoind.client.new_address().expect("miner");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine");
+    wallet.sync().await.expect("post-spend sync");
+
+    // Sync should have observed `target_outpoint` as spent and pruned its lease.
+    assert!(
+        !wallet.leased_outpoints().contains(&target_outpoint),
+        "sync must prune lease whose outpoint is now spent on-chain"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn refill_workflow_skips_existing_pool_members() {
+    // The composer documents that callers query existing pool size first, then request
+    // only the delta. Verify that `create_reserved_utxos` doesn't try to re-spend
+    // existing pool members back to themselves (it adds them to the exclude set).
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, general_kp, _) =
+        build_operator_wallet(&bitcoind, 11, 12, 3, Amount::from_btc(0.5).unwrap()).await;
+
+    let utxo_value = Amount::from_btc(0.01).unwrap();
+    let fee_rate = FeeRate::from_sat_per_vb(5).unwrap();
+
+    // First batch: seed the pool with 2 UTXOs.
+    let first = wallet
+        .create_reserved_utxos(fee_rate, utxo_value, 2)
+        .await
+        .expect("first seed");
+    let signed = sign_and_finalize(first.psbt, general_kp);
+    bitcoind
+        .client
+        .send_raw_transaction(&signed)
+        .expect("broadcast first");
+    let miner_addr = bitcoind.client.new_address().expect("miner");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine");
+    wallet.sync().await.expect("sync after first");
+
+    let pool_after_first = wallet.reserved_utxos_with_value(utxo_value);
+    let pool_outpoints_first: BTreeSet<OutPoint> =
+        pool_after_first.iter().map(|u| u.outpoint).collect();
+    assert_eq!(pool_after_first.len(), 2);
+
+    // Refill: ask for 2 more. The composer must NOT spend the existing 2 back to itself.
+    let refill = wallet
+        .create_reserved_utxos(fee_rate, utxo_value, 2)
+        .await
+        .expect("refill");
+    for spent in refill.spent() {
+        assert!(
+            !pool_outpoints_first.contains(&spent),
+            "refill must not spend an existing pool UTXO ({spent})"
+        );
+    }
+    let signed_refill = sign_and_finalize(refill.psbt, general_kp);
+    bitcoind
+        .client
+        .send_raw_transaction(&signed_refill)
+        .expect("broadcast refill");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine refill");
+    wallet.sync().await.expect("sync after refill");
+
+    let pool_after_refill = wallet.reserved_utxos_with_value(utxo_value);
+    assert_eq!(
+        pool_after_refill.len(),
+        4,
+        "pool should now contain the original 2 + the 2 we just added"
+    );
+}

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -1,4 +1,7 @@
-#![allow(unused_crate_dependencies)]
+#![expect(
+    unused_crate_dependencies,
+    reason = "this integration-test binary doesn't reference every dev-dependency declared in Cargo.toml; some are pulled in only by the lib's unit tests or other test targets"
+)]
 //! Crate-level integration tests for `operator-wallet` against a real `bitcoind` regtest
 //! node (via `corepc-node`).
 //!

--- a/functional-tests/tests/fulfillment/fn_fulfillment_idempotency_test.py
+++ b/functional-tests/tests/fulfillment/fn_fulfillment_idempotency_test.py
@@ -160,6 +160,14 @@ class FulfillmentIdempotencyTest(StrataTestBase):
         )
         self.logger.info("Verified fulfillment tx is unconfirmed before restart")
 
+        # Stop the assignee operator BEFORE touching the mempool. A running operator's tx-driver
+        # rebroadcasts the pending fulfillment tx the moment bitcoind restarts, which would race
+        # the "mempool is empty" assertion below. Snapshot its log offset first so the
+        # post-restart resubmission is still captured.
+        restart_log_offsets = snapshot_log_offsets([assignee_logfile])
+        self.logger.info(f"Stopping assigned operator-{assignee_idx} before clearing mempool")
+        bridge_nodes[assignee_idx].stop()
+
         # Clear mempool by deleting mempool.dat
         self.logger.info("Clearing mempool by deleting mempool.dat...")
         logfile_path = bitcoind_service.stdout
@@ -197,12 +205,8 @@ class FulfillmentIdempotencyTest(StrataTestBase):
         assert utxo_status is not None, "Deposit UTXO should still be unspent"
         self.logger.info("Confirmed deposit UTXO is still unspent")
 
-        # --- Restart operator and capture resubmitted fulfillment ---
-        # Capture log offset before restart to catch all post-restart logs
-        restart_log_offsets = snapshot_log_offsets([assignee_logfile])
-
+        # --- Restart the (already-stopped) operator and capture resubmitted fulfillment ---
         self.logger.info(f"Restarting assigned operator-{assignee_idx}")
-        bridge_nodes[assignee_idx].stop()
         bridge_nodes[assignee_idx].start()
         wait_until_bridge_ready(bridge_rpcs[assignee_idx])
         self.logger.info(f"Operator-{assignee_idx} restarted and ready")


### PR DESCRIPTION
**Stacked on #559** (`azz/str-3426-drop-bdk-wallet-leak`). Will rebase onto main when #559 merges. **Closes STR-3435 and supersedes STR-3436** (combined into this single PR — see the ticket update for context).

## Summary

Reshapes the operator wallet around a **composition model**:

- A small `GeneralWallet` trait covering only what genuinely differs between backends (UTXO discovery, funding, signing).
- A concrete `OperatorWallet<G: GeneralWallet>` composer holding the always-native reserved wallet, lease bookkeeping, anchor filtering, and cross-wallet transaction construction.

The original `OperatorWalletBackend` design covered everything (general + reserved + leasing + signing) on one trait. That breaks down for Fireblocks because Fireblocks only hosts the general wallet — the reserved wallet stays native, and lease management is identical between backends. The composition design puts only the differing surface on a trait; everything shared lives on the composer.

## What's in this PR

- `crates/operator-wallet/src/general.rs` — `GeneralWallet` trait + `FundedPsbt` + `UtxoInfo`. Methods use AFIT desugared to `impl Future + Send` for codebase consistency.
- `crates/operator-wallet/src/general/native.rs` — `NativeGeneralWallet`, BDK-backed, descriptor-only. All returned PSBTs have `witness_utxo` populated but no signatures — caller signs via secret-service.
- `crates/operator-wallet/src/lib.rs` — `OperatorWallet<G>` composer with all the high-level wallet operations.
- `crates/operator-wallet/src/sync.rs` — `Backend::sync_wallet` no longer takes a lease set; the composer prunes leases after sync by intersecting with the live UTXO set.
- `crates/bridge-exec/src/{deposit,stake/staking,graph/common,graph/counterproof_nack}.rs` — call sites updated.
- `crates/bridge-exec/src/output_handles.rs` — `NativeWallet` type alias = `OperatorWallet<NativeGeneralWallet>`. `Arc<RwLock<_>>` preserved so executors can hold multi-step critical sections.
- `bin/strata-bridge/src/mode/services/{operator_wallet,orchestrator}.rs` — construct `OperatorWallet<NativeGeneralWallet>` at startup.

## What's deferred

- `NativeGeneralWallet::build_cpfp_child` returns `CpfpChildNotImplemented`. **STR-3439** (CPFP wiring in tx-driver) fills the body once there's an integration path to exercise it.
- Fireblocks `GeneralWallet` impl — **STR-3437**.

## CPFP-child contract (for forward reference)

- Native impl: PSBT returned with both inputs unsigned, `witness_utxo` + `tap_internal_key` populated. Caller signs both via secret-service.
- Fireblocks impl (forthcoming): PSBT returned with anchor unsigned, funding input ECDSA-signed by Fireblocks. Caller signs anchor via secret-service.

## Test plan

- [x] `just lint` passes
- [x] `cargo check --workspace --tests --all-features` passes
- [ ] Functional tests (recommend running before merge given the executor API changes)
- [ ] `NativeGeneralWallet::build_cpfp_child` will be exercised by STR-3439's regression test

Closes STR-3435.
Supersedes STR-3436.