### PR TITLE
feat(bridge-exec): introduce FeeSource trait with BitcoinCore + MempoolExplorer policies (STR-3438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155a5a185e42c6b77ac7b88a15143d930a9e9727a5b7b77eed417404ab15c247"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,6 +3682,24 @@ dependencies = [
  "data-encoding",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deepsize2"
@@ -11684,6 +11712,7 @@ name = "strata-bridge-exec"
 version = "0.1.0"
 dependencies = [
  "algebra",
+ "async-trait",
  "bdk_bitcoind_rpc",
  "bdk_wallet",
  "bitcoin",
@@ -11698,6 +11727,7 @@ dependencies = [
  "metrics",
  "musig2",
  "operator-wallet",
+ "reqwest 0.12.28",
  "secret-service-client",
  "secret-service-proto",
  "serde",
@@ -11726,7 +11756,10 @@ dependencies = [
  "terrors",
  "thiserror 2.0.18",
  "tokio",
+ "toml 0.8.23",
  "tracing",
+ "url",
+ "wiremock",
  "zkaleido",
  "zkaleido-sp1-groth16-verifier",
 ]
@@ -14134,6 +14167,29 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if 1.0.4",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,8 @@ toml = "0.8.20"
 tower = "0.5.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+url = { version = "2.5", features = ["serde"] }
+wiremock = "0.6"
 zeroize = { version = "1.8.2", features = ["derive"] }
 
 [patch.crates-io]

--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use strata_bridge_asm_events::config::AsmRpcConfig;
 pub(crate) use strata_bridge_counterproof::ProofBackendConfig as CounterproofBackendConfig;
 use strata_bridge_db::fdb::cfg::Config as FdbConfig;
+use strata_bridge_exec::fees::FeeSourceConfig;
 use strata_bridge_p2p_service::GossipsubScoringPreset;
 pub(crate) use strata_bridge_proof::ProofBackendConfig;
 
@@ -74,6 +75,12 @@ pub(crate) struct Config {
     /// reaction to fee-market moves between blocks.
     #[serde(default = "default_cpfp_bump_check_interval")]
     pub cpfp_bump_check_interval: Duration,
+
+    /// Source of fee-rate estimates for bridge transactions. Defaults to Bitcoin Core with
+    /// `conf_target = 1`; operators on networks where `estimatesmartfee` is unreliable should
+    /// configure the mempool-explorer variant.
+    #[serde(default)]
+    pub fee_source: FeeSourceConfig,
 
     /// Configuration required to connector to a _local_ instance of the secret service server.
     pub secret_service_client: SecretServiceConfig,

--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -15,6 +15,16 @@ const fn default_cpfp_bump_check_interval() -> Duration {
     Duration::from_secs(30)
 }
 
+/// Default CPFP fee premium (percent) — see [`Config::cpfp_fee_premium_percent`].
+const fn default_cpfp_fee_premium_percent() -> u32 {
+    5
+}
+
+/// Default CPFP package fee floor (sats/vbyte) — see [`Config::cpfp_min_package_fee_rate`].
+const fn default_cpfp_min_package_fee_rate() -> u64 {
+    10
+}
+
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 use strata_bridge_asm_events::config::AsmRpcConfig;
@@ -61,6 +71,20 @@ pub(crate) struct Config {
 
     /// The maximum fee rate for any transaction (in sats/vb).
     pub max_fee_rate: u64,
+
+    /// Premium applied on top of the next-block fee estimate when pricing a CPFP bump target,
+    /// as a percentage of the estimate (e.g. `5` = +5%). Rounded up, so the premium raises
+    /// the target and never lowers it. `0` prices the child at the raw estimate. Default 5,
+    /// per the product fee decision.
+    #[serde(default = "default_cpfp_fee_premium_percent")]
+    pub cpfp_fee_premium_percent: u32,
+
+    /// Floor (in sats/vb) on the package fee rate the CPFP ladder targets. The child pays
+    /// the package shortfall, so the package always lands at or above this value.
+    /// Default 10, per the product fee decision. Must not exceed `max_fee_rate`.
+    /// The startup checks reject a floor above the cap.
+    #[serde(default = "default_cpfp_min_package_fee_rate")]
+    pub cpfp_min_package_fee_rate: u64,
 
     /// Background-refresh cadence for the cached fee rate. The bridge spawns a tokio task at
     /// startup that polls the configured fee source at this interval and stores the result in

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -22,8 +22,8 @@ use strata_bridge_db::fdb::client::FdbClient;
 use strata_bridge_exec::{
     config::ExecutionConfig,
     cpfp_adapters::{
-        BitcoindCpfpFeeSource, BitcoindCpfpMempool, OperatorWalletCpfpAdapter,
-        build_anchor_input_signer, build_multi_anchor_signer, build_wallet_input_signer,
+        BitcoindCpfpMempool, OperatorWalletCpfpAdapter, build_anchor_input_signer,
+        build_multi_anchor_signer, build_wallet_input_signer,
     },
     output_handles::OutputHandles,
 };
@@ -173,12 +173,6 @@ where
         pending_asm_events: VecDeque::new(),
     };
 
-    let exec_cfg = build_exec_config(params, config, &sm_config, claim_funding_utxo_value);
-
-    // CPFP wiring: build the cached fee-source over a bitcoind-backed estimator, then bundle
-    // the wallet / fee-source / package-submitter / anchor-signer adapters into a
-    // `CpfpContext`. The tx-driver consumes this in its bump loop.
-    //
     // Validate both Duration knobs up-front — `tokio::time::interval` panics if `period` is
     // zero, and the panic would surface deep inside `CachedFeeSource::spawn` /
     // `TxDriver::with_cpfp` as a cryptic task crash. Fail at orchestrator startup with a
@@ -195,13 +189,35 @@ where
             config.cpfp_bump_check_interval
         ));
     }
+
     let btc_rpc_arc = Arc::new(btc_rpc_client.clone());
-    let bitcoind_fee_source = Arc::new(BitcoindCpfpFeeSource::new(btc_rpc_arc.clone(), 1));
+
+    // Build the configured fee source and wrap it once in a background-refreshed cache. That one
+    // cache is shared by the executors (per-tx-build estimates via `CachedFeeSource::current`) and
+    // the CPFP bump loop below, so neither hits the network on its hot path. Built up-front so a
+    // misconfigured fee source fails fast at boot rather than on the first duty firing.
+    let live_fee_source = config
+        .fee_source
+        .clone()
+        .build(btc_rpc_arc.clone())
+        .map_err(|e| anyhow!("failed to construct fee source from config: {e}"))?;
     let cached_fee_source = Arc::new(
-        CachedFeeSource::spawn(bitcoind_fee_source, config.fee_refresh_interval)
+        CachedFeeSource::spawn(Arc::new(live_fee_source), config.fee_refresh_interval)
             .await
             .map_err(|e| anyhow!("failed to initialize cached fee source: {e}"))?,
     );
+
+    let exec_cfg = build_exec_config(
+        params,
+        config,
+        &sm_config,
+        claim_funding_utxo_value,
+        cached_fee_source.clone(),
+    );
+
+    // CPFP wiring: bundle the wallet / shared fee-source / package-submitter / anchor-signer
+    // adapters into a `CpfpContext` the tx-driver consumes in its bump loop.
+    //
     // Fetch the operator's pubkeys up-front: needed both for the CPFP adapter
     // (`operator_general_pubkey` is used as the foreign-UTXO `tap_internal_key` for
     // `ParentTxCombined` strategies) and for `OutputHandles` (anchor inference key + caveat
@@ -486,6 +502,7 @@ fn build_exec_config(
     config: &Config,
     sm_config: &SMConfig,
     claim_funding_utxo_value: bitcoin::Amount,
+    fee_source: Arc<CachedFeeSource>,
 ) -> ExecutionConfig {
     ExecutionConfig {
         network: params.network,
@@ -497,5 +514,6 @@ fn build_exec_config(
         claim_funding_utxo_value,
         funding_uxto_pool_size: config.operator_wallet.claim_funding_pool_size,
         graph_sm_cfg: sm_config.graph.clone(),
+        fee_source,
     }
 }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -335,6 +335,11 @@ where
         multi_anchor_signer,
         wallet_input_signer,
         max_fee_rate: exec_cfg.maximum_fee_rate,
+        // Fee knobs are consumer policy on the CPFP path only; wallet-funded transactions
+        // price from `wallet_tx_fee_rate` and never touch them.
+        fee_premium_percent: config.cpfp_fee_premium_percent,
+        min_package_fee_rate: FeeRate::from_sat_per_vb(config.cpfp_min_package_fee_rate)
+            .expect("validated at startup: cpfp_min_package_fee_rate is a valid fee rate"),
         mempool: cpfp_submitter,
     };
     let tx_driver = TxDriver::with_cpfp(

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -193,7 +193,8 @@ where
     let btc_rpc_arc = Arc::new(btc_rpc_client.clone());
 
     // Build the configured fee source and wrap it once in a background-refreshed cache. That one
-    // cache is shared by the executors (per-tx-build estimates via `CachedFeeSource::current`) and
+    // cache is shared by the executors (per-tx-build estimates via `CachedFeeSource::try_current`,
+    // which aborts duty pricing when the cache is stale) and
     // the CPFP bump loop below, so neither hits the network on its hot path. Built up-front so a
     // misconfigured fee source fails fast at boot rather than on the first duty firing.
     let live_fee_source = config

--- a/bin/strata-bridge/src/mode/services/startup_checks.rs
+++ b/bin/strata-bridge/src/mode/services/startup_checks.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 use algebra::retry::{Strategy, retry_with};
 use anyhow::{Context, Result, anyhow};
-use bitcoin::Amount;
+use bitcoin::{Amount, FeeRate};
 use jsonrpsee::http_client::HttpClient;
 use mosaic_rpc_api::MosaicRpcClient;
 use mosaic_rpc_types::RpcCircuitInfoEntry;
@@ -29,6 +29,8 @@ pub(in crate::mode) async fn verify(
     bridge_proof_host: &BridgeProofHost,
     counterproof_host: &BridgeCounterproofHost,
 ) -> Result<()> {
+    verify_cpfp_fee_config(config)?;
+
     verify_predicates(params, bridge_proof_host, counterproof_host)?;
 
     let asm_params = fetch_asm_params(asm_rpc_client, &config.asm_rpc)
@@ -41,6 +43,33 @@ pub(in crate::mode) async fn verify(
         .context("fetching Mosaic circuit definitions for startup consistency check")?;
     verify_mosaic_vkey(counterproof_host.vkey_hash(), &circuit_defs)
         .context("bridge/Mosaic counterproof vkey mismatch")?;
+    Ok(())
+}
+
+/// The CPFP fee knobs must not contradict each other: a package floor above the cap would
+/// clamp every bump to the cap and the operator's two settings would fight. Checked at
+/// startup so the mismatch aborts the node instead of surfacing as a warn on every bump.
+fn verify_cpfp_fee_config(config: &Config) -> Result<()> {
+    let cap = FeeRate::from_sat_per_vb(config.max_fee_rate).ok_or_else(|| {
+        anyhow!(
+            "max_fee_rate = {} sat/vB is not a valid fee rate",
+            config.max_fee_rate
+        )
+    })?;
+    let floor = FeeRate::from_sat_per_vb(config.cpfp_min_package_fee_rate).ok_or_else(|| {
+        anyhow!(
+            "cpfp_min_package_fee_rate = {} sat/vB is not a valid fee rate",
+            config.cpfp_min_package_fee_rate
+        )
+    })?;
+    if floor > cap {
+        anyhow::bail!(
+            "cpfp_min_package_fee_rate = {} sat/vB exceeds max_fee_rate = {} sat/vB; \
+             the floor would clamp every CPFP bump to the cap",
+            config.cpfp_min_package_fee_rate,
+            config.max_fee_rate
+        );
+    }
     Ok(())
 }
 

--- a/crates/bridge-exec/Cargo.toml
+++ b/crates/bridge-exec/Cargo.toml
@@ -35,6 +35,7 @@ strata-mosaic-client-api.workspace = true
 zkaleido.workspace = true
 zkaleido-sp1-groth16-verifier = { workspace = true, optional = true }
 
+async-trait.workspace = true
 bdk_wallet.workspace = true
 bitcoin.workspace = true
 bitcoin-bosd = { workspace = true, features = ["address"] }
@@ -45,13 +46,15 @@ futures.workspace = true
 jsonrpsee = { workspace = true, features = ["client"] }
 metrics.workspace = true
 musig2.workspace = true
-serde.workspace = true
+reqwest.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 ssz.workspace = true
 terrors.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 strata-bridge-test-utils.workspace = true
@@ -59,6 +62,9 @@ strata-bridge-test-utils.workspace = true
 bdk_bitcoind_rpc.workspace = true
 corepc-node.workspace = true
 serial_test.workspace = true
+tokio = { workspace = true, features = ["test-util", "macros"] }
+toml.workspace = true
+wiremock.workspace = true
 
 [features]
 default = []

--- a/crates/bridge-exec/src/config.rs
+++ b/crates/bridge-exec/src/config.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use bitcoin::{Amount, FeeRate, Network};
+use btc_tracker::cpfp::CachedFeeSource;
 use strata_bridge_sm::graph::config::GraphSMCfg;
 use strata_l1_txfmt::MagicBytes;
 
@@ -42,4 +43,9 @@ pub struct ExecutionConfig {
     /// The graph state-machine configuration, shared with the GSM to keep protocol parameters
     /// and static keys consistent across graph construction paths.
     pub graph_sm_cfg: Arc<GraphSMCfg>,
+
+    /// Background-refreshed fee-rate cache shared with the tx-driver's CPFP bump loop. Executors
+    /// read the current cached rate via [`CachedFeeSource::current`] per tx-build (no network I/O
+    /// on the hot path); the cache is refreshed by a background task at the configured interval.
+    pub fee_source: Arc<CachedFeeSource>,
 }

--- a/crates/bridge-exec/src/config.rs
+++ b/crates/bridge-exec/src/config.rs
@@ -44,8 +44,10 @@ pub struct ExecutionConfig {
     /// and static keys consistent across graph construction paths.
     pub graph_sm_cfg: Arc<GraphSMCfg>,
 
-    /// Background-refreshed fee-rate cache shared with the tx-driver's CPFP bump loop. Executors
-    /// read the current cached rate via [`CachedFeeSource::current`] per tx-build (no network I/O
-    /// on the hot path); the cache is refreshed by a background task at the configured interval.
+    /// Background-refreshed fee-rate cache shared with the tx-driver's CPFP bump loop.
+    /// Executors read the cached rate via [`CachedFeeSource::try_current`] per tx-build —
+    /// no network I/O on the hot path, and a stale cache aborts the duty, which retries
+    /// after the source recovers. A background task refreshes the cache at the configured
+    /// interval.
     pub fee_source: Arc<CachedFeeSource>,
 }

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -1,9 +1,10 @@
 //! Bridge-side implementations of the [`btc_tracker::cpfp`] traits.
 //!
-//! `btc-tracker` defines [`CpfpWallet`], [`CpfpFeeSource`], and [`CpfpMempool`] as
-//! abstract interfaces so the crate stays at the bottom of the dependency graph. The concrete
-//! adapters that wire those traits to the bridge's actual wallet, fee source, and Bitcoin Core
-//! client live here.
+//! `btc-tracker` defines [`CpfpWallet`], `CpfpFeeSource`, and [`CpfpMempool`] as abstract
+//! interfaces so the crate stays at the bottom of the dependency graph. The concrete adapters
+//! that wire those traits to the bridge's actual wallet and Bitcoin Core client live here; the
+//! fee source itself is built in `bridge-exec::fees` and wrapped in
+//! `btc_tracker::cpfp::CachedFeeSource`.
 
 use std::sync::Arc;
 
@@ -12,12 +13,11 @@ use bitcoin::{
     secp256k1::{Message, schnorr::Signature},
     taproot::{ControlBlock, LeafVersion},
 };
-use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
+use bitcoind_async_client::Client as BitcoinClient;
 use btc_tracker::{
     cpfp::{
-        AnchorSpendState, ChildPsbt, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet,
-        CpfpWalletError, FeeSourceError, FundingLease, InputSignFut, InputSigner, MempoolError,
-        SignerError, WalletFundedPsbt,
+        AnchorSpendState, ChildPsbt, CpfpMempool, CpfpStrategy, CpfpWallet, CpfpWalletError,
+        FundingLease, InputSignFut, InputSigner, MempoolError, SignerError, WalletFundedPsbt,
     },
     submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
 };
@@ -187,49 +187,6 @@ impl CpfpWallet for OperatorWalletCpfpAdapter {
                 psbt,
                 lease: Arc::new(WalletFundingLease(lease)),
             })
-        }
-    }
-}
-
-/// [`CpfpFeeSource`] backed by `bitcoind`'s `estimatesmartfee`.
-///
-/// Floors the result at 1 sat/vB. `estimatesmartfee` reports no rate at all when it has too
-/// little data to work with (a fresh regtest, an early signet), and can report below min-relay
-/// on a quiet network — either way the bump loop must not target a rate that would leave the
-/// package unrelayable.
-#[derive(Debug)]
-pub struct BitcoindCpfpFeeSource {
-    client: Arc<BitcoinClient>,
-    conf_target: u16,
-}
-
-impl BitcoindCpfpFeeSource {
-    /// Constructs a fee source that polls `client.estimate_smart_fee(conf_target)` each call.
-    pub const fn new(client: Arc<BitcoinClient>, conf_target: u16) -> Self {
-        Self {
-            client,
-            conf_target,
-        }
-    }
-}
-
-impl CpfpFeeSource for BitcoindCpfpFeeSource {
-    fn estimate(
-        &self,
-    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
-        let client = self.client.clone();
-        let conf_target = self.conf_target;
-        async move {
-            let smart_fee = client
-                .estimate_smart_fee(conf_target)
-                .await
-                .map_err(|e| FeeSourceError(format!("estimate_smart_fee: {e:?}")))?;
-            // `estimatesmartfee` reports no `fee_rate` when it has insufficient data (fresh
-            // regtest, early signet); floor at 1 sat/vB in that case and whenever the node
-            // reports something below it, so the bump loop never targets a rate that would
-            // leave the package below min-relay.
-            let floor = FeeRate::from_sat_per_vb(1).expect("1 sat/vB is always a valid FeeRate");
-            Ok(smart_fee.fee_rate.unwrap_or(floor).max(floor))
         }
     }
 }

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -25,11 +25,8 @@ use strata_bridge_primitives::{
     types::{BitcoinBlockHeight, DepositIdx, GraphIdx, OperatorIdx},
 };
 use strata_bridge_sm::deposit::duties::{DepositDuty, NagDuty};
-use strata_bridge_tx_graph::{
-    fee,
-    transactions::prelude::{
-        CooperativePayoutTx, SweepTx, WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
-    },
+use strata_bridge_tx_graph::transactions::prelude::{
+    CooperativePayoutTx, SweepTx, WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
 };
 use tracing::{error, info, warn};
 
@@ -37,6 +34,7 @@ use crate::{
     chain::{self, CpfpKind, is_txid_onchain, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
+    fees::wallet_tx_fee_rate,
     output_handles::OutputHandles,
 };
 
@@ -505,41 +503,19 @@ async fn fulfill_withdrawal(
         .checked_sub(cfg.operator_fee)
         .expect("deposit amount must be greater than operator fee");
 
-    // Get fee rate estimate from bitcoind, bounded from below by `fee::FEE_RATE` so the
-    // withdrawal-fulfillment v3 transaction always meets the bridge's hardcoded minimum even
-    // on networks where `estimatesmartfee` returns a value below `minrelaytxfee`.
-    let smart_fee = output_handles
-        .bitcoind_rpc_client
-        .estimate_smart_fee(1)
-        .await
-        .map_err(|e| ExecutorError::WalletErr(format!("failed to estimate fee: {e}")))?;
-    info!(?smart_fee, "estimated fee rate for withdrawal fulfillment");
-
-    let fee_rate = smart_fee
-        .fee_rate
-        .unwrap_or(fee::FEE_RATE)
-        .max(fee::FEE_RATE);
-
-    // The following approach trades off maximal liveness for maximal safety:
-    // It is not safe to broadcast at a lower fee rate when the network fee rate is high as there is
-    // a chance that the fulfillment transaction will be settled after a reassignment, causing an
-    // operator to lose funds. The safest approach is to abort.
-    if fee_rate > cfg.maximum_fee_rate {
-        return Err(ExecutorError::FeeRateTooHigh {
-            fee_rate,
-            max: cfg.maximum_fee_rate,
-        });
-    }
-
-    // Check if fee rate exceeds maximum configured rate
-    if fee_rate > cfg.maximum_fee_rate {
-        warn!(
-            %fee_rate,
-            maximum_fee_rate = %cfg.maximum_fee_rate,
-            "fee rate exceeds maximum, skipping fulfillment"
-        );
-        return Ok(());
-    }
+    // Price from the shared cached fee source, floored at `MIN_WALLET_TX_FEE_RATE` so the
+    // withdrawal-fulfillment v3 transaction stays relayable. The network-backed sources clamp
+    // their reports to the ≥1 sat/vB truncation guard (`FixedFeeSource` returns its rate
+    // verbatim); the helper's floor is the higher bridge-policy minimum either way.
+    //
+    // A rate above `maximum_fee_rate` rejects with `FeeRateTooHigh`, trading liveness for
+    // safety: broadcasting at a capped-down rate risks the fulfillment settling after a
+    // reassignment, costing the operator funds. The error keeps the duty failure visible in
+    // observability, matching how `stake::staking::estimate_funding_fee_rate` surfaces the
+    // same condition; the duty dispatcher retries, and if the fee market stays above the cap
+    // the operator notices via the error log instead of a silent skip.
+    let fee_rate = wallet_tx_fee_rate(&cfg.fee_source, cfg.maximum_fee_rate)?;
+    info!(%fee_rate, "fee rate for withdrawal fulfillment");
 
     info!(%deposit_idx, "pre-conditions satisfied, attempting to fulfill withdrawal request");
 

--- a/crates/bridge-exec/src/errors.rs
+++ b/crates/bridge-exec/src/errors.rs
@@ -89,6 +89,11 @@ pub enum ExecutorError {
         /// The maximum fee rate allowed by the configuration.
         max: FeeRate,
     },
+
+    /// The cached fee rate is older than its staleness bound, so duty pricing refuses it.
+    /// The duty retries after the fee source recovers.
+    #[error("fee source stale: {0}")]
+    FeeSourceStale(#[from] btc_tracker::cpfp::StaleFeeRate),
 }
 
 impl From<OneOf<(FdbBindingError, LayerError)>> for ExecutorError {

--- a/crates/bridge-exec/src/fees.rs
+++ b/crates/bridge-exec/src/fees.rs
@@ -80,6 +80,14 @@ pub enum FeeSourceError {
     /// The configured mempool explorer URL is malformed.
     #[error("invalid mempool explorer url: {0}")]
     InvalidConfig(String),
+    /// A configured confirmation target is outside Bitcoin Core's accepted `1..=1008` range.
+    #[error("{field} = {target} is outside Bitcoin Core's estimatesmartfee range (1..=1008)")]
+    InvalidConfTarget {
+        /// Which config field carried the bad value.
+        field: &'static str,
+        /// The rejected value.
+        target: u16,
+    },
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -99,6 +107,10 @@ pub struct BitcoindFeeSource<R> {
 
 impl<R: FeeRateRpc> BitcoindFeeSource<R> {
     /// Creates a new source that queries `estimatesmartfee(conf_target)` on `client`.
+    ///
+    /// `conf_target` must be in `1..=1008` (Bitcoin Core rejects everything else).
+    /// [`FeeSourceConfig::build`] validates before it constructs; a direct caller owns
+    /// that check itself.
     pub const fn new(client: Arc<R>, conf_target: u16) -> Self {
         Self {
             client,
@@ -349,6 +361,25 @@ pub enum FeeSourceConfig {
     },
 }
 
+/// Bitcoin Core rejects `estimatesmartfee` confirmation targets outside `1..=1008`.
+const MAX_CONF_TARGET: u16 = 1008;
+
+/// Rejects a confirmation target that Bitcoin Core's `estimatesmartfee` will refuse.
+///
+/// The two variants fail at very different times without this check. `BitcoinCore` fails at
+/// boot — the cached source's first synchronous refresh propagates the RPC error and the
+/// orchestrator aborts, with a cryptic message. `MempoolExplorer` is the dangerous one: a
+/// working explorer masks a broken `fallback_conf_target` entirely, every later refresh
+/// through the fallback fails, and the cache serves the last explorer quote forever — the
+/// misconfiguration surfaces on the day the fallback is first needed, which is the worst
+/// possible time to discover it.
+const fn validate_conf_target(target: u16, field: &'static str) -> Result<(), FeeSourceError> {
+    if target == 0 || target > MAX_CONF_TARGET {
+        return Err(FeeSourceError::InvalidConfTarget { field, target });
+    }
+    Ok(())
+}
+
 impl FeeSourceConfig {
     /// Constructs the configured [`CpfpFeeSource`] from this config + a Bitcoin Core RPC client.
     ///
@@ -359,14 +390,19 @@ impl FeeSourceConfig {
         R: FeeRateRpc + 'static,
     {
         match self {
-            Self::BitcoinCore { conf_target } => Ok(ConfiguredFeeSource::Bitcoind(
-                BitcoindFeeSource::new(bitcoind, conf_target),
-            )),
+            Self::BitcoinCore { conf_target } => {
+                validate_conf_target(conf_target, "conf_target")?;
+                Ok(ConfiguredFeeSource::Bitcoind(BitcoindFeeSource::new(
+                    bitcoind,
+                    conf_target,
+                )))
+            }
             Self::MempoolExplorer {
                 base_url,
                 policy,
                 fallback_conf_target,
             } => {
+                validate_conf_target(fallback_conf_target, "fallback_conf_target")?;
                 let fallback = BitcoindFeeSource::new(bitcoind, fallback_conf_target);
                 Ok(ConfiguredFeeSource::Mempool(MempoolExplorerFeeSource::new(
                     base_url, policy, fallback,
@@ -434,7 +470,10 @@ pub(crate) fn wallet_tx_fee_rate(
     fee_source: &CachedFeeSource,
     maximum_fee_rate: FeeRate,
 ) -> Result<FeeRate, ExecutorError> {
-    let fee_rate = fee_source.current().max(MIN_WALLET_TX_FEE_RATE);
+    // `try_current`, not `current`: a duty that prices from a frozen quote broadcasts at
+    // whatever the market was when the source died. The error aborts the duty, and the
+    // retry succeeds after the source recovers.
+    let fee_rate = fee_source.try_current()?.max(MIN_WALLET_TX_FEE_RATE);
     if fee_rate > maximum_fee_rate {
         return Err(ExecutorError::FeeRateTooHigh {
             fee_rate,
@@ -725,6 +764,66 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// An out-of-range `fallback_conf_target` must fail at build time, not on the day the
+    /// fallback is first exercised. A working explorer masks the broken fallback entirely:
+    /// every later refresh through it fails, the cache serves the last explorer quote
+    /// forever, and the operator learns about the typo during the outage the fallback
+    /// existed for.
+    #[test]
+    fn build_rejects_out_of_range_conf_targets() {
+        for bad in [0u16, 1009] {
+            let cfg = FeeSourceConfig::MempoolExplorer {
+                base_url: "https://mempool.space".parse().unwrap(),
+                policy: MempoolFeePolicy::Fastest,
+                fallback_conf_target: bad,
+            };
+            let err = cfg.build(Arc::new(MockFeeRateRpc::returning(1)));
+            assert!(
+                matches!(
+                    err,
+                    Err(FeeSourceError::InvalidConfTarget {
+                        field: "fallback_conf_target",
+                        target,
+                    }) if target == bad
+                ),
+                "fallback_conf_target = {bad} must be rejected at build"
+            );
+
+            let cfg = FeeSourceConfig::BitcoinCore { conf_target: bad };
+            let err = cfg.build(Arc::new(MockFeeRateRpc::returning(1)));
+            assert!(
+                matches!(
+                    err,
+                    Err(FeeSourceError::InvalidConfTarget {
+                        field: "conf_target",
+                        target,
+                    }) if target == bad
+                ),
+                "conf_target = {bad} must be rejected at build"
+            );
+        }
+
+        // The range boundaries themselves are valid, for both variants.
+        for good in [1u16, 1008] {
+            assert!(
+                FeeSourceConfig::BitcoinCore { conf_target: good }
+                    .build(Arc::new(MockFeeRateRpc::returning(1)))
+                    .is_ok(),
+                "conf_target = {good} must build"
+            );
+            assert!(
+                FeeSourceConfig::MempoolExplorer {
+                    base_url: "https://mempool.space".parse().unwrap(),
+                    policy: MempoolFeePolicy::Fastest,
+                    fallback_conf_target: good,
+                }
+                .build(Arc::new(MockFeeRateRpc::returning(1)))
+                .is_ok(),
+                "fallback_conf_target = {good} must build"
+            );
+        }
     }
 
     #[test]

--- a/crates/bridge-exec/src/fees.rs
+++ b/crates/bridge-exec/src/fees.rs
@@ -29,7 +29,9 @@ use std::{
 use async_trait::async_trait;
 use bitcoin::FeeRate;
 use bitcoind_async_client::{ClientResult, traits::Reader};
-use btc_tracker::cpfp::{CachedFeeSource, CpfpFeeSource, FeeSourceError as CpfpFeeSourceError};
+use btc_tracker::cpfp::{
+    CachedFeeSource, CpfpFeeSource, FeeSourceError as CpfpFeeSourceError, FeeTarget, TargetRates,
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
@@ -111,19 +113,25 @@ impl<R: FeeRateRpc> BitcoindFeeSource<R> {
     /// `conf_target` must be in `1..=1008` (Bitcoin Core rejects everything else).
     /// [`FeeSourceConfig::build`] validates before it constructs; a direct caller owns
     /// that check itself.
+    ///
+    /// `conf_target` controls the [`FeeTarget::Standard`] slot only; the
+    /// [`FeeTarget::NextBlock`] slot always queries `estimatesmartfee(1)`.
     pub const fn new(client: Arc<R>, conf_target: u16) -> Self {
         Self {
             client,
             conf_target,
         }
     }
-}
 
-impl<R: FeeRateRpc> CpfpFeeSource for BitcoindFeeSource<R> {
-    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+    /// One `estimatesmartfee` round trip for `target`, floored at [`MIN_SOURCE_FEE_RATE`].
+    async fn estimate_target(&self, target: FeeTarget) -> Result<FeeRate, CpfpFeeSourceError> {
+        let conf_target = match target {
+            FeeTarget::Standard => self.conf_target,
+            FeeTarget::NextBlock => 1,
+        };
         let rate = self
             .client
-            .estimate_smart_fee(self.conf_target)
+            .estimate_smart_fee(conf_target)
             .await
             .map_err(|e| CpfpFeeSourceError(FeeSourceError::Bitcoind(e).to_string()))?;
         let rate = match rate {
@@ -136,13 +144,34 @@ impl<R: FeeRateRpc> CpfpFeeSource for BitcoindFeeSource<R> {
                 // misconfigured node is indistinguishable from a genuinely calm mempool,
                 // and every bump quietly targets the minimum forever.
                 warn!(
-                    conf_target = self.conf_target,
+                    conf_target,
                     "estimatesmartfee returned no estimate; falling back to the floor fee rate"
                 );
                 MIN_SOURCE_FEE_RATE
             }
         };
         Ok(rate.max(MIN_SOURCE_FEE_RATE))
+    }
+}
+
+impl<R: FeeRateRpc> CpfpFeeSource for BitcoindFeeSource<R> {
+    async fn estimate(&self, target: FeeTarget) -> Result<FeeRate, CpfpFeeSourceError> {
+        self.estimate_target(target).await
+    }
+
+    async fn estimate_all(&self) -> Result<TargetRates, CpfpFeeSourceError> {
+        // Dedupe when the configured standard tier is already the next-block tier:
+        // two `estimatesmartfee(1)` round trips would buy one answer.
+        let next_block = self.estimate_target(FeeTarget::NextBlock).await?;
+        let standard = if self.conf_target == 1 {
+            next_block
+        } else {
+            self.estimate_target(FeeTarget::Standard).await?
+        };
+        Ok(TargetRates {
+            standard,
+            next_block,
+        })
     }
 }
 
@@ -227,6 +256,9 @@ impl<R: FeeRateRpc> MempoolExplorerFeeSource<R> {
     /// indicated by `policy`. `base_url` is e.g. `https://mempool.space/signet` or
     /// `https://mempool.space` for mainnet.
     ///
+    /// `policy` controls the [`FeeTarget::Standard`] slot only; the
+    /// [`FeeTarget::NextBlock`] slot always selects the fastest tier.
+    ///
     /// Returns an error if `base_url` is malformed enough that we cannot construct the
     /// recommended-fees URL from it.
     pub fn new(
@@ -251,6 +283,15 @@ impl<R: FeeRateRpc> MempoolExplorerFeeSource<R> {
         })
     }
 
+    /// Maps a [`FeeTarget`] onto the explorer tier it consumes. Next-block is always the
+    /// endpoint's `fastestFee` tier, whatever the configured policy is.
+    const fn tier_for(target: FeeTarget, configured: MempoolFeePolicy) -> MempoolFeePolicy {
+        match target {
+            FeeTarget::Standard => configured,
+            FeeTarget::NextBlock => MempoolFeePolicy::Fastest,
+        }
+    }
+
     async fn fetch_recommended(&self) -> Result<RecommendedFees, FeeSourceError> {
         let response = SHARED_HTTP_CLIENT
             .get(self.recommended_fees_url.clone())
@@ -267,12 +308,32 @@ impl<R: FeeRateRpc> MempoolExplorerFeeSource<R> {
 }
 
 impl<R: FeeRateRpc> CpfpFeeSource for MempoolExplorerFeeSource<R> {
-    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+    async fn estimate(&self, target: FeeTarget) -> Result<FeeRate, CpfpFeeSourceError> {
         match self.fetch_recommended().await {
-            Ok(fees) => Ok(clamp_to_min(fees.select(self.policy))),
+            Ok(fees) => Ok(clamp_to_min(
+                fees.select(Self::tier_for(target, self.policy)),
+            )),
             Err(e) => {
                 warn!(error = %e, "mempool explorer fee lookup failed; falling back to bitcoind");
-                self.fallback.estimate().await
+                self.fallback.estimate(target).await
+            }
+        }
+    }
+
+    /// One HTTP call feeds both slots — the endpoint returns every tier at once.
+    async fn estimate_all(&self) -> Result<TargetRates, CpfpFeeSourceError> {
+        match self.fetch_recommended().await {
+            Ok(fees) => Ok(TargetRates {
+                standard: clamp_to_min(
+                    fees.select(Self::tier_for(FeeTarget::Standard, self.policy)),
+                ),
+                next_block: clamp_to_min(
+                    fees.select(Self::tier_for(FeeTarget::NextBlock, self.policy)),
+                ),
+            }),
+            Err(e) => {
+                warn!(error = %e, "mempool explorer fee lookup failed; falling back to bitcoind");
+                self.fallback.estimate_all().await
             }
         }
     }
@@ -297,8 +358,15 @@ impl FixedFeeSource {
 }
 
 impl CpfpFeeSource for FixedFeeSource {
-    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+    async fn estimate(&self, _target: FeeTarget) -> Result<FeeRate, CpfpFeeSourceError> {
         Ok(self.0)
+    }
+
+    async fn estimate_all(&self) -> Result<TargetRates, CpfpFeeSourceError> {
+        Ok(TargetRates {
+            standard: self.0,
+            next_block: self.0,
+        })
     }
 }
 
@@ -323,11 +391,19 @@ pub enum ConfiguredFeeSource<R> {
 }
 
 impl<R: FeeRateRpc> CpfpFeeSource for ConfiguredFeeSource<R> {
-    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+    async fn estimate(&self, target: FeeTarget) -> Result<FeeRate, CpfpFeeSourceError> {
         match self {
-            Self::Bitcoind(s) => s.estimate().await,
-            Self::Mempool(s) => s.estimate().await,
-            Self::Fixed(s) => s.estimate().await,
+            Self::Bitcoind(s) => s.estimate(target).await,
+            Self::Mempool(s) => s.estimate(target).await,
+            Self::Fixed(s) => s.estimate(target).await,
+        }
+    }
+
+    async fn estimate_all(&self) -> Result<TargetRates, CpfpFeeSourceError> {
+        match self {
+            Self::Bitcoind(s) => s.estimate_all().await,
+            Self::Mempool(s) => s.estimate_all().await,
+            Self::Fixed(s) => s.estimate_all().await,
         }
     }
 }
@@ -341,7 +417,8 @@ impl<R: FeeRateRpc> CpfpFeeSource for ConfiguredFeeSource<R> {
 pub enum FeeSourceConfig {
     /// Query Bitcoin Core's `estimatesmartfee(conf_target)` directly.
     BitcoinCore {
-        /// Block confirmation target passed to `estimatesmartfee`.
+        /// Block confirmation target passed to `estimatesmartfee` for `Standard` estimates.
+        /// The `NextBlock` target always queries conf target 1.
         conf_target: u16,
     },
     /// Query a mempool.space-compatible explorer's `/api/v1/fees/recommended` endpoint, with
@@ -349,7 +426,8 @@ pub enum FeeSourceConfig {
     MempoolExplorer {
         /// Base URL, e.g. `https://mempool.space/signet` or `https://mempool.space`.
         base_url: Url,
-        /// Which tier of the recommended-fees response to use.
+        /// The tier of the recommended-fees response to use for `Standard` estimates. The
+        /// `NextBlock` target always uses the fastest tier.
         policy: MempoolFeePolicy,
         /// `conf_target` passed to `estimatesmartfee` on the fallback path.
         fallback_conf_target: u16,
@@ -472,8 +550,11 @@ pub(crate) fn wallet_tx_fee_rate(
 ) -> Result<FeeRate, ExecutorError> {
     // `try_current`, not `current`: a duty that prices from a frozen quote broadcasts at
     // whatever the market was when the source died. The error aborts the duty, and the
-    // retry succeeds after the source recovers.
-    let fee_rate = fee_source.try_current()?.max(MIN_WALLET_TX_FEE_RATE);
+    // retry succeeds after the source recovers. `Standard`: wallet-funded transactions are
+    // not time-critical and do not pay the next-block premium tier.
+    let fee_rate = fee_source
+        .try_current(FeeTarget::Standard)?
+        .max(MIN_WALLET_TX_FEE_RATE);
     if fee_rate > maximum_fee_rate {
         return Err(ExecutorError::FeeRateTooHigh {
             fee_rate,
@@ -529,6 +610,22 @@ mod tests {
         }
     }
 
+    /// [`MockFeeRateRpc`] variant that records the conf target of every `estimatesmartfee`
+    /// call, for asserting the [`FeeTarget`] → conf-target mapping.
+    #[derive(Debug)]
+    struct CapturingFeeRateRpc {
+        rate: ClientResult<Option<FeeRate>>,
+        conf_targets: std::sync::Mutex<Vec<u16>>,
+    }
+
+    #[async_trait]
+    impl FeeRateRpc for CapturingFeeRateRpc {
+        async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<Option<FeeRate>> {
+            self.conf_targets.lock().unwrap().push(conf_target);
+            self.rate.clone()
+        }
+    }
+
     fn recommended_fees_body(
         fastest: u64,
         half_hour: u64,
@@ -548,14 +645,40 @@ mod tests {
     #[tokio::test]
     async fn bitcoind_happy_path() {
         let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning(5)), 1);
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(5).unwrap());
+    }
+
+    #[tokio::test]
+    async fn bitcoind_maps_targets_to_conf_targets() {
+        let capturing = Arc::new(CapturingFeeRateRpc {
+            rate: Ok(FeeRate::from_sat_per_vb(5)),
+            conf_targets: std::sync::Mutex::new(Vec::new()),
+        });
+        let source = BitcoindFeeSource::new(capturing.clone(), 3);
+        source.estimate(FeeTarget::NextBlock).await.unwrap();
+        source.estimate(FeeTarget::Standard).await.unwrap();
+        // NextBlock always queries conf target 1; Standard queries the configured target.
+        assert_eq!(*capturing.conf_targets.lock().unwrap(), vec![1, 3]);
+    }
+
+    #[tokio::test]
+    async fn bitcoind_estimate_all_dedupes_when_standard_is_next_block() {
+        let capturing = Arc::new(CapturingFeeRateRpc {
+            rate: Ok(FeeRate::from_sat_per_vb(5)),
+            conf_targets: std::sync::Mutex::new(Vec::new()),
+        });
+        let source = BitcoindFeeSource::new(capturing.clone(), 1);
+        let rates = source.estimate_all().await.unwrap();
+        // One round trip fills both slots when the configured standard tier is already 1.
+        assert_eq!(*capturing.conf_targets.lock().unwrap(), vec![1]);
+        assert_eq!(rates.standard, rates.next_block);
     }
 
     #[tokio::test]
     async fn bitcoind_floors_zero_to_one() {
         let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning(0)), 1);
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(1).unwrap());
     }
 
@@ -565,15 +688,15 @@ mod tests {
     #[tokio::test]
     async fn bitcoind_floors_missing_estimate_to_one() {
         let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning_none()), 1);
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(1).unwrap());
     }
 
     #[tokio::test]
     async fn bitcoind_propagates_rpc_error() {
         let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
-        let err = source.estimate().await.unwrap_err();
-        assert!(err.contains("bitcoind"), "unexpected error: {err}");
+        let err = source.estimate(FeeTarget::Standard).await.unwrap_err();
+        assert!(err.0.contains("bitcoind"), "unexpected error: {err}");
     }
 
     #[tokio::test]
@@ -594,7 +717,7 @@ mod tests {
             fallback,
         )
         .unwrap();
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(10).unwrap());
     }
 
@@ -616,8 +739,43 @@ mod tests {
             fallback,
         )
         .unwrap();
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(3).unwrap());
+    }
+
+    /// Pins the `FeeTarget`-to-tier mapping: `Standard` reads the configured policy (economy
+    /// here) and `NextBlock` always reads the fastest tier. A regression mapping `NextBlock`
+    /// to the configured policy would leave this suite green while pricing CPFP children at
+    /// the slower tier.
+    #[tokio::test]
+    async fn mempool_maps_targets_to_tiers() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/fees/recommended"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(recommended_fees_body(10, 7, 5, 3, 1)),
+            )
+            .mount(&server)
+            .await;
+
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
+        let source = MempoolExplorerFeeSource::new(
+            Url::parse(&server.uri()).unwrap(),
+            MempoolFeePolicy::Economy,
+            fallback,
+        )
+        .unwrap();
+        assert_eq!(
+            source.estimate(FeeTarget::Standard).await.unwrap(),
+            FeeRate::from_sat_per_vb(3).unwrap()
+        );
+        assert_eq!(
+            source.estimate(FeeTarget::NextBlock).await.unwrap(),
+            FeeRate::from_sat_per_vb(10).unwrap()
+        );
+        let rates = source.estimate_all().await.unwrap();
+        assert_eq!(rates.standard, FeeRate::from_sat_per_vb(3).unwrap());
+        assert_eq!(rates.next_block, FeeRate::from_sat_per_vb(10).unwrap());
     }
 
     #[tokio::test]
@@ -636,7 +794,7 @@ mod tests {
             fallback,
         )
         .unwrap();
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         // Fallback succeeded; the mempool error is absorbed.
         assert_eq!(rate, FeeRate::from_sat_per_vb(4).unwrap());
     }
@@ -657,7 +815,7 @@ mod tests {
             fallback,
         )
         .unwrap();
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(6).unwrap());
     }
 
@@ -678,14 +836,14 @@ mod tests {
         )
         .unwrap();
         // Mempool error is absorbed; surfaced error is from the bitcoind fallback.
-        let err = source.estimate().await.unwrap_err();
-        assert!(err.contains("bitcoind"), "unexpected error: {err}");
+        let err = source.estimate(FeeTarget::Standard).await.unwrap_err();
+        assert!(err.0.contains("bitcoind"), "unexpected error: {err}");
     }
 
     #[tokio::test]
     async fn fixed_source_returns_configured_rate() {
         let source = FixedFeeSource::from_sat_per_vb(7).unwrap();
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(7).unwrap());
     }
 
@@ -705,7 +863,7 @@ mod tests {
         let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
         let source =
             MempoolExplorerFeeSource::new(base, MempoolFeePolicy::Fastest, fallback).unwrap();
-        let rate = source.estimate().await.unwrap();
+        let rate = source.estimate(FeeTarget::Standard).await.unwrap();
         assert_eq!(rate, FeeRate::from_sat_per_vb(12).unwrap());
     }
 

--- a/crates/bridge-exec/src/fees.rs
+++ b/crates/bridge-exec/src/fees.rs
@@ -1,0 +1,736 @@
+//! Fee-rate sources for bridge transactions.
+//!
+//! Provides three implementations of [`btc_tracker::cpfp::CpfpFeeSource`]:
+//!
+//! * [`BitcoindFeeSource`] — queries `estimatesmartfee` on the local Bitcoin Core RPC.
+//! * [`MempoolExplorerFeeSource`] — queries a mempool.space-compatible explorer's
+//!   `/api/v1/fees/recommended` endpoint; falls back to a wrapped [`BitcoindFeeSource`] on any HTTP
+//!   or decode failure so a downed mempool explorer never blocks tx publishing.
+//! * [`FixedFeeSource`] — returns a constant rate (tests, manual overrides).
+//!
+//! The network-backed sources clamp their reported rate to [`MIN_SOURCE_FEE_RATE`];
+//! [`FixedFeeSource`] deliberately returns the configured rate verbatim (it is the manual
+//! escape hatch, so it must be able to say exactly what the operator asked for).
+//!
+//! The orchestrator builds the configured source via [`FeeSourceConfig::build`] and wraps it in
+//! a [`btc_tracker::cpfp::CachedFeeSource`], which refreshes in the background and is shared by
+//! both the executors (per-tx-build fee estimates) and the tx-driver's CPFP/RBF bump loop — so
+//! neither hits the network per call.
+
+// `MIN_SOURCE_FEE_RATE` is referenced from the public module/item docs above; allowing
+// `private_intra_doc_links` here keeps the references resolvable without exporting the const.
+#![allow(rustdoc::private_intra_doc_links)]
+
+use std::{
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use bitcoin::FeeRate;
+use bitcoind_async_client::{ClientResult, traits::Reader};
+use btc_tracker::cpfp::{CachedFeeSource, CpfpFeeSource, FeeSourceError as CpfpFeeSourceError};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::warn;
+use url::Url;
+
+use crate::errors::ExecutorError;
+
+/// Narrow trait covering only the RPC surface the fee source needs.
+///
+/// Auto-implemented for every [`Reader`], and tests can implement it directly without modeling
+/// the dozens of other [`Reader`] methods. The fallback path only needs `estimate_smart_fee`,
+/// so the trait stays single-method on purpose.
+#[async_trait]
+pub trait FeeRateRpc: Send + Sync + std::fmt::Debug {
+    /// See [`Reader::estimate_smart_fee`]. `None` means bitcoind had insufficient data to
+    /// produce an estimate (fresh regtest, early signet), which callers treat as "fall back to
+    /// the floor" rather than as an error.
+    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<Option<FeeRate>>;
+}
+
+#[async_trait]
+impl<R: Reader + std::fmt::Debug + Send + Sync> FeeRateRpc for R {
+    async fn estimate_smart_fee(&self, conf_target: u16) -> ClientResult<Option<FeeRate>> {
+        Ok(<R as Reader>::estimate_smart_fee(self, conf_target)
+            .await?
+            .fee_rate)
+    }
+}
+
+/// Errors produced by [`CpfpFeeSource`] implementations.
+#[derive(Debug, Error)]
+pub enum FeeSourceError {
+    /// Bitcoin Core RPC reported an error.
+    #[error("bitcoind: {0}")]
+    Bitcoind(#[from] bitcoind_async_client::error::ClientError),
+    /// The mempool explorer call failed (HTTP error, non-2xx, or timeout).
+    ///
+    /// Never surfaced from `estimate()`: the explorer source always wraps a Bitcoin Core
+    /// fallback, so this is logged (`warn`) and absorbed. If the fallback then fails too,
+    /// callers see the *bitcoind* error, not this one.
+    #[error("mempool explorer: {0}")]
+    MempoolHttp(String),
+    /// The mempool explorer response could not be decoded as the expected JSON shape.
+    ///
+    /// Never surfaced from `estimate()` — same absorption story as [`Self::MempoolHttp`].
+    #[error("mempool explorer decode: {0}")]
+    MempoolDecode(String),
+    /// The configured mempool explorer URL is malformed.
+    #[error("invalid mempool explorer url: {0}")]
+    InvalidConfig(String),
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Bitcoin Core
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Fee source backed by Bitcoin Core's `estimatesmartfee`.
+///
+/// Note: Bitcoin Core's `estimatesmartfee` ignores the current mempool entirely — it only looks
+/// at recent block fees. Useful as a fallback or for closed networks, but on a public network
+/// with a varied mempool the [`MempoolExplorerFeeSource`] gives more responsive estimates.
+#[derive(Debug, Clone)]
+pub struct BitcoindFeeSource<R> {
+    client: Arc<R>,
+    conf_target: u16,
+}
+
+impl<R: FeeRateRpc> BitcoindFeeSource<R> {
+    /// Creates a new source that queries `estimatesmartfee(conf_target)` on `client`.
+    pub const fn new(client: Arc<R>, conf_target: u16) -> Self {
+        Self {
+            client,
+            conf_target,
+        }
+    }
+}
+
+impl<R: FeeRateRpc> CpfpFeeSource for BitcoindFeeSource<R> {
+    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+        let rate = self
+            .client
+            .estimate_smart_fee(self.conf_target)
+            .await
+            .map_err(|e| CpfpFeeSourceError(FeeSourceError::Bitcoind(e).to_string()))?;
+        let rate = match rate {
+            Some(rate) => rate,
+            None => {
+                // `estimatesmartfee` reports no estimate when it lacks data — normal on a
+                // fresh regtest, but on a real network it means the node is cold, pruned of
+                // fee history, or running `-blocksonly`. Substituting the floor keeps the
+                // bridge publishing either way, but do it LOUDLY: without this log a
+                // misconfigured node is indistinguishable from a genuinely calm mempool,
+                // and every bump quietly targets the minimum forever.
+                warn!(
+                    conf_target = self.conf_target,
+                    "estimatesmartfee returned no estimate; falling back to the floor fee rate"
+                );
+                MIN_SOURCE_FEE_RATE
+            }
+        };
+        Ok(rate.max(MIN_SOURCE_FEE_RATE))
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Mempool explorer (mempool.space-compatible)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Recommended-fee tier to consume from the mempool explorer response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MempoolFeePolicy {
+    /// `fastestFee` — designed to confirm in the next block.
+    Fastest,
+    /// `halfHourFee`.
+    HalfHour,
+    /// `hourFee`.
+    Hour,
+    /// `economyFee` — willing to wait several blocks for cheaper.
+    Economy,
+    /// `minimumFee`.
+    Minimum,
+}
+
+/// Response from a mempool.space-compatible `/api/v1/fees/recommended` endpoint.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+struct RecommendedFees {
+    #[serde(rename = "fastestFee")]
+    fastest_fee: u64,
+    #[serde(rename = "halfHourFee")]
+    half_hour_fee: u64,
+    #[serde(rename = "hourFee")]
+    hour_fee: u64,
+    #[serde(rename = "economyFee")]
+    economy_fee: u64,
+    #[serde(rename = "minimumFee")]
+    minimum_fee: u64,
+}
+
+impl RecommendedFees {
+    const fn select(self, policy: MempoolFeePolicy) -> u64 {
+        match policy {
+            MempoolFeePolicy::Fastest => self.fastest_fee,
+            MempoolFeePolicy::HalfHour => self.half_hour_fee,
+            MempoolFeePolicy::Hour => self.hour_fee,
+            MempoolFeePolicy::Economy => self.economy_fee,
+            MempoolFeePolicy::Minimum => self.minimum_fee,
+        }
+    }
+}
+
+/// Shared HTTP client used for all mempool explorer lookups. Pooled for connection reuse —
+/// every call would otherwise pay the TLS handshake.
+///
+/// The 10-second total timeout is the load-bearing knob here: `reqwest::Client::new()` defaults
+/// to no timeout, which means a hanging mempool explorer would indefinitely block the duty
+/// future awaiting `estimate()`. The fallback to Bitcoin Core only triggers on an error result,
+/// not on a never-resolving future. 10s is a conservative cap — recommended-fees responses are
+/// small, hosted on a CDN, and arrive in well under a second under normal conditions.
+static SHARED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("reqwest::Client::builder with rustls-tls; failure here means a build-time misconfiguration")
+});
+
+/// Fee source backed by a mempool.space-compatible explorer's recommended-fees endpoint, with
+/// a Bitcoin Core fallback.
+///
+/// Falls back to the wrapped [`BitcoindFeeSource`] on any HTTP error, non-2xx status, or decode
+/// failure. The fallback error replaces the mempool error in the result; the mempool error is
+/// only logged. This matches strata's behaviour: a downed mempool explorer must never block tx
+/// publishing.
+#[derive(Debug, Clone)]
+pub struct MempoolExplorerFeeSource<R> {
+    recommended_fees_url: Url,
+    policy: MempoolFeePolicy,
+    fallback: BitcoindFeeSource<R>,
+}
+
+impl<R: FeeRateRpc> MempoolExplorerFeeSource<R> {
+    /// Creates a new source that GETs `{base_url}/api/v1/fees/recommended` and selects the field
+    /// indicated by `policy`. `base_url` is e.g. `https://mempool.space/signet` or
+    /// `https://mempool.space` for mainnet.
+    ///
+    /// Returns an error if `base_url` is malformed enough that we cannot construct the
+    /// recommended-fees URL from it.
+    pub fn new(
+        base_url: Url,
+        policy: MempoolFeePolicy,
+        fallback: BitcoindFeeSource<R>,
+    ) -> Result<Self, FeeSourceError> {
+        // Ensure the base URL has a trailing slash so `Url::join` treats it as a directory.
+        // Without this, `join("api/v1/fees/recommended")` would replace the last path segment.
+        let mut url = base_url;
+        if !url.path().ends_with('/') {
+            let path = format!("{}/", url.path());
+            url.set_path(&path);
+        }
+        let recommended_fees_url = url
+            .join("api/v1/fees/recommended")
+            .map_err(|e| FeeSourceError::InvalidConfig(format!("{e:?}")))?;
+        Ok(Self {
+            recommended_fees_url,
+            policy,
+            fallback,
+        })
+    }
+
+    async fn fetch_recommended(&self) -> Result<RecommendedFees, FeeSourceError> {
+        let response = SHARED_HTTP_CLIENT
+            .get(self.recommended_fees_url.clone())
+            .send()
+            .await
+            .map_err(|e| FeeSourceError::MempoolHttp(format!("{e}")))?
+            .error_for_status()
+            .map_err(|e| FeeSourceError::MempoolHttp(format!("{e}")))?;
+        response
+            .json::<RecommendedFees>()
+            .await
+            .map_err(|e| FeeSourceError::MempoolDecode(format!("{e}")))
+    }
+}
+
+impl<R: FeeRateRpc> CpfpFeeSource for MempoolExplorerFeeSource<R> {
+    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+        match self.fetch_recommended().await {
+            Ok(fees) => Ok(clamp_to_min(fees.select(self.policy))),
+            Err(e) => {
+                warn!(error = %e, "mempool explorer fee lookup failed; falling back to bitcoind");
+                self.fallback.estimate().await
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fixed (for tests / manual overrides)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Fee source that returns a constant rate, regardless of network conditions.
+///
+/// Intended for tests and emergency manual overrides. Returns the configured rate verbatim —
+/// no clamping. If you set this to a value below 1 sat/vB you'll get what you ask for.
+#[derive(Debug, Clone, Copy)]
+pub struct FixedFeeSource(pub FeeRate);
+
+impl FixedFeeSource {
+    /// Creates a new fixed source from a sat/vB integer rate.
+    pub fn from_sat_per_vb(rate: u64) -> Option<Self> {
+        FeeRate::from_sat_per_vb(rate).map(Self)
+    }
+}
+
+impl CpfpFeeSource for FixedFeeSource {
+    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+        Ok(self.0)
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Config + builder
+// ────────────────────────────────────────────────────────────────────────────
+
+/// The concrete [`CpfpFeeSource`] selected by a [`FeeSourceConfig`].
+///
+/// A single enum (rather than `Box<dyn CpfpFeeSource>`) keeps the AFIT [`CpfpFeeSource`] trait
+/// usable without a boxed-future shim: the orchestrator wraps this in a
+/// [`btc_tracker::cpfp::CachedFeeSource`] and shares that one cache with both the executors and
+/// the CPFP bump loop.
+#[derive(Debug)]
+pub enum ConfiguredFeeSource<R> {
+    /// Bitcoin Core `estimatesmartfee`.
+    Bitcoind(BitcoindFeeSource<R>),
+    /// mempool.space-compatible explorer with a Bitcoin Core fallback.
+    Mempool(MempoolExplorerFeeSource<R>),
+    /// Constant rate (tests / manual overrides).
+    Fixed(FixedFeeSource),
+}
+
+impl<R: FeeRateRpc> CpfpFeeSource for ConfiguredFeeSource<R> {
+    async fn estimate(&self) -> Result<FeeRate, CpfpFeeSourceError> {
+        match self {
+            Self::Bitcoind(s) => s.estimate().await,
+            Self::Mempool(s) => s.estimate().await,
+            Self::Fixed(s) => s.estimate().await,
+        }
+    }
+}
+
+/// Serializable operator-side configuration that selects a [`CpfpFeeSource`] policy.
+///
+/// Built into a concrete [`ConfiguredFeeSource`] at startup via [`FeeSourceConfig::build`],
+/// taking the operator's Bitcoin Core RPC client as the fallback source for the mempool variant.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FeeSourceConfig {
+    /// Query Bitcoin Core's `estimatesmartfee(conf_target)` directly.
+    BitcoinCore {
+        /// Block confirmation target passed to `estimatesmartfee`.
+        conf_target: u16,
+    },
+    /// Query a mempool.space-compatible explorer's `/api/v1/fees/recommended` endpoint, with
+    /// Bitcoin Core as the fallback if the explorer is unreachable.
+    MempoolExplorer {
+        /// Base URL, e.g. `https://mempool.space/signet` or `https://mempool.space`.
+        base_url: Url,
+        /// Which tier of the recommended-fees response to use.
+        policy: MempoolFeePolicy,
+        /// `conf_target` passed to `estimatesmartfee` on the fallback path.
+        fallback_conf_target: u16,
+    },
+    /// Return a constant rate. Intended for tests and emergency manual overrides.
+    Fixed {
+        /// sat/vB.
+        fee_rate: u64,
+    },
+}
+
+impl FeeSourceConfig {
+    /// Constructs the configured [`CpfpFeeSource`] from this config + a Bitcoin Core RPC client.
+    ///
+    /// `bitcoind` is used as the primary source for [`FeeSourceConfig::BitcoinCore`], and as the
+    /// fallback for [`FeeSourceConfig::MempoolExplorer`].
+    pub fn build<R>(self, bitcoind: Arc<R>) -> Result<ConfiguredFeeSource<R>, FeeSourceError>
+    where
+        R: FeeRateRpc + 'static,
+    {
+        match self {
+            Self::BitcoinCore { conf_target } => Ok(ConfiguredFeeSource::Bitcoind(
+                BitcoindFeeSource::new(bitcoind, conf_target),
+            )),
+            Self::MempoolExplorer {
+                base_url,
+                policy,
+                fallback_conf_target,
+            } => {
+                let fallback = BitcoindFeeSource::new(bitcoind, fallback_conf_target);
+                Ok(ConfiguredFeeSource::Mempool(MempoolExplorerFeeSource::new(
+                    base_url, policy, fallback,
+                )?))
+            }
+            Self::Fixed { fee_rate } => {
+                let source = FixedFeeSource::from_sat_per_vb(fee_rate).ok_or_else(|| {
+                    FeeSourceError::InvalidConfig(format!(
+                        "fixed fee rate {fee_rate} sat/vB exceeds FeeRate's u64 sat/kwu range"
+                    ))
+                })?;
+                Ok(ConfiguredFeeSource::Fixed(source))
+            }
+        }
+    }
+}
+
+impl Default for FeeSourceConfig {
+    /// Defaults to Bitcoin Core with `conf_target = 1`.
+    fn default() -> Self {
+        Self::BitcoinCore { conf_target: 1 }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// minimum fee rates
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Floor for every network-backed source's reported rate — Core's default `minrelaytxfee`
+/// expressed in sat/vB. Sources can legitimately report below it (a quiet mempool, an
+/// explorer's economy tier at 0) or nothing at all (`estimatesmartfee` with insufficient
+/// data); targeting below min-relay would leave the resulting transaction or package
+/// unrelayable, so those sources clamp up to this floor.
+const MIN_SOURCE_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(1);
+
+/// Minimum rate at which the bridge broadcasts a *wallet-funded* transaction (withdrawal
+/// fulfillment, stake funding). The configured source already clamps to [`MIN_SOURCE_FEE_RATE`];
+/// this is the higher bridge-policy floor that keeps these v3 (TRUC) transactions relayable even
+/// when the source reports a lower rate.
+///
+/// Deliberately a standalone constant, not a reuse of `strata_bridge_tx_graph::fee::FEE_RATE`:
+/// that constant is the rate presigned transactions are *built at*, not a minimum, and is slated
+/// for removal once CPFP fully supersedes the static-fee scheme.
+pub const MIN_WALLET_TX_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(2);
+
+// ────────────────────────────────────────────────────────────────────────────
+// helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+fn clamp_to_min(raw_sat_per_vb: u64) -> FeeRate {
+    FeeRate::from_sat_per_vb(raw_sat_per_vb)
+        .unwrap_or(MIN_SOURCE_FEE_RATE)
+        .max(MIN_SOURCE_FEE_RATE)
+}
+
+/// Fee rate for a *wallet-funded* transaction (claim-funding refill, stake funding,
+/// withdrawal fulfillment): the shared source's current cached estimate, floored at
+/// [`MIN_WALLET_TX_FEE_RATE`] so the resulting v3 (TRUC) transaction stays relayable, and
+/// rejected outright when it exceeds the operator's `maximum_fee_rate` policy.
+///
+/// Presigned bridge transactions do NOT use this — their fee is fixed at
+/// `strata_bridge_tx_graph::fee::FEE_RATE` by construction and is raised after the fact by
+/// the CPFP bump loop instead.
+pub(crate) fn wallet_tx_fee_rate(
+    fee_source: &CachedFeeSource,
+    maximum_fee_rate: FeeRate,
+) -> Result<FeeRate, ExecutorError> {
+    let fee_rate = fee_source.current().max(MIN_WALLET_TX_FEE_RATE);
+    if fee_rate > maximum_fee_rate {
+        return Err(ExecutorError::FeeRateTooHigh {
+            fee_rate,
+            max: maximum_fee_rate,
+        });
+    }
+    Ok(fee_rate)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use bitcoind_async_client::{ClientResult, error::ClientError};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    use super::*;
+
+    /// Test stub for [`FeeRateRpc`]. Returns a configured rate or error; nothing else.
+    #[derive(Debug)]
+    struct MockFeeRateRpc {
+        rate: ClientResult<Option<FeeRate>>,
+    }
+
+    impl MockFeeRateRpc {
+        fn returning(sat_per_vb: u64) -> Self {
+            Self {
+                rate: Ok(FeeRate::from_sat_per_vb(sat_per_vb)),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                rate: Err(ClientError::Request("boom".to_string())),
+            }
+        }
+
+        /// `estimatesmartfee` succeeded but produced no estimate (insufficient data —
+        /// fresh regtest, early signet, `-blocksonly` node).
+        fn returning_none() -> Self {
+            Self { rate: Ok(None) }
+        }
+    }
+
+    #[async_trait]
+    impl FeeRateRpc for MockFeeRateRpc {
+        async fn estimate_smart_fee(&self, _conf_target: u16) -> ClientResult<Option<FeeRate>> {
+            self.rate.clone()
+        }
+    }
+
+    fn recommended_fees_body(
+        fastest: u64,
+        half_hour: u64,
+        hour: u64,
+        economy: u64,
+        minimum: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "fastestFee": fastest,
+            "halfHourFee": half_hour,
+            "hourFee": hour,
+            "economyFee": economy,
+            "minimumFee": minimum,
+        })
+    }
+
+    #[tokio::test]
+    async fn bitcoind_happy_path() {
+        let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning(5)), 1);
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(5).unwrap());
+    }
+
+    #[tokio::test]
+    async fn bitcoind_floors_zero_to_one() {
+        let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning(0)), 1);
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(1).unwrap());
+    }
+
+    /// The `Ok(None)` arm is distinct from a zero estimate: bitcoind is saying "no idea",
+    /// not "zero". It must resolve to the floor, not an error — a cold node must not block
+    /// publishing.
+    #[tokio::test]
+    async fn bitcoind_floors_missing_estimate_to_one() {
+        let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning_none()), 1);
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(1).unwrap());
+    }
+
+    #[tokio::test]
+    async fn bitcoind_propagates_rpc_error() {
+        let source = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
+        let err = source.estimate().await.unwrap_err();
+        assert!(err.contains("bitcoind"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn mempool_happy_path_fastest() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/fees/recommended"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(recommended_fees_body(10, 7, 5, 3, 1)),
+            )
+            .mount(&server)
+            .await;
+
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
+        let source = MempoolExplorerFeeSource::new(
+            Url::parse(&server.uri()).unwrap(),
+            MempoolFeePolicy::Fastest,
+            fallback,
+        )
+        .unwrap();
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(10).unwrap());
+    }
+
+    #[tokio::test]
+    async fn mempool_happy_path_economy() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/fees/recommended"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(recommended_fees_body(10, 7, 5, 3, 1)),
+            )
+            .mount(&server)
+            .await;
+
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
+        let source = MempoolExplorerFeeSource::new(
+            Url::parse(&server.uri()).unwrap(),
+            MempoolFeePolicy::Economy,
+            fallback,
+        )
+        .unwrap();
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(3).unwrap());
+    }
+
+    #[tokio::test]
+    async fn mempool_fallback_on_5xx() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/fees/recommended"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning(4)), 1);
+        let source = MempoolExplorerFeeSource::new(
+            Url::parse(&server.uri()).unwrap(),
+            MempoolFeePolicy::Fastest,
+            fallback,
+        )
+        .unwrap();
+        let rate = source.estimate().await.unwrap();
+        // Fallback succeeded; the mempool error is absorbed.
+        assert_eq!(rate, FeeRate::from_sat_per_vb(4).unwrap());
+    }
+
+    #[tokio::test]
+    async fn mempool_fallback_on_malformed_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/fees/recommended"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("not json"))
+            .mount(&server)
+            .await;
+
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::returning(6)), 1);
+        let source = MempoolExplorerFeeSource::new(
+            Url::parse(&server.uri()).unwrap(),
+            MempoolFeePolicy::Fastest,
+            fallback,
+        )
+        .unwrap();
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(6).unwrap());
+    }
+
+    #[tokio::test]
+    async fn mempool_and_fallback_both_fail() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/fees/recommended"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
+        let source = MempoolExplorerFeeSource::new(
+            Url::parse(&server.uri()).unwrap(),
+            MempoolFeePolicy::Fastest,
+            fallback,
+        )
+        .unwrap();
+        // Mempool error is absorbed; surfaced error is from the bitcoind fallback.
+        let err = source.estimate().await.unwrap_err();
+        assert!(err.contains("bitcoind"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn fixed_source_returns_configured_rate() {
+        let source = FixedFeeSource::from_sat_per_vb(7).unwrap();
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(7).unwrap());
+    }
+
+    #[tokio::test]
+    async fn mempool_base_url_without_trailing_slash_works() {
+        // mempool.space/signet style — must still resolve to .../signet/api/v1/fees/recommended.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/signet/api/v1/fees/recommended"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(recommended_fees_body(12, 8, 6, 4, 2)),
+            )
+            .mount(&server)
+            .await;
+
+        let base = Url::parse(&format!("{}/signet", server.uri())).unwrap();
+        let fallback = BitcoindFeeSource::new(Arc::new(MockFeeRateRpc::failing()), 1);
+        let source =
+            MempoolExplorerFeeSource::new(base, MempoolFeePolicy::Fastest, fallback).unwrap();
+        let rate = source.estimate().await.unwrap();
+        assert_eq!(rate, FeeRate::from_sat_per_vb(12).unwrap());
+    }
+
+    #[test]
+    fn clamp_to_min_handles_overflow_without_panicking() {
+        // Far above any plausible `estimatesmartfee` output, but reachable from a stubbed
+        // `Fixed { fee_rate: u64::MAX }` config or a misbehaving mock. Must return a finite
+        // FeeRate, not panic.
+        let rate = clamp_to_min(u64::MAX);
+        assert_eq!(rate, FeeRate::from_sat_per_vb(1).unwrap());
+    }
+
+    #[test]
+    fn fee_source_config_roundtrips_through_toml_bitcoincore() {
+        let toml_str = r#"
+            kind = "bitcoin_core"
+            conf_target = 6
+        "#;
+        let cfg: FeeSourceConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg, FeeSourceConfig::BitcoinCore { conf_target: 6 });
+    }
+
+    #[test]
+    fn fee_source_config_roundtrips_through_toml_mempool() {
+        let toml_str = r#"
+            kind = "mempool_explorer"
+            base_url = "https://mempool.space/signet"
+            policy = "fastest"
+            fallback_conf_target = 1
+        "#;
+        let cfg: FeeSourceConfig = toml::from_str(toml_str).unwrap();
+        assert!(matches!(
+            cfg,
+            FeeSourceConfig::MempoolExplorer {
+                policy: MempoolFeePolicy::Fastest,
+                fallback_conf_target: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn fee_source_config_roundtrips_through_toml_mempool_half_hour() {
+        // Verifies the snake_case rename on MempoolFeePolicy works for multi-word variants.
+        let toml_str = r#"
+            kind = "mempool_explorer"
+            base_url = "https://mempool.space"
+            policy = "half_hour"
+            fallback_conf_target = 1
+        "#;
+        let cfg: FeeSourceConfig = toml::from_str(toml_str).unwrap();
+        assert!(matches!(
+            cfg,
+            FeeSourceConfig::MempoolExplorer {
+                policy: MempoolFeePolicy::HalfHour,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn fee_source_config_default_is_bitcoin_core_conf_target_1() {
+        // Preserves pre-PR behaviour for operators upgrading without touching their config.
+        let cfg = FeeSourceConfig::default();
+        assert_eq!(cfg, FeeSourceConfig::BitcoinCore { conf_target: 1 });
+    }
+}

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -21,7 +21,6 @@ use strata_bridge_primitives::{
 };
 use strata_bridge_sm::graph::{context::GraphSMCtx, machine::generate_game_graph};
 use strata_bridge_tx_graph::{
-    fee,
     game_graph::{DepositParams, GameGraph},
     transactions::claim::ClaimTx,
 };
@@ -36,6 +35,7 @@ use crate::{
     chain::{self, CpfpKind, is_outpoint_unspent, is_txid_onchain, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
+    fees::wallet_tx_fee_rate,
     output_handles::OutputHandles,
 };
 
@@ -197,7 +197,10 @@ async fn ensure_claim_funding_outpoint(
                 // fresh sync says the inputs are still spendable.
                 let refill = wallet
                     .create_reserved_utxos(
-                        fee::FEE_RATE,
+                        // Wallet-funded tx: track the live fee source rather than the
+                        // presigned-graph floor, so a refill issued into a busy mempool
+                        // actually confirms.
+                        wallet_tx_fee_rate(&cfg.fee_source, cfg.maximum_fee_rate)?,
                         cfg.claim_funding_utxo_value,
                         batch_size,
                         GeneralUtxoPolicy::ConfirmedOnly,

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -6,7 +6,7 @@ use bitcoin::{
     sighash::{Prevouts, SighashCache},
     taproot,
 };
-use btc_tracker::event::TxStatus;
+use btc_tracker::{cpfp::FeeTarget, event::TxStatus};
 use operator_wallet::{AnyOperatorWallet, Lease, LeaseOwner};
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_primitives::types::GraphIdx;
@@ -66,8 +66,12 @@ pub(super) async fn publish_unstaking_burn(
     // meant an operator's configured fee policy (e.g. mempool-explorer) was honoured for
     // deposits and stake funding but silently ignored here — and a bitcoind hiccup failed the
     // burn duty where the other paths ride it out on the cache. Floor at the same
-    // wallet-funded minimum the other v3 paths use.
-    let fee_rate = cfg.fee_source.try_current()?.max(MIN_WALLET_TX_FEE_RATE);
+    // wallet-funded minimum the other v3 paths use. `Standard`: the burn is not time-critical
+    // and does not pay the next-block premium tier.
+    let fee_rate = cfg
+        .fee_source
+        .try_current(FeeTarget::Standard)?
+        .max(MIN_WALLET_TX_FEE_RATE);
     debug!(%graph_idx, %fee_rate, "selected fee rate for unstaking burn transaction");
     if fee_rate > cfg.maximum_fee_rate {
         warn!(

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -6,7 +6,6 @@ use bitcoin::{
     sighash::{Prevouts, SighashCache},
     taproot,
 };
-use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use operator_wallet::{AnyOperatorWallet, Lease, LeaseOwner};
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
@@ -18,6 +17,7 @@ use crate::{
     chain::{CpfpKind, ParentFee, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
+    fees::MIN_WALLET_TX_FEE_RATE,
     output_handles::OutputHandles,
 };
 
@@ -61,7 +61,13 @@ pub(super) async fn publish_unstaking_burn(
 ) -> Result<(), ExecutorError> {
     info!(%graph_idx, "preparing unstaking burn transaction");
 
-    let fee_rate = burn_fee_rate(output_handles).await?;
+    // Read the shared cached fee source rather than a live `estimatesmartfee` round-trip:
+    // this was the one duty-path caller left bypassing `cfg.fee_source` after STR-3438, which
+    // meant an operator's configured fee policy (e.g. mempool-explorer) was honoured for
+    // deposits and stake funding but silently ignored here — and a bitcoind hiccup failed the
+    // burn duty where the other paths ride it out on the cache. Floor at the same
+    // wallet-funded minimum the other v3 paths use.
+    let fee_rate = cfg.fee_source.current().max(MIN_WALLET_TX_FEE_RATE);
     debug!(%graph_idx, %fee_rate, "selected fee rate for unstaking burn transaction");
     if fee_rate > cfg.maximum_fee_rate {
         warn!(
@@ -142,33 +148,6 @@ pub(super) async fn publish_unstaking_burn(
             Err(e)
         }
     }
-}
-
-/// Returns the fee rate used for an unstaking burn attempt.
-///
-/// The executor asks Bitcoin Core for a one-block estimate and floors missing or low estimates at
-/// the network broadcast minimum so the constructed transaction remains relayable.
-async fn burn_fee_rate(output_handles: &OutputHandles) -> Result<FeeRate, ExecutorError> {
-    let smart_fee = output_handles
-        .bitcoind_rpc_client
-        .estimate_smart_fee(1)
-        .await
-        .map_err(|e| {
-            warn!(
-                ?e,
-                "failed to estimate fee rate for unstaking burn transaction"
-            );
-            ExecutorError::WalletErr(format!("failed to estimate fee: {e}"))
-        })?;
-
-    let fee_rate = smart_fee
-        .fee_rate
-        .unwrap_or(FeeRate::BROADCAST_MIN)
-        .max(FeeRate::BROADCAST_MIN);
-
-    debug!(%fee_rate, "computed unstaking burn fee rate");
-
-    Ok(fee_rate)
 }
 
 /// Selects and leases a general-wallet UTXO that can pay for the burn transaction.

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -67,7 +67,7 @@ pub(super) async fn publish_unstaking_burn(
     // deposits and stake funding but silently ignored here — and a bitcoind hiccup failed the
     // burn duty where the other paths ride it out on the cache. Floor at the same
     // wallet-funded minimum the other v3 paths use.
-    let fee_rate = cfg.fee_source.current().max(MIN_WALLET_TX_FEE_RATE);
+    let fee_rate = cfg.fee_source.try_current()?.max(MIN_WALLET_TX_FEE_RATE);
     debug!(%graph_idx, %fee_rate, "selected fee rate for unstaking burn transaction");
     if fee_rate > cfg.maximum_fee_rate {
         warn!(

--- a/crates/bridge-exec/src/lib.rs
+++ b/crates/bridge-exec/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod cpfp_adapters;
 pub mod deposit;
 pub mod errors;
+pub mod fees;
 pub mod graph;
 pub mod output_handles;
 pub mod stake;

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -9,7 +9,6 @@ use bitcoin::{
     secp256k1::{Message, XOnlyPublicKey},
     sighash::{Prevouts, SighashCache},
 };
-use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PubNonce};
@@ -32,6 +31,7 @@ use crate::{
     chain::{self, CpfpKind, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
+    fees::wallet_tx_fee_rate,
     output_handles::OutputHandles,
     stake::utils::get_preimage,
 };
@@ -211,7 +211,7 @@ async fn read_or_create_stake_funding(
     }
 
     info!(%operator_idx, "no persisted stake funding reservation; creating a new funding tx");
-    let fee_rate = estimate_funding_fee_rate(cfg, output_handles).await?;
+    let fee_rate = estimate_funding_fee_rate(cfg)?;
 
     info!(%fee_rate, %funding_amount, "creating stake funding transaction");
     // Stake funding is one reserved-wallet UTXO of `funding_amount`. The reserved-utxo API
@@ -270,32 +270,9 @@ async fn read_or_create_stake_funding(
     }
 }
 
-async fn estimate_funding_fee_rate(
-    cfg: &ExecutionConfig,
-    output_handles: &OutputHandles,
-) -> Result<FeeRate, ExecutorError> {
-    info!("fetching fee rate from bitcoind");
-    let smart_fee = output_handles
-        .bitcoind_rpc_client
-        .estimate_smart_fee(1)
-        .await?;
-    info!(?smart_fee, "fetched fee rate from bitcoind");
-
-    // Bound the rate from below by `fee::FEE_RATE` so this v3 (TRUC) funding transaction
-    // always meets the bridge's hardcoded minimum, even on networks like signet where
-    // `estimatesmartfee` may return a value below `minrelaytxfee`.
-    let fee_rate = smart_fee
-        .fee_rate
-        .unwrap_or(fee::FEE_RATE)
-        .max(fee::FEE_RATE);
-
-    if fee_rate > cfg.maximum_fee_rate {
-        return Err(ExecutorError::FeeRateTooHigh {
-            fee_rate,
-            max: cfg.maximum_fee_rate,
-        });
-    }
-
+fn estimate_funding_fee_rate(cfg: &ExecutionConfig) -> Result<FeeRate, ExecutorError> {
+    let fee_rate = wallet_tx_fee_rate(&cfg.fee_source, cfg.maximum_fee_rate)?;
+    info!(%fee_rate, "fee rate for stake funding");
     Ok(fee_rate)
 }
 

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -382,6 +382,9 @@ async fn cpfp_e2e_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer,
         max_fee_rate,
+        // Neutral fee knobs: the e2e tests pin the raw-estimate-to-cap behavior.
+        fee_premium_percent: 0,
+        min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
         mempool: cpfp_submitter,
     };
 
@@ -574,6 +577,9 @@ async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer,
         max_fee_rate,
+        // Neutral fee knobs: the e2e tests pin the raw-estimate-to-cap behavior.
+        fee_premium_percent: 0,
+        min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
         mempool: cpfp_submitter,
     };
 
@@ -790,6 +796,9 @@ async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer,
         max_fee_rate,
+        // Neutral fee knobs: the e2e tests pin the raw-estimate-to-cap behavior.
+        fee_premium_percent: 0,
+        min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
         mempool: cpfp_submitter,
     };
 
@@ -1001,6 +1010,9 @@ async fn cpfp_e2e_multi_anchor_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer: test_input_signer(operator_keypair),
         max_fee_rate: FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap(),
+        // Neutral fee knobs: the e2e tests pin the raw-estimate-to-cap behavior.
+        fee_premium_percent: 0,
+        min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
         mempool: Arc::new(BitcoindCpfpMempool::new(async_client.clone())),
     };
 
@@ -1139,6 +1151,9 @@ async fn cpfp_e2e_multi_anchor_contention_is_quiet() {
             anchor_input_signer: test_input_signer(operator_keypair),
             wallet_input_signer: test_input_signer(operator_keypair),
             max_fee_rate: FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap(),
+            // Neutral fee knobs: the e2e tests pin the raw-estimate-to-cap behavior.
+            fee_premium_percent: 0,
+            min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
             mempool: Arc::new(BitcoindCpfpMempool::new(async_client.clone())),
         };
         let strategy = CpfpStrategy::MultiAnchorBearing {
@@ -1207,6 +1222,9 @@ async fn cpfp_e2e_multi_anchor_contention_is_quiet() {
         anchor_input_signer: ctx2.anchor_input_signer,
         wallet_input_signer: ctx2.wallet_input_signer,
         max_fee_rate: ctx2.max_fee_rate,
+        // Neutral fee knobs: the e2e tests pin the raw-estimate-to-cap behavior.
+        fee_premium_percent: 0,
+        min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
         mempool: Arc::new(BlindToSpends(BitcoindCpfpMempool::new(
             async_client.clone(),
         ))),

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -69,9 +69,23 @@ struct FixedFeeSource(FeeRate);
 impl cpfp::CpfpFeeSource for FixedFeeSource {
     fn estimate(
         &self,
+        _target: cpfp::FeeTarget,
     ) -> impl std::future::Future<Output = Result<FeeRate, cpfp::FeeSourceError>> + Send {
         let rate = self.0;
         async move { Ok(rate) }
+    }
+
+    fn estimate_all(
+        &self,
+    ) -> impl std::future::Future<Output = Result<cpfp::TargetRates, cpfp::FeeSourceError>> + Send
+    {
+        let rate = self.0;
+        async move {
+            Ok(cpfp::TargetRates {
+                standard: rate,
+                next_block: rate,
+            })
+        }
     }
 }
 

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -484,6 +484,14 @@ pub struct CachedFeeSource {
     /// Anchor point for the `last_refresh_unix_ms` clock. Same instant for the duration
     /// of the [`CachedFeeSource`]'s lifetime.
     spawn_anchor: std::time::Instant,
+    /// Age past which the cached value stops being served to duty pricing
+    /// ([`Self::try_current`]). Ten refresh intervals: one or two missed refreshes are
+    /// normal for RPC transport, ten consecutive misses show the source is down.
+    max_staleness: Duration,
+    /// Latch for the bump-path stale warning: one warning per stale episode, reset by the
+    /// first fresh read. Without the latch, N tracked parents × the bump triggers repeat
+    /// the same warning hundreds of times per hour during one incident.
+    stale_warned: Arc<std::sync::atomic::AtomicBool>,
     task: JoinHandle<()>,
 }
 
@@ -496,6 +504,7 @@ impl Debug for CachedFeeSource {
                 "seconds_since_last_refresh",
                 &self.seconds_since_last_refresh(),
             )
+            .field("max_staleness", &self.max_staleness)
             .field("task_finished", &self.task.is_finished())
             .finish()
     }
@@ -555,6 +564,8 @@ impl CachedFeeSource {
             cached_sat_per_kwu,
             last_refresh_unix_ms,
             spawn_anchor,
+            max_staleness: refresh_interval.saturating_mul(STALENESS_REFRESH_MULTIPLE),
+            stale_warned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             task,
         })
     }
@@ -564,11 +575,37 @@ impl CachedFeeSource {
         FeeRate::from_sat_per_kwu(self.cached_sat_per_kwu.load(Ordering::Relaxed))
     }
 
+    /// Returns the cached fee rate, or the cache age when the value is stale.
+    ///
+    /// Duty pricing must use this accessor. A frozen quote prices a transaction at the
+    /// market rate from before the source failed, with no signal. The error aborts the
+    /// duty, and the duty retries after the source recovers. The bump loop stays on the
+    /// infallible [`Self::current`]: a bump at a stale rate is better than no bump,
+    /// because the parent pays only the protocol floor without one.
+    pub fn try_current(&self) -> Result<FeeRate, StaleFeeRate> {
+        // Millisecond precision, not `seconds_since_last_refresh`: that accessor truncates
+        // to whole seconds, and a truncated age compares wrong against sub-second bounds.
+        let last_ms = self.last_refresh_unix_ms.load(Ordering::Relaxed);
+        let now_ms = self
+            .spawn_anchor
+            .elapsed()
+            .as_millis()
+            .min(u64::MAX as u128) as u64;
+        let age = Duration::from_millis(now_ms.saturating_sub(last_ms));
+        if age > self.max_staleness {
+            return Err(StaleFeeRate {
+                age,
+                max_staleness: self.max_staleness,
+            });
+        }
+        Ok(self.current())
+    }
+
     /// Returns the number of seconds since the cache was last *successfully* refreshed.
-    /// Returns 0 for the initial refresh in [`Self::spawn`]. Lets callers decide how much
-    /// to trust the cached value — e.g., the bump loop could log a warning when the cache
-    /// is older than several refresh intervals (indicating the underlying source has been
-    /// failing).
+    /// Returns 0 for the initial refresh in [`Self::spawn`]. [`Self::try_current`] applies
+    /// the staleness bound for duty pricing, and the [`CpfpFeeSource`] impl logs a warning on
+    /// the bump path when the bound is exceeded; this accessor is the observability
+    /// surface behind both.
     pub fn seconds_since_last_refresh(&self) -> u64 {
         let last_ms = self.last_refresh_unix_ms.load(Ordering::Relaxed);
         let now_ms = self
@@ -582,17 +619,55 @@ impl CachedFeeSource {
 
 impl CpfpFeeSource for CachedFeeSource {
     /// Returns the cached value. Never returns `Err` — refresh failures are logged at the
-    /// background task and the prior value is retained.
+    /// background task and the prior value is retained. A stale cache logs one warning
+    /// per stale episode: on the bump path a stale rate is still worth acting on, and the
+    /// latch keeps one incident from repeating the warning on every bump trigger.
     fn estimate(
         &self,
     ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
+        match self.try_current() {
+            Err(stale) => {
+                if !self.stale_warned.swap(true, Ordering::Relaxed) {
+                    warn!(
+                        age_secs = stale.age.as_secs(),
+                        max_secs = stale.max_staleness.as_secs(),
+                        "fee cache is stale; the bump loop continues on the last known rate"
+                    );
+                }
+            }
+            Ok(_) => self.stale_warned.store(false, Ordering::Relaxed),
+        }
         let value = self.current();
         async move { Ok(value) }
     }
 }
 
+/// Multiple of the refresh interval past which the cache counts as stale.
+const STALENESS_REFRESH_MULTIPLE: u32 = 10;
+
+/// The fee cache has not refreshed inside its staleness bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StaleFeeRate {
+    /// Time since the last successful refresh.
+    pub age: Duration,
+    /// The bound the age exceeded.
+    pub max_staleness: Duration,
+}
+
+impl fmt::Display for StaleFeeRate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "fee cache is stale: last successful refresh {}s ago exceeds the {}s bound",
+            self.age.as_secs(),
+            self.max_staleness.as_secs()
+        )
+    }
+}
+
+impl std::error::Error for StaleFeeRate {}
+
 /// What already spends the output a CPFP child would spend, if anything.
-///
 /// The bump loop probes this state before every build, for every strategy. The probed
 /// output is the anchor for the anchor-bearing strategies, and the payout output for
 /// `ParentTxCombined`.
@@ -2695,6 +2770,37 @@ pub(crate) mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         assert_eq!(cache.current(), FeeRate::from_sat_per_vb(30).unwrap());
+    }
+
+    /// `try_current` refuses a cache that has not refreshed inside its staleness bound,
+    /// while `current` keeps serving the last value for the bump path. The bound is ten
+    /// refresh intervals, so a source that dies after the initial estimate exceeds it.
+    #[tokio::test]
+    async fn a_stale_cache_fails_try_current_and_serves_current() {
+        let flippable = Arc::new(FlippableFeeSource {
+            inner: Mutex::new(Ok(FeeRate::from_sat_per_vb(5).unwrap())),
+        });
+        let cache = CachedFeeSource::spawn(flippable.clone(), Duration::from_millis(10))
+            .await
+            .unwrap();
+        assert!(
+            cache.try_current().is_ok(),
+            "a fresh cache serves duty pricing"
+        );
+
+        // Every later refresh fails; the bound is 10 × 10 ms = 100 ms.
+        *flippable.inner.lock().unwrap() = Err("source died".to_string());
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let err = cache
+            .try_current()
+            .expect_err("a stale cache must refuse duty pricing");
+        assert!(err.age > err.max_staleness);
+        assert_eq!(
+            cache.current(),
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            "the bump path keeps the last known rate"
+        );
     }
 
     #[tokio::test]

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -899,6 +899,16 @@ where
     /// target to this and warns when clamping kicks in. Per design, exceeding this is an
     /// operator policy decision: we don't escalate.
     pub max_fee_rate: FeeRate,
+    /// Premium applied on top of the next-block fee estimate when pricing a CPFP bump
+    /// target, as a percentage of the estimate (e.g. `5` = +5%). Computed in sat/kwu and
+    /// rounded up, so the premium raises the target and never lowers it. A value of `0`
+    /// prices the child at the raw estimate.
+    pub fee_premium_percent: u32,
+    /// Floor on the package fee rate the bump ladder targets. The child pays the package
+    /// shortfall, including the parent's below-floor portion. When the parent sat at a
+    /// lower rate, the child's fee lifts the whole package to the floor. Applied after the
+    /// premium, before the [`Self::max_fee_rate`] clamp.
+    pub min_package_fee_rate: FeeRate,
     /// Submits `[parent, child]` packages via bitcoind. Wrapper around the
     /// [`submitpackage::submit_package`] helper.
     pub mempool: Arc<P>,
@@ -918,6 +928,8 @@ where
             multi_anchor_signer: self.multi_anchor_signer.clone(),
             wallet_input_signer: self.wallet_input_signer.clone(),
             max_fee_rate: self.max_fee_rate,
+            fee_premium_percent: self.fee_premium_percent,
+            min_package_fee_rate: self.min_package_fee_rate,
             mempool: self.mempool.clone(),
         }
     }
@@ -936,6 +948,8 @@ where
             .field("anchor_input_signer", &"<closure>")
             .field("wallet_input_signer", &"<closure>")
             .field("max_fee_rate", &self.max_fee_rate)
+            .field("fee_premium_percent", &self.fee_premium_percent)
+            .field("min_package_fee_rate", &self.min_package_fee_rate)
             .field("mempool", &self.mempool)
             .finish()
     }
@@ -992,6 +1006,15 @@ impl BumpReason {
 /// transactions price from [`FeeTarget::Standard`] through the same cache; they never
 /// touch this path.
 ///
+/// ## Premium and package floor
+///
+/// Before the cap clamp, the ladder raises the next-block estimate by
+/// `fee_premium_percent` (a percentage, rounded up in sat/kwu) and floors it at
+/// `min_package_fee_rate`. The floor bounds the package fee rate target. The child pays
+/// the package shortfall, so the package always lands at or above the floor. Both knobs
+/// are consumer policy on this context. Sources report raw market estimates, and
+/// wallet-funded transactions never pass through either knob.
+///
 /// ## Cap-and-warn at `max_fee_rate`
 ///
 /// When the fee source reports above `ctx.max_fee_rate`, the target is clamped and a warning
@@ -1027,6 +1050,24 @@ where
         .estimate(FeeTarget::NextBlock)
         .await
         .map_err(CpfpError::FeeSource)?;
+
+    // Apply the premium (a percentage of the next-block estimate, computed in sat/kwu and
+    // rounded up, so it raises the target and never lowers it), then the package floor,
+    // before the cap clamp below. A zero premium and a zero floor reproduce the raw
+    // estimate: both knobs are consumer policy and default to the values the operator set
+    // in the bridge config.
+    let estimated = if ctx.fee_premium_percent > 0 {
+        let rate_kwu = estimated.to_sat_per_kwu() as u128;
+        let multiplier = (ctx.fee_premium_percent as u128) + 100;
+        let premiumed = rate_kwu.saturating_mul(multiplier).div_ceil(100);
+        // A source rate or premium large enough that the raised rate does not fit a
+        // u64 saturates at the maximum instead of wrapping low; the cap clamp below
+        // then bounds it with a warning.
+        FeeRate::from_sat_per_kwu(premiumed.try_into().unwrap_or(u64::MAX))
+    } else {
+        estimated
+    };
+    let estimated = estimated.max(ctx.min_package_fee_rate);
 
     // ── 2. Clamp to max_fee_rate, warn if clamping kicked in ────────────────
     let target = if estimated > ctx.max_fee_rate {
@@ -1846,6 +1887,11 @@ pub(crate) mod tests {
             anchor_input_signer: anchor_signer,
             wallet_input_signer: wallet_signer,
             max_fee_rate,
+            // Neutral fee knobs: the existing ladder tests pin the raw estimate → clamp
+            // behaviour, so the premium and floor stay off here. The knob tests below
+            // construct their context directly with the PRD values.
+            fee_premium_percent: 0,
+            min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
             mempool: submitter,
         }
     }
@@ -2905,7 +2951,7 @@ pub(crate) mod tests {
             FeeRate::from_sat_per_vb(100).unwrap(),
         );
         let mut handle = CpfpHandle::default();
-        let outcome = perform_bump(
+        let bumped = perform_bump(
             &ctx,
             &parent,
             anchor_strategy(anchor_key),
@@ -2916,8 +2962,8 @@ pub(crate) mod tests {
         .await
         .expect("bump at the next-block rate must succeed");
         assert!(
-            matches!(outcome, BumpOutcome::Submitted),
-            "the next-block bump must submit a package: {outcome:?}"
+            matches!(bumped, BumpOutcome::Submitted),
+            "the next-block bump must submit a package: {bumped:?}"
         );
         assert_eq!(
             handle.last_pkg_fee_rate,
@@ -3140,6 +3186,218 @@ pub(crate) mod tests {
         }
     }
 
+    // ── Fee-knob tests (premium + package floor) ────────────────────────────
+    //
+    // The [`context`] helper pins neutral knobs (premium 0, floor 0 = raw estimate), so
+    // these tests build their context directly with the PRD values and assert the exact
+    // target the ladder computes: `handle.last_pkg_fee_rate` is the ladder's target, set
+    // only on a successful bump.
+
+    fn knob_test_context(
+        parent: &Transaction,
+        anchor_key: XOnlyPublicKey,
+        estimate: FeeRate,
+        premium_percent: u32,
+        min_package: FeeRate,
+        max_fee_rate: FeeRate,
+    ) -> CpfpContext<FakeWallet, FakeFeeSource, FakeSubmitter> {
+        let wallet_funding = vec![OutPoint {
+            txid: parent.compute_txid(),
+            vout: 7,
+        }];
+        let psbt = synthetic_child_psbt(parent, 0, anchor_key);
+        CpfpContext {
+            wallet: Arc::new(FakeWallet::returning(psbt, wallet_funding)),
+            fee_source: Arc::new(FakeFeeSource::returning(estimate)),
+            anchor_input_signer: fake_input_signer_ok(),
+            multi_anchor_signer: fake_input_signer_ok(),
+            wallet_input_signer: fake_input_signer_ok(),
+            max_fee_rate,
+            fee_premium_percent: premium_percent,
+            min_package_fee_rate: min_package,
+            mempool: Arc::new(FakeSubmitter::ok()),
+        }
+    }
+
+    #[tokio::test]
+    async fn fee_premium_raises_the_target() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        // 20 sat/vB × 1.05 = 21 sat/vB; the 10 sat/vB floor does not bind below the premium.
+        let ctx = knob_test_context(
+            &parent,
+            anchor_key,
+            FeeRate::from_sat_per_vb(20).unwrap(),
+            5,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            FeeRate::from_sat_per_vb(100).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("bump at the premium rate must succeed");
+        assert!(
+            matches!(bumped, BumpOutcome::Submitted),
+            "expected a submitted package: {bumped:?}"
+        );
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(21).unwrap()),
+            "5% premium on 20 sat/vB is 21 sat/vB"
+        );
+    }
+
+    #[tokio::test]
+    async fn package_floor_lifts_a_low_estimate() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        // Premium 0 is a no-op: the raw 3 sat/vB estimate lifts straight to the 10 sat/vB
+        // floor. A zero premium with a zero floor (the [`context`] helper) would keep 3.
+        let ctx = knob_test_context(
+            &parent,
+            anchor_key,
+            FeeRate::from_sat_per_vb(3).unwrap(),
+            0,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            FeeRate::from_sat_per_vb(100).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("bump at the floor must succeed");
+        assert!(
+            matches!(bumped, BumpOutcome::Submitted),
+            "expected a submitted package: {bumped:?}"
+        );
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(10).unwrap())
+        );
+    }
+
+    /// Pins the premium-then-floor order: the premium is computed on the raw estimate,
+    /// then the floor is applied to the premiumed rate. Premium 5% on 3 sat/vB is
+    /// 788 sat/kwu (below the floor); a floor-first regression would apply the premium to
+    /// the floored 10 sat/vB and land at 2625 sat/kwu instead of exactly the floor.
+    #[tokio::test]
+    async fn floor_applies_after_the_premium() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ctx = knob_test_context(
+            &parent,
+            anchor_key,
+            FeeRate::from_sat_per_vb(3).unwrap(),
+            5,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            FeeRate::from_sat_per_vb(100).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("bump at the floored premiumed rate must succeed");
+        assert!(
+            matches!(bumped, BumpOutcome::Submitted),
+            "expected a submitted package: {bumped:?}"
+        );
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(10).unwrap()),
+            "the floor must apply to the premiumed rate, not the other way round"
+        );
+    }
+
+    #[tokio::test]
+    async fn cap_wins_over_premium_and_floor() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        // 20 × 105 / 100 = 21, floor 10 does not bind, then the 12 sat/vB cap clamps the
+        // target. Order matters: the cap clamps the premium-raised rate, not the raw
+        // estimate.
+        let ctx = knob_test_context(
+            &parent,
+            anchor_key,
+            FeeRate::from_sat_per_vb(20).unwrap(),
+            5,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            FeeRate::from_sat_per_vb(12).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("clamped bump must succeed");
+        assert!(
+            matches!(bumped, BumpOutcome::Submitted),
+            "expected a submitted package: {bumped:?}"
+        );
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(12).unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn fee_premium_rounds_up_in_sat_kwu() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        // 3 sat/vB = 750 sat/kwu; 750 × 105 / 100 = 787.5, rounded up to 788. The rounding
+        // is conservative: the premium never lowers the target.
+        let ctx = knob_test_context(
+            &parent,
+            anchor_key,
+            FeeRate::from_sat_per_vb(3).unwrap(),
+            5,
+            FeeRate::from_sat_per_vb_unchecked(0),
+            FeeRate::from_sat_per_vb(100).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("premium bump must succeed");
+        assert!(
+            matches!(bumped, BumpOutcome::Submitted),
+            "expected a submitted package: {bumped:?}"
+        );
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_kwu(788))
+        );
+    }
+
     /// A constant-byte signer whose output is recognisable in the final witness, so a test can
     /// prove *which* signer produced a given signature rather than only that signing happened.
     fn fake_input_signer_const(byte: u8) -> InputSigner {
@@ -3225,6 +3483,9 @@ pub(crate) mod tests {
             multi_anchor_signer: fake_input_signer_const(0xAA),
             wallet_input_signer: fake_input_signer_const(0xBB),
             max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
+            // Neutral fee knobs: this test pins signer selection, not pricing.
+            fee_premium_percent: 0,
+            min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
             mempool: submitter.clone(),
         };
         let strategy = CpfpStrategy::MultiAnchorBearing {

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -413,17 +413,55 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, CpfpWalletError>> + Send;
 }
 
-/// Source of fee-rate estimates used to drive the package target. Defined in this crate
-/// (rather than reusing a wallet- or executor-side abstraction) so `btc-tracker` stays at
-/// the bottom of the dependency graph; callers implement it for their estimator of choice.
+/// Which market tier a fee estimate targets.
 ///
-/// In production the live estimator is wrapped in a [`CachedFeeSource`] so the bump loop
-/// reads from a hot atomic instead of hitting the network per call. The tracker refreshes
-/// it in the background on `refresh_interval`.
+/// The bridge prices two kinds of transaction. A CPFP child must confirm in the next block
+/// per the product fee decision, so the bump ladder reads [`FeeTarget::NextBlock`].
+/// Wallet-funded transactions (claim-funding refills, stake funding, unstaking burns,
+/// withdrawal fulfillments) are not time-critical and read [`FeeTarget::Standard`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeeTarget {
+    /// The configured standard tier: the source's configured confirmation target
+    /// (Bitcoin Core) or configured policy tier (mempool explorer).
+    Standard,
+    /// The source's fastest tier: confirmation target 1 (Bitcoin Core) or `fastestFee`
+    /// (mempool explorer).
+    NextBlock,
+}
+
+/// A paired fee estimate: one rate per [`FeeTarget`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TargetRates {
+    /// The rate for [`FeeTarget::Standard`].
+    pub standard: FeeRate,
+    /// The rate for [`FeeTarget::NextBlock`].
+    pub next_block: FeeRate,
+}
+
+/// Source of fee-rate estimates used to drive the package target.
+///
+/// Lives here (the lowest crate that needs it) rather than in `bridge-exec` to keep the
+/// dependency graph acyclic — `bridge-exec` depends on `btc-tracker`, and its concrete sources
+/// (`bridge-exec::fees::{BitcoindFeeSource, MempoolExplorerFeeSource, FixedFeeSource}`) implement
+/// this trait. In production the configured source is wrapped in a [`CachedFeeSource`] so the
+/// bump loop and the executors both read from a hot atomic instead of hitting the network per
+/// call; the tracker refreshes in the background on `refresh_interval`.
 pub trait CpfpFeeSource: Send + Sync + fmt::Debug {
-    /// Returns the current sat/vB target for the next block.
-    fn estimate(&self)
-        -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send;
+    /// Returns the current sat/vB rate for `target`.
+    fn estimate(
+        &self,
+        target: FeeTarget,
+    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send;
+
+    /// Returns a paired estimate for both targets, in one upstream round trip where the
+    /// source supports it.
+    ///
+    /// [`CachedFeeSource`] drives its refresh loop through this method so one call fills
+    /// both cache slots. A source must answer this without paying more upstream than two
+    /// separate [`Self::estimate`] calls.
+    fn estimate_all(
+        &self,
+    ) -> impl std::future::Future<Output = Result<TargetRates, FeeSourceError>> + Send;
 }
 
 /// Boxed future returned by an [`InputSigner`]; pinned + Send so it can fly across the
@@ -453,14 +491,14 @@ pub type InputSignFut =
 /// the corresponding outputs were constructed (keyed-Taproot, no script tree).
 pub type InputSigner = Arc<dyn Fn(Message) -> InputSignFut + Send + Sync>;
 
-/// A [`CpfpFeeSource`] that caches the most recent estimate in a shared atomic, refreshed in
-/// the background by a tokio task at a configurable interval.
+/// A [`CpfpFeeSource`] that caches one estimate per [`FeeTarget`] in shared atomics,
+/// refreshed in the background by a tokio task at a configurable interval.
 ///
 /// Wraps any underlying [`CpfpFeeSource`] (typically the live `bridge-exec::fees::FeeSource`
 /// going to Bitcoin Core or mempool.space). Reads from the cache are constant-time —
-/// `estimate()` returns the latest cached value without I/O, so the bump loop in
-/// [`TxDriver`](crate::tx_driver::TxDriver) can poll it on a fast timer without rate-limiting
-/// the underlying source.
+/// `estimate()` returns the latest cached value for the requested target without I/O, so
+/// the bump loop in [`TxDriver`](crate::tx_driver::TxDriver) can poll it on a fast timer
+/// without rate-limiting the underlying source.
 ///
 /// ## Initialization semantics
 ///
@@ -475,7 +513,10 @@ pub type InputSigner = Arc<dyn Fn(Message) -> InputSignFut + Send + Sync>;
 /// runs an infinite loop; tokio's `JoinHandle::abort` cancels it cleanly. In tests this
 /// ensures one test's tracker doesn't leak into the next.
 pub struct CachedFeeSource {
-    cached_sat_per_kwu: Arc<AtomicU64>,
+    /// Last successful refresh, in sat/kwu, for [`FeeTarget::Standard`].
+    standard_sat_per_kwu: Arc<AtomicU64>,
+    /// Last successful refresh, in sat/kwu, for [`FeeTarget::NextBlock`].
+    next_block_sat_per_kwu: Arc<AtomicU64>,
     /// Monotonic-millis-since-spawn of the most recent successful refresh. Stored as
     /// milliseconds elapsed from a process-start anchor [`Instant`] so it fits in `u64`
     /// and avoids wall-clock skew. Inspected via [`Self::seconds_since_last_refresh`] —
@@ -497,9 +538,15 @@ pub struct CachedFeeSource {
 
 impl Debug for CachedFeeSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let kwu = self.cached_sat_per_kwu.load(Ordering::Relaxed);
         f.debug_struct("CachedFeeSource")
-            .field("cached_sat_per_kwu", &kwu)
+            .field(
+                "standard_sat_per_kwu",
+                &self.standard_sat_per_kwu.load(Ordering::Relaxed),
+            )
+            .field(
+                "next_block_sat_per_kwu",
+                &self.next_block_sat_per_kwu.load(Ordering::Relaxed),
+            )
             .field(
                 "seconds_since_last_refresh",
                 &self.seconds_since_last_refresh(),
@@ -517,9 +564,9 @@ impl Drop for CachedFeeSource {
 }
 
 impl CachedFeeSource {
-    /// Performs one initial refresh from `underlying`, spawns a background task that re-polls
-    /// every `refresh_interval`, and returns a `CachedFeeSource` whose `estimate()` reads from
-    /// the cached atomic.
+    /// Performs one initial refresh from `underlying` (both targets, one round trip),
+    /// spawns a background task that re-polls every `refresh_interval`, and returns a
+    /// `CachedFeeSource` whose `estimate()` reads from the cached atomics.
     pub async fn spawn<U>(
         underlying: Arc<U>,
         refresh_interval: Duration,
@@ -528,14 +575,17 @@ impl CachedFeeSource {
         U: CpfpFeeSource + 'static,
     {
         let spawn_anchor = std::time::Instant::now();
-        let initial = underlying.estimate().await?;
-        let cached_sat_per_kwu = Arc::new(AtomicU64::new(initial.to_sat_per_kwu()));
+        let initial = underlying.estimate_all().await?;
+        let standard_sat_per_kwu = Arc::new(AtomicU64::new(initial.standard.to_sat_per_kwu()));
+        let next_block_sat_per_kwu = Arc::new(AtomicU64::new(initial.next_block.to_sat_per_kwu()));
         // Stamp the initial refresh time so `seconds_since_last_refresh()` returns ~0 right
         // after `spawn()` returns; otherwise the AtomicU64 would still be 0 and the elapsed
-        // calc would report the time since `spawn_anchor` instead.
+        // calc would report the time since `spawn_anchor` instead. One stamp covers both
+        // slots: a single refresh fills both.
         let initial_elapsed_ms = spawn_anchor.elapsed().as_millis().min(u64::MAX as u128) as u64;
         let last_refresh_unix_ms = Arc::new(AtomicU64::new(initial_elapsed_ms));
-        let cache_clone = cached_sat_per_kwu.clone();
+        let standard_clone = standard_sat_per_kwu.clone();
+        let next_block_clone = next_block_sat_per_kwu.clone();
         let last_refresh_clone = last_refresh_unix_ms.clone();
         let task = tokio::task::spawn(async move {
             let mut tick = tokio::time::interval(refresh_interval);
@@ -544,9 +594,11 @@ impl CachedFeeSource {
             tick.tick().await;
             loop {
                 tick.tick().await;
-                match underlying.estimate().await {
-                    Ok(rate) => {
-                        cache_clone.store(rate.to_sat_per_kwu(), Ordering::Relaxed);
+                match underlying.estimate_all().await {
+                    Ok(rates) => {
+                        standard_clone.store(rates.standard.to_sat_per_kwu(), Ordering::Relaxed);
+                        next_block_clone
+                            .store(rates.next_block.to_sat_per_kwu(), Ordering::Relaxed);
                         let elapsed =
                             spawn_anchor.elapsed().as_millis().min(u64::MAX as u128) as u64;
                         last_refresh_clone.store(elapsed, Ordering::Relaxed);
@@ -554,14 +606,15 @@ impl CachedFeeSource {
                     Err(e) => {
                         warn!(
                             error = %e,
-                            "fee-rate refresh failed; retaining last cached value"
+                            "fee-rate refresh failed; retaining last cached values"
                         );
                     }
                 }
             }
         });
         Ok(Self {
-            cached_sat_per_kwu,
+            standard_sat_per_kwu,
+            next_block_sat_per_kwu,
             last_refresh_unix_ms,
             spawn_anchor,
             max_staleness: refresh_interval.saturating_mul(STALENESS_REFRESH_MULTIPLE),
@@ -570,9 +623,13 @@ impl CachedFeeSource {
         })
     }
 
-    /// Returns the most recently cached fee rate without I/O.
-    pub fn current(&self) -> FeeRate {
-        FeeRate::from_sat_per_kwu(self.cached_sat_per_kwu.load(Ordering::Relaxed))
+    /// Returns the most recently cached fee rate for `target` without I/O.
+    pub fn current(&self, target: FeeTarget) -> FeeRate {
+        let kwu = match target {
+            FeeTarget::Standard => self.standard_sat_per_kwu.load(Ordering::Relaxed),
+            FeeTarget::NextBlock => self.next_block_sat_per_kwu.load(Ordering::Relaxed),
+        };
+        FeeRate::from_sat_per_kwu(kwu)
     }
 
     /// Returns the cached fee rate, or the cache age when the value is stale.
@@ -582,7 +639,7 @@ impl CachedFeeSource {
     /// duty, and the duty retries after the source recovers. The bump loop stays on the
     /// infallible [`Self::current`]: a bump at a stale rate is better than no bump,
     /// because the parent pays only the protocol floor without one.
-    pub fn try_current(&self) -> Result<FeeRate, StaleFeeRate> {
+    pub fn try_current(&self, target: FeeTarget) -> Result<FeeRate, StaleFeeRate> {
         // Millisecond precision, not `seconds_since_last_refresh`: that accessor truncates
         // to whole seconds, and a truncated age compares wrong against sub-second bounds.
         let last_ms = self.last_refresh_unix_ms.load(Ordering::Relaxed);
@@ -598,7 +655,7 @@ impl CachedFeeSource {
                 max_staleness: self.max_staleness,
             });
         }
-        Ok(self.current())
+        Ok(self.current(target))
     }
 
     /// Returns the number of seconds since the cache was last *successfully* refreshed.
@@ -615,17 +672,12 @@ impl CachedFeeSource {
             .min(u64::MAX as u128) as u64;
         now_ms.saturating_sub(last_ms) / 1_000
     }
-}
 
-impl CpfpFeeSource for CachedFeeSource {
-    /// Returns the cached value. Never returns `Err` — refresh failures are logged at the
-    /// background task and the prior value is retained. A stale cache logs one warning
-    /// per stale episode: on the bump path a stale rate is still worth acting on, and the
-    /// latch keeps one incident from repeating the warning on every bump trigger.
-    fn estimate(
-        &self,
-    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
-        match self.try_current() {
+    /// Warns once per stale episode. A stale cache keeps serving the last known rate on the
+    /// bump path; the latch keeps one incident from repeating the warning on every bump
+    /// trigger.
+    fn note_staleness(&self) {
+        match self.try_current(FeeTarget::Standard) {
             Err(stale) => {
                 if !self.stale_warned.swap(true, Ordering::Relaxed) {
                     warn!(
@@ -637,8 +689,31 @@ impl CpfpFeeSource for CachedFeeSource {
             }
             Ok(_) => self.stale_warned.store(false, Ordering::Relaxed),
         }
-        let value = self.current();
+    }
+}
+
+impl CpfpFeeSource for CachedFeeSource {
+    /// Returns the cached value for `target`. Never returns `Err` — refresh failures are
+    /// logged by the background task and the prior value is retained.
+    fn estimate(
+        &self,
+        target: FeeTarget,
+    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
+        self.note_staleness();
+        let value = self.current(target);
         async move { Ok(value) }
+    }
+
+    /// Returns both cached values. Staleness is shared: one refresh fills both slots.
+    fn estimate_all(
+        &self,
+    ) -> impl std::future::Future<Output = Result<TargetRates, FeeSourceError>> + Send {
+        self.note_staleness();
+        let rates = TargetRates {
+            standard: self.current(FeeTarget::Standard),
+            next_block: self.current(FeeTarget::NextBlock),
+        };
+        async move { Ok(rates) }
     }
 }
 
@@ -753,8 +828,15 @@ impl CpfpWallet for CpfpDisabled {
 impl CpfpFeeSource for CpfpDisabled {
     fn estimate(
         &self,
+        _target: FeeTarget,
     ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
         async { unreachable!("CpfpDisabled::estimate should never be called") }
+    }
+
+    fn estimate_all(
+        &self,
+    ) -> impl std::future::Future<Output = Result<TargetRates, FeeSourceError>> + Send {
+        async { unreachable!("CpfpDisabled::estimate_all should never be called") }
     }
 }
 
@@ -903,6 +985,13 @@ impl BumpReason {
 /// `handle.last_pkg_fee_rate` and `handle.last_child_txid` describe what actually reached the
 /// mempool, so those advance only on success.
 ///
+/// ## Fee target
+///
+/// The ladder reads [`FeeTarget::NextBlock`]: a CPFP child must confirm in the next block
+/// per the product fee decision, so it targets the source's fastest tier. Wallet-funded
+/// transactions price from [`FeeTarget::Standard`] through the same cache; they never
+/// touch this path.
+///
 /// ## Cap-and-warn at `max_fee_rate`
 ///
 /// When the fee source reports above `ctx.max_fee_rate`, the target is clamped and a warning
@@ -932,10 +1021,10 @@ where
 {
     let parent_txid = parent.compute_txid();
 
-    // ── 1. Query the fee source ─────────────────────────────────────────────
+    // ── 1. Query the fee source (next-block tier: the child must confirm next block) ──
     let estimated = ctx
         .fee_source
-        .estimate()
+        .estimate(FeeTarget::NextBlock)
         .await
         .map_err(CpfpError::FeeSource)?;
 
@@ -1391,9 +1480,22 @@ pub(crate) mod tests {
     impl CpfpFeeSource for FakeFeeSource {
         fn estimate(
             &self,
+            _target: FeeTarget,
         ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
             let r = self.rate.lock().unwrap().clone();
             async move { r }
+        }
+
+        fn estimate_all(
+            &self,
+        ) -> impl std::future::Future<Output = Result<TargetRates, FeeSourceError>> + Send {
+            let r = self.rate.lock().unwrap().clone();
+            async move {
+                r.map(|rate| TargetRates {
+                    standard: rate,
+                    next_block: rate,
+                })
+            }
         }
     }
 
@@ -2704,9 +2806,16 @@ pub(crate) mod tests {
         let cache = CachedFeeSource::spawn(underlying, Duration::from_secs(60))
             .await
             .expect("initial refresh must succeed");
-        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(7).unwrap());
+        assert_eq!(
+            cache.current(FeeTarget::Standard),
+            FeeRate::from_sat_per_vb(7).unwrap()
+        );
+        assert_eq!(
+            cache.current(FeeTarget::NextBlock),
+            FeeRate::from_sat_per_vb(7).unwrap()
+        );
         // Trait impl returns the same.
-        let via_trait = cache.estimate().await.unwrap();
+        let via_trait = cache.estimate(FeeTarget::NextBlock).await.unwrap();
         assert_eq!(via_trait, FeeRate::from_sat_per_vb(7).unwrap());
     }
 
@@ -2715,6 +2824,106 @@ pub(crate) mod tests {
         let underlying = Arc::new(FakeFeeSource::failing());
         let result = CachedFeeSource::spawn(underlying, Duration::from_secs(60)).await;
         assert!(result.is_err(), "initial refresh failure must propagate");
+    }
+
+    /// Fee source that answers differently per target, for exercising the dual slots of
+    /// [`CachedFeeSource`].
+    #[derive(Debug)]
+    struct TwoTierFeeSource {
+        standard: FeeRate,
+        next_block: FeeRate,
+    }
+    impl CpfpFeeSource for TwoTierFeeSource {
+        fn estimate(
+            &self,
+            target: FeeTarget,
+        ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
+            let rate = match target {
+                FeeTarget::Standard => self.standard,
+                FeeTarget::NextBlock => self.next_block,
+            };
+            async move { Ok(rate) }
+        }
+
+        #[expect(clippy::manual_async_fn, reason = "mirror AFIT trait signature shape")]
+        fn estimate_all(
+            &self,
+        ) -> impl std::future::Future<Output = Result<TargetRates, FeeSourceError>> + Send {
+            async move {
+                Ok(TargetRates {
+                    standard: self.standard,
+                    next_block: self.next_block,
+                })
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn cached_fee_source_keeps_distinct_rates_per_target() {
+        let underlying = Arc::new(TwoTierFeeSource {
+            standard: FeeRate::from_sat_per_vb(3).unwrap(),
+            next_block: FeeRate::from_sat_per_vb(12).unwrap(),
+        });
+        let cache = CachedFeeSource::spawn(underlying, Duration::from_secs(60))
+            .await
+            .unwrap();
+        assert_eq!(
+            cache.current(FeeTarget::Standard),
+            FeeRate::from_sat_per_vb(3).unwrap()
+        );
+        assert_eq!(
+            cache.current(FeeTarget::NextBlock),
+            FeeRate::from_sat_per_vb(12).unwrap()
+        );
+        let paired = cache.estimate_all().await.unwrap();
+        assert_eq!(paired.standard, FeeRate::from_sat_per_vb(3).unwrap());
+        assert_eq!(paired.next_block, FeeRate::from_sat_per_vb(12).unwrap());
+    }
+
+    /// Pins the ladder's target read: `perform_bump` must price from
+    /// [`FeeTarget::NextBlock`], not [`FeeTarget::Standard`]. The source returns distinct
+    /// rates per target; a ladder regressed to reading `Standard` would target 10 sat/vB
+    /// instead of 20 and this assert fails.
+    #[tokio::test]
+    async fn bump_ladder_prices_from_the_next_block_target() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let wallet_funding = vec![OutPoint {
+            txid: parent.compute_txid(),
+            vout: 7,
+        }];
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+        let ctx = context(
+            Arc::new(TwoTierFeeSource {
+                standard: FeeRate::from_sat_per_vb(10).unwrap(),
+                next_block: FeeRate::from_sat_per_vb(20).unwrap(),
+            }),
+            Arc::new(FakeWallet::returning(psbt, wallet_funding)),
+            Arc::new(FakeSubmitter::ok()),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(100).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let outcome = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("bump at the next-block rate must succeed");
+        assert!(
+            matches!(outcome, BumpOutcome::Submitted),
+            "the next-block bump must submit a package: {outcome:?}"
+        );
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(20).unwrap()),
+            "the ladder target must derive from the next-block rate"
+        );
     }
 
     /// Fee source whose result can be swapped mid-test, for exercising the background
@@ -2726,9 +2935,22 @@ pub(crate) mod tests {
     impl CpfpFeeSource for FlippableFeeSource {
         fn estimate(
             &self,
+            _target: FeeTarget,
         ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
             let r = self.inner.lock().unwrap().clone();
             async move { r }
+        }
+
+        fn estimate_all(
+            &self,
+        ) -> impl std::future::Future<Output = Result<TargetRates, FeeSourceError>> + Send {
+            let r = self.inner.lock().unwrap().clone();
+            async move {
+                r.map(|rate| TargetRates {
+                    standard: rate,
+                    next_block: rate,
+                })
+            }
         }
     }
 
@@ -2743,7 +2965,10 @@ pub(crate) mod tests {
         let cache = CachedFeeSource::spawn(flippable.clone(), Duration::from_millis(5))
             .await
             .unwrap();
-        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(10).unwrap());
+        assert_eq!(
+            cache.current(FeeTarget::Standard),
+            FeeRate::from_sat_per_vb(10).unwrap()
+        );
 
         // Flip underlying to failing.
         *flippable.inner.lock().unwrap() = Err(FeeSourceError("transient blip".into()));
@@ -2751,7 +2976,10 @@ pub(crate) mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Cache still reports 10.
-        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(10).unwrap());
+        assert_eq!(
+            cache.current(FeeTarget::Standard),
+            FeeRate::from_sat_per_vb(10).unwrap()
+        );
     }
 
     #[tokio::test]
@@ -2763,13 +2991,19 @@ pub(crate) mod tests {
         let cache = CachedFeeSource::spawn(flippable.clone(), Duration::from_millis(5))
             .await
             .unwrap();
-        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(5).unwrap());
+        assert_eq!(
+            cache.current(FeeTarget::Standard),
+            FeeRate::from_sat_per_vb(5).unwrap()
+        );
 
         *flippable.inner.lock().unwrap() = Ok(FeeRate::from_sat_per_vb(30).unwrap());
         // Allow a few refresh ticks to fire.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(30).unwrap());
+        assert_eq!(
+            cache.current(FeeTarget::Standard),
+            FeeRate::from_sat_per_vb(30).unwrap()
+        );
     }
 
     /// `try_current` refuses a cache that has not refreshed inside its staleness bound,
@@ -2784,20 +3018,20 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(
-            cache.try_current().is_ok(),
+            cache.try_current(FeeTarget::Standard).is_ok(),
             "a fresh cache serves duty pricing"
         );
 
         // Every later refresh fails; the bound is 10 × 10 ms = 100 ms.
-        *flippable.inner.lock().unwrap() = Err("source died".to_string());
+        *flippable.inner.lock().unwrap() = Err(FeeSourceError("source died".into()));
         tokio::time::sleep(Duration::from_millis(300)).await;
 
         let err = cache
-            .try_current()
+            .try_current(FeeTarget::Standard)
             .expect_err("a stale cache must refuse duty pricing");
         assert!(err.age > err.max_staleness);
         assert_eq!(
-            cache.current(),
+            cache.current(FeeTarget::Standard),
             FeeRate::from_sat_per_vb(5).unwrap(),
             "the bump path keeps the last known rate"
         );

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -1483,6 +1483,9 @@ mod cpfp_lifecycle_tests {
             multi_anchor_signer: fake_input_signer_ok(),
             wallet_input_signer: fake_input_signer_ok(),
             max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
+            // Neutral fee knobs: the tx_driver tests pin the raw-estimate-to-cap behavior.
+            fee_premium_percent: 0,
+            min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
             mempool: Arc::new(submitter),
         }
     }
@@ -1536,6 +1539,9 @@ mod cpfp_lifecycle_tests {
                 multi_anchor_signer: fake_input_signer_ok(),
                 wallet_input_signer: fake_input_signer_ok(),
                 max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
+                // Neutral fee knobs: the tx_driver tests pin the raw-estimate-to-cap behavior.
+                fee_premium_percent: 0,
+                min_package_fee_rate: FeeRate::from_sat_per_vb_unchecked(0),
                 mempool: submitter.clone(),
             };
             let (parents, mark) =

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -365,6 +365,7 @@ pub(crate) const fn executor_error_class(error: &ExecutorError) -> &'static str 
         ExecutorError::InvalidTxStructure(_) => "invalid_transaction_structure",
         ExecutorError::FeeRateTooHigh { .. } => "fee_rate_too_high",
         ExecutorError::StakeFundingTxInMempool(_) => "stake_funding_tx_in_mempool",
+        ExecutorError::FeeSourceStale(_) => "fee_source_stale",
     }
 }
 


### PR DESCRIPTION
Closes [STR-3438](https://alpenlabs.atlassian.net/browse/STR-3438).

## Summary

Replaces the two direct \`estimate_smart_fee(1)\` calls in \`deposit.rs\` and \`stake/staking.rs\` with a configurable fee-source abstraction. Mirrors strata's btcio shape (per Slack discussion with @Rajil1213 and @bewakes), kept bridge-local per Rajil's call against a shared crate.

## Design

\`FeeSource\` trait + 3 impls in \`crates/bridge-exec/src/fees.rs\`:

| Policy | Behaviour |
|---|---|
| \`BitcoinCore { conf_target }\` | Wraps \`estimatesmartfee\` |
| \`MempoolExplorer { base_url, policy, fallback_conf_target }\` | GETs \`/api/v1/fees/recommended\` on a mempool.space-compatible explorer, with BitcoinCore as the fallback on any HTTP/decode failure (mempool error absorbed, only logged — a downed explorer must never block tx publishing) |
| \`Fixed { fee_rate }\` | Tests / manual overrides |

Operator-side config selects via \`FeeSourceConfig\` (snake_case tagged enum), built into \`Arc<dyn FeeSource>\` at orchestrator boot. \`#[serde(default)]\` → \`BitcoinCore { conf_target: 1 }\`, preserving pre-PR behaviour for existing operator config.toml files.

## Deliberate divergences from strata's impl

- **No \`×2\` multiplier**. Strata doubles the rate as a temporary hedge until proper fee bumping lands (and wants to drop it). The bridge has STR-3439 (CPFP + RBF in tx-driver) for that — we skip the hack.
- **No shared crate**. Per Rajil: \"pretty straightforward and probably overkill to have a separate crate for.\"
- **Clamp adopted**: \`max(rate, 1)\` per Jose's STR-2018 fix (alpenlabs/alpen#1811) against \`bitcoind-async-client\`'s sub-1 sat/vB truncation.

## Hardening from local audit

- 10s timeout on \`SHARED_HTTP_CLIENT\` — reqwest default is no timeout; a hanging mempool explorer would otherwise block the duty future indefinitely (the fallback only fires on errors, not on never-resolving futures).
- \`clamp_to_min\` uses \`unwrap_or_else\` rather than \`expect\` to guard against absurd inputs (e.g. \`Fixed { fee_rate: u64::MAX }\`).

## Scope notes

The ticket cited three call sites but the third (\`graph/common.rs:166\`) is a hardcoded \`fee::FEE_RATE\` constant for the claim-funding refill self-spend, not a live \`estimate_smart_fee\` call. Left as-is — that's a different conversation about whether self-spend refills should use live estimates.

## Responsibility split (for context)

The \`FeeSource\` trait is stateless. Callers fetch once per tx-build. Live fee tracking — periodically re-checking to drive RBF bumps — is the tx-driver's job once CPFP wiring lands in STR-3439. The trait deliberately does not poll, cache, or push.

## Test plan

- [x] \`cargo fmt --all && cargo clippy --workspace --all-targets --all-features\` clean
- [x] 15 fee-source unit tests (happy paths, fallback on 5xx / malformed JSON / both fail, URL trailing-slash handling, overflow safety, default check, toml roundtrip for all variants incl. multi-word \`half_hour\`)
- [ ] CI green

[STR-3438]: https://alpenlabs.atlassian.net/browse/STR-3438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ