### PR TITLE
feat(bridge-exec): wire CPFP + aggressive RBF for bridge txs (STR-3439)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11663,6 +11663,8 @@ dependencies = [
  "operator-wallet",
  "secret-service-client",
  "secret-service-proto",
+ "serde",
+ "serde_json",
  "serial_test",
  "ssz",
  "strata-asm-proto-bridge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11663,6 +11663,7 @@ dependencies = [
  "operator-wallet",
  "secret-service-client",
  "secret-service-proto",
+ "serial_test",
  "ssz",
  "strata-asm-proto-bridge",
  "strata-asm-proto-bridge-txs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,9 @@ bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoincore-rpc = "0.19.0"
 bitcoind-async-client = { version = "0.14.0", default-features = false, features = [
   "30_2",
+  # `raw_rpc` exposes `call_raw`, which the CPFP bump loop needs for
+  # `gettxspendingprevout`. The typed surface of the client does not cover it.
+  "raw_rpc",
 ] }
 borsh = { version = "1.6.1", features = ["derive"] }
 cfg-if = "1.0"

--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -4,6 +4,17 @@
 //! different operators.
 use std::{fmt, net::SocketAddr, path::PathBuf, time::Duration};
 
+/// Default cadence for the background fee-rate refresh task — see
+/// [`Config::fee_refresh_interval`].
+const fn default_fee_refresh_interval() -> Duration {
+    Duration::from_secs(30)
+}
+
+/// Default cadence for the CPFP bump-check timer — see [`Config::cpfp_bump_check_interval`].
+const fn default_cpfp_bump_check_interval() -> Duration {
+    Duration::from_secs(30)
+}
+
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 use strata_bridge_asm_events::config::AsmRpcConfig;
@@ -49,6 +60,20 @@ pub(crate) struct Config {
 
     /// The maximum fee rate for any transaction (in sats/vb).
     pub max_fee_rate: u64,
+
+    /// Background-refresh cadence for the cached fee rate. The bridge spawns a tokio task at
+    /// startup that polls the configured fee source at this interval and stores the result in
+    /// a shared atomic; the CPFP bump loop reads from that cache instead of hitting the
+    /// underlying source per call. Defaults to 30 seconds.
+    #[serde(default = "default_fee_refresh_interval")]
+    pub fee_refresh_interval: Duration,
+
+    /// Cadence at which the CPFP bump loop polls the cached fee rate and attempts an RBF bump
+    /// of any active CPFP parent whose current package rate is below the new target. Defaults
+    /// to 30 seconds. Set higher to reduce wallet-lock contention; set lower for snappier
+    /// reaction to fee-market moves between blocks.
+    #[serde(default = "default_cpfp_bump_check_interval")]
+    pub cpfp_bump_check_interval: Duration,
 
     /// Configuration required to connector to a _local_ instance of the secret service server.
     pub secret_service_client: SecretServiceConfig,

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -1,6 +1,10 @@
 //! Provides operator wallet initialization.
 
-use std::{num::NonZero, sync::Arc, time::Instant};
+use std::{
+    num::NonZero,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use anyhow::anyhow;
 use bdk_bitcoind_rpc::bitcoincore_rpc;
@@ -91,18 +95,42 @@ pub(in crate::mode) async fn init_operator_wallet(
     })
 }
 
-/// Performs a one-shot sync of the operator wallet against its backend.
+/// Interval between attempts when the initial operator wallet sync fails.
+const INITIAL_SYNC_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Syncs the operator wallet against its backend until one sync succeeds, then returns.
 ///
-/// Intended to run as a background task at startup so the wallet has a head start before its
-/// first on-demand use. A sync failure is logged and swallowed: callers must still sync the wallet
-/// before use, so a failed initial sync must not crash the node.
+/// Intended to run as a background task at startup. The retry loop matters because syncs
+/// are duty-driven after startup: without it, a bitcoind or backend outage at boot leaves
+/// the wallet empty, and every CPFP bump fails with `InsufficientFunding` until the first
+/// duty happens to call `sync()`. A failed attempt does not crash the node — it is logged
+/// and retried.
 pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(wallet: Arc<RwLock<NativeWallet>>) {
     info!("starting initial operator wallet sync");
-    let start = Instant::now();
-    match wallet.write().await.sync().await {
-        Ok(()) => info!(time_spent=?start.elapsed(), "initial operator wallet sync complete"),
-        Err(e) => {
-            warn!(?e, time_spent=?start.elapsed(), "initial operator wallet sync failed, first use might be slow")
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        let start = Instant::now();
+        // Bind the result so the write guard (a temporary in this expression) drops here.
+        // A `match` directly on the expression keeps the guard alive through the arms, and
+        // the retry sleep then holds the wallet write lock for the whole interval — every
+        // duty and the health probe stall behind it.
+        let result = wallet.write().await.sync().await;
+        match result {
+            Ok(()) => {
+                info!(time_spent=?start.elapsed(), attempt, "initial operator wallet sync complete");
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    ?e,
+                    time_spent=?start.elapsed(),
+                    attempt,
+                    retry_in=?INITIAL_SYNC_RETRY_INTERVAL,
+                    "initial operator wallet sync failed; wallet stays unusable until a sync succeeds"
+                );
+                tokio::time::sleep(INITIAL_SYNC_RETRY_INTERVAL).await;
+            }
         }
     }
 }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -221,11 +221,9 @@ where
     // and `OperatorTable::select_btc_x_only(our_pubkey)`), but the explicit lookup catches
     // configuration drift between secret-service and the static params file.
     //
-    // The OTHER invariant the CPFP path depends on — `watchtower_pubkey == musig2_pubkey`
-    // for counterproof / counterproof_ack anchors — is anchored at the `CovenantKeys`
-    // definition itself via `_covenant_keys_field_audit` (see `crates/common/src/params.rs`).
-    // That destructuring forces a compile error if anyone adds a separate `watchtower` field,
-    // which is the cue to thread per-anchor keys through `CpfpKind::AnchorAt`.
+    // The related invariant is `watchtower_pubkey == musig2_pubkey`. The operator table makes
+    // it, from `covenant[i].musig2`. A field change on `CovenantKeys` breaks the compilation
+    // of `_covenant_keys_field_audit` (see `crates/common/src/params.rs`).
     params
         .keys
         .covenant
@@ -233,8 +231,7 @@ where
         .find(|c| c.musig2 == operator_musig2_pubkey)
         .ok_or_else(|| {
             anyhow!(
-                "operator musig2 pubkey {} is not in the configured covenant set; \
-                 cannot establish watchtower-key = musig2-key invariant required by CPFP",
+                "operator musig2 pubkey {} is not in the configured covenant set",
                 operator_musig2_pubkey,
             )
         })?;

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -21,7 +21,7 @@ use strata_bridge_db::fdb::client::FdbClient;
 use strata_bridge_exec::{
     config::ExecutionConfig,
     cpfp_adapters::{
-        BitcoindCpfpFeeSource, BitcoindCpfpPackageSubmitter, OperatorWalletCpfpAdapter,
+        BitcoindCpfpFeeSource, BitcoindCpfpMempool, OperatorWalletCpfpAdapter,
         build_anchor_input_signer, build_multi_anchor_signer, build_wallet_input_signer,
     },
     output_handles::{NativeWallet, OutputHandles},
@@ -243,7 +243,7 @@ where
         wallet.clone(),
         operator_general_pubkey,
     ));
-    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(btc_rpc_arc.clone()));
+    let cpfp_submitter = Arc::new(BitcoindCpfpMempool::new(btc_rpc_arc.clone()));
     // Two distinct signers, bound to two distinct keys:
     //   - anchor inputs use the musig2-signer pubkey (the bridge tx-graph keys every KeyedAnchor to
     //     this pubkey — see `bridge-sm::graph::context::generate_key_data`).
@@ -261,7 +261,7 @@ where
         multi_anchor_signer,
         wallet_input_signer,
         max_fee_rate: exec_cfg.maximum_fee_rate,
-        package_submitter: cpfp_submitter,
+        mempool: cpfp_submitter,
     };
     let tx_driver = TxDriver::with_cpfp(
         zmq_client,

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -225,7 +225,7 @@ where
     // for counterproof / counterproof_ack anchors — is anchored at the `CovenantKeys`
     // definition itself via `_covenant_keys_field_audit` (see `crates/common/src/params.rs`).
     // That destructuring forces a compile error if anyone adds a separate `watchtower` field,
-    // which is the cue to thread per-anchor keys through `CpfpKind::InferAnchor`.
+    // which is the cue to thread per-anchor keys through `CpfpKind::AnchorAt`.
     params
         .keys
         .covenant

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -5,16 +5,25 @@ use std::{cmp, collections::VecDeque, num::NonZero, sync::Arc, time::Duration};
 use anyhow::anyhow;
 use bitcoin::{FeeRate, relative};
 use bitcoind_async_client::Client as BitcoinClient;
-use btc_tracker::{client::BtcNotifyHealthEvent, tx_driver::TxDriver};
+use btc_tracker::{
+    client::BtcNotifyHealthEvent,
+    cpfp::{CachedFeeSource, CpfpContext},
+    tx_driver::TxDriver,
+};
 use jsonrpsee::http_client::HttpClient;
 use libp2p_identity::ed25519::Keypair;
 use secret_service_client::SecretServiceClient;
+use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_asm_events::client::{AsmEventFeed, AsmFeedHealthEvent};
 use strata_bridge_common::params::Params;
 use strata_bridge_counterproof::BridgeCounterproofHost;
 use strata_bridge_db::fdb::client::FdbClient;
 use strata_bridge_exec::{
     config::ExecutionConfig,
+    cpfp_adapters::{
+        BitcoindCpfpFeeSource, BitcoindCpfpPackageSubmitter, OperatorWalletCpfpAdapter,
+        build_anchor_input_signer, build_multi_anchor_signer, build_wallet_input_signer,
+    },
     output_handles::{NativeWallet, OutputHandles},
 };
 use strata_bridge_orchestrator::{
@@ -28,6 +37,7 @@ use strata_bridge_sm::{
     self, deposit::config::DepositSMCfg, graph::config::GraphSMCfg, stake::config::StakeSMCfg,
 };
 use strata_bridge_tx_graph::{
+    fee,
     game_graph::{AdminMultisig, ProtocolParams as TxGraphProtocolParams},
     stake_graph::ProtocolParams as StakeGraphProtocolParams,
 };
@@ -163,7 +173,104 @@ where
     };
 
     let exec_cfg = build_exec_config(params, config, &sm_config, claim_funding_utxo_value);
-    let tx_driver = TxDriver::new(zmq_client, btc_rpc_client.clone()).await;
+
+    // CPFP wiring: build the cached fee-source over a bitcoind-backed estimator, then bundle
+    // the wallet / fee-source / package-submitter / anchor-signer adapters into a
+    // `CpfpContext`. The tx-driver consumes this in its bump loop.
+    //
+    // Validate both Duration knobs up-front — `tokio::time::interval` panics if `period` is
+    // zero, and the panic would surface deep inside `CachedFeeSource::spawn` /
+    // `TxDriver::with_cpfp` as a cryptic task crash. Fail at orchestrator startup with a
+    // clear message instead.
+    if config.fee_refresh_interval.is_zero() {
+        return Err(anyhow!(
+            "config.fee_refresh_interval must be > 0; got {:?}",
+            config.fee_refresh_interval
+        ));
+    }
+    if config.cpfp_bump_check_interval.is_zero() {
+        return Err(anyhow!(
+            "config.cpfp_bump_check_interval must be > 0; got {:?}",
+            config.cpfp_bump_check_interval
+        ));
+    }
+    let btc_rpc_arc = Arc::new(btc_rpc_client.clone());
+    let bitcoind_fee_source = Arc::new(BitcoindCpfpFeeSource::new(btc_rpc_arc.clone(), 1));
+    let cached_fee_source = Arc::new(
+        CachedFeeSource::spawn(bitcoind_fee_source, config.fee_refresh_interval)
+            .await
+            .map_err(|e| anyhow!("failed to initialize cached fee source: {e}"))?,
+    );
+    // Fetch the operator's pubkeys up-front: needed both for the CPFP adapter
+    // (`operator_general_pubkey` is used as the foreign-UTXO `tap_internal_key` for
+    // `ParentTxCombined` strategies) and for `OutputHandles` (anchor inference key + caveat
+    // pubkeys for the publishing helper).
+    let operator_musig2_pubkey = s2_client
+        .musig2_signer()
+        .pubkey()
+        .await
+        .map_err(|e| anyhow!("failed to fetch operator musig2 pubkey from s2: {e:?}"))?;
+    let operator_general_pubkey = s2_client
+        .general_wallet_signer()
+        .pubkey()
+        .await
+        .map_err(|e| anyhow!("failed to fetch operator general wallet pubkey from s2: {e:?}"))?;
+
+    // Sanity check that our own musig2 pubkey is present in the covenant set. This is
+    // tautological by construction today (the operator table is built from `covenant.iter`
+    // and `OperatorTable::select_btc_x_only(our_pubkey)`), but the explicit lookup catches
+    // configuration drift between secret-service and the static params file.
+    //
+    // The OTHER invariant the CPFP path depends on — `watchtower_pubkey == musig2_pubkey`
+    // for counterproof / counterproof_ack anchors — is anchored at the `CovenantKeys`
+    // definition itself via `_covenant_keys_field_audit` (see `crates/common/src/params.rs`).
+    // That destructuring forces a compile error if anyone adds a separate `watchtower` field,
+    // which is the cue to thread per-anchor keys through `CpfpKind::InferAnchor`.
+    params
+        .keys
+        .covenant
+        .iter()
+        .find(|c| c.musig2 == operator_musig2_pubkey)
+        .ok_or_else(|| {
+            anyhow!(
+                "operator musig2 pubkey {} is not in the configured covenant set; \
+                 cannot establish watchtower-key = musig2-key invariant required by CPFP",
+                operator_musig2_pubkey,
+            )
+        })?;
+
+    let cpfp_wallet = Arc::new(OperatorWalletCpfpAdapter::new(
+        wallet.clone(),
+        operator_general_pubkey,
+    ));
+    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(btc_rpc_arc.clone()));
+    // Two distinct signers, bound to two distinct keys:
+    //   - anchor inputs use the musig2-signer pubkey (the bridge tx-graph keys every KeyedAnchor to
+    //     this pubkey — see `bridge-sm::graph::context::generate_key_data`).
+    //   - wallet funding inputs use the general-wallet-signer pubkey (the descriptor key of
+    //     `NativeGeneralWallet`).
+    let anchor_input_signer = build_anchor_input_signer(s2_client.clone());
+    // Script-path variant for `MultiAnchor` anchors (contest, bridge-proof-timeout): same
+    // musig2 key, signed untweaked because the leaf is satisfied directly.
+    let multi_anchor_signer = build_multi_anchor_signer(s2_client.clone());
+    let wallet_input_signer = build_wallet_input_signer(s2_client.clone());
+    let cpfp_ctx = CpfpContext {
+        wallet: cpfp_wallet,
+        fee_source: cached_fee_source,
+        anchor_input_signer,
+        multi_anchor_signer,
+        wallet_input_signer,
+        max_fee_rate: exec_cfg.maximum_fee_rate,
+        package_submitter: cpfp_submitter,
+    };
+    let tx_driver = TxDriver::with_cpfp(
+        zmq_client,
+        btc_rpc_client.clone(),
+        Some(cpfp_ctx),
+        fee::FEE_RATE,
+        config.cpfp_bump_check_interval,
+    )
+    .await;
     let tx_driver_health = tx_driver.health_handle();
     health_registry.mark_ok(COMPONENT_TX_DRIVER, "driver_initialized");
     spawn_tx_driver_probe(
@@ -182,6 +289,9 @@ where
         mosaic_client,
         bridge_proof_host,
         counterproof_host,
+        operator_general_pubkey,
+        operator_musig2_pubkey,
+        network: params.network,
     };
     let duty_dispatcher = DutyDispatcher::new(exec_cfg.into(), output_handles.into());
 

--- a/crates/bridge-exec/Cargo.toml
+++ b/crates/bridge-exec/Cargo.toml
@@ -45,6 +45,8 @@ futures.workspace = true
 jsonrpsee = { workspace = true, features = ["client"] }
 metrics.workspace = true
 musig2.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 ssz.workspace = true
 terrors.workspace = true
 thiserror.workspace = true

--- a/crates/bridge-exec/Cargo.toml
+++ b/crates/bridge-exec/Cargo.toml
@@ -56,6 +56,7 @@ strata-bridge-test-utils.workspace = true
 
 bdk_bitcoind_rpc.workspace = true
 corepc-node.workspace = true
+serial_test.workspace = true
 
 [features]
 default = []

--- a/crates/bridge-exec/src/chain.rs
+++ b/crates/bridge-exec/src/chain.rs
@@ -7,11 +7,9 @@ use bitcoin::{
 use bitcoind_async_client::{Client as BitcoinClient, error::ClientError, traits::Reader};
 use btc_tracker::{cpfp::CpfpStrategy, event::TxStatus, tx_driver::TxDriver};
 use strata_bridge_tx_graph::fee;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
-use crate::{
-    cpfp_adapters::infer_anchor_strategy, errors::ExecutorError, output_handles::OutputHandles,
-};
+use crate::{errors::ExecutorError, output_handles::OutputHandles};
 
 /// Computes the fee paid by a tx that follows the bridge protocol floor rate
 /// ([`fee::FEE_RATE`] = 2 sat/vB). This is the right helper for presigned bridge txs
@@ -66,6 +64,57 @@ pub(crate) fn first_general_payout_outpoint(
         output_handles.operator_general_pubkey,
         output_handles.network,
     )
+}
+
+/// Validates the caller-named anchor vout and returns the CPFP strategy for it.
+///
+/// The caller names the vout from its tx type's own constant, so a mismatch here is a code
+/// defect: the constant and the builder disagree. The check compares the output's script
+/// against the operator-keyed anchor script and its value against the anchor dust floor.
+/// The value check is `>=`, not `==` — `CounterproofAckTx` folds its input connectors'
+/// residual into the anchor, so that anchor carries two times the dust value.
+///
+/// On a mismatch this logs at error level and returns `None`. The transaction still
+/// publishes: it is signed and the protocol needs it on chain. Only the bump path is lost,
+/// and the error names exactly what to fix.
+fn checked_anchor_strategy(
+    tx: &Transaction,
+    anchor_vout: u32,
+    anchor_pubkey: bitcoin::XOnlyPublicKey,
+    network: bitcoin::Network,
+    parent_fee: Amount,
+    label: &str,
+) -> Option<CpfpStrategy> {
+    let txid = tx.compute_txid();
+    let expected_script = Address::p2tr(SECP256K1, anchor_pubkey, None, network).script_pubkey();
+    let expected_value = fee::anchor_dust_value();
+    let Some(output) = tx.output.get(anchor_vout as usize) else {
+        error!(
+            %txid,
+            %label,
+            anchor_vout,
+            n_outputs = tx.output.len(),
+            "anchor vout is out of range; publishing without CPFP"
+        );
+        return None;
+    };
+    if output.script_pubkey != expected_script || output.value < expected_value {
+        error!(
+            %txid,
+            %label,
+            anchor_vout,
+            output_value = %output.value,
+            expected_min_value = %expected_value,
+            script_matches = output.script_pubkey == expected_script,
+            "named output is not an operator-keyed anchor; publishing without CPFP"
+        );
+        return None;
+    }
+    Some(CpfpStrategy::AnchorBearing {
+        anchor_vout,
+        anchor_internal_key: anchor_pubkey,
+        parent_fee,
+    })
 }
 
 /// Inner helper for [`first_general_payout_outpoint`]; takes the pubkey/network explicitly so
@@ -152,9 +201,11 @@ pub(crate) async fn is_outpoint_unspent(
 /// Hint that lets the caller of [`publish_signed_transaction`] override how the CPFP
 /// strategy is selected for a parent transaction.
 ///
-/// - [`Self::InferAnchor`]: scan the parent for an operator-keyed Taproot anchor output via
-///   [`infer_anchor_strategy`]. Applies to claim/stake/unstaking_intent/counterproof/
-///   counterproof_ack and any other tx with a `KeyedAnchor` connector.
+/// - [`Self::AnchorAt`]: the parent carries an operator-keyed Taproot anchor at a vout that the
+///   caller knows statically (each tx type exports its anchor vout as a constant). Applies to
+///   claim/stake/unstaking_intent/counterproof/counterproof_ack and any other tx with a
+///   `KeyedAnchor` connector. The publish helper checks the named output against the expected
+///   anchor script and value before it enables CPFP.
 /// - [`Self::PayoutCombined`] (for txs implementing
 ///   [`strata_bridge_connectors::ParentTxCombined`]): no keyed anchor; instead the caller-supplied
 ///   operator-owned output (`payout_outpoint`) is spent by the CPFP child. Applies to
@@ -171,8 +222,12 @@ pub(crate) async fn is_outpoint_unspent(
 ///   bridge proof).
 #[derive(Debug, Clone)]
 pub(crate) enum CpfpKind {
-    /// Look for an operator-keyed anchor on the parent.
-    InferAnchor,
+    /// The parent carries an operator-keyed Taproot anchor at this vout.
+    AnchorAt {
+        /// Index of the anchor output on the parent. Callers pass the tx type's own
+        /// constant (for example `StakeTx::CPFP_VOUT`), not a discovered value.
+        anchor_vout: u32,
+    },
     /// Build the child by spending the given operator-owned output of the parent.
     PayoutCombined { payout_outpoint: OutPoint },
     /// Look for the first output paying the operator's general-wallet script and use it as
@@ -182,9 +237,9 @@ pub(crate) enum CpfpKind {
     /// Bump a multi-leaf (`MultiAnchor`) anchor script-path, satisfying the leaf this operator
     /// is entitled to as a watchtower of the parent's graph.
     ///
-    /// Used by `contest` and `bridge_proof_timeout`. Unlike [`Self::InferAnchor`] nothing is
-    /// inferred from the transaction: which leaf we may satisfy depends on the graph's
-    /// watchtower set and our slot within it, which only the state machine knows.
+    /// Used by `contest` and `bridge_proof_timeout`. The leaf this operator can satisfy
+    /// depends on the graph's watchtower set and on this operator's slot in it. Only the
+    /// state machine knows both, so the caller supplies the full spend data.
     MultiAnchor {
         /// Index of the anchor output on the parent.
         anchor_vout: u32,
@@ -216,12 +271,15 @@ pub(crate) async fn publish_signed_transaction(
     parent_fee: Amount,
     cpfp: CpfpKind,
 ) -> Result<(), ExecutorError> {
+    let inference_based = matches!(cpfp, CpfpKind::InferGeneralPayout);
     let strategy = match cpfp {
-        CpfpKind::InferAnchor => infer_anchor_strategy(
+        CpfpKind::AnchorAt { anchor_vout } => checked_anchor_strategy(
             signed_tx,
+            anchor_vout,
             output_handles.operator_musig2_pubkey,
             output_handles.network,
             parent_fee,
+            label,
         ),
         CpfpKind::PayoutCombined { payout_outpoint } => Some(CpfpStrategy::ParentTxCombined {
             payout_outpoint,
@@ -244,6 +302,18 @@ pub(crate) async fn publish_signed_transaction(
         }),
         CpfpKind::None => None,
     };
+    // `InferGeneralPayout` scans for an output that can legitimately be absent (BDK adds no
+    // change output when the inputs match exactly). A miss is therefore a warn, not an
+    // error, and the transaction publishes without CPFP. `AnchorAt` misses are logged as
+    // errors inside `checked_anchor_strategy` — a named vout that fails validation is a
+    // code defect, not an expected state.
+    if strategy.is_none() && inference_based {
+        warn!(
+            txid = %signed_tx.compute_txid(),
+            %label,
+            "no output pays the operator's general-wallet script; publishing without CPFP"
+        );
+    }
     drive_with_optional_cpfp(
         &output_handles.tx_driver,
         signed_tx,
@@ -293,9 +363,14 @@ mod tests {
         transaction::Version,
     };
     use bitcoind_async_client::{Auth, Client as BitcoinClient, traits::Reader};
+    use btc_tracker::cpfp::CpfpStrategy;
     use corepc_node::{Conf, Input, Node, Output};
+    use strata_bridge_tx_graph::fee;
 
-    use super::{first_payout_outpoint_keyed_to, is_outpoint_unspent, is_txid_onchain};
+    use super::{
+        checked_anchor_strategy, first_payout_outpoint_keyed_to, is_outpoint_unspent,
+        is_txid_onchain,
+    };
 
     /// Per-coinbase reward on regtest before any halving.
     const REGTEST_COINBASE_AMOUNT: Amount = Amount::from_sat(50 * 100_000_000);
@@ -313,6 +388,59 @@ mod tests {
             input: vec![],
             output: outputs,
         }
+    }
+
+    /// The caller names the anchor vout from its tx type's constant. The check accepts a
+    /// correct anchor, accepts an anchor above the dust value (the counterproof-ACK shape,
+    /// which carries two times dust), and rejects a wrong vout, a wrong script, and a value
+    /// below dust. A rejection returns `None`: the tx publishes without CPFP.
+    #[test]
+    fn checked_anchor_accepts_named_anchor_and_rejects_mismatches() {
+        let anchor_key = xonly_from_seed(1);
+        let other_key = xonly_from_seed(2);
+        let network = Network::Regtest;
+        let anchor_script = Address::p2tr(SECP256K1, anchor_key, None, network).script_pubkey();
+        let other_script = Address::p2tr(SECP256K1, other_key, None, network).script_pubkey();
+        let dust = fee::anchor_dust_value();
+        let parent_fee = Amount::from_sat(220);
+
+        let tx = dummy_v3_tx(vec![
+            TxOut {
+                value: Amount::from_sat(10_000),
+                script_pubkey: other_script,
+            },
+            TxOut {
+                value: dust,
+                script_pubkey: anchor_script.clone(),
+            },
+        ]);
+
+        // Correct vout resolves to the strategy.
+        let strategy = checked_anchor_strategy(&tx, 1, anchor_key, network, parent_fee, "t");
+        assert!(matches!(
+            strategy,
+            Some(CpfpStrategy::AnchorBearing { anchor_vout: 1, .. })
+        ));
+
+        // An anchor above the dust value (counterproof-ACK shape) also resolves.
+        let ack_tx = dummy_v3_tx(vec![TxOut {
+            value: dust * 2,
+            script_pubkey: anchor_script,
+        }]);
+        assert!(
+            checked_anchor_strategy(&ack_tx, 0, anchor_key, network, parent_fee, "t").is_some()
+        );
+
+        // A vout that names a non-anchor output is rejected.
+        assert!(checked_anchor_strategy(&tx, 0, anchor_key, network, parent_fee, "t").is_none());
+        // A vout past the outputs is rejected.
+        assert!(checked_anchor_strategy(&tx, 9, anchor_key, network, parent_fee, "t").is_none());
+        // A value below dust is rejected even on the right script.
+        let low = dummy_v3_tx(vec![TxOut {
+            value: dust - Amount::from_sat(1),
+            script_pubkey: Address::p2tr(SECP256K1, anchor_key, None, network).script_pubkey(),
+        }]);
+        assert!(checked_anchor_strategy(&low, 0, anchor_key, network, parent_fee, "t").is_none());
     }
 
     #[test]

--- a/crates/bridge-exec/src/chain.rs
+++ b/crates/bridge-exec/src/chain.rs
@@ -66,13 +66,18 @@ pub(crate) fn first_general_payout_outpoint(
     )
 }
 
-/// Validates the caller-named anchor vout and returns the CPFP strategy for it.
+/// Validates the caller-named anchor and returns the CPFP strategy for it.
 ///
-/// The caller names the vout from its tx type's own constant, so a mismatch here is a code
+/// `anchor_key` comes from the anchor connector of the transaction that the caller published.
+/// A duty carries the key when the state machine builds the transaction. `signing_key` is the
+/// key that this operator can produce a signature for. A child of an anchor keyed to any other
+/// key carries a signature that no mempool accepts, so the two must match.
+///
+/// The caller names the vout from its tx type's own constant, so a mismatch there is a code
 /// defect: the constant and the builder disagree. The check compares the output's script
-/// against the operator-keyed anchor script and its value against the anchor dust floor.
-/// The value check is `>=`, not `==` — `CounterproofAckTx` folds its input connectors'
-/// residual into the anchor, so that anchor carries two times the dust value.
+/// against the anchor script and its value against the anchor dust floor. The value check is
+/// `>=`, not `==` — `CounterproofAckTx` folds its input connectors' residual into the anchor,
+/// so that anchor carries two times the dust value.
 ///
 /// On a mismatch this logs at error level and returns `None`. The transaction still
 /// publishes: it is signed and the protocol needs it on chain. Only the bump path is lost,
@@ -80,13 +85,25 @@ pub(crate) fn first_general_payout_outpoint(
 fn checked_anchor_strategy(
     tx: &Transaction,
     anchor_vout: u32,
-    anchor_pubkey: bitcoin::XOnlyPublicKey,
+    anchor_key: bitcoin::XOnlyPublicKey,
+    signing_key: bitcoin::XOnlyPublicKey,
     network: bitcoin::Network,
     parent_fee: Amount,
     label: &str,
 ) -> Option<CpfpStrategy> {
     let txid = tx.compute_txid();
-    let expected_script = Address::p2tr(SECP256K1, anchor_pubkey, None, network).script_pubkey();
+    if anchor_key != signing_key {
+        error!(
+            %txid,
+            %label,
+            anchor_vout,
+            %anchor_key,
+            %signing_key,
+            "anchor is keyed to a key this operator cannot sign with; publishing without CPFP"
+        );
+        return None;
+    }
+    let expected_script = Address::p2tr(SECP256K1, anchor_key, None, network).script_pubkey();
     let expected_value = fee::anchor_dust_value();
     let Some(output) = tx.output.get(anchor_vout as usize) else {
         error!(
@@ -106,13 +123,13 @@ fn checked_anchor_strategy(
             output_value = %output.value,
             expected_min_value = %expected_value,
             script_matches = output.script_pubkey == expected_script,
-            "named output is not an operator-keyed anchor; publishing without CPFP"
+            "named output is not the anchor that the caller named; publishing without CPFP"
         );
         return None;
     }
     Some(CpfpStrategy::AnchorBearing {
         anchor_vout,
-        anchor_internal_key: anchor_pubkey,
+        anchor_internal_key: anchor_key,
         parent_fee,
     })
 }
@@ -222,11 +239,17 @@ pub(crate) async fn is_outpoint_unspent(
 ///   bridge proof).
 #[derive(Debug, Clone)]
 pub(crate) enum CpfpKind {
-    /// The parent carries an operator-keyed Taproot anchor at this vout.
+    /// The parent carries a keyed Taproot anchor at this vout.
     AnchorAt {
         /// Index of the anchor output on the parent. Callers pass the tx type's own
         /// constant (for example `StakeTx::CPFP_VOUT`), not a discovered value.
         anchor_vout: u32,
+        /// Internal key of that anchor. Callers read it from the anchor connector of the
+        /// transaction, through
+        /// [`ParentTx::cpfp_connector`](strata_bridge_connectors::ParentTx::cpfp_connector).
+        /// The key that reaches the bump is therefore the key that built the output. A duty
+        /// whose transaction the state machine builds carries the key with it.
+        anchor_key: bitcoin::XOnlyPublicKey,
     },
     /// Build the child by spending the given operator-owned output of the parent.
     PayoutCombined { payout_outpoint: OutPoint },
@@ -273,9 +296,13 @@ pub(crate) async fn publish_signed_transaction(
 ) -> Result<(), ExecutorError> {
     let inference_based = matches!(cpfp, CpfpKind::InferGeneralPayout);
     let strategy = match cpfp {
-        CpfpKind::AnchorAt { anchor_vout } => checked_anchor_strategy(
+        CpfpKind::AnchorAt {
+            anchor_vout,
+            anchor_key,
+        } => checked_anchor_strategy(
             signed_tx,
             anchor_vout,
+            anchor_key,
             output_handles.operator_musig2_pubkey,
             output_handles.network,
             parent_fee,
@@ -416,7 +443,8 @@ mod tests {
         ]);
 
         // Correct vout resolves to the strategy.
-        let strategy = checked_anchor_strategy(&tx, 1, anchor_key, network, parent_fee, "t");
+        let strategy =
+            checked_anchor_strategy(&tx, 1, anchor_key, anchor_key, network, parent_fee, "t");
         assert!(matches!(
             strategy,
             Some(CpfpStrategy::AnchorBearing { anchor_vout: 1, .. })
@@ -428,19 +456,37 @@ mod tests {
             script_pubkey: anchor_script,
         }]);
         assert!(
-            checked_anchor_strategy(&ack_tx, 0, anchor_key, network, parent_fee, "t").is_some()
+            checked_anchor_strategy(&ack_tx, 0, anchor_key, anchor_key, network, parent_fee, "t")
+                .is_some()
         );
 
         // A vout that names a non-anchor output is rejected.
-        assert!(checked_anchor_strategy(&tx, 0, anchor_key, network, parent_fee, "t").is_none());
+        assert!(
+            checked_anchor_strategy(&tx, 0, anchor_key, anchor_key, network, parent_fee, "t")
+                .is_none()
+        );
         // A vout past the outputs is rejected.
-        assert!(checked_anchor_strategy(&tx, 9, anchor_key, network, parent_fee, "t").is_none());
+        assert!(
+            checked_anchor_strategy(&tx, 9, anchor_key, anchor_key, network, parent_fee, "t")
+                .is_none()
+        );
         // A value below dust is rejected even on the right script.
         let low = dummy_v3_tx(vec![TxOut {
             value: dust - Amount::from_sat(1),
             script_pubkey: Address::p2tr(SECP256K1, anchor_key, None, network).script_pubkey(),
         }]);
-        assert!(checked_anchor_strategy(&low, 0, anchor_key, network, parent_fee, "t").is_none());
+        assert!(
+            checked_anchor_strategy(&low, 0, anchor_key, anchor_key, network, parent_fee, "t")
+                .is_none()
+        );
+
+        // An anchor keyed to a key this operator cannot sign with disables the bump. A child
+        // of that anchor carries a signature that no mempool accepts.
+        assert!(
+            checked_anchor_strategy(&tx, 1, anchor_key, other_key, network, parent_fee, "t")
+                .is_none(),
+            "an anchor key that this operator cannot sign with must disable the bump"
+        );
     }
 
     #[test]

--- a/crates/bridge-exec/src/chain.rs
+++ b/crates/bridge-exec/src/chain.rs
@@ -1,11 +1,107 @@
 //! Shared Bitcoin chain helpers for executors.
 
-use bitcoin::{OutPoint, Transaction, Txid};
+use bitcoin::{
+    Address, Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid, secp256k1::SECP256K1,
+    taproot::ControlBlock,
+};
 use bitcoind_async_client::{Client as BitcoinClient, error::ClientError, traits::Reader};
-use btc_tracker::{event::TxStatus, tx_driver::TxDriver};
+use btc_tracker::{cpfp::CpfpStrategy, event::TxStatus, tx_driver::TxDriver};
+use strata_bridge_tx_graph::fee;
 use tracing::{debug, info, warn};
 
-use crate::errors::ExecutorError;
+use crate::{
+    cpfp_adapters::infer_anchor_strategy, errors::ExecutorError, output_handles::OutputHandles,
+};
+
+/// Computes the fee paid by a tx that follows the bridge protocol floor rate
+/// ([`fee::FEE_RATE`] = 2 sat/vB). This is the right helper for presigned bridge txs
+/// (claim, stake, contest, counterproof, payout, slash, ack, etc.) — their fee is exactly
+/// `vsize × FEE_RATE` by construction. Wallet-funded txs (withdrawal fulfillment, stake
+/// funding, unstaking intent funding) use [`exact_fee_from_prevouts`] instead because they
+/// may be funded at a higher rate.
+///
+/// Cannot overflow in practice: `tx.vsize()` is bounded by the consensus 4 MWU limit, well
+/// inside `u64`.
+pub(crate) fn parent_fee_for_floor_tx(tx: &Transaction) -> Amount {
+    // `Transaction::vsize()` returns `usize`. Both supported targets (x86_64, aarch64) have
+    // `usize == u64`, but use `try_into` to avoid a silent truncation hazard if a future
+    // 32-bit target ever ships a tx larger than `u32::MAX` vB (impossible in practice but
+    // the lint cleanup is free).
+    let vsize_vb: u64 = tx
+        .vsize()
+        .try_into()
+        .expect("tx.vsize() fits in u64 on every supported target");
+    fee::FEE_RATE
+        .fee_vb(vsize_vb)
+        .expect("protocol-floor × tx vsize cannot overflow Amount")
+}
+
+/// Scans `tx.output` for the first output paying the operator's general-wallet P2TR script
+/// (the script of `tr(operator_general_pubkey)` on `output_handles.network`). Returns the
+/// outpoint, or `None` if no matching output exists.
+///
+/// Used by [`CpfpKind::InferGeneralPayout`] to opportunistically classify a tx as
+/// `PayoutCombined` when an operator-owned output happens to be present. Three call sites
+/// rely on this:
+///
+/// - **Withdrawal fulfillment**: BDK adds a change output back to the general wallet at
+///   `WithdrawalFulfillmentTx::OPTIONAL_CHANGE_VOUT` (vout 2) when selected inputs exceed
+///   user_amount + fee. When change exists, CPFP via that output.
+/// - **Stake funding**: BDK adds a change output back to the general wallet (vout depends on BDK
+///   ordering, typically vout 1 after the reserved-wallet output at vout 0).
+/// - **Slash**: The calling watchtower's payout is at `vout = 1 + their_index_in_watchtowers` keyed
+///   to their payout descriptor (= the general-wallet P2TR, by the bridge's `payout_descriptor`
+///   convention). Scan finds it without threading the index through.
+///
+/// Brittle assumption: matches by exact `script_pubkey` equality. If two different
+/// operators happened to share the same payout descriptor, the first match wins — but each
+/// operator has a unique general-wallet key in practice (one per s2 instance), so this
+/// can't collide in production.
+pub(crate) fn first_general_payout_outpoint(
+    tx: &Transaction,
+    output_handles: &OutputHandles,
+) -> Option<OutPoint> {
+    first_payout_outpoint_keyed_to(
+        tx,
+        output_handles.operator_general_pubkey,
+        output_handles.network,
+    )
+}
+
+/// Inner helper for [`first_general_payout_outpoint`]; takes the pubkey/network explicitly so
+/// it can be unit-tested without constructing a full [`OutputHandles`].
+fn first_payout_outpoint_keyed_to(
+    tx: &Transaction,
+    pubkey: bitcoin::XOnlyPublicKey,
+    network: bitcoin::Network,
+) -> Option<OutPoint> {
+    let expected_script = Address::p2tr(SECP256K1, pubkey, None, network).script_pubkey();
+    let txid = tx.compute_txid();
+    tx.output.iter().enumerate().find_map(|(vout, o)| {
+        if o.script_pubkey != expected_script {
+            return None;
+        }
+        u32::try_from(vout).ok().map(|vout| OutPoint { txid, vout })
+    })
+}
+
+/// Computes the exact fee paid by `tx` from its input `prevouts` (in input order). Returns
+/// `None` if the input or output sum overflows `Amount` or if outputs exceed inputs (an
+/// invariant violation in a real tx, but explicitly fallible here so callers can surface
+/// the error instead of panicking on an unexpected state).
+///
+/// Used by wallet-funded callers (withdrawal fulfillment, stake funding, unstaking intent
+/// funding) where the fee rate is whatever BDK chose, not the bridge protocol floor.
+pub(crate) fn exact_fee_from_prevouts(prevouts: &[TxOut], tx: &Transaction) -> Option<Amount> {
+    let inputs_sum = prevouts
+        .iter()
+        .try_fold(Amount::ZERO, |acc, o| acc.checked_add(o.value))?;
+    let outputs_sum = tx
+        .output
+        .iter()
+        .try_fold(Amount::ZERO, |acc, o| acc.checked_add(o.value))?;
+    inputs_sum.checked_sub(outputs_sum)
+}
 
 /// Returns whether the provided transaction ID already exists on chain (confirmed or in the
 /// mempool).
@@ -53,24 +149,134 @@ pub(crate) async fn is_outpoint_unspent(
     }
 }
 
-/// Publishes a signed transaction to Bitcoin and waits for the provided transaction status
-/// condition to be met.
+/// Hint that lets the caller of [`publish_signed_transaction`] override how the CPFP
+/// strategy is selected for a parent transaction.
+///
+/// - [`Self::InferAnchor`]: scan the parent for an operator-keyed Taproot anchor output via
+///   [`infer_anchor_strategy`]. Applies to claim/stake/unstaking_intent/counterproof/
+///   counterproof_ack and any other tx with a `KeyedAnchor` connector.
+/// - [`Self::PayoutCombined`] (for txs implementing
+///   [`strata_bridge_connectors::ParentTxCombined`]): no keyed anchor; instead the caller-supplied
+///   operator-owned output (`payout_outpoint`) is spent by the CPFP child. Applies to
+///   cooperative_payout, uncontested_payout, contested_payout, unstaking, counterproof_nack — all
+///   the txs whose payout vout is statically known to the caller.
+/// - [`Self::InferGeneralPayout`]: scan the parent for the FIRST output paying the operator's
+///   general-wallet script and use it as the CPFP payout. Applies to txs whose operator-owned
+///   output isn't at a fixed vout — wallet-funded txs whose BDK change output may or may not exist
+///   (withdrawal fulfillment, stake funding) and the slash tx (where the calling watchtower's vout
+///   = `1 + their_index_in_filtered_watchtowers`, which we discover by script-match rather than
+///   threading the index through). If no matching output exists, the helper falls back to
+///   [`Self::None`].
+/// - [`Self::None`]: broadcast as-is. Use only when the tx genuinely has no CPFP hook (deposit,
+///   bridge proof).
+#[derive(Debug, Clone)]
+pub(crate) enum CpfpKind {
+    /// Look for an operator-keyed anchor on the parent.
+    InferAnchor,
+    /// Build the child by spending the given operator-owned output of the parent.
+    PayoutCombined { payout_outpoint: OutPoint },
+    /// Look for the first output paying the operator's general-wallet script and use it as
+    /// the CPFP payout. Falls back to no-CPFP if no such output exists (e.g. BDK didn't add
+    /// a change output).
+    InferGeneralPayout,
+    /// Bump a multi-leaf (`MultiAnchor`) anchor script-path, satisfying the leaf this operator
+    /// is entitled to as a watchtower of the parent's graph.
+    ///
+    /// Used by `contest` and `bridge_proof_timeout`. Unlike [`Self::InferAnchor`] nothing is
+    /// inferred from the transaction: which leaf we may satisfy depends on the graph's
+    /// watchtower set and our slot within it, which only the state machine knows.
+    MultiAnchor {
+        /// Index of the anchor output on the parent.
+        anchor_vout: u32,
+        /// The leaf script this operator may satisfy.
+        leaf_script: ScriptBuf,
+        /// Control block proving the leaf's membership in the anchor's tree.
+        control_block: ControlBlock,
+    },
+    /// No CPFP — broadcast as-is.
+    None,
+}
+
+/// Publishes a signed transaction and waits for the configured status. The `cpfp` parameter
+/// drives strategy selection — see [`CpfpKind`].
+///
+/// `parent_fee` must be the **exact fee** paid by `signed_tx` — passed in by the caller
+/// because computing it correctly requires either prevout lookups (expensive RPC) or
+/// information the funding step already had. For presigned bridge txs, callers use
+/// [`parent_fee_for_floor_tx`] (FEE_RATE × vsize). For wallet-funded txs they pass
+/// `Psbt::fee()` (BDK populates witness_utxo on every input) or
+/// [`exact_fee_from_prevouts`] (when the prevouts are known explicitly). An incorrect
+/// `parent_fee` makes the CPFP child either overpay (too low estimate) or underpay (too
+/// high estimate), so accuracy here matters.
 pub(crate) async fn publish_signed_transaction(
+    output_handles: &OutputHandles,
+    signed_tx: &Transaction,
+    label: &str,
+    wait_condition: fn(&TxStatus) -> bool,
+    parent_fee: Amount,
+    cpfp: CpfpKind,
+) -> Result<(), ExecutorError> {
+    let strategy = match cpfp {
+        CpfpKind::InferAnchor => infer_anchor_strategy(
+            signed_tx,
+            output_handles.operator_musig2_pubkey,
+            output_handles.network,
+            parent_fee,
+        ),
+        CpfpKind::PayoutCombined { payout_outpoint } => Some(CpfpStrategy::ParentTxCombined {
+            payout_outpoint,
+            parent_fee,
+        }),
+        CpfpKind::InferGeneralPayout => first_general_payout_outpoint(signed_tx, output_handles)
+            .map(|payout_outpoint| CpfpStrategy::ParentTxCombined {
+                payout_outpoint,
+                parent_fee,
+            }),
+        CpfpKind::MultiAnchor {
+            anchor_vout,
+            leaf_script,
+            control_block,
+        } => Some(CpfpStrategy::MultiAnchorBearing {
+            anchor_vout,
+            leaf_script,
+            control_block,
+            parent_fee,
+        }),
+        CpfpKind::None => None,
+    };
+    drive_with_optional_cpfp(
+        &output_handles.tx_driver,
+        signed_tx,
+        label,
+        wait_condition,
+        strategy,
+    )
+    .await
+}
+
+async fn drive_with_optional_cpfp(
     tx_driver: &TxDriver,
     signed_tx: &Transaction,
     label: &str,
     wait_condition: fn(&TxStatus) -> bool,
+    cpfp: Option<CpfpStrategy>,
 ) -> Result<(), ExecutorError> {
     let txid = signed_tx.compute_txid();
-    info!(%txid, %label, "publishing transaction");
+    let cpfp_enabled = cpfp.is_some();
+    info!(%txid, %label, cpfp_enabled, "publishing transaction");
 
-    tx_driver
-        .drive(signed_tx.clone(), wait_condition)
-        .await
-        .map_err(|e| {
-            warn!(%txid, %label, ?e, "failed to publish transaction");
-            ExecutorError::TxDriverErr(e)
-        })?;
+    let drive_result = match cpfp {
+        Some(strategy) => {
+            tx_driver
+                .drive_with_cpfp(signed_tx.clone(), strategy, wait_condition)
+                .await
+        }
+        None => tx_driver.drive(signed_tx.clone(), wait_condition).await,
+    };
+    drive_result.map_err(|e| {
+        warn!(%txid, %label, ?e, "failed to publish transaction");
+        ExecutorError::TxDriverErr(e)
+    })?;
 
     info!(%txid, %label, "transaction reached target status");
     Ok(())
@@ -79,15 +285,104 @@ pub(crate) async fn publish_signed_transaction(
 #[cfg(test)]
 mod tests {
     use bitcoin::{
-        Amount, OutPoint, Transaction, Txid, consensus::encode::deserialize_hex, hashes::Hash,
+        Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxOut, Txid, absolute,
+        consensus::encode::deserialize_hex,
+        hashes::Hash,
+        key::Secp256k1,
+        secp256k1::{SECP256K1, SecretKey},
+        transaction::Version,
     };
     use bitcoind_async_client::{Auth, Client as BitcoinClient, traits::Reader};
     use corepc_node::{Conf, Input, Node, Output};
 
-    use super::{is_outpoint_unspent, is_txid_onchain};
+    use super::{first_payout_outpoint_keyed_to, is_outpoint_unspent, is_txid_onchain};
 
     /// Per-coinbase reward on regtest before any halving.
     const REGTEST_COINBASE_AMOUNT: Amount = Amount::from_sat(50 * 100_000_000);
+
+    fn xonly_from_seed(seed: u8) -> bitcoin::XOnlyPublicKey {
+        let sk = SecretKey::from_slice(&[seed; 32]).unwrap();
+        let kp = bitcoin::key::Keypair::from_secret_key(&Secp256k1::new(), &sk);
+        kp.x_only_public_key().0
+    }
+
+    fn dummy_v3_tx(outputs: Vec<TxOut>) -> Transaction {
+        Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output: outputs,
+        }
+    }
+
+    #[test]
+    fn first_payout_finds_matching_output_at_first_match() {
+        let our_key = xonly_from_seed(1);
+        let other_key = xonly_from_seed(2);
+        let our_script = Address::p2tr(SECP256K1, our_key, None, Network::Regtest).script_pubkey();
+        let other_script =
+            Address::p2tr(SECP256K1, other_key, None, Network::Regtest).script_pubkey();
+        let tx = dummy_v3_tx(vec![
+            TxOut {
+                value: Amount::ZERO,
+                script_pubkey: ScriptBuf::new(),
+            }, // vout 0: OP_RETURN-style placeholder
+            TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: other_script,
+            }, // vout 1: other key
+            TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: our_script,
+            }, // vout 2: our key
+        ]);
+        let found = first_payout_outpoint_keyed_to(&tx, our_key, Network::Regtest)
+            .expect("should find our output");
+        assert_eq!(found.vout, 2);
+    }
+
+    #[test]
+    fn first_payout_returns_none_when_no_match() {
+        // WFT funding-without-change case: BDK didn't add a change output, so no operator
+        // output exists on this tx.
+        let our_key = xonly_from_seed(1);
+        let other_key = xonly_from_seed(2);
+        let other_script =
+            Address::p2tr(SECP256K1, other_key, None, Network::Regtest).script_pubkey();
+        let tx = dummy_v3_tx(vec![
+            TxOut {
+                value: Amount::ZERO,
+                script_pubkey: ScriptBuf::new(),
+            },
+            TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: other_script,
+            },
+        ]);
+        assert!(first_payout_outpoint_keyed_to(&tx, our_key, Network::Regtest).is_none());
+    }
+
+    #[test]
+    fn first_payout_picks_first_match_when_multiple_match() {
+        // Defensive: if two outputs somehow pay our script, return the FIRST. The slash tx
+        // shouldn't ever produce duplicate payouts (each watchtower has a unique
+        // descriptor), but enforce the deterministic-first-match invariant.
+        let our_key = xonly_from_seed(1);
+        let our_script = Address::p2tr(SECP256K1, our_key, None, Network::Regtest).script_pubkey();
+        let tx = dummy_v3_tx(vec![
+            TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: our_script.clone(),
+            }, // vout 0
+            TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: our_script,
+            }, // vout 1
+        ]);
+        let found = first_payout_outpoint_keyed_to(&tx, our_key, Network::Regtest)
+            .expect("should find first match");
+        assert_eq!(found.vout, 0);
+    }
 
     fn setup_btc_client(bitcoind: &Node) -> BitcoinClient {
         let cookie = bitcoind

--- a/crates/bridge-exec/src/chain.rs
+++ b/crates/bridge-exec/src/chain.rs
@@ -11,16 +11,41 @@ use tracing::{debug, error, info, warn};
 
 use crate::{errors::ExecutorError, output_handles::OutputHandles};
 
+/// How the publish path learns the exact fee that a parent pays.
+///
+/// The CPFP child pays the difference between what the parent already paid and what the
+/// package target asks for, so a wrong value here makes the child overpay or underpay.
+///
+/// [`Self::Floor`] derives the fee from the transaction that it publishes. That removes the
+/// one mistake a caller-computed value allows: a fee derived from a different transaction
+/// than the one that reaches the network.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ParentFee {
+    /// The parent pays the bridge protocol floor rate, so its fee is `vsize × FEE_RATE` by
+    /// construction. Every presigned bridge transaction is in this class.
+    Floor,
+    /// The caller funded the parent and knows the fee that it paid. Wallet-funded
+    /// transactions are in this class, because a wallet funds at the market rate and not at
+    /// the protocol floor.
+    Exact(Amount),
+}
+
+impl ParentFee {
+    /// Resolves to the fee that `tx` pays.
+    fn resolve(self, tx: &Transaction) -> Amount {
+        match self {
+            Self::Floor => parent_fee_for_floor_tx(tx),
+            Self::Exact(fee) => fee,
+        }
+    }
+}
+
 /// Computes the fee paid by a tx that follows the bridge protocol floor rate
-/// ([`fee::FEE_RATE`] = 2 sat/vB). This is the right helper for presigned bridge txs
-/// (claim, stake, contest, counterproof, payout, slash, ack, etc.) — their fee is exactly
-/// `vsize × FEE_RATE` by construction. Wallet-funded txs (withdrawal fulfillment, stake
-/// funding, unstaking intent funding) use [`exact_fee_from_prevouts`] instead because they
-/// may be funded at a higher rate.
+/// ([`fee::FEE_RATE`] = 2 sat/vB).
 ///
 /// Cannot overflow in practice: `tx.vsize()` is bounded by the consensus 4 MWU limit, well
 /// inside `u64`.
-pub(crate) fn parent_fee_for_floor_tx(tx: &Transaction) -> Amount {
+fn parent_fee_for_floor_tx(tx: &Transaction) -> Amount {
     // `Transaction::vsize()` returns `usize`. Both supported targets (x86_64, aarch64) have
     // `usize == u64`, but use `try_into` to avoid a silent truncation hazard if a future
     // 32-bit target ever ships a tx larger than `u32::MAX` vB (impossible in practice but
@@ -278,22 +303,20 @@ pub(crate) enum CpfpKind {
 /// Publishes a signed transaction and waits for the configured status. The `cpfp` parameter
 /// drives strategy selection — see [`CpfpKind`].
 ///
-/// `parent_fee` must be the **exact fee** paid by `signed_tx` — passed in by the caller
-/// because computing it correctly requires either prevout lookups (expensive RPC) or
-/// information the funding step already had. For presigned bridge txs, callers use
-/// [`parent_fee_for_floor_tx`] (FEE_RATE × vsize). For wallet-funded txs they pass
-/// `Psbt::fee()` (BDK populates witness_utxo on every input) or
-/// [`exact_fee_from_prevouts`] (when the prevouts are known explicitly). An incorrect
-/// `parent_fee` makes the CPFP child either overpay (too low estimate) or underpay (too
-/// high estimate), so accuracy here matters.
+/// `parent_fee` states how to learn the exact fee that `signed_tx` pays — see [`ParentFee`].
+/// A presigned bridge transaction passes [`ParentFee::Floor`]. A wallet-funded transaction
+/// passes [`ParentFee::Exact`] with `Psbt::fee()`, which BDK fills because it populates
+/// `witness_utxo` on every input, or with [`exact_fee_from_prevouts`] when the prevouts are
+/// known explicitly.
 pub(crate) async fn publish_signed_transaction(
     output_handles: &OutputHandles,
     signed_tx: &Transaction,
     label: &str,
     wait_condition: fn(&TxStatus) -> bool,
-    parent_fee: Amount,
+    parent_fee: ParentFee,
     cpfp: CpfpKind,
 ) -> Result<(), ExecutorError> {
+    let parent_fee = parent_fee.resolve(signed_tx);
     let inference_based = matches!(cpfp, CpfpKind::InferGeneralPayout);
     let strategy = match cpfp {
         CpfpKind::AnchorAt {

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -15,12 +15,14 @@ use bitcoin::{
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::{
     cpfp::{
-        AnchorSpendState, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet, InputSignFut,
-        InputSigner, WalletFundedPsbt,
+        AnchorSpendState, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet, FundingLease,
+        InputSignFut, InputSigner, WalletFundedPsbt,
     },
     submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
 };
-use operator_wallet::{AnchorInfo, GeneralWallet, OperatorWallet};
+use operator_wallet::{
+    AnchorInfo, AnchorOwnership, GeneralWallet, Lease, OperatorWallet, ReplacedChild,
+};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_connectors::{Connector, prelude::MultiAnchor};
@@ -69,21 +71,46 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> OperatorWalletCpfpAdapter<G> 
     }
 }
 
+/// Presents an [`operator_wallet::Lease`] through the [`FundingLease`] interface of
+/// `btc-tracker`.
+///
+/// The wrapper exists because the orphan rule blocks a direct implementation: the trait
+/// belongs to `btc-tracker`, the lease type belongs to `operator-wallet`, and neither is local
+/// to this crate. The wrapper adds no behaviour. Dropping it drops the lease, and that is what
+/// returns the outpoints to the spendable set.
+#[derive(Debug)]
+struct WalletFundingLease(Lease);
+
+impl FundingLease for WalletFundingLease {
+    fn outpoints(&self) -> &[OutPoint] {
+        self.0.outpoints()
+    }
+}
+
 impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWalletCpfpAdapter<G> {
     fn build_cpfp_child(
         &self,
         parent: &Transaction,
         strategy: CpfpStrategy,
         target_pkg_fee_rate: FeeRate,
-        replacing: Option<&[OutPoint]>,
+        replacing: Option<&dyn FundingLease>,
         prior_child_fee: Option<Amount>,
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
         // Clone what we need into the future so the returned future owns its captures.
         let wallet_arc = self.wallet.clone();
         let parent_owned = parent.clone();
-        let replacing_owned: Option<Vec<OutPoint>> = replacing.map(<[OutPoint]>::to_vec);
+        let replacing_owned: Option<Vec<OutPoint>> =
+            replacing.map(|lease| lease.outpoints().to_vec());
         let operator_general_pubkey = self.operator_general_pubkey;
-        let combined_is_wallet_output = matches!(strategy, CpfpStrategy::ParentTxCombined { .. });
+        // `ParentTxCombined` spends the operator's own payout output, so that output belongs
+        // in the lease. Every other strategy spends an anchor keyed to a protocol key, which
+        // the wallet can never select for another transaction.
+        let anchor_ownership = match strategy {
+            CpfpStrategy::ParentTxCombined { .. } => AnchorOwnership::Wallet,
+            CpfpStrategy::AnchorBearing { .. } | CpfpStrategy::MultiAnchorBearing { .. } => {
+                AnchorOwnership::Foreign
+            }
+        };
         async move {
             // Both strategies funnel through the same `build_cpfp_child` machinery — only
             // the foreign-UTXO descriptor (anchor vs. payout) differs.
@@ -114,50 +141,26 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
                     control_block,
                 },
             };
-            let anchor_outpoint = OutPoint {
-                txid: parent_owned.compute_txid(),
-                vout: foreign.vout(),
-            };
             let mut wallet = wallet_arc.write().await;
             let funded = wallet
                 .build_cpfp_child(
                     &parent_owned,
                     parent_fee,
                     foreign,
+                    anchor_ownership,
                     target_pkg_fee_rate,
-                    replacing_owned.as_deref(),
-                    prior_child_fee,
+                    ReplacedChild {
+                        inputs: replacing_owned.as_deref().unwrap_or(&[]),
+                        fee: prior_child_fee,
+                    },
                 )
                 .await
                 .map_err(|e| format!("{e}"))?;
-            // `FundedPsbt::spent()` lists every input, foreign outpoint included. What
-            // enters the handle depends on the strategy:
-            //
-            // - Anchor strategies: drop the anchor outpoint. The anchor is keyed to the musig2 key,
-            //   so it is never a wallet UTXO. The first sync prunes its lease, and each later
-            //   release of a set that still contains it logs a warning on a correct path.
-            // - `ParentTxCombined`: keep the payout outpoint. The payout IS a wallet UTXO, so the
-            //   sync prune retains its lease while it is live, and only the handle's terminal
-            //   releases free it. A dropped record here leaves the full payout value leased until
-            //   process restart. Selection stays safe: the builder skips the foreign outpoint as a
-            //   funding candidate and admits it through `add_foreign_utxo` only.
-            let spent = funded
-                .spent()
-                .into_iter()
-                .filter(|op| combined_is_wallet_output || *op != anchor_outpoint)
-                .collect();
+            let (psbt, lease) = funded.into_parts();
             Ok(WalletFundedPsbt {
-                psbt: funded.psbt,
-                spent,
+                psbt,
+                lease: Arc::new(WalletFundingLease(lease)),
             })
-        }
-    }
-
-    fn release(&self, outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send {
-        let wallet_arc = self.wallet.clone();
-        let outpoints_owned = outpoints.to_vec();
-        async move {
-            wallet_arc.write().await.release(&outpoints_owned);
         }
     }
 }

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -15,8 +15,8 @@ use bitcoin::{
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::{
     cpfp::{
-        AnchorSpendState, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet, FundingLease,
-        InputSignFut, InputSigner, WalletFundedPsbt,
+        AnchorSpendState, ChildPsbt, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet,
+        FundingLease, InputSignFut, InputSigner, WalletFundedPsbt,
     },
     submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
 };
@@ -157,6 +157,9 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
                 .await
                 .map_err(|e| format!("{e}"))?;
             let (psbt, lease) = funded.into_parts();
+            // The backend states its signing through the final fields, and each input
+            // carries its spent output. A violation fails here rather than on chain.
+            let psbt = ChildPsbt::new(psbt).map_err(|e| e.to_string())?;
             Ok(WalletFundedPsbt {
                 psbt,
                 lease: Arc::new(WalletFundingLease(lease)),

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -141,7 +141,10 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
                     control_block,
                 },
             };
-            let mut wallet = wallet_arc.write().await;
+            // A shared lock: the composer serializes selection internally, so a bump does
+            // not need to exclude a health probe or a descriptor read for the length of a
+            // backend round trip.
+            let wallet = wallet_arc.read().await;
             let funded = wallet
                 .build_cpfp_child(
                     &parent_owned,

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -8,8 +8,8 @@
 use std::sync::Arc;
 
 use bitcoin::{
-    Address, Amount, FeeRate, Network, OutPoint, ScriptBuf, Transaction, XOnlyPublicKey,
-    secp256k1::{Message, SECP256K1, schnorr::Signature},
+    Amount, FeeRate, OutPoint, ScriptBuf, Transaction, Txid, XOnlyPublicKey,
+    secp256k1::{Message, schnorr::Signature},
     taproot::{ControlBlock, LeafVersion},
 };
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
@@ -24,7 +24,6 @@ use operator_wallet::{AnchorInfo, GeneralWallet, OperatorWallet};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_connectors::{Connector, prelude::MultiAnchor};
-use strata_bridge_tx_graph::fee;
 use tokio::sync::RwLock;
 use tracing::warn;
 
@@ -77,12 +76,14 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
         strategy: CpfpStrategy,
         target_pkg_fee_rate: FeeRate,
         replacing: Option<&[OutPoint]>,
+        prior_child_fee: Option<Amount>,
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
         // Clone what we need into the future so the returned future owns its captures.
         let wallet_arc = self.wallet.clone();
         let parent_owned = parent.clone();
         let replacing_owned: Option<Vec<OutPoint>> = replacing.map(<[OutPoint]>::to_vec);
         let operator_general_pubkey = self.operator_general_pubkey;
+        let combined_is_wallet_output = matches!(strategy, CpfpStrategy::ParentTxCombined { .. });
         async move {
             // Both strategies funnel through the same `build_cpfp_child` machinery — only
             // the foreign-UTXO descriptor (anchor vs. payout) differs.
@@ -113,6 +114,10 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
                     control_block,
                 },
             };
+            let anchor_outpoint = OutPoint {
+                txid: parent_owned.compute_txid(),
+                vout: foreign.vout(),
+            };
             let mut wallet = wallet_arc.write().await;
             let funded = wallet
                 .build_cpfp_child(
@@ -121,14 +126,38 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
                     foreign,
                     target_pkg_fee_rate,
                     replacing_owned.as_deref(),
+                    prior_child_fee,
                 )
                 .await
                 .map_err(|e| format!("{e}"))?;
-            let spent = funded.spent();
+            // `FundedPsbt::spent()` lists every input, foreign outpoint included. What
+            // enters the handle depends on the strategy:
+            //
+            // - Anchor strategies: drop the anchor outpoint. The anchor is keyed to the musig2 key,
+            //   so it is never a wallet UTXO. The first sync prunes its lease, and each later
+            //   release of a set that still contains it logs a warning on a correct path.
+            // - `ParentTxCombined`: keep the payout outpoint. The payout IS a wallet UTXO, so the
+            //   sync prune retains its lease while it is live, and only the handle's terminal
+            //   releases free it. A dropped record here leaves the full payout value leased until
+            //   process restart. Selection stays safe: the builder skips the foreign outpoint as a
+            //   funding candidate and admits it through `add_foreign_utxo` only.
+            let spent = funded
+                .spent()
+                .into_iter()
+                .filter(|op| combined_is_wallet_output || *op != anchor_outpoint)
+                .collect();
             Ok(WalletFundedPsbt {
                 psbt: funded.psbt,
                 spent,
             })
+        }
+    }
+
+    fn release(&self, outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send {
+        let wallet_arc = self.wallet.clone();
+        let outpoints_owned = outpoints.to_vec();
+        async move {
+            wallet_arc.write().await.release(&outpoints_owned);
         }
     }
 }
@@ -219,6 +248,9 @@ impl CpfpMempool for BitcoindCpfpMempool {
             let Some(spending_txid) = spends.into_iter().find_map(|s| s.spending_txid) else {
                 return Ok(AnchorSpendState::Unspent);
             };
+            let spending_txid: Txid = spending_txid
+                .parse()
+                .map_err(|e| format!("gettxspendingprevout returned a bad txid: {e}"))?;
 
             // A spender exists. When the mempool holds it, its ancestor totals give the package
             // rate that this operator competes against.
@@ -239,7 +271,10 @@ impl CpfpMempool for BitcoindCpfpMempool {
                 .checked_div(entry.ancestor_size.max(1))
                 .map(|per_vb| FeeRate::from_sat_per_vb_unchecked(per_vb.to_sat()))
                 .ok_or_else(|| "ancestor fee rate overflowed".to_string())?;
-            Ok(AnchorSpendState::SpentInMempool(rate))
+            Ok(AnchorSpendState::SpentInMempool {
+                spender: spending_txid,
+                pkg_fee_rate: rate,
+            })
         }
     }
 }
@@ -265,53 +300,6 @@ struct MempoolEntry {
 struct MempoolEntryFees {
     /// Total fee of this transaction and its unconfirmed ancestors.
     ancestor: f64,
-}
-
-/// Looks for a keyed-Taproot anchor on `parent.output` keyed to `anchor_pubkey`, and if
-/// found returns the corresponding [`CpfpStrategy::AnchorBearing`].
-///
-/// `anchor_pubkey` must be the **musig2-signer** pubkey (the "btc key" from the operator
-/// table) — every bridge-graph tx (claim, stake, unstaking_intent, counterproof, ack)
-/// constructs its `KeyedAnchor` (from `strata_bridge_tx_graph::prelude`) with that
-/// key as the internal Taproot key. The dust value comes from [`fee::anchor_dust_value`] so
-/// the helper tracks any future change to the bridge's anchor sizing.
-///
-/// `parent_fee` must be provided by the caller; an accurate value is critical to the CPFP
-/// math (the child's vbytes-to-cover-the-package depends on what the parent already pays).
-pub fn infer_anchor_strategy(
-    parent: &Transaction,
-    anchor_pubkey: XOnlyPublicKey,
-    network: Network,
-    parent_fee: Amount,
-) -> Option<CpfpStrategy> {
-    let anchor_value = fee::anchor_dust_value();
-    let expected_script = Address::p2tr(SECP256K1, anchor_pubkey, None, network).script_pubkey();
-    let matches: Vec<u32> = parent
-        .output
-        .iter()
-        .enumerate()
-        .filter_map(|(vout, txout)| {
-            (txout.value == anchor_value && txout.script_pubkey == expected_script)
-                .then(|| u32::try_from(vout).ok())
-                .flatten()
-        })
-        .collect();
-    // Bridge txs are constructed with at most one operator-keyed anchor output. If a future
-    // refactor accidentally produces a tx with two outputs that both match (same script + same
-    // dust value), `find_map`-style "first match" would silently pick the wrong one — make
-    // the assumption explicit.
-    debug_assert!(
-        matches.len() <= 1,
-        "parent tx has {} outputs matching the operator-keyed anchor pattern; expected ≤ 1",
-        matches.len()
-    );
-    matches
-        .first()
-        .map(|&anchor_vout| CpfpStrategy::AnchorBearing {
-            anchor_vout,
-            anchor_internal_key: anchor_pubkey,
-            parent_fee,
-        })
 }
 
 /// Builds the script-path anchor signer used for `MultiAnchor` CPFP children.

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -290,12 +290,8 @@ impl CpfpMempool for BitcoindCpfpMempool {
                 .await
                 .map_err(|e| MempoolError(format!("getmempoolentry: {e:?}")))?;
 
-            let ancestor_fee = Amount::from_btc(entry.fees.ancestor)
-                .map_err(|e| MempoolError(format!("ancestor fee is not a valid amount: {e}")))?;
-            let rate = ancestor_fee
-                .checked_div(entry.ancestor_size.max(1))
-                .map(|per_vb| FeeRate::from_sat_per_vb_unchecked(per_vb.to_sat()))
-                .ok_or_else(|| MempoolError("ancestor fee rate overflowed".into()))?;
+            let rate = ancestor_fee_rate(entry.fees.ancestor, entry.ancestor_size)
+                .map_err(MempoolError)?;
             Ok(AnchorSpendState::SpentInMempool {
                 spender: spending_txid,
                 pkg_fee_rate: rate,
@@ -429,4 +425,67 @@ pub fn multi_anchor_spend_material(
         .spend_info()
         .control_block(&(leaf_script.clone(), LeafVersion::TapScript))?;
     Some((leaf_script, control_block))
+}
+
+/// One vbyte is four weight units, and one kiloweight unit is 1000 weight units,
+/// so one sat/vB is 250 sat per kiloweight unit.
+const SAT_PER_KWU_PER_SAT_PER_VB: u64 = 250;
+
+/// Computes the package rate from the ancestor totals `getmempoolentry` reports.
+///
+/// The rate is computed directly in sat/kwu — the unit `FeeRate` carries — instead of
+/// dividing sat by vbytes first. Dividing first truncates the observed rate to whole
+/// sat/vB, while the target is fractional sat/kwu: a child sitting at target then
+/// reads as underpriced, and the rebuild floor ratchets the package to ceil(target).
+/// The remaining truncation is one sat/kwu (1/250 sat/vB), the smallest step
+/// `FeeRate` can express.
+fn ancestor_fee_rate(ancestor_fee_btc: f64, ancestor_size: u64) -> Result<FeeRate, String> {
+    let fee_sat = Amount::from_btc(ancestor_fee_btc)
+        .map_err(|e| format!("ancestor fee is not a valid amount: {e}"))?
+        .to_sat();
+    let sat_per_kwu = fee_sat
+        .checked_mul(SAT_PER_KWU_PER_SAT_PER_VB)
+        .and_then(|f| f.checked_div(ancestor_size.max(1)))
+        .ok_or("ancestor fee rate overflowed")?;
+    Ok(FeeRate::from_sat_per_kwu(sat_per_kwu))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fractional package rate keeps its fractional part: 1005 sat over 100 vB is
+    /// 10.05 sat/vB, which a sat/vB division truncates to 10 sat/vB (2500 sat/kwu) but
+    /// which reads 2512 sat/kwu at the precision `FeeRate` carries (2512.5, floored).
+    #[test]
+    fn the_ancestor_rate_keeps_fractional_sat_per_vb() {
+        // 1005 sat is 0.00001005 BTC; the float round-trips to 1005 sat.
+        let rate = ancestor_fee_rate(0.00001005_f64, 100).expect("valid inputs");
+        assert_eq!(rate.to_sat_per_kwu(), 2512);
+    }
+
+    /// A whole-number rate is unchanged by the precision: 2500 sat over 250 vB is 10
+    /// sat/vB = 2500 sat/kwu either way.
+    #[test]
+    fn the_ancestor_rate_is_exact_for_whole_sat_per_vb() {
+        let rate = ancestor_fee_rate(0.000025_f64, 250).expect("valid inputs");
+        assert_eq!(rate.to_sat_per_kwu(), 2500);
+    }
+
+    /// A tiny fee over an odd size keeps its fraction instead of truncating to zero:
+    /// 1 sat over 3 vB is 83.33... sat/kwu, not 0.
+    #[test]
+    fn the_ancestor_rate_does_not_truncate_a_tiny_fee_to_zero() {
+        let rate = ancestor_fee_rate(0.00000001_f64, 3).expect("valid inputs");
+        assert_eq!(rate.to_sat_per_kwu(), 83);
+    }
+
+    /// A sat-to-sat-kwu widening overflow is an error, not a saturating rate.
+    #[test]
+    fn the_ancestor_rate_rejects_an_overflow() {
+        // 8e8 BTC is 8e16 sat: valid as an Amount (u64 holds ~1.8e19 sat),
+        // but x250 overflows u64.
+        let err = ancestor_fee_rate(8e8_f64, 1).expect_err("must overflow");
+        assert_eq!(err, "ancestor fee rate overflowed");
+    }
 }

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -259,10 +259,10 @@ impl CpfpMempool for BitcoindCpfpMempool {
     ) -> impl std::future::Future<Output = Result<AnchorSpendState, MempoolError>> + Send {
         let client = self.client.clone();
         async move {
-            // `gettxspendingprevout` reports the transaction that spends an outpoint, whether
-            // that transaction sits in the mempool or in a block. Core 24.0 added it, and the
-            // bridge already needs Core 24.0 for `submitpackage`. The typed surface of the
-            // client does not cover it, so call it raw.
+            // `gettxspendingprevout` reports the mempool transaction that spends an outpoint.
+            // It is mempool-only: a spend that confirmed reads as `Unspent` here. Core 24.0
+            // added it, and the bridge already needs Core 24.0 for `submitpackage`. The
+            // typed surface of the client does not cover it, so call it raw.
             let query =
                 serde_json::json!([{ "txid": anchor.txid.to_string(), "vout": anchor.vout }]);
             let spends: Vec<PrevoutSpend> = client
@@ -277,18 +277,18 @@ impl CpfpMempool for BitcoindCpfpMempool {
                 MempoolError(format!("gettxspendingprevout returned a bad txid: {e}"))
             })?;
 
-            // A spender exists. When the mempool holds it, its ancestor totals give the package
-            // rate that this operator competes against.
+            // A spender exists. Its ancestor totals give the package rate that this operator
+            // competes against.
             //
-            // When the mempool does not hold it, the spender is confirmed and no child can
-            // improve the parent. A transient RPC failure reads the same way here. The cost of
-            // that confusion is one skipped bump, and the next trigger retries.
-            let entry: Result<MempoolEntry, _> = client
+            // A failed lookup is an error, not a confirmed spend. The probe is mempool-only
+            // and never reports a confirmed spend, so a spender that the first call reported
+            // and the entry lookup cannot find is an RPC failure or a state divergence. The
+            // ladder treats the error as "probe unavailable" and builds; the submission is
+            // the authority.
+            let entry: MempoolEntry = client
                 .call_raw("getmempoolentry", &[serde_json::json!(spending_txid)])
-                .await;
-            let Ok(entry) = entry else {
-                return Ok(AnchorSpendState::Confirmed);
-            };
+                .await
+                .map_err(|e| MempoolError(format!("getmempoolentry: {e:?}")))?;
 
             let ancestor_fee = Amount::from_btc(entry.fees.ancestor)
                 .map_err(|e| MempoolError(format!("ancestor fee is not a valid amount: {e}")))?;

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -1,0 +1,352 @@
+//! Bridge-side implementations of the [`btc_tracker::cpfp`] traits.
+//!
+//! `btc-tracker` defines [`CpfpWallet`], [`CpfpFeeSource`], and [`CpfpPackageSubmitter`] as
+//! abstract interfaces so the crate stays at the bottom of the dependency graph. The concrete
+//! adapters that wire those traits to the bridge's actual wallet, fee source, and Bitcoin Core
+//! client live here.
+
+use std::sync::Arc;
+
+use bitcoin::{
+    Address, Amount, FeeRate, Network, OutPoint, ScriptBuf, Transaction, XOnlyPublicKey,
+    secp256k1::{Message, SECP256K1, schnorr::Signature},
+    taproot::{ControlBlock, LeafVersion},
+};
+use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
+use btc_tracker::{
+    cpfp::{
+        CpfpFeeSource, CpfpPackageSubmitter, CpfpStrategy, CpfpWallet, InputSignFut, InputSigner,
+        WalletFundedPsbt,
+    },
+    submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
+};
+use operator_wallet::{AnchorInfo, GeneralWallet, OperatorWallet};
+use secret_service_client::SecretServiceClient;
+use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
+use strata_bridge_connectors::{Connector, prelude::MultiAnchor};
+use strata_bridge_tx_graph::fee;
+use tokio::sync::RwLock;
+use tracing::warn;
+
+/// Wraps the bridge's `Arc<RwLock<OperatorWallet<G>>>` and implements [`CpfpWallet`] over it.
+///
+/// Both [`CpfpStrategy`] variants funnel through
+/// [`OperatorWallet::build_cpfp_child`](operator_wallet::OperatorWallet::build_cpfp_child) with the
+/// foreign-UTXO machinery — the difference between them is just which output on the parent
+/// the child consumes:
+/// - [`CpfpStrategy::AnchorBearing`]: a 330-sat keyed-Taproot anchor at `anchor_vout`, internal key
+///   = the operator's musig2 pubkey (the "btc key" from the operator table).
+/// - [`CpfpStrategy::ParentTxCombined`]: the operator's payout output at `payout_outpoint.vout`,
+///   internal key = the operator's general-wallet pubkey (the bridge assumes the operator's
+///   covenant `payout_descriptor` resolves to the general-wallet P2TR — if not, signing fails
+///   downstream and the bump is skipped + retried).
+///
+/// Treating the payout as a foreign UTXO (rather than asking BDK to track it in the wallet's
+/// UTXO set) is essential: the parent has NOT been broadcast at the time we build the child
+/// (we submit `[parent, child]` as a v3 1P1C package), so BDK has no knowledge of the
+/// payout outpoint. `add_foreign_utxo` accepts it with a caller-provided `witness_utxo`.
+#[derive(Debug)]
+pub struct OperatorWalletCpfpAdapter<G: GeneralWallet + std::fmt::Debug + 'static> {
+    wallet: Arc<RwLock<OperatorWallet<G>>>,
+    /// Operator's general-wallet pubkey. Used as the foreign-UTXO `tap_internal_key` when
+    /// CPFPing a [`CpfpStrategy::ParentTxCombined`] parent — every payout output across
+    /// cooperative_payout / uncontested_payout / contested_payout / unstaking goes to the
+    /// operator's payout descriptor, which the bridge expects to be the general-wallet P2TR.
+    operator_general_pubkey: XOnlyPublicKey,
+}
+
+impl<G: GeneralWallet + std::fmt::Debug + 'static> OperatorWalletCpfpAdapter<G> {
+    /// Constructs a new adapter wrapping the shared wallet handle. `operator_general_pubkey`
+    /// is the operator's general-wallet x-only pubkey (typically fetched once at
+    /// orchestrator startup via `s2_client.general_wallet_signer().pubkey()`).
+    pub const fn new(
+        wallet: Arc<RwLock<OperatorWallet<G>>>,
+        operator_general_pubkey: XOnlyPublicKey,
+    ) -> Self {
+        Self {
+            wallet,
+            operator_general_pubkey,
+        }
+    }
+}
+
+impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWalletCpfpAdapter<G> {
+    fn build_cpfp_child(
+        &self,
+        parent: &Transaction,
+        strategy: CpfpStrategy,
+        target_pkg_fee_rate: FeeRate,
+        replacing: Option<&[OutPoint]>,
+    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
+        // Clone what we need into the future so the returned future owns its captures.
+        let wallet_arc = self.wallet.clone();
+        let parent_owned = parent.clone();
+        let replacing_owned: Option<Vec<OutPoint>> = replacing.map(<[OutPoint]>::to_vec);
+        let operator_general_pubkey = self.operator_general_pubkey;
+        async move {
+            // Both strategies funnel through the same `build_cpfp_child` machinery — only
+            // the foreign-UTXO descriptor (anchor vs. payout) differs.
+            let parent_fee = strategy.parent_fee();
+            let foreign = match strategy {
+                CpfpStrategy::AnchorBearing {
+                    anchor_vout,
+                    anchor_internal_key,
+                    ..
+                } => AnchorInfo::KeyPath {
+                    vout: anchor_vout,
+                    internal_key: anchor_internal_key,
+                },
+                CpfpStrategy::ParentTxCombined {
+                    payout_outpoint, ..
+                } => AnchorInfo::KeyPath {
+                    vout: payout_outpoint.vout,
+                    internal_key: operator_general_pubkey,
+                },
+                CpfpStrategy::MultiAnchorBearing {
+                    anchor_vout,
+                    leaf_script,
+                    control_block,
+                    ..
+                } => AnchorInfo::ScriptPath {
+                    vout: anchor_vout,
+                    leaf_script,
+                    control_block,
+                },
+            };
+            let mut wallet = wallet_arc.write().await;
+            let funded = wallet
+                .build_cpfp_child(
+                    &parent_owned,
+                    parent_fee,
+                    foreign,
+                    target_pkg_fee_rate,
+                    replacing_owned.as_deref(),
+                )
+                .await
+                .map_err(|e| format!("{e}"))?;
+            let spent = funded.spent();
+            Ok(WalletFundedPsbt {
+                psbt: funded.psbt,
+                spent,
+            })
+        }
+    }
+}
+
+/// [`CpfpFeeSource`] backed by `bitcoind`'s `estimatesmartfee`.
+///
+/// Floors the result at 1 sat/vB. `estimatesmartfee` reports no rate at all when it has too
+/// little data to work with (a fresh regtest, an early signet), and can report below min-relay
+/// on a quiet network — either way the bump loop must not target a rate that would leave the
+/// package unrelayable.
+#[derive(Debug)]
+pub struct BitcoindCpfpFeeSource {
+    client: Arc<BitcoinClient>,
+    conf_target: u16,
+}
+
+impl BitcoindCpfpFeeSource {
+    /// Constructs a fee source that polls `client.estimate_smart_fee(conf_target)` each call.
+    pub const fn new(client: Arc<BitcoinClient>, conf_target: u16) -> Self {
+        Self {
+            client,
+            conf_target,
+        }
+    }
+}
+
+impl CpfpFeeSource for BitcoindCpfpFeeSource {
+    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+        let client = self.client.clone();
+        let conf_target = self.conf_target;
+        async move {
+            let smart_fee = client
+                .estimate_smart_fee(conf_target)
+                .await
+                .map_err(|e| format!("estimate_smart_fee: {e:?}"))?;
+            // `estimatesmartfee` reports no `fee_rate` when it has insufficient data (fresh
+            // regtest, early signet); floor at 1 sat/vB in that case and whenever the node
+            // reports something below it, so the bump loop never targets a rate that would
+            // leave the package below min-relay.
+            let floor = FeeRate::from_sat_per_vb(1).expect("1 sat/vB is always a valid FeeRate");
+            Ok(smart_fee.fee_rate.unwrap_or(floor).max(floor))
+        }
+    }
+}
+
+/// [`CpfpPackageSubmitter`] backed by the typed
+/// [`btc_tracker::submitpackage::submit_package`] wrapper over [`BitcoinClient`].
+#[derive(Debug)]
+pub struct BitcoindCpfpPackageSubmitter {
+    client: Arc<BitcoinClient>,
+}
+
+impl BitcoindCpfpPackageSubmitter {
+    /// Constructs a submitter forwarding to the given Bitcoin Core client.
+    pub const fn new(client: Arc<BitcoinClient>) -> Self {
+        Self { client }
+    }
+}
+
+impl CpfpPackageSubmitter for BitcoindCpfpPackageSubmitter {
+    fn submit_package(
+        &self,
+        txs: &[Transaction],
+    ) -> impl std::future::Future<Output = Result<SubmitPackageSummary, SubmitPackageError>> + Send
+    {
+        let client = self.client.clone();
+        let txs = txs.to_vec();
+        async move { submitpackage::submit_package(client.as_ref(), &txs).await }
+    }
+}
+
+/// Looks for a keyed-Taproot anchor on `parent.output` keyed to `anchor_pubkey`, and if
+/// found returns the corresponding [`CpfpStrategy::AnchorBearing`].
+///
+/// `anchor_pubkey` must be the **musig2-signer** pubkey (the "btc key" from the operator
+/// table) — every bridge-graph tx (claim, stake, unstaking_intent, counterproof, ack)
+/// constructs its `KeyedAnchor` (from `strata_bridge_tx_graph::prelude`) with that
+/// key as the internal Taproot key. The dust value comes from [`fee::anchor_dust_value`] so
+/// the helper tracks any future change to the bridge's anchor sizing.
+///
+/// `parent_fee` must be provided by the caller; an accurate value is critical to the CPFP
+/// math (the child's vbytes-to-cover-the-package depends on what the parent already pays).
+pub fn infer_anchor_strategy(
+    parent: &Transaction,
+    anchor_pubkey: XOnlyPublicKey,
+    network: Network,
+    parent_fee: Amount,
+) -> Option<CpfpStrategy> {
+    let anchor_value = fee::anchor_dust_value();
+    let expected_script = Address::p2tr(SECP256K1, anchor_pubkey, None, network).script_pubkey();
+    let matches: Vec<u32> = parent
+        .output
+        .iter()
+        .enumerate()
+        .filter_map(|(vout, txout)| {
+            (txout.value == anchor_value && txout.script_pubkey == expected_script)
+                .then(|| u32::try_from(vout).ok())
+                .flatten()
+        })
+        .collect();
+    // Bridge txs are constructed with at most one operator-keyed anchor output. If a future
+    // refactor accidentally produces a tx with two outputs that both match (same script + same
+    // dust value), `find_map`-style "first match" would silently pick the wrong one — make
+    // the assumption explicit.
+    debug_assert!(
+        matches.len() <= 1,
+        "parent tx has {} outputs matching the operator-keyed anchor pattern; expected ≤ 1",
+        matches.len()
+    );
+    matches
+        .first()
+        .map(|&anchor_vout| CpfpStrategy::AnchorBearing {
+            anchor_vout,
+            anchor_internal_key: anchor_pubkey,
+            parent_fee,
+        })
+}
+
+/// Builds the script-path anchor signer used for `MultiAnchor` CPFP children.
+///
+/// Identical key to [`build_anchor_input_signer`] — the operator's musig2 signer, which doubles
+/// as its watchtower key — but signs **untweaked**. A script-path spend satisfies the leaf
+/// directly, so the signature must be over the raw key rather than the BIP-341 tap-tweaked
+/// output key. This is the same mode `publish_contest` already uses when signing the contest
+/// transaction's own input.
+pub fn build_multi_anchor_signer(s2_client: SecretServiceClient) -> InputSigner {
+    let s2 = Arc::new(s2_client);
+    let signer: InputSigner = Arc::new(move |msg: Message| {
+        let s2 = s2.clone();
+        let fut: InputSignFut = Box::pin(async move {
+            let digest: &[u8; 32] = msg.as_ref();
+            let sig = s2
+                .musig2_signer()
+                .sign_no_tweak(digest)
+                .await
+                .map_err(|e| {
+                    warn!(?e, "secret-service multi-anchor (script-path) sign failed");
+                    format!("{e:?}")
+                })?;
+            Ok::<Signature, String>(sig)
+        });
+        fut
+    });
+    signer
+}
+
+/// Constructs the [`InputSigner`] closure that signs the **anchor input** of a CPFP child.
+///
+/// Wraps `s2.musig2_signer().sign(digest, None)` — the bridge constructs every keyed anchor
+/// with the operator's musig2-signer pubkey as the internal Taproot key (see
+/// [`bridge-sm::graph::context`](strata_bridge_sm) `generate_key_data`, which feeds
+/// `OperatorTable::idx_to_btc_key` into `KeyData::operator_pubkey`). The `None` tweak
+/// applies the BIP-341 tap-tweak with an empty merkle root, matching how the anchor was
+/// constructed (keyed-Taproot, no script tree).
+pub fn build_anchor_input_signer(s2_client: SecretServiceClient) -> InputSigner {
+    let s2 = Arc::new(s2_client);
+    let signer: InputSigner = Arc::new(move |msg: Message| {
+        let s2 = s2.clone();
+        let fut: InputSignFut = Box::pin(async move {
+            let digest: &[u8; 32] = msg.as_ref();
+            let sig = s2.musig2_signer().sign(digest, None).await.map_err(|e| {
+                warn!(?e, "secret-service anchor sign failed");
+                format!("{e:?}")
+            })?;
+            Ok::<Signature, String>(sig)
+        });
+        fut
+    });
+    signer
+}
+
+/// Constructs the [`InputSigner`] closure that signs the **wallet funding inputs** of a CPFP
+/// child.
+///
+/// Wraps `s2.general_wallet_signer().sign(digest, None)` — the operator-wallet's
+/// `tr(general_pubkey)` descriptor keys its UTXOs to the general-wallet signer's pubkey, so
+/// every funding input the child consumes is signed by that signer. As with the anchor
+/// signer, `None` applies the BIP-341 tap-tweak with an empty merkle root.
+pub fn build_wallet_input_signer(s2_client: SecretServiceClient) -> InputSigner {
+    let s2 = Arc::new(s2_client);
+    let signer: InputSigner = Arc::new(move |msg: Message| {
+        let s2 = s2.clone();
+        let fut: InputSignFut = Box::pin(async move {
+            let digest: &[u8; 32] = msg.as_ref();
+            let sig = s2
+                .general_wallet_signer()
+                .sign(digest, None)
+                .await
+                .map_err(|e| {
+                    warn!(?e, "secret-service wallet-input sign failed");
+                    format!("{e:?}")
+                })?;
+            Ok::<Signature, String>(sig)
+        });
+        fut
+    });
+    signer
+}
+
+/// Derives the script-path spend material for one leaf of a [`MultiAnchor`] CPFP output.
+///
+/// `leaf_index` is the *dense per-graph watchtower slot* — the same value the state machine
+/// computes with `watchtower_slot_for_operator` and ships in the publishing duty. It is not a
+/// global operator index.
+///
+/// Mirrors what [`Connector::finalize_input`] does when satisfying a script-path spend, but
+/// hands the pieces back rather than writing them into a PSBT, because the CPFP child is built
+/// and signed a step at a time by the bump loop.
+///
+/// Returns `None` when `leaf_index` is out of range for this anchor, which would mean the caller
+/// believes it is a watchtower of a graph whose anchor says otherwise.
+pub fn multi_anchor_spend_material(
+    anchor: &MultiAnchor,
+    leaf_index: usize,
+) -> Option<(ScriptBuf, ControlBlock)> {
+    let leaf_script = anchor.leaf_scripts().into_iter().nth(leaf_index)?;
+    let control_block = anchor
+        .spend_info()
+        .control_block(&(leaf_script.clone(), LeafVersion::TapScript))?;
+    Some((leaf_script, control_block))
+}

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -16,12 +16,14 @@ use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::{
     cpfp::{
         AnchorSpendState, ChildPsbt, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet,
-        FundingLease, InputSignFut, InputSigner, WalletFundedPsbt,
+        CpfpWalletError, FeeSourceError, FundingLease, InputSignFut, InputSigner, MempoolError,
+        SignerError, WalletFundedPsbt,
     },
     submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
 };
 use operator_wallet::{
-    AnchorInfo, AnchorOwnership, GeneralWallet, Lease, OperatorWallet, ReplacedChild,
+    AnchorInfo, AnchorOwnership, ErrorPermanence, GeneralWallet, Lease, OperatorWallet,
+    ReplacedChild,
 };
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
@@ -95,7 +97,7 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
         target_pkg_fee_rate: FeeRate,
         replacing: Option<&dyn FundingLease>,
         prior_child_fee: Option<Amount>,
-    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
+    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, CpfpWalletError>> + Send {
         // Clone what we need into the future so the returned future owns its captures.
         let wallet_arc = self.wallet.clone();
         let parent_owned = parent.clone();
@@ -158,11 +160,23 @@ impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWallet
                     },
                 )
                 .await
-                .map_err(|e| format!("{e}"))?;
+                // Classify at the boundary. The wallet knows which failures repeat for a
+                // signed parent, and the driver reads that to stop bumping one that cannot
+                // carry a child at all.
+                .map_err(|e| {
+                    let message = e.to_string();
+                    if e.is_permanent() {
+                        CpfpWalletError::Unbumpable(message)
+                    } else {
+                        CpfpWalletError::Transient(message)
+                    }
+                })?;
             let (psbt, lease) = funded.into_parts();
-            // The backend states its signing through the final fields, and each input
-            // carries its spent output. A violation fails here rather than on chain.
-            let psbt = ChildPsbt::new(psbt).map_err(|e| e.to_string())?;
+            // A contract violation is a fault of the backend build, not a property of the
+            // parent, and the offending input depends on which UTXOs selection picked. The
+            // next attempt selects again.
+            let psbt =
+                ChildPsbt::new(psbt).map_err(|e| CpfpWalletError::Transient(e.to_string()))?;
             Ok(WalletFundedPsbt {
                 psbt,
                 lease: Arc::new(WalletFundingLease(lease)),
@@ -194,14 +208,16 @@ impl BitcoindCpfpFeeSource {
 }
 
 impl CpfpFeeSource for BitcoindCpfpFeeSource {
-    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+    fn estimate(
+        &self,
+    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
         let client = self.client.clone();
         let conf_target = self.conf_target;
         async move {
             let smart_fee = client
                 .estimate_smart_fee(conf_target)
                 .await
-                .map_err(|e| format!("estimate_smart_fee: {e:?}"))?;
+                .map_err(|e| FeeSourceError(format!("estimate_smart_fee: {e:?}")))?;
             // `estimatesmartfee` reports no `fee_rate` when it has insufficient data (fresh
             // regtest, early signet); floor at 1 sat/vB in that case and whenever the node
             // reports something below it, so the bump loop never targets a rate that would
@@ -240,7 +256,7 @@ impl CpfpMempool for BitcoindCpfpMempool {
     fn anchor_spend_state(
         &self,
         anchor: OutPoint,
-    ) -> impl std::future::Future<Output = Result<AnchorSpendState, String>> + Send {
+    ) -> impl std::future::Future<Output = Result<AnchorSpendState, MempoolError>> + Send {
         let client = self.client.clone();
         async move {
             // `gettxspendingprevout` reports the transaction that spends an outpoint, whether
@@ -252,14 +268,14 @@ impl CpfpMempool for BitcoindCpfpMempool {
             let spends: Vec<PrevoutSpend> = client
                 .call_raw("gettxspendingprevout", &[query])
                 .await
-                .map_err(|e| format!("gettxspendingprevout: {e:?}"))?;
+                .map_err(|e| MempoolError(format!("gettxspendingprevout: {e:?}")))?;
 
             let Some(spending_txid) = spends.into_iter().find_map(|s| s.spending_txid) else {
                 return Ok(AnchorSpendState::Unspent);
             };
-            let spending_txid: Txid = spending_txid
-                .parse()
-                .map_err(|e| format!("gettxspendingprevout returned a bad txid: {e}"))?;
+            let spending_txid: Txid = spending_txid.parse().map_err(|e| {
+                MempoolError(format!("gettxspendingprevout returned a bad txid: {e}"))
+            })?;
 
             // A spender exists. When the mempool holds it, its ancestor totals give the package
             // rate that this operator competes against.
@@ -275,11 +291,11 @@ impl CpfpMempool for BitcoindCpfpMempool {
             };
 
             let ancestor_fee = Amount::from_btc(entry.fees.ancestor)
-                .map_err(|e| format!("ancestor fee is not a valid amount: {e}"))?;
+                .map_err(|e| MempoolError(format!("ancestor fee is not a valid amount: {e}")))?;
             let rate = ancestor_fee
                 .checked_div(entry.ancestor_size.max(1))
                 .map(|per_vb| FeeRate::from_sat_per_vb_unchecked(per_vb.to_sat()))
-                .ok_or_else(|| "ancestor fee rate overflowed".to_string())?;
+                .ok_or_else(|| MempoolError("ancestor fee rate overflowed".into()))?;
             Ok(AnchorSpendState::SpentInMempool {
                 spender: spending_txid,
                 pkg_fee_rate: rate,
@@ -330,9 +346,9 @@ pub fn build_multi_anchor_signer(s2_client: SecretServiceClient) -> InputSigner 
                 .await
                 .map_err(|e| {
                     warn!(?e, "secret-service multi-anchor (script-path) sign failed");
-                    format!("{e:?}")
+                    SignerError(format!("{e:?}"))
                 })?;
-            Ok::<Signature, String>(sig)
+            Ok::<Signature, SignerError>(sig)
         });
         fut
     });
@@ -355,9 +371,9 @@ pub fn build_anchor_input_signer(s2_client: SecretServiceClient) -> InputSigner 
             let digest: &[u8; 32] = msg.as_ref();
             let sig = s2.musig2_signer().sign(digest, None).await.map_err(|e| {
                 warn!(?e, "secret-service anchor sign failed");
-                format!("{e:?}")
+                SignerError(format!("{e:?}"))
             })?;
-            Ok::<Signature, String>(sig)
+            Ok::<Signature, SignerError>(sig)
         });
         fut
     });
@@ -383,9 +399,9 @@ pub fn build_wallet_input_signer(s2_client: SecretServiceClient) -> InputSigner 
                 .await
                 .map_err(|e| {
                     warn!(?e, "secret-service wallet-input sign failed");
-                    format!("{e:?}")
+                    SignerError(format!("{e:?}"))
                 })?;
-            Ok::<Signature, String>(sig)
+            Ok::<Signature, SignerError>(sig)
         });
         fut
     });

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -1,6 +1,6 @@
 //! Bridge-side implementations of the [`btc_tracker::cpfp`] traits.
 //!
-//! `btc-tracker` defines [`CpfpWallet`], [`CpfpFeeSource`], and [`CpfpPackageSubmitter`] as
+//! `btc-tracker` defines [`CpfpWallet`], [`CpfpFeeSource`], and [`CpfpMempool`] as
 //! abstract interfaces so the crate stays at the bottom of the dependency graph. The concrete
 //! adapters that wire those traits to the bridge's actual wallet, fee source, and Bitcoin Core
 //! client live here.
@@ -15,8 +15,8 @@ use bitcoin::{
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::{
     cpfp::{
-        CpfpFeeSource, CpfpPackageSubmitter, CpfpStrategy, CpfpWallet, InputSignFut, InputSigner,
-        WalletFundedPsbt,
+        AnchorSpendState, CpfpFeeSource, CpfpMempool, CpfpStrategy, CpfpWallet, InputSignFut,
+        InputSigner, WalletFundedPsbt,
     },
     submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
 };
@@ -174,21 +174,21 @@ impl CpfpFeeSource for BitcoindCpfpFeeSource {
     }
 }
 
-/// [`CpfpPackageSubmitter`] backed by the typed
+/// [`CpfpMempool`] backed by the typed
 /// [`btc_tracker::submitpackage::submit_package`] wrapper over [`BitcoinClient`].
 #[derive(Debug)]
-pub struct BitcoindCpfpPackageSubmitter {
+pub struct BitcoindCpfpMempool {
     client: Arc<BitcoinClient>,
 }
 
-impl BitcoindCpfpPackageSubmitter {
+impl BitcoindCpfpMempool {
     /// Constructs a submitter forwarding to the given Bitcoin Core client.
     pub const fn new(client: Arc<BitcoinClient>) -> Self {
         Self { client }
     }
 }
 
-impl CpfpPackageSubmitter for BitcoindCpfpPackageSubmitter {
+impl CpfpMempool for BitcoindCpfpMempool {
     fn submit_package(
         &self,
         txs: &[Transaction],
@@ -198,6 +198,73 @@ impl CpfpPackageSubmitter for BitcoindCpfpPackageSubmitter {
         let txs = txs.to_vec();
         async move { submitpackage::submit_package(client.as_ref(), &txs).await }
     }
+
+    fn anchor_spend_state(
+        &self,
+        anchor: OutPoint,
+    ) -> impl std::future::Future<Output = Result<AnchorSpendState, String>> + Send {
+        let client = self.client.clone();
+        async move {
+            // `gettxspendingprevout` reports the transaction that spends an outpoint, whether
+            // that transaction sits in the mempool or in a block. Core 24.0 added it, and the
+            // bridge already needs Core 24.0 for `submitpackage`. The typed surface of the
+            // client does not cover it, so call it raw.
+            let query =
+                serde_json::json!([{ "txid": anchor.txid.to_string(), "vout": anchor.vout }]);
+            let spends: Vec<PrevoutSpend> = client
+                .call_raw("gettxspendingprevout", &[query])
+                .await
+                .map_err(|e| format!("gettxspendingprevout: {e:?}"))?;
+
+            let Some(spending_txid) = spends.into_iter().find_map(|s| s.spending_txid) else {
+                return Ok(AnchorSpendState::Unspent);
+            };
+
+            // A spender exists. When the mempool holds it, its ancestor totals give the package
+            // rate that this operator competes against.
+            //
+            // When the mempool does not hold it, the spender is confirmed and no child can
+            // improve the parent. A transient RPC failure reads the same way here. The cost of
+            // that confusion is one skipped bump, and the next trigger retries.
+            let entry: Result<MempoolEntry, _> = client
+                .call_raw("getmempoolentry", &[serde_json::json!(spending_txid)])
+                .await;
+            let Ok(entry) = entry else {
+                return Ok(AnchorSpendState::Confirmed);
+            };
+
+            let ancestor_fee = Amount::from_btc(entry.fees.ancestor)
+                .map_err(|e| format!("ancestor fee is not a valid amount: {e}"))?;
+            let rate = ancestor_fee
+                .checked_div(entry.ancestor_size.max(1))
+                .map(|per_vb| FeeRate::from_sat_per_vb_unchecked(per_vb.to_sat()))
+                .ok_or_else(|| "ancestor fee rate overflowed".to_string())?;
+            Ok(AnchorSpendState::SpentInMempool(rate))
+        }
+    }
+}
+
+/// One entry of a `gettxspendingprevout` response.
+#[derive(Debug, serde::Deserialize)]
+struct PrevoutSpend {
+    /// Absent when nothing spends the outpoint.
+    #[serde(rename = "spendingtxid")]
+    spending_txid: Option<String>,
+}
+
+/// The subset of `getmempoolentry` that the bump loop reads.
+#[derive(Debug, serde::Deserialize)]
+struct MempoolEntry {
+    fees: MempoolEntryFees,
+    #[serde(rename = "ancestorsize")]
+    ancestor_size: u64,
+}
+
+/// Fee totals of a mempool entry, denominated in BTC as bitcoind reports them.
+#[derive(Debug, serde::Deserialize)]
+struct MempoolEntryFees {
+    /// Total fee of this transaction and its unconfirmed ancestors.
+    ancestor: f64,
 }
 
 /// Looks for a keyed-Taproot anchor on `parent.output` keyed to `anchor_pubkey`, and if

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -33,7 +33,7 @@ use strata_bridge_tx_graph::{
 use tracing::{error, info, warn};
 
 use crate::{
-    chain::{is_txid_onchain, publish_signed_transaction},
+    chain::{self, CpfpKind, is_txid_onchain, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
     output_handles::OutputHandles,
@@ -452,11 +452,17 @@ async fn publish_deposit(
     let drt_txid = signed_deposit_transaction.input[0].previous_output.txid;
     info!(%txid, %drt_txid, "publishing deposit transaction");
 
+    // The deposit tx has no operator-owned output: the SPS-50 header output is value-zero
+    // OP_RETURN and the deposit connector is n_of_n. It also has no keyed anchor — fee is
+    // baked into the DRT surcharge (`DepositTx::drt_required`). CPFP isn't possible here;
+    // if it gets evicted, the eviction arm re-broadcasts the bare tx at its baked-in rate.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_deposit_transaction,
         "deposit",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_deposit_transaction),
+        CpfpKind::None,
     )
     .await
 }
@@ -677,11 +683,24 @@ async fn fulfill_withdrawal(
     };
 
     info!(%deposit_idx, %txid, "submitting withdrawal fulfillment transaction");
+    // wft is wallet-funded: BDK chose the rate, not the protocol floor. `Psbt::fee()` gives
+    // the exact value (`witness_utxo` is populated on every input, so the difference
+    // sum_inputs − sum_outputs resolves cleanly).
+    let wft_fee = wft_psbt
+        .fee()
+        .map_err(|e| ExecutorError::WalletErr(format!("wft psbt fee: {e:?}")))?;
+    // BDK adds a change output to the operator's general wallet at
+    // `WithdrawalFulfillmentTx::OPTIONAL_CHANGE_VOUT = 2` when selected inputs exceed
+    // (user_amount + fee). `InferGeneralPayout` scans for that change output and uses it
+    // as the CPFP payout; if BDK didn't add change (inputs match exactly), the helper
+    // returns `None` and we broadcast without CPFP.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "withdrawal fulfillment",
         TxStatus::is_buried,
+        wft_fee,
+        CpfpKind::InferGeneralPayout,
     )
     .await?;
 
@@ -897,11 +916,21 @@ async fn publish_payout(
 
     info!(%txid, "broadcasting payout transaction");
 
+    // Cooperative payout: vout 0 is the operator's payout output. Use ParentTxCombined so
+    // the CPFP child spends that output + adds wallet funding (no keyed anchor on this tx).
+    let coop_payout_outpoint = OutPoint {
+        txid: finalized_tx.compute_txid(),
+        vout: strata_bridge_tx_graph::transactions::cooperative_payout::CooperativePayoutTx::PAYOUT_VOUT,
+    };
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &finalized_tx,
         "cooperative payout",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&finalized_tx),
+        CpfpKind::PayoutCombined {
+            payout_outpoint: coop_payout_outpoint,
+        },
     )
     .await?;
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -462,7 +462,7 @@ async fn publish_deposit(
         &signed_deposit_transaction,
         "deposit",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_deposit_transaction),
+        chain::ParentFee::Floor,
         CpfpKind::None,
     )
     .await
@@ -728,7 +728,7 @@ async fn fulfill_withdrawal(
         &signed_tx,
         "withdrawal fulfillment",
         TxStatus::is_buried,
-        wft_fee,
+        chain::ParentFee::Exact(wft_fee),
         CpfpKind::InferGeneralPayout,
     )
     .await?;
@@ -956,7 +956,7 @@ async fn publish_payout(
         &finalized_tx,
         "cooperative payout",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&finalized_tx),
+        chain::ParentFee::Floor,
         CpfpKind::PayoutCombined {
             payout_outpoint: coop_payout_outpoint,
         },

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -577,8 +577,15 @@ async fn fulfill_withdrawal(
             }
             None => {
                 info!(%deposit_idx, "selecting new funding outpoints");
+                // Confirmed inputs only: the withdrawal fulfillment is v3, and TRUC rejects
+                // a v3 transaction with an unconfirmed ancestor outside the one-parent-
+                // one-child shape. An unconfirmed funding input makes it unrelayable.
                 let funded = wallet
-                    .fund_v3_transaction(unfunded_tx.clone(), fee_rate)
+                    .fund_v3_transaction(
+                        unfunded_tx.clone(),
+                        fee_rate,
+                        operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+                    )
                     .await;
                 match funded {
                     Ok(funded) => {

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -1103,10 +1103,12 @@ async fn publish_sweep(
     info!(%txid, "broadcasting sweep transaction");
 
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &finalized_tx,
         "sweep",
         TxStatus::is_buried,
+        chain::ParentFee::Floor,
+        CpfpKind::None,
     )
     .await?;
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -14,6 +14,7 @@ use bitcoin_bosd::Descriptor;
 use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use musig2::{AggNonce, PartialSignature, PubNonce, aggregate_partial_signatures};
+use operator_wallet::LeaseOwner;
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_connectors::SigningInfo;
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
@@ -567,66 +568,87 @@ async fn fulfill_withdrawal(
             .get_withdrawal_funding_outpoints(deposit_idx)
             .await?;
 
+        // Every path that ends with a funded PSBT commits its lease. The database row keeps
+        // the funding outpoints of a deposit across duties and across restarts, and the
+        // transaction that spends them is signed and published after this block releases the
+        // wallet lock. A sync frees the lease once the spend confirms.
+        //
+        // A commit here is not redundant with the row. The sync prune drops the committed
+        // lease as soon as the fulfillment transaction reaches a mempool, so a later eviction
+        // leaves the outpoints held by nothing while a retry still needs them. `commit` is
+        // idempotent: a retry whose outpoints are already held adds no second record.
         let funding_result = match persisted_funding_outpoints.as_deref() {
             Some(outpoints) => {
                 info!(%deposit_idx, "reusing persisted funding outpoints");
                 wallet
-                    .fund_v3_transaction_with_inputs(unfunded_tx, outpoints, fee_rate)
+                    .fund_v3_transaction_with_inputs(
+                        unfunded_tx,
+                        outpoints,
+                        fee_rate,
+                        LeaseOwner::WithdrawalFulfillment,
+                    )
                     .await
-                    .map(|funded| funded.psbt)
+                    .map(|funded| {
+                        let (psbt, lease) = funded.into_parts();
+                        lease.commit();
+                        psbt
+                    })
             }
             None => {
                 info!(%deposit_idx, "selecting new funding outpoints");
                 // Confirmed inputs only: the withdrawal fulfillment is v3, and TRUC rejects
                 // a v3 transaction with an unconfirmed ancestor outside the one-parent-
                 // one-child shape. An unconfirmed funding input makes it unrelayable.
-                let funded = wallet
+                let candidate = wallet
                     .fund_v3_transaction(
                         unfunded_tx.clone(),
                         fee_rate,
                         operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+                        LeaseOwner::WithdrawalFulfillment,
                     )
                     .await;
-                match funded {
-                    Ok(funded) => {
-                        let candidate_outpoints = funded.spent();
+                match candidate {
+                    Ok(candidate) => {
+                        let candidate_outpoints = candidate.lease().outpoints().to_vec();
                         let assignment = output_handles
                             .db
                             .get_or_set_withdrawal_funding_outpoints(
                                 deposit_idx,
-                                candidate_outpoints.clone(),
+                                candidate_outpoints,
                             )
                             .await;
 
                         match assignment {
                             Ok(FundingAssignment::Created(outpoints)) => {
                                 info!(%deposit_idx, ?outpoints, "persisted withdrawal funding outpoints");
-                                Ok(funded.psbt)
+                                let (psbt, lease) = candidate.into_parts();
+                                lease.commit();
+                                Ok(psbt)
                             }
                             Ok(FundingAssignment::Existing(outpoints)) => {
                                 info!(
                                     %deposit_idx,
                                     "using existing withdrawal funding outpoints saved by another duty"
                                 );
-                                let stale_candidate_outpoints: Vec<_> = candidate_outpoints
-                                    .iter()
-                                    .copied()
-                                    .filter(|outpoint| !outpoints.contains(outpoint))
-                                    .collect();
-                                wallet.release(&stale_candidate_outpoints);
+                                // Drop the whole candidate lease before the rebuild. The
+                                // wallet write lock is held across both calls, so no other
+                                // duty can take the outpoints in between.
+                                drop(candidate);
                                 wallet
                                     .fund_v3_transaction_with_inputs(
                                         unfunded_tx,
                                         &outpoints,
                                         fee_rate,
+                                        LeaseOwner::WithdrawalFulfillment,
                                     )
                                     .await
-                                    .map(|funded| funded.psbt)
+                                    .map(|funded| {
+                                        let (psbt, lease) = funded.into_parts();
+                                        lease.commit();
+                                        psbt
+                                    })
                             }
-                            Err(err) => {
-                                wallet.release(&candidate_outpoints);
-                                return Err(err.into());
-                            }
+                            Err(err) => return Err(err.into()),
                         }
                     }
                     Err(err) => Err(err),

--- a/crates/bridge-exec/src/graph/bridge_proof.rs
+++ b/crates/bridge-exec/src/graph/bridge_proof.rs
@@ -25,7 +25,9 @@ use tracing::{info, warn};
 use zkaleido::ZkVmError;
 
 use crate::{
-    chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    errors::ExecutorError,
+    output_handles::OutputHandles,
 };
 
 /// Generates the bridge proof anchored at the given block height and publishes
@@ -92,11 +94,17 @@ pub(super) async fn generate_and_publish_bridge_proof(
 
     let signed_tx = bridge_proof_tx.finalize_partial(signature);
 
+    // Bridge proof tx has no operator-owned output and no keyed anchor — its only output is
+    // a zero-value OP_RETURN encoding the proof bytes. The fee comes from the contest
+    // proof-connector input's surcharge. Not CPFP-able from the operator side; eviction
+    // resubmit is the only recovery path.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "bridge proof",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_tx),
+        CpfpKind::None,
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/bridge_proof.rs
+++ b/crates/bridge-exec/src/graph/bridge_proof.rs
@@ -103,7 +103,7 @@ pub(super) async fn generate_and_publish_bridge_proof(
         &signed_tx,
         "bridge proof",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_tx),
+        chain::ParentFee::Floor,
         CpfpKind::None,
     )
     .await

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -720,7 +720,7 @@ pub(super) async fn publish_claim(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, io, sync::Arc, time::Duration};
+    use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
     use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client as CoreRpcClient};
     use bitcoin::{
@@ -742,12 +742,23 @@ mod tests {
         sync_fails: bool,
     }
 
+    /// Error of the reconciliation mock. Nothing in these tests reads the classification.
+    #[derive(Debug, thiserror::Error)]
+    #[error("{0}")]
+    struct MockError(String);
+
+    impl operator_wallet::ErrorPermanence for MockError {
+        fn is_permanent(&self) -> bool {
+            false
+        }
+    }
+
     impl GeneralWallet for ReconciliationGeneralWallet {
-        type Error = io::Error;
+        type Error = MockError;
 
         async fn sync(&mut self) -> Result<(), Self::Error> {
             if self.sync_fails {
-                Err(io::Error::other("test sync failure"))
+                Err(MockError("test sync failure".into()))
             } else {
                 Ok(())
             }

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -702,13 +702,12 @@ pub(super) async fn publish_claim(
             .push(signature.serialize());
     }
 
-    let parent_fee = chain::parent_fee_for_floor_tx(&signed_claim_tx);
     publish_signed_transaction(
         output_handles,
         &signed_claim_tx,
         "claim",
         TxStatus::is_buried,
-        parent_fee,
+        chain::ParentFee::Floor,
         CpfpKind::AnchorAt {
             anchor_vout: ClaimTx::CPFP_VOUT,
             anchor_key: claim_tx.cpfp_connector().internal_key(),

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -163,14 +163,15 @@ async fn ensure_claim_funding_outpoint(
             ),
         }
 
-        match wallet
+        let reserved = wallet
             .reserve_utxo_with_value(
                 cfg.claim_funding_utxo_value,
                 LeaseOwner::ClaimFunding,
                 predicate::never::<UtxoInfo>,
             )
-            .0
-        {
+            .await
+            .0;
+        match reserved {
             Some(reserved) => reserved,
             None => {
                 warn!("could not acquire claim funding utxo. attempting refill...");
@@ -259,6 +260,7 @@ async fn ensure_claim_funding_outpoint(
                         LeaseOwner::ClaimFunding,
                         predicate::never::<UtxoInfo>,
                     )
+                    .await
                     .0
                     .expect("funding utxos must be available after refill")
             }
@@ -760,7 +762,7 @@ mod tests {
         }
 
         async fn fund_v3_transaction(
-            &mut self,
+            &self,
             _outputs: Vec<TxOut>,
             _explicit_inputs: Option<&[OutPoint]>,
             _fee_rate: FeeRate,
@@ -770,7 +772,7 @@ mod tests {
         }
 
         async fn build_cpfp_child(
-            &mut self,
+            &self,
             _parent: &Transaction,
             _parent_fee: bitcoin::Amount,
             _anchor: operator_wallet::AnchorInfo,

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -1,7 +1,5 @@
 //! Executors for uncontested payout graph duties.
 
-use std::collections::BTreeSet;
-
 use algebra::predicate;
 use bitcoin::{
     OutPoint, TapSighashType, TxOut, Txid, XOnlyPublicKey,
@@ -11,7 +9,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
-use operator_wallet::{GeneralUtxoPolicy, GeneralWallet, OperatorWallet, UtxoInfo};
+use operator_wallet::{GeneralUtxoPolicy, LeaseOwner, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
 use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
@@ -153,7 +151,7 @@ async fn ensure_claim_funding_outpoint(
     }
 
     info!(?graph_idx, "fetching funding outpoint from wallet");
-    let funding_outpoint = {
+    let (funding_outpoint, funding_lease) = {
         let mut wallet = output_handles.wallet.write().await;
 
         match wallet.sync().await {
@@ -165,10 +163,14 @@ async fn ensure_claim_funding_outpoint(
         }
 
         match wallet
-            .reserve_utxo_with_value(cfg.claim_funding_utxo_value, predicate::never::<UtxoInfo>)
+            .reserve_utxo_with_value(
+                cfg.claim_funding_utxo_value,
+                LeaseOwner::ClaimFunding,
+                predicate::never::<UtxoInfo>,
+            )
             .0
         {
-            Some(outpoint) => outpoint,
+            Some(reserved) => reserved,
             None => {
                 warn!("could not acquire claim funding utxo. attempting refill...");
                 // How many we need to top the pool back up to the configured target. We
@@ -187,29 +189,22 @@ async fn ensure_claim_funding_outpoint(
                         .count()
                 };
                 let batch_size = cfg.funding_uxto_pool_size.saturating_sub(current_pool_size);
-                let funded = wallet
+                // `refill` holds the general-wallet inputs of the refill transaction. A path
+                // that ends before the transaction reaches a mempool drops it, which returns
+                // those inputs to the pool. A path that cannot tell drops it only when a
+                // fresh sync says the inputs are still spendable.
+                let refill = wallet
                     .create_reserved_utxos(
                         fee::FEE_RATE,
                         cfg.claim_funding_utxo_value,
                         batch_size,
                         GeneralUtxoPolicy::ConfirmedOnly,
+                        LeaseOwner::ClaimFundingRefill,
                     )
                     .await
                     .map_err(|e| ExecutorError::WalletErr(format!("refill failed: {e}")))?;
-                let spent = funded.spent();
-                let tx = match sign_claim_funding_tx(&output_handles.s2_client, funded.psbt).await {
-                    Ok(tx) => tx,
-                    Err(err) => {
-                        wallet.release(&spent);
-                        warn!(
-                            ?err,
-                            ?spent,
-                            "claim-funding refill signing failed; released inputs"
-                        );
-
-                        return Err(err);
-                    }
-                };
+                let (refill_psbt, refill_lease) = refill.into_parts();
+                let tx = sign_claim_funding_tx(&output_handles.s2_client, refill_psbt).await?;
                 let txid = tx.compute_txid();
                 info!(%txid, "submitting claim funding tx to the tx driver");
                 if let Err(err) = output_handles
@@ -217,16 +212,41 @@ async fn ensure_claim_funding_outpoint(
                     .drive(tx, predicate::eq(TxStatus::Mempool))
                     .await
                 {
-                    warn!(
-                        ?err,
-                        ?spent,
-                        "claim-funding tx driver failed; syncing wallet before reconciling input leases"
-                    );
-                    reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &spent).await;
-
+                    // A driver failure does not say whether the transaction reached the
+                    // network. `drive` broadcasts first and reports a failure of the wait
+                    // that follows, so the inputs can already be spent.
+                    //
+                    // Sync, then decide. A successful sync makes the wallet view
+                    // authoritative: the inputs of a broadcast transaction have left the
+                    // spendable set, and dropping the lease returns only the inputs that no
+                    // transaction spends. A failed sync leaves the view stale, and a release
+                    // against stale data hands a live transaction's inputs to the next duty,
+                    // which then broadcasts a conflicting spend. Hold them instead and let a
+                    // later sync prune them.
+                    match wallet.sync().await {
+                        Ok(()) => warn!(
+                            ?err,
+                            inputs = ?refill_lease.outpoints(),
+                            "claim-funding tx driver failed; releasing the refill inputs"
+                        ),
+                        Err(sync_err) => {
+                            warn!(
+                                ?err,
+                                ?sync_err,
+                                inputs = ?refill_lease.outpoints(),
+                                "claim-funding tx driver failed and the wallet sync failed; \
+                                 holding the refill inputs"
+                            );
+                            refill_lease.commit();
+                        }
+                    }
                     return Err(err.into());
                 }
                 info!(%txid, "claim funding tx detected in mempool");
+                // The transaction is in a mempool and spends these inputs. The lease must
+                // outlive this duty whatever the sync below reports, or a failed sync makes
+                // the inputs of a live transaction selectable again.
+                refill_lease.commit();
 
                 wallet.sync().await.map_err(|e| {
                     error!(?e, "could not sync wallet after refilling funding utxos");
@@ -235,6 +255,7 @@ async fn ensure_claim_funding_outpoint(
                 wallet
                     .reserve_utxo_with_value(
                         cfg.claim_funding_utxo_value,
+                        LeaseOwner::ClaimFunding,
                         predicate::never::<UtxoInfo>,
                     )
                     .0
@@ -248,9 +269,13 @@ async fn ensure_claim_funding_outpoint(
         .get_or_set_claim_funding_outpoint(graph_idx, funding_outpoint)
         .await;
 
+    // The database now owns the claim-funding outpoint of this graph, so the reservation
+    // outlives this duty. `commit` keeps it held after `funding_lease` drops. The two paths
+    // that do not commit drop the lease instead, which returns the outpoint to the pool.
     let assigned_outpoint = match assignment {
         Ok(FundingAssignment::Created(outpoint)) => {
             info!(?graph_idx, %outpoint, "saved funding outpoint to disk");
+            funding_lease.commit();
             outpoint
         }
         Ok(FundingAssignment::Existing(outpoint)) => {
@@ -259,61 +284,15 @@ async fn ensure_claim_funding_outpoint(
                 %outpoint,
                 "using existing funding outpoint saved by another duty"
             );
-            if outpoint != funding_outpoint {
-                let mut wallet = output_handles.wallet.write().await;
-                wallet.release(&[funding_outpoint]);
+            if outpoint == funding_outpoint {
+                funding_lease.commit();
             }
             outpoint
         }
-        Err(err) => {
-            let mut wallet = output_handles.wallet.write().await;
-            wallet.release(&[funding_outpoint]);
-            return Err(err.into());
-        }
+        Err(err) => return Err(err.into()),
     };
 
     Ok(assigned_outpoint)
-}
-
-async fn reconcile_claim_funding_leases_after_driver_failure<G: GeneralWallet>(
-    wallet: &mut OperatorWallet<G>,
-    spent: &[OutPoint],
-) {
-    if let Err(sync_err) = wallet.sync().await {
-        warn!(
-            ?sync_err,
-            ?spent,
-            "could not sync wallet after tx-driver failure; retaining claim-funding input leases"
-        );
-        return;
-    }
-
-    let live_general_outpoints: BTreeSet<_> = wallet
-        .general()
-        .list_utxos()
-        .into_iter()
-        .map(|u| u.outpoint)
-        .collect();
-    let still_unspent: Vec<_> = spent
-        .iter()
-        .copied()
-        .filter(|outpoint| live_general_outpoints.contains(outpoint))
-        .collect();
-    let pruned_count = spent.len().saturating_sub(still_unspent.len());
-
-    if pruned_count > 0 {
-        info!(
-            pruned_count,
-            "wallet sync pruned claim-funding input leases no longer seen as spendable"
-        );
-    }
-    if !still_unspent.is_empty() {
-        wallet.release(&still_unspent);
-        warn!(
-            ?still_unspent,
-            "released claim-funding input leases after wallet sync showed they are still spendable"
-        );
-    }
 }
 
 /// Fetches the owner's adaptor pubkey and the per-watchtower fault pubkeys from mosaic.
@@ -752,7 +731,7 @@ mod tests {
     };
     use strata_bridge_test_utils::bridge_fixtures::test_operator_table;
 
-    use super::{reconcile_claim_funding_leases_after_driver_failure, watchtower_idxs};
+    use super::watchtower_idxs;
 
     #[derive(Debug)]
     struct ReconciliationGeneralWallet {
@@ -857,8 +836,11 @@ mod tests {
         assert_eq!(later_watchtowers, vec![1, 2, 3]);
     }
 
+    /// The claim-funding refill syncs the wallet before its lease drops, so that a
+    /// transaction that did reach the network removes its own inputs from selection. This
+    /// test covers the prune half of that sequence.
     #[tokio::test]
-    async fn reconciliation_prunes_spent_inputs_and_releases_live_inputs() {
+    async fn a_sync_prunes_leases_on_inputs_that_left_the_spendable_set() {
         let bitcoind = Node::with_conf("bitcoind", &Conf::default()).expect("bitcoind starts");
         let spent = OutPoint {
             txid: Txid::from_slice(&[1; 32]).expect("valid txid"),
@@ -875,16 +857,20 @@ mod tests {
             BTreeSet::from([spent, live]),
         );
 
-        reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &[spent, live]).await;
+        wallet.sync().await.expect("sync succeeds");
 
-        assert!(
-            wallet.leased_outpoints().is_empty(),
-            "sync should prune the spent input and reconciliation should release the live input"
+        assert_eq!(
+            wallet.leased_outpoints(),
+            BTreeSet::from([live]),
+            "the spent input loses its lease; the live one keeps it"
         );
     }
 
+    /// A failed sync must not prune. The refill path reads the sync outcome to decide whether
+    /// to release its inputs, and a prune on stale data frees inputs that a live transaction
+    /// still spends.
     #[tokio::test]
-    async fn reconciliation_retains_input_leases_when_sync_fails() {
+    async fn a_failed_sync_leaves_every_lease_in_place() {
         let bitcoind = Node::with_conf("bitcoind", &Conf::default()).expect("bitcoind starts");
         let input = OutPoint {
             txid: Txid::from_slice(&[3; 32]).expect("valid txid"),
@@ -897,8 +883,8 @@ mod tests {
             BTreeSet::from([input]),
         );
 
-        reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &[input]).await;
+        wallet.sync().await.expect_err("sync fails");
 
-        assert_eq!(wallet.leased_outpoints(), &BTreeSet::from([input]));
+        assert_eq!(wallet.leased_outpoints(), BTreeSet::from([input]));
     }
 }

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -34,7 +34,7 @@ use tracing::{error, info, warn};
 
 use super::utils::sign_claim_funding_tx;
 use crate::{
-    chain::{is_outpoint_unspent, is_txid_onchain, publish_signed_transaction},
+    chain::{self, CpfpKind, is_outpoint_unspent, is_txid_onchain, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
     output_handles::OutputHandles,
@@ -722,11 +722,14 @@ pub(super) async fn publish_claim(
             .push(signature.serialize());
     }
 
+    let parent_fee = chain::parent_fee_for_floor_tx(&signed_claim_tx);
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_claim_tx,
         "claim",
         TxStatus::is_buried,
+        parent_fee,
+        CpfpKind::InferAnchor,
     )
     .await
 }
@@ -787,7 +790,8 @@ mod tests {
         async fn build_cpfp_child(
             &mut self,
             _parent: &Transaction,
-            _anchor_vout: u32,
+            _parent_fee: bitcoin::Amount,
+            _anchor: operator_wallet::AnchorInfo,
             _target_pkg_fee_rate: FeeRate,
             _exclude: &[OutPoint],
         ) -> Result<FundedPsbt, Self::Error> {

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -729,7 +729,9 @@ pub(super) async fn publish_claim(
         "claim",
         TxStatus::is_buried,
         parent_fee,
-        CpfpKind::InferAnchor,
+        CpfpKind::AnchorAt {
+            anchor_vout: ClaimTx::CPFP_VOUT,
+        },
     )
     .await
 }
@@ -794,6 +796,7 @@ mod tests {
             _anchor: operator_wallet::AnchorInfo,
             _target_pkg_fee_rate: FeeRate,
             _exclude: &[OutPoint],
+            _replaced: operator_wallet::ReplacedChild<'_>,
         ) -> Result<FundedPsbt, Self::Error> {
             unreachable!("reconciliation tests do not build CPFP transactions")
         }

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -11,6 +11,7 @@ use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
 use operator_wallet::{GeneralUtxoPolicy, LeaseOwner, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
+use strata_bridge_connectors::{Connector, ParentTx};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
 use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
 use strata_bridge_primitives::{
@@ -710,6 +711,7 @@ pub(super) async fn publish_claim(
         parent_fee,
         CpfpKind::AnchorAt {
             anchor_vout: ClaimTx::CPFP_VOUT,
+            anchor_key: claim_tx.cpfp_connector().internal_key(),
         },
     )
     .await

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -1,4 +1,4 @@
-use bitcoin::{OutPoint, Transaction};
+use bitcoin::{OutPoint, Transaction, XOnlyPublicKey};
 use btc_tracker::event::TxStatus;
 use musig2::secp256k1::schnorr::Signature;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
@@ -132,14 +132,13 @@ pub(super) async fn publish_contested_payout(
 pub(super) async fn publish_counterproof_ack(
     output_handles: &OutputHandles,
     signed_counter_proof_ack_tx: &Transaction,
+    anchor_key: XOnlyPublicKey,
 ) -> Result<(), ExecutorError> {
-    // The counterproof-ack carries a keyed anchor at `CounterproofAckTx::CPFP_VOUT`. The
-    // anchor key is the watchtower pubkey, which equals the musig2 pubkey (see the
-    // watchtower-key note in `bin/strata-bridge::operator_wallet`; the compile-time
-    // `_covenant_keys_field_audit` in `crates/common::params` guards the identity). This
-    // anchor is not at the dust floor: `CounterproofAckTx` folds the residual of its input
-    // connectors into it (2 × dust). The publish-time check therefore accepts each value
-    // at or above dust.
+    // The counterproof-ack carries a keyed anchor at `CounterproofAckTx::CPFP_VOUT`, keyed to
+    // the watchtower that the ACK is for. The state machine builds that anchor and reports
+    // its key with the duty. This anchor is not at the dust floor: `CounterproofAckTx` folds
+    // the residual of its input connectors into it (2 × dust). The publish-time check
+    // therefore accepts each value at or above dust.
     publish_signed_transaction(
         output_handles,
         signed_counter_proof_ack_tx,
@@ -148,6 +147,7 @@ pub(super) async fn publish_counterproof_ack(
         chain::parent_fee_for_floor_tx(signed_counter_proof_ack_tx),
         CpfpKind::AnchorAt {
             anchor_vout: CounterproofAckTx::CPFP_VOUT,
+            anchor_key,
         },
     )
     .await

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -1,13 +1,20 @@
-use bitcoin::Transaction;
+use bitcoin::{OutPoint, Transaction};
 use btc_tracker::event::TxStatus;
 use musig2::secp256k1::schnorr::Signature;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
+use strata_bridge_connectors::ParentTx;
 use strata_bridge_primitives::types::OperatorIdx;
-use strata_bridge_tx_graph::transactions::prelude::ContestTx;
+use strata_bridge_sm::graph::duties::MultiAnchorSpend;
+use strata_bridge_tx_graph::transactions::{
+    contested_payout::ContestedPayoutTx, prelude::ContestTx,
+};
 use tracing::{info, warn};
 
 use crate::{
-    chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    cpfp_adapters::multi_anchor_spend_material,
+    errors::ExecutorError,
+    output_handles::OutputHandles,
 };
 
 /// Signs and publishes the contest transaction to challenge a faulty claim.
@@ -34,13 +41,35 @@ pub(super) async fn publish_contest(
             ExecutorError::SecretServiceErr(e)
         })?;
 
+    // Resolve the CPFP handle before finalizing: contest carries a `MultiAnchor`, so the child
+    // spends the leaf keyed to *our* watchtower slot — the same slot we just signed the contest
+    // input with. `infer_anchor_strategy` cannot find this: it only matches key-path anchors, so
+    // leaving this as `InferAnchor` silently published contests with no fee bumping at all.
+    let cpfp =
+        match multi_anchor_spend_material(contest_tx.cpfp_connector(), watchtower_index as usize) {
+            Some((leaf_script, control_block)) => CpfpKind::MultiAnchor {
+                anchor_vout: contest_tx.cpfp_outpoint().vout,
+                leaf_script,
+                control_block,
+            },
+            None => {
+                warn!(
+                    watchtower_index,
+                    "no MultiAnchor leaf for this operator; publishing contest without CPFP"
+                );
+                CpfpKind::None
+            }
+        };
+
     let signed_tx = contest_tx.finalize(*n_of_n_signature, watchtower_index, watchtower_signature);
 
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "contest",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_tx),
+        cpfp,
     )
     .await
 }
@@ -49,12 +78,31 @@ pub(super) async fn publish_contest(
 pub(super) async fn publish_bridge_proof_timeout(
     output_handles: &OutputHandles,
     signed_timeout_tx: &Transaction,
+    cpfp_anchor: Option<&MultiAnchorSpend>,
 ) -> Result<(), ExecutorError> {
+    // The timeout carries a `MultiAnchor`, so bumping it is a script-path spend of the leaf
+    // keyed to our watchtower slot. The state machine resolves that slot — it depends on which
+    // operator owns the graph, which the transaction bytes don't reveal. `None` means we own the
+    // graph and hold no leaf, so there is nothing to bump with.
+    let cpfp = match cpfp_anchor {
+        Some(anchor) => CpfpKind::MultiAnchor {
+            anchor_vout: anchor.anchor_vout,
+            leaf_script: anchor.leaf_script.clone(),
+            control_block: anchor.control_block.clone(),
+        },
+        None => {
+            info!("publishing bridge proof timeout for own graph; no watchtower leaf to CPFP with");
+            CpfpKind::None
+        }
+    };
+
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         signed_timeout_tx,
         "bridge proof timeout",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(signed_timeout_tx),
+        cpfp,
     )
     .await
 }
@@ -64,11 +112,18 @@ pub(super) async fn publish_contested_payout(
     output_handles: &OutputHandles,
     signed_contested_payout_tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    // Contested payout: vout 0 is the contesting operator's payout. Use ParentTxCombined.
+    let payout_outpoint = OutPoint {
+        txid: signed_contested_payout_tx.compute_txid(),
+        vout: ContestedPayoutTx::CPFP_VOUT,
+    };
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         signed_contested_payout_tx,
         "contested payout",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(signed_contested_payout_tx),
+        CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await
 }
@@ -78,11 +133,19 @@ pub(super) async fn publish_counterproof_ack(
     output_handles: &OutputHandles,
     signed_counter_proof_ack_tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    // The counterproof-ack carries a keyed anchor — historically keyed to the watchtower
+    // pubkey (today equal to the musig2 pubkey per
+    // `bin/strata-bridge::operator_wallet`'s note that those sets coincide). The
+    // `InferAnchor` matcher looks at the musig2 pubkey, so this works as long as that
+    // identity holds; if the keys ever diverge, the orchestrator startup-time assertion
+    // would catch the regression.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         signed_counter_proof_ack_tx,
         "counterproof ack",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(signed_counter_proof_ack_tx),
+        CpfpKind::InferAnchor,
     )
     .await
 }
@@ -92,11 +155,20 @@ pub(super) async fn publish_slash(
     output_handles: &OutputHandles,
     signed_slash_tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    // Slash pays each watchtower at `vout = 1 + their_index_in_watchtowers` keyed to their
+    // `payout_descriptor`. The bridge's convention is that every operator's payout
+    // descriptor resolves to their general-wallet P2TR, so `InferGeneralPayout` finds the
+    // calling watchtower's specific payout output by script-match — no need to thread the
+    // index through bridge-sm. If no matching output exists (e.g. operator's
+    // payout_descriptor diverges from their general-wallet key), the helper falls back to
+    // no-CPFP.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         signed_slash_tx,
         "slash",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(signed_slash_tx),
+        CpfpKind::InferGeneralPayout,
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -6,7 +6,7 @@ use strata_bridge_connectors::ParentTx;
 use strata_bridge_primitives::types::OperatorIdx;
 use strata_bridge_sm::graph::duties::MultiAnchorSpend;
 use strata_bridge_tx_graph::transactions::{
-    contested_payout::ContestedPayoutTx, prelude::ContestTx,
+    contested_payout::ContestedPayoutTx, counterproof_ack::CounterproofAckTx, prelude::ContestTx,
 };
 use tracing::{info, warn};
 
@@ -41,10 +41,10 @@ pub(super) async fn publish_contest(
             ExecutorError::SecretServiceErr(e)
         })?;
 
-    // Resolve the CPFP handle before finalizing: contest carries a `MultiAnchor`, so the child
-    // spends the leaf keyed to *our* watchtower slot — the same slot we just signed the contest
-    // input with. `infer_anchor_strategy` cannot find this: it only matches key-path anchors, so
-    // leaving this as `InferAnchor` silently published contests with no fee bumping at all.
+    // Resolve the CPFP data before finalization. The contest tx carries a `MultiAnchor`,
+    // and the child spends the leaf keyed to this operator's watchtower slot — the same
+    // slot that signed the contest input. A key-path anchor kind cannot describe a
+    // script-path spend, so the caller supplies the leaf and control block here.
     let cpfp =
         match multi_anchor_spend_material(contest_tx.cpfp_connector(), watchtower_index as usize) {
             Some((leaf_script, control_block)) => CpfpKind::MultiAnchor {
@@ -133,19 +133,22 @@ pub(super) async fn publish_counterproof_ack(
     output_handles: &OutputHandles,
     signed_counter_proof_ack_tx: &Transaction,
 ) -> Result<(), ExecutorError> {
-    // The counterproof-ack carries a keyed anchor — historically keyed to the watchtower
-    // pubkey (today equal to the musig2 pubkey per
-    // `bin/strata-bridge::operator_wallet`'s note that those sets coincide). The
-    // `InferAnchor` matcher looks at the musig2 pubkey, so this works as long as that
-    // identity holds; if the keys ever diverge, the orchestrator startup-time assertion
-    // would catch the regression.
+    // The counterproof-ack carries a keyed anchor at `CounterproofAckTx::CPFP_VOUT`. The
+    // anchor key is the watchtower pubkey, which equals the musig2 pubkey (see the
+    // watchtower-key note in `bin/strata-bridge::operator_wallet`; the compile-time
+    // `_covenant_keys_field_audit` in `crates/common::params` guards the identity). This
+    // anchor is not at the dust floor: `CounterproofAckTx` folds the residual of its input
+    // connectors into it (2 × dust). The publish-time check therefore accepts each value
+    // at or above dust.
     publish_signed_transaction(
         output_handles,
         signed_counter_proof_ack_tx,
         "counterproof ack",
         TxStatus::is_buried,
         chain::parent_fee_for_floor_tx(signed_counter_proof_ack_tx),
-        CpfpKind::InferAnchor,
+        CpfpKind::AnchorAt {
+            anchor_vout: CounterproofAckTx::CPFP_VOUT,
+        },
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/contested.rs
+++ b/crates/bridge-exec/src/graph/contested.rs
@@ -68,7 +68,7 @@ pub(super) async fn publish_contest(
         &signed_tx,
         "contest",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_tx),
+        chain::ParentFee::Floor,
         cpfp,
     )
     .await
@@ -101,7 +101,7 @@ pub(super) async fn publish_bridge_proof_timeout(
         signed_timeout_tx,
         "bridge proof timeout",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(signed_timeout_tx),
+        chain::ParentFee::Floor,
         cpfp,
     )
     .await
@@ -122,7 +122,7 @@ pub(super) async fn publish_contested_payout(
         signed_contested_payout_tx,
         "contested payout",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(signed_contested_payout_tx),
+        chain::ParentFee::Floor,
         CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await
@@ -144,7 +144,7 @@ pub(super) async fn publish_counterproof_ack(
         signed_counter_proof_ack_tx,
         "counterproof ack",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(signed_counter_proof_ack_tx),
+        chain::ParentFee::Floor,
         CpfpKind::AnchorAt {
             anchor_vout: CounterproofAckTx::CPFP_VOUT,
             anchor_key,
@@ -170,7 +170,7 @@ pub(super) async fn publish_slash(
         signed_slash_tx,
         "slash",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(signed_slash_tx),
+        chain::ParentFee::Floor,
         CpfpKind::InferGeneralPayout,
     )
     .await

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -36,7 +36,9 @@ use zkaleido::ProofReceipt;
 use zkaleido_sp1_groth16_verifier::Sp1Groth16Proof;
 
 use crate::{
-    chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    config::ExecutionConfig,
+    errors::ExecutorError,
     output_handles::OutputHandles,
 };
 
@@ -200,11 +202,15 @@ async fn generate_and_publish_counterproof(
     };
     let signed_tx = counterproof_tx.finalize(&witness);
 
+    // Counterproof carries a keyed anchor — see note on `publish_counterproof_ack` for the
+    // watchtower-vs-musig2 key identity assumption.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "counterproof",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_tx),
+        CpfpKind::InferAnchor,
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -215,7 +215,7 @@ async fn generate_and_publish_counterproof(
         &signed_tx,
         "counterproof",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_tx),
+        chain::ParentFee::Floor,
         CpfpKind::AnchorAt {
             anchor_vout: CounterproofTx::CPFP_VOUT,
             anchor_key,

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -202,15 +202,17 @@ async fn generate_and_publish_counterproof(
     };
     let signed_tx = counterproof_tx.finalize(&witness);
 
-    // Counterproof carries a keyed anchor — see note on `publish_counterproof_ack` for the
-    // watchtower-vs-musig2 key identity assumption.
+    // The counterproof carries a keyed anchor at a fixed vout. See the note on
+    // `publish_counterproof_ack` for the watchtower-vs-musig2 key identity.
     publish_signed_transaction(
         output_handles,
         &signed_tx,
         "counterproof",
         TxStatus::is_buried,
         chain::parent_fee_for_floor_tx(&signed_tx),
-        CpfpKind::InferAnchor,
+        CpfpKind::AnchorAt {
+            anchor_vout: CounterproofTx::CPFP_VOUT,
+        },
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -11,7 +11,10 @@ use ssz::Decode;
 use strata_asm_proto_bridge::OperatorClaimUnlock;
 use strata_asm_proto_bridge_txs::BRIDGE_SUBPROTOCOL_ID;
 use strata_asm_rpc::traits::{AsmMohoApiClient, AsmProofApiClient};
-use strata_bridge_connectors::prelude::{ContestCounterproofWitness, ContestProofConnector};
+use strata_bridge_connectors::{
+    Connector, ParentTx,
+    prelude::{ContestCounterproofWitness, ContestProofConnector},
+};
 use strata_bridge_counterproof::{
     BitcoinTxOut, BridgeCounterproofHost, CounterproofInput, CounterproofMode, CounterproofProgram,
     HeavierChainProof, RawBitcoinTx,
@@ -200,10 +203,13 @@ async fn generate_and_publish_counterproof(
         n_of_n_signature,
         operator_signatures,
     };
+    // Read the anchor key before `finalize` consumes the transaction. The key belongs to the
+    // watchtower that this counterproof is for, and the publish path checks that this
+    // operator can sign with it.
+    let anchor_key = counterproof_tx.cpfp_connector().internal_key();
     let signed_tx = counterproof_tx.finalize(&witness);
 
-    // The counterproof carries a keyed anchor at a fixed vout. See the note on
-    // `publish_counterproof_ack` for the watchtower-vs-musig2 key identity.
+    // The counterproof carries a keyed anchor at a fixed vout.
     publish_signed_transaction(
         output_handles,
         &signed_tx,
@@ -212,6 +218,7 @@ async fn generate_and_publish_counterproof(
         chain::parent_fee_for_floor_tx(&signed_tx),
         CpfpKind::AnchorAt {
             anchor_vout: CounterproofTx::CPFP_VOUT,
+            anchor_key,
         },
     )
     .await

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -1,6 +1,6 @@
 //! Executor for the counterproof NACK transaction.
 
-use bitcoin::{TxOut, hashes::Hash};
+use bitcoin::{OutPoint, TxOut, hashes::Hash};
 use btc_tracker::event::TxStatus;
 use strata_bridge_primitives::{
     scripts::taproot::TaprootTweak,
@@ -11,7 +11,9 @@ use strata_mosaic_client_api::types::{CompletedSignatures, Sighash, Tweak};
 use tracing::{info, warn};
 
 use crate::{
-    chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    errors::ExecutorError,
+    output_handles::OutputHandles,
 };
 
 /// Signs and publishes the counterproof NACK transaction to reject an invalid counterproof.
@@ -102,11 +104,20 @@ async fn sign_and_broadcast_nack(
     let signed_tx = nack_tx.finalize_partial(wt_fault_signature);
 
     info!(%deposit_idx, %game_index, %counterprover_idx, "publishing counterproof nack transaction");
+    // Counterproof-nack has a single output: a P2TR to the operator's general wallet at
+    // vout 0 (see the `push_output` call in `publish_counterproof_nack`). Use
+    // ParentTxCombined so a CPFP child can spend that output under fee pressure.
+    let payout_outpoint = OutPoint {
+        txid: signed_tx.compute_txid(),
+        vout: 0,
+    };
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "counterproof nack",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_tx),
+        CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -116,7 +116,7 @@ async fn sign_and_broadcast_nack(
         &signed_tx,
         "counterproof nack",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_tx),
+        chain::ParentFee::Floor,
         CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -173,8 +173,12 @@ pub async fn execute_graph_duty(
             )
             .await
         }
-        GraphDuty::PublishBridgeProofTimeout { signed_timeout_tx } => {
-            publish_bridge_proof_timeout(&output_handles, signed_timeout_tx).await
+        GraphDuty::PublishBridgeProofTimeout {
+            signed_timeout_tx,
+            cpfp_anchor,
+        } => {
+            publish_bridge_proof_timeout(&output_handles, signed_timeout_tx, cpfp_anchor.as_ref())
+                .await
         }
         GraphDuty::PotentialCounterProof {
             graph_idx,

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -207,7 +207,11 @@ pub async fn execute_graph_duty(
         }
         GraphDuty::PublishCounterProofAck {
             signed_counter_proof_ack_tx,
-        } => publish_counterproof_ack(&output_handles, signed_counter_proof_ack_tx).await,
+            anchor_key,
+        } => {
+            publish_counterproof_ack(&output_handles, signed_counter_proof_ack_tx, *anchor_key)
+                .await
+        }
         GraphDuty::PublishCounterProofNack {
             deposit_idx,
             counterprover_idx,

--- a/crates/bridge-exec/src/graph/uncontested.rs
+++ b/crates/bridge-exec/src/graph/uncontested.rs
@@ -1,10 +1,13 @@
 //! Executors for payout graph duties.
 
-use bitcoin::Transaction;
+use bitcoin::{OutPoint, Transaction};
 use btc_tracker::event::TxStatus;
+use strata_bridge_tx_graph::transactions::uncontested_payout::UncontestedPayoutTx;
 
 use crate::{
-    chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    errors::ExecutorError,
+    output_handles::OutputHandles,
 };
 
 /// Publishes the signed uncontested payout transaction to Bitcoin.
@@ -12,11 +15,19 @@ pub(super) async fn publish_uncontested_payout(
     output_handles: &OutputHandles,
     signed_uncontested_payout_tx: &Transaction,
 ) -> Result<(), ExecutorError> {
+    // Uncontested payout: vout 0 is the operator's payout. No keyed anchor on this tx; use
+    // ParentTxCombined so the CPFP child spends that output for fee-bumping.
+    let payout_outpoint = OutPoint {
+        txid: signed_uncontested_payout_tx.compute_txid(),
+        vout: UncontestedPayoutTx::CPFP_VOUT,
+    };
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         signed_uncontested_payout_tx,
         "uncontested payout",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(signed_uncontested_payout_tx),
+        CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await
 }

--- a/crates/bridge-exec/src/graph/uncontested.rs
+++ b/crates/bridge-exec/src/graph/uncontested.rs
@@ -26,7 +26,7 @@ pub(super) async fn publish_uncontested_payout(
         signed_uncontested_payout_tx,
         "uncontested payout",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(signed_uncontested_payout_tx),
+        chain::ParentFee::Floor,
         CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -14,7 +14,7 @@ use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnTx;
 use tracing::{debug, info, warn};
 
 use crate::{
-    chain::publish_signed_transaction,
+    chain::{CpfpKind, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
     output_handles::{NativeWallet, OutputHandles},
@@ -113,11 +113,17 @@ pub(super) async fn publish_unstaking_burn(
     };
 
     info!(%graph_idx, txid = %signed_tx.compute_txid(), "publishing unstaking burn transaction");
+    // Preserve this executor's pre-CPFP behaviour: the burn tx is already wallet-funded at the
+    // estimated market fee rate, so it broadcasts without a CPFP child. `parent_fee` is the
+    // exact fee the plan paid (unused while `cpfp` is `None`, but kept accurate so flipping to
+    // a CPFP strategy later is a one-line change).
     let publish_result = publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "unstaking burn",
         TxStatus::is_buried,
+        plan.fee,
+        CpfpKind::None,
     )
     .await;
 

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -241,39 +241,41 @@ async fn select_funding(
         "selecting wallet funding UTXO for unstaking burn"
     );
 
-    let funding = wallet.select_general_utxo(LeaseOwner::UnstakingBurn, |utxo| {
-        let output_value = match payout_connector_value
-            .checked_add(utxo.amount)
-            .and_then(|input_value| input_value.checked_sub(plan.fee))
-        {
-            Some(output_value) => output_value,
-            None => {
+    let funding = wallet
+        .select_general_utxo(LeaseOwner::UnstakingBurn, |utxo| {
+            let output_value = match payout_connector_value
+                .checked_add(utxo.amount)
+                .and_then(|input_value| input_value.checked_sub(plan.fee))
+            {
+                Some(output_value) => output_value,
+                None => {
+                    debug!(
+                        %graph_idx,
+                        outpoint = %utxo.outpoint,
+                        utxo_value = %utxo.amount,
+                        fee = %plan.fee,
+                        "wallet UTXO cannot cover unstaking burn fee"
+                    );
+                    return false;
+                }
+            };
+
+            if output_value < min_output_value {
                 debug!(
                     %graph_idx,
                     outpoint = %utxo.outpoint,
                     utxo_value = %utxo.amount,
+                    %output_value,
+                    %min_output_value,
                     fee = %plan.fee,
-                    "wallet UTXO cannot cover unstaking burn fee"
+                    "wallet UTXO cannot fund non-dust unstaking burn output"
                 );
                 return false;
             }
-        };
 
-        if output_value < min_output_value {
-            debug!(
-                %graph_idx,
-                outpoint = %utxo.outpoint,
-                utxo_value = %utxo.amount,
-                %output_value,
-                %min_output_value,
-                fee = %plan.fee,
-                "wallet UTXO cannot fund non-dust unstaking burn output"
-            );
-            return false;
-        }
-
-        true
-    });
+            true
+        })
+        .await;
 
     let Some((funding, lease)) = funding else {
         warn!(

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -8,6 +8,7 @@ use bitcoin::{
 };
 use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
+use operator_wallet::{Lease, LeaseOwner};
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_primitives::types::GraphIdx;
 use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnTx;
@@ -72,7 +73,9 @@ pub(super) async fn publish_unstaking_burn(
         return Ok(());
     }
 
-    let (funding, plan) = {
+    // `funding_lease` holds the wallet UTXO that pays for the burn. Every failure path below
+    // drops it, which returns the UTXO to the pool.
+    let (funding, funding_lease, plan) = {
         let mut wallet = output_handles.wallet.write().await;
         select_funding(
             &mut wallet,
@@ -103,11 +106,6 @@ pub(super) async fn publish_unstaking_burn(
                 %e,
                 "failed to sign unstaking burn transaction; releasing wallet funding outpoint"
             );
-            output_handles
-                .wallet
-                .write()
-                .await
-                .release(&[funding.outpoint]);
             return Err(e);
         }
     };
@@ -127,21 +125,23 @@ pub(super) async fn publish_unstaking_burn(
     )
     .await;
 
-    if let Err(ref e) = publish_result {
-        warn!(
-            %graph_idx,
-            funding_outpoint = %funding.outpoint,
-            %e,
-            "failed to publish unstaking burn transaction; releasing wallet funding outpoint"
-        );
-        output_handles
-            .wallet
-            .write()
-            .await
-            .release(&[funding.outpoint]);
+    match publish_result {
+        Ok(()) => {
+            // The transaction reached the network and spends this UTXO. The lease stays in
+            // place until a sync observes the spend.
+            funding_lease.commit();
+            Ok(())
+        }
+        Err(e) => {
+            warn!(
+                %graph_idx,
+                funding_outpoint = %funding.outpoint,
+                %e,
+                "failed to publish unstaking burn transaction; releasing wallet funding outpoint"
+            );
+            Err(e)
+        }
     }
-
-    publish_result
 }
 
 /// Returns the fee rate used for an unstaking burn attempt.
@@ -207,7 +207,7 @@ async fn select_funding(
     unstaking_burn_tx: &UnstakingBurnTx,
     unstaking_preimage: [u8; 32],
     fee_rate: FeeRate,
-) -> Result<(WalletFunding, BurnTxPlan), ExecutorError> {
+) -> Result<(WalletFunding, Lease, BurnTxPlan), ExecutorError> {
     let payout_connector_value = unstaking_burn_tx.prevouts()[CONNECTOR_INPUT_INDEX].value;
 
     info!(%graph_idx, "syncing wallet before funding unstaking burn transaction");
@@ -241,7 +241,7 @@ async fn select_funding(
         "selecting wallet funding UTXO for unstaking burn"
     );
 
-    let funding = wallet.select_and_lease_general_utxo(|utxo| {
+    let funding = wallet.select_general_utxo(LeaseOwner::UnstakingBurn, |utxo| {
         let output_value = match payout_connector_value
             .checked_add(utxo.amount)
             .and_then(|input_value| input_value.checked_sub(plan.fee))
@@ -275,7 +275,7 @@ async fn select_funding(
         true
     });
 
-    let Some(funding) = funding else {
+    let Some((funding, lease)) = funding else {
         warn!(
             %graph_idx,
             %payout_connector_value,
@@ -317,6 +317,7 @@ async fn select_funding(
             outpoint: funding.outpoint,
             prevout: funding.into(),
         },
+        lease,
         plan,
     ))
 }
@@ -679,7 +680,7 @@ mod tests {
         let fee_rate = FeeRate::from_sat_per_vb(2).expect("fee rate should be valid");
         let min_output_value = wallet.general_script_pubkey().minimal_non_dust();
 
-        let (funding, plan) = select_funding(
+        let (funding, _lease, plan) = select_funding(
             &mut wallet,
             TEST_GRAPH_IDX,
             &unstaking_burn_tx,

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -15,7 +15,7 @@ use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnTx;
 use tracing::{debug, info, warn};
 
 use crate::{
-    chain::{CpfpKind, publish_signed_transaction},
+    chain::{CpfpKind, ParentFee, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
     output_handles::{NativeWallet, OutputHandles},
@@ -120,7 +120,7 @@ pub(super) async fn publish_unstaking_burn(
         &signed_tx,
         "unstaking burn",
         TxStatus::is_buried,
-        plan.fee,
+        ParentFee::Exact(plan.fee),
         CpfpKind::None,
     )
     .await;

--- a/crates/bridge-exec/src/lib.rs
+++ b/crates/bridge-exec/src/lib.rs
@@ -11,8 +11,14 @@
 
 mod chain;
 pub mod config;
+pub mod cpfp_adapters;
 pub mod deposit;
 pub mod errors;
 pub mod graph;
 pub mod output_handles;
 pub mod stake;
+
+#[cfg(test)]
+use bdk_bitcoind_rpc as _;
+#[cfg(test)]
+use serial_test as _;

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -2,6 +2,7 @@
 
 use std::{fmt, sync::Arc};
 
+use bitcoin::{Network, XOnlyPublicKey};
 use bitcoind_async_client::Client as BitcoinClient;
 use btc_tracker::tx_driver::TxDriver;
 use jsonrpsee::http_client::HttpClient;
@@ -65,6 +66,26 @@ pub struct OutputHandles {
 
     /// Host used to generate bridge counterproofs.
     pub counterproof_host: BridgeCounterproofHost,
+
+    /// Operator's general-wallet x-only pubkey. Cached at orchestrator startup so the
+    /// CPFP-publishing path doesn't have to round-trip to secret-service on every broadcast.
+    /// Used by [`crate::cpfp_adapters::build_wallet_input_signer`] when signing the
+    /// operator-owned funding inputs of CPFP children.
+    pub operator_general_pubkey: XOnlyPublicKey,
+
+    /// Operator's musig2-signer x-only pubkey (the "btc key" from the operator table).
+    /// Every bridge tx that participates in CPFP carries a keyed-Taproot anchor keyed
+    /// to this pubkey (see `KeyData::operator_pubkey` in `bridge-sm`, fed from
+    /// `OperatorTable::idx_to_btc_key`). Cached at orchestrator startup so
+    /// [`crate::cpfp_adapters::infer_anchor_strategy`] can detect anchors without an RPC
+    /// hop. (Counterproof/ack txs key their anchors to the operator's watchtower key,
+    /// which today equals the musig2 key per `bin/strata-bridge::operator_wallet`'s
+    /// watchtower-key note; if those sets ever diverge this needs to grow.)
+    pub operator_musig2_pubkey: XOnlyPublicKey,
+
+    /// Bitcoin network — needed alongside [`Self::operator_musig2_pubkey`] to derive the
+    /// expected anchor `script_pubkey` for CPFP-strategy inference.
+    pub network: Network,
 }
 
 impl fmt::Debug for OutputHandles {

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -77,7 +77,7 @@ pub struct OutputHandles {
     /// Every bridge tx that participates in CPFP carries a keyed-Taproot anchor keyed
     /// to this pubkey (see `KeyData::operator_pubkey` in `bridge-sm`, fed from
     /// `OperatorTable::idx_to_btc_key`). Cached at orchestrator startup so
-    /// [`crate::cpfp_adapters::infer_anchor_strategy`] can detect anchors without an RPC
+    /// `chain::checked_anchor_strategy` can validate a named anchor vout without an RPC
     /// hop. (Counterproof/ack txs key their anchors to the operator's watchtower key,
     /// which today equals the musig2 key per `bin/strata-bridge::operator_wallet`'s
     /// watchtower-key note; if those sets ever diverge this needs to grow.)

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -63,9 +63,13 @@ pub async fn execute_stake_duty(
             )
             .await
         }
-        StakeDuty::PublishStake { operator_idx, tx } => {
+        StakeDuty::PublishStake {
+            operator_idx,
+            tx,
+            anchor_key,
+        } => {
             info!(%operator_idx, stake_txid=%tx.compute_txid(), "executing StakeDuty::PublishStake");
-            staking::publish_stake(&cfg, &output_handles, tx).await
+            staking::publish_stake(&cfg, &output_handles, tx, *anchor_key).await
         }
         StakeDuty::PublishUnstakingIntent {
             unsigned_tx,

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -29,8 +29,11 @@ use strata_bridge_tx_graph::{fee, musig_functor::StakeFunctor, transactions::pre
 use tracing::{error, info, warn};
 
 use crate::{
-    chain::publish_signed_transaction, config::ExecutionConfig, errors::ExecutorError,
-    output_handles::OutputHandles, stake::utils::get_preimage,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    config::ExecutionConfig,
+    errors::ExecutorError,
+    output_handles::OutputHandles,
+    stake::utils::get_preimage,
 };
 
 pub(crate) async fn publish_stake_data(
@@ -50,11 +53,25 @@ pub(crate) async fn publish_stake_data(
 
     info!(%operator_idx, %stake_funding_txid, "submitting stake funding transaction");
     let signed_tx = sign_reservation(output_handles, &reservation).await?;
+    // The funding tx is wallet-funded; its exact fee is the sum of input prevouts (from the
+    // reservation) minus the sum of outputs. CPFP needs the exact value because the child's
+    // fee math depends on it (see `chain::publish_signed_transaction` docs).
+    let stake_funding_fee = chain::exact_fee_from_prevouts(&reservation.prevouts, &signed_tx)
+        .ok_or_else(|| {
+            ExecutorError::WalletErr("stake funding fee arithmetic overflowed".into())
+        })?;
+    // Stake funding is wallet-funded. The reserved-wallet output at vout 0 is consumed
+    // immediately by the stake tx (can't CPFP via it without conflicting), but BDK
+    // typically adds a change output to the general wallet. `InferGeneralPayout` finds
+    // that change output and uses it as the CPFP payout; if no change exists (inputs
+    // exactly match), the helper falls back to no-CPFP.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "stake funding tx",
         TxStatus::is_buried,
+        stake_funding_fee,
+        CpfpKind::InferGeneralPayout,
     )
     .await?;
 
@@ -458,10 +475,12 @@ pub(crate) async fn publish_stake(
 
     info!(%stake_txid, "publishing signed stake transaction");
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_tx,
         "stake tx",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_tx),
+        CpfpKind::InferAnchor,
     )
     .await?;
     info!(%stake_txid, "stake transaction confirmed on-chain");

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -143,7 +143,9 @@ async fn read_or_create_stake_funding(
         // The database row keeps this reservation across restarts, so the lease has no owning
         // value to drop. Startup rehydration holds the same outpoints. This call covers the
         // case where the row was written after startup read the funds.
-        wallet.lease_committed(inputs, LeaseOwner::StakeFunding);
+        wallet
+            .lease_committed(inputs, LeaseOwner::StakeFunding)
+            .await;
         return Ok(reservation);
     }
 
@@ -194,7 +196,9 @@ async fn read_or_create_stake_funding(
                 .iter()
                 .map(|txin| txin.previous_output)
                 .collect();
-            wallet.lease_committed(assigned_inputs, LeaseOwner::StakeFunding);
+            wallet
+                .lease_committed(assigned_inputs, LeaseOwner::StakeFunding)
+                .await;
             Ok(reservation)
         }
         Err(err) => Err(err.into()),

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -13,7 +13,7 @@ use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PubNonce};
-use operator_wallet::GeneralUtxoPolicy;
+use operator_wallet::{GeneralUtxoPolicy, LeaseOwner};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_connectors::prelude::UnstakingIntentOutput;
 use strata_bridge_db::{
@@ -140,7 +140,10 @@ async fn read_or_create_stake_funding(
             .iter()
             .map(|txin| txin.previous_output)
             .collect();
-        wallet.lease(&inputs);
+        // The database row keeps this reservation across restarts, so the lease has no owning
+        // value to drop. Startup rehydration holds the same outpoints. This call covers the
+        // case where the row was written after startup read the funds.
+        wallet.lease_committed(inputs, LeaseOwner::StakeFunding);
         return Ok(reservation);
     }
 
@@ -151,23 +154,20 @@ async fn read_or_create_stake_funding(
     // Stake funding is one reserved-wallet UTXO of `funding_amount`. The reserved-utxo API
     // takes denomination + quantity uniformly (claim-funding pool uses larger quantity
     // with a smaller per-UTXO value); for the stake-funding case it's always quantity 1.
-    let funded = wallet
+    // `candidate` holds the inputs that the wallet selected. Each path below that does not
+    // become the stored reservation drops it, which returns those inputs to the pool.
+    let candidate = wallet
         .create_reserved_utxos(
             fee_rate,
             funding_amount,
             1,
             GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::StakeFunding,
         )
         .await
         .map_err(|e| ExecutorError::WalletErr(format!("stake funding failed: {e}")))?;
-    let reservation = reservation_from_psbt(&funded.psbt);
-
-    let candidate_inputs: Vec<OutPoint> = reservation
-        .unsigned_tx
-        .input
-        .iter()
-        .map(|txin| txin.previous_output)
-        .collect();
+    let (candidate_psbt, candidate_lease) = candidate.into_parts();
+    let reservation = reservation_from_psbt(&candidate_psbt);
 
     info!(%operator_idx, "persisting stake funding reservation");
     let assignment = output_handles
@@ -176,33 +176,28 @@ async fn read_or_create_stake_funding(
         .await;
 
     match assignment {
-        Ok(FundingAssignment::Created(reservation)) => Ok(reservation),
+        Ok(FundingAssignment::Created(reservation)) => {
+            candidate_lease.commit();
+            Ok(reservation)
+        }
         Ok(FundingAssignment::Existing(reservation)) => {
             info!(%operator_idx, "using existing stake funding reservation saved by another duty");
+            drop(candidate_lease);
+            validate_reservation(
+                &reservation,
+                &wallet.reserved_script_pubkey(),
+                funding_amount,
+            )?;
             let assigned_inputs: Vec<OutPoint> = reservation
                 .unsigned_tx
                 .input
                 .iter()
                 .map(|txin| txin.previous_output)
                 .collect();
-            let stale_candidate_inputs: Vec<_> = candidate_inputs
-                .iter()
-                .copied()
-                .filter(|outpoint| !assigned_inputs.contains(outpoint))
-                .collect();
-            wallet.release(&stale_candidate_inputs);
-            validate_reservation(
-                &reservation,
-                &wallet.reserved_script_pubkey(),
-                funding_amount,
-            )?;
-            wallet.lease(&assigned_inputs);
+            wallet.lease_committed(assigned_inputs, LeaseOwner::StakeFunding);
             Ok(reservation)
         }
-        Err(err) => {
-            wallet.release(&candidate_inputs);
-            Err(err.into())
-        }
+        Err(err) => Err(err.into()),
     }
 }
 

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -431,6 +431,7 @@ pub(crate) async fn publish_stake(
     cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
     tx: &Transaction,
+    anchor_key: XOnlyPublicKey,
 ) -> Result<(), ExecutorError> {
     let stake_txid = tx.compute_txid();
     let funding_input = tx.input[0].previous_output;
@@ -477,6 +478,7 @@ pub(crate) async fn publish_stake(
         chain::parent_fee_for_floor_tx(&signed_tx),
         CpfpKind::AnchorAt {
             anchor_vout: StakeTx::CPFP_VOUT,
+            anchor_key,
         },
     )
     .await?;

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -480,7 +480,9 @@ pub(crate) async fn publish_stake(
         "stake tx",
         TxStatus::is_buried,
         chain::parent_fee_for_floor_tx(&signed_tx),
-        CpfpKind::InferAnchor,
+        CpfpKind::AnchorAt {
+            anchor_vout: StakeTx::CPFP_VOUT,
+        },
     )
     .await?;
     info!(%stake_txid, "stake transaction confirmed on-chain");

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -70,7 +70,7 @@ pub(crate) async fn publish_stake_data(
         &signed_tx,
         "stake funding tx",
         TxStatus::is_buried,
-        stake_funding_fee,
+        chain::ParentFee::Exact(stake_funding_fee),
         CpfpKind::InferGeneralPayout,
     )
     .await?;
@@ -475,7 +475,7 @@ pub(crate) async fn publish_stake(
         &signed_tx,
         "stake tx",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_tx),
+        chain::ParentFee::Floor,
         CpfpKind::AnchorAt {
             anchor_vout: StakeTx::CPFP_VOUT,
             anchor_key,

--- a/crates/bridge-exec/src/stake/unstaking.rs
+++ b/crates/bridge-exec/src/stake/unstaking.rs
@@ -6,11 +6,13 @@
 use bitcoin::{OutPoint, Transaction, secp256k1::schnorr};
 use btc_tracker::event::TxStatus;
 use strata_bridge_connectors::prelude::UnstakingIntentWitness;
-use strata_bridge_tx_graph::transactions::prelude::UnstakingIntentTx;
+use strata_bridge_tx_graph::transactions::{prelude::UnstakingIntentTx, unstaking::UnstakingTx};
 use tracing::info;
 
 use crate::{
-    chain::publish_signed_transaction, errors::ExecutorError, output_handles::OutputHandles,
+    chain::{self, CpfpKind, publish_signed_transaction},
+    errors::ExecutorError,
+    output_handles::OutputHandles,
     stake::utils::get_preimage,
 };
 
@@ -31,11 +33,14 @@ pub(crate) async fn publish_unstaking_intent(
     let signed_unstaking_intent_tx = unstaking_intent_tx.finalize(&unstaking_intent_witness);
     let unstaking_intent_txid = signed_unstaking_intent_tx.compute_txid();
     info!(%unstaking_intent_txid, "publishing unstaking intent transaction");
+    // Unstaking intent carries a keyed anchor; CPFP via InferAnchor.
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         &signed_unstaking_intent_tx,
         "unstaking intent tx",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(&signed_unstaking_intent_tx),
+        CpfpKind::InferAnchor,
     )
     .await?;
     info!(%unstaking_intent_txid, "unstaking intent transaction confirmed on-chain");
@@ -48,11 +53,19 @@ pub(crate) async fn publish_unstaking_tx(
 ) -> Result<(), ExecutorError> {
     let unstaking_txid = signed_tx.compute_txid();
     info!(%unstaking_txid, "publishing unstaking transaction");
+    // Unstaking pays the operator at vout 0 (the operator-controlled output). Use
+    // ParentTxCombined — the unstaking tx has no keyed anchor.
+    let payout_outpoint = OutPoint {
+        txid: signed_tx.compute_txid(),
+        vout: UnstakingTx::OPERATOR_VOUT,
+    };
     publish_signed_transaction(
-        &output_handles.tx_driver,
+        output_handles,
         signed_tx,
         "unstaking tx",
         TxStatus::is_buried,
+        chain::parent_fee_for_floor_tx(signed_tx),
+        CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await?;
     info!(%unstaking_txid, "unstaking transaction confirmed on-chain");

--- a/crates/bridge-exec/src/stake/unstaking.rs
+++ b/crates/bridge-exec/src/stake/unstaking.rs
@@ -5,7 +5,7 @@
 
 use bitcoin::{OutPoint, Transaction, secp256k1::schnorr};
 use btc_tracker::event::TxStatus;
-use strata_bridge_connectors::prelude::UnstakingIntentWitness;
+use strata_bridge_connectors::{Connector, ParentTx, prelude::UnstakingIntentWitness};
 use strata_bridge_tx_graph::transactions::{prelude::UnstakingIntentTx, unstaking::UnstakingTx};
 use tracing::info;
 
@@ -30,6 +30,8 @@ pub(crate) async fn publish_unstaking_intent(
         unstaking_preimage: preimage,
     };
 
+    // Read the anchor key before `finalize` consumes the transaction.
+    let anchor_key = unstaking_intent_tx.cpfp_connector().internal_key();
     let signed_unstaking_intent_tx = unstaking_intent_tx.finalize(&unstaking_intent_witness);
     let unstaking_intent_txid = signed_unstaking_intent_tx.compute_txid();
     info!(%unstaking_intent_txid, "publishing unstaking intent transaction");
@@ -42,6 +44,7 @@ pub(crate) async fn publish_unstaking_intent(
         chain::parent_fee_for_floor_tx(&signed_unstaking_intent_tx),
         CpfpKind::AnchorAt {
             anchor_vout: UnstakingIntentTx::CPFP_VOUT,
+            anchor_key,
         },
     )
     .await?;

--- a/crates/bridge-exec/src/stake/unstaking.rs
+++ b/crates/bridge-exec/src/stake/unstaking.rs
@@ -41,7 +41,7 @@ pub(crate) async fn publish_unstaking_intent(
         &signed_unstaking_intent_tx,
         "unstaking intent tx",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(&signed_unstaking_intent_tx),
+        chain::ParentFee::Floor,
         CpfpKind::AnchorAt {
             anchor_vout: UnstakingIntentTx::CPFP_VOUT,
             anchor_key,
@@ -69,7 +69,7 @@ pub(crate) async fn publish_unstaking_tx(
         signed_tx,
         "unstaking tx",
         TxStatus::is_buried,
-        chain::parent_fee_for_floor_tx(signed_tx),
+        chain::ParentFee::Floor,
         CpfpKind::PayoutCombined { payout_outpoint },
     )
     .await?;

--- a/crates/bridge-exec/src/stake/unstaking.rs
+++ b/crates/bridge-exec/src/stake/unstaking.rs
@@ -33,14 +33,16 @@ pub(crate) async fn publish_unstaking_intent(
     let signed_unstaking_intent_tx = unstaking_intent_tx.finalize(&unstaking_intent_witness);
     let unstaking_intent_txid = signed_unstaking_intent_tx.compute_txid();
     info!(%unstaking_intent_txid, "publishing unstaking intent transaction");
-    // Unstaking intent carries a keyed anchor; CPFP via InferAnchor.
+    // The unstaking intent carries a keyed anchor at a fixed vout.
     publish_signed_transaction(
         output_handles,
         &signed_unstaking_intent_tx,
         "unstaking intent tx",
         TxStatus::is_buried,
         chain::parent_fee_for_floor_tx(&signed_unstaking_intent_tx),
-        CpfpKind::InferAnchor,
+        CpfpKind::AnchorAt {
+            anchor_vout: UnstakingIntentTx::CPFP_VOUT,
+        },
     )
     .await?;
     info!(%unstaking_intent_txid, "unstaking intent transaction confirmed on-chain");

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -200,7 +200,7 @@ async fn build_v3_parent(
         }],
     };
     let funded = {
-        let mut wallet = wallet.write().await;
+        let wallet = wallet.read().await;
         wallet
             .fund_v3_transaction(
                 unsigned_tx,
@@ -458,7 +458,7 @@ async fn build_v3_payout_parent(
         }],
     };
     let funded = {
-        let mut wallet = wallet.write().await;
+        let wallet = wallet.read().await;
         wallet
             .fund_v3_transaction(
                 unsigned_tx,
@@ -654,7 +654,7 @@ async fn build_v3_mixed_parent(
         ],
     };
     let funded = {
-        let mut wallet = wallet.write().await;
+        let wallet = wallet.read().await;
         wallet
             .fund_v3_transaction(
                 unsigned_tx,
@@ -850,7 +850,7 @@ async fn build_v3_multi_anchor_parent(
         output: vec![anchor.tx_out()],
     };
     let funded = {
-        let mut wallet = wallet.write().await;
+        let wallet = wallet.read().await;
         wallet
             .fund_v3_transaction(
                 unsigned_tx,

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -65,7 +65,9 @@ const PARENT_FEE_RATE_SAT_PER_VB: u64 = 5;
 struct FixedFeeSource(FeeRate);
 
 impl cpfp::CpfpFeeSource for FixedFeeSource {
-    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+    fn estimate(
+        &self,
+    ) -> impl std::future::Future<Output = Result<FeeRate, cpfp::FeeSourceError>> + Send {
         let rate = self.0;
         async move { Ok(rate) }
     }
@@ -964,7 +966,9 @@ async fn cpfp_e2e_multi_anchor_against_bitcoind() {
     // consult it, so any routing regression surfaces as a hard test failure here too.
     let anchor_input_signer: InputSigner = Arc::new(move |_msg: Message| {
         Box::pin(async move {
-            Err("anchor_input_signer must not be called for a MultiAnchorBearing bump".to_string())
+            Err(cpfp::SignerError(
+                "anchor_input_signer must not be called for a MultiAnchorBearing bump".into(),
+            ))
         })
     });
     let ctx = CpfpContext {
@@ -1230,7 +1234,7 @@ impl cpfp::CpfpMempool for BlindToSpends {
     async fn anchor_spend_state(
         &self,
         _anchor: OutPoint,
-    ) -> Result<cpfp::AnchorSpendState, String> {
+    ) -> Result<cpfp::AnchorSpendState, cpfp::MempoolError> {
         Ok(cpfp::AnchorSpendState::Unspent)
     }
 }

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -39,7 +39,9 @@ use bitcoin::{
     transaction::Version,
 };
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
-use btc_tracker::cpfp::{self, BumpReason, CpfpContext, CpfpHandle, CpfpStrategy, InputSigner};
+use btc_tracker::cpfp::{
+    self, BumpOutcome, BumpReason, CpfpContext, CpfpHandle, CpfpStrategy, InputSigner,
+};
 use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
 use serial_test::serial;
 use strata_bridge_connectors::{Connector, multi_anchor::MultiAnchor};
@@ -382,8 +384,9 @@ async fn cpfp_e2e_against_bitcoind() {
     )
     .await
     .expect("perform_bump must succeed end-to-end");
-    assert!(
+    assert_eq!(
         bumped,
+        BumpOutcome::Submitted,
         "expected the bump to fire (target {TEST_FEE_TARGET} sat/vB > floor)"
     );
 
@@ -569,8 +572,9 @@ async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
     )
     .await
     .expect("perform_bump must succeed end-to-end for ParentTxCombined");
-    assert!(
+    assert_eq!(
         bumped,
+        BumpOutcome::Submitted,
         "expected the bump to fire (target {TEST_FEE_TARGET} sat/vB > floor)"
     );
 
@@ -784,7 +788,11 @@ async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
     )
     .await
     .expect("perform_bump must succeed end-to-end for InferGeneralPayout shape");
-    assert!(bumped, "bump must fire at target above floor");
+    assert_eq!(
+        bumped,
+        BumpOutcome::Submitted,
+        "bump must fire at target above floor"
+    );
 
     let child_txid = handle.last_child_txid.expect("child txid populated");
     let _ = async_client
@@ -992,7 +1000,11 @@ async fn cpfp_e2e_multi_anchor_against_bitcoind() {
     )
     .await
     .expect("perform_bump must succeed end-to-end for MultiAnchorBearing");
-    assert!(bumped, "bump must fire at target above floor");
+    assert_eq!(
+        bumped,
+        BumpOutcome::Submitted,
+        "bump must fire at target above floor"
+    );
 
     // ── 6. Mempool + package feerate + confirmation ────────────────────────
     let child_txid = handle.last_child_txid.expect("child txid populated");
@@ -1129,7 +1141,11 @@ async fn cpfp_e2e_multi_anchor_contention_is_quiet() {
     )
     .await
     .expect("the first watchtower must win the anchor");
-    assert!(bumped, "the first bump must submit a package");
+    assert_eq!(
+        bumped,
+        BumpOutcome::Submitted,
+        "the first bump must submit a package"
+    );
 
     // Watchtower 1 now sees the anchor taken at target, and skips.
     let (ctx1, strategy1) = context_for(1);
@@ -1144,9 +1160,11 @@ async fn cpfp_e2e_multi_anchor_contention_is_quiet() {
     )
     .await
     .expect("a lost anchor is not an error");
-    assert!(
-        !bumped,
-        "the second watchtower must skip, not submit a package that cannot win"
+    assert_eq!(
+        bumped,
+        BumpOutcome::ParentIsLive,
+        "the second watchtower must stand down, and it must report that the first \
+         watchtower's child already carries the parent"
     );
     assert!(
         handle1.last_child_txid.is_none(),

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -200,7 +200,11 @@ async fn build_v3_parent(
     let funded = {
         let mut wallet = wallet.write().await;
         wallet
-            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .fund_v3_transaction(
+                unsigned_tx,
+                parent_fee_rate,
+                operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+            )
             .await
             .expect("fund_v3_transaction (parent)")
     };
@@ -446,7 +450,11 @@ async fn build_v3_payout_parent(
     let funded = {
         let mut wallet = wallet.write().await;
         wallet
-            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .fund_v3_transaction(
+                unsigned_tx,
+                parent_fee_rate,
+                operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+            )
             .await
             .expect("fund_v3_transaction (payout parent)")
     };
@@ -630,7 +638,11 @@ async fn build_v3_mixed_parent(
     let funded = {
         let mut wallet = wallet.write().await;
         wallet
-            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .fund_v3_transaction(
+                unsigned_tx,
+                parent_fee_rate,
+                operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+            )
             .await
             .expect("fund_v3_transaction (mixed parent)")
     };
@@ -811,7 +823,11 @@ async fn build_v3_multi_anchor_parent(
     let funded = {
         let mut wallet = wallet.write().await;
         wallet
-            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .fund_v3_transaction(
+                unsigned_tx,
+                parent_fee_rate,
+                operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+            )
             .await
             .expect("fund_v3_transaction (multi-anchor parent)")
     };

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -204,11 +204,18 @@ async fn build_v3_parent(
                 unsigned_tx,
                 parent_fee_rate,
                 operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+                operator_wallet::LeaseOwner::ClaimFundingRefill,
             )
             .await
             .expect("fund_v3_transaction (parent)")
     };
-    let mut psbt = funded.psbt;
+    // Commit the lease on the parent's funding inputs, exactly as every production executor
+    // does once it publishes a parent. The inputs stay held until a sync observes the spend.
+    // Without this, they return to the spendable set while the parent is still unbroadcast,
+    // the CPFP child can select one of them, and `submitpackage` rejects the package with
+    // "conflict-in-package".
+    let (mut psbt, funding_lease) = funded.into_parts();
+    funding_lease.commit();
     sign_funding_inputs(&mut psbt, operator_keypair, &[]).expect("sign parent funding inputs");
     finalize_to_tx(psbt)
 }
@@ -454,11 +461,18 @@ async fn build_v3_payout_parent(
                 unsigned_tx,
                 parent_fee_rate,
                 operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+                operator_wallet::LeaseOwner::ClaimFundingRefill,
             )
             .await
             .expect("fund_v3_transaction (payout parent)")
     };
-    let mut psbt = funded.psbt;
+    // Commit the lease on the parent's funding inputs, exactly as every production executor
+    // does once it publishes a parent. The inputs stay held until a sync observes the spend.
+    // Without this, they return to the spendable set while the parent is still unbroadcast,
+    // the CPFP child can select one of them, and `submitpackage` rejects the package with
+    // "conflict-in-package".
+    let (mut psbt, funding_lease) = funded.into_parts();
+    funding_lease.commit();
     sign_funding_inputs(&mut psbt, operator_keypair, &[])
         .expect("sign payout parent funding inputs");
     finalize_to_tx(psbt)
@@ -642,11 +656,18 @@ async fn build_v3_mixed_parent(
                 unsigned_tx,
                 parent_fee_rate,
                 operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+                operator_wallet::LeaseOwner::ClaimFundingRefill,
             )
             .await
             .expect("fund_v3_transaction (mixed parent)")
     };
-    let mut psbt = funded.psbt;
+    // Commit the lease on the parent's funding inputs, exactly as every production executor
+    // does once it publishes a parent. The inputs stay held until a sync observes the spend.
+    // Without this, they return to the spendable set while the parent is still unbroadcast,
+    // the CPFP child can select one of them, and `submitpackage` rejects the package with
+    // "conflict-in-package".
+    let (mut psbt, funding_lease) = funded.into_parts();
+    funding_lease.commit();
     sign_funding_inputs(&mut psbt, operator_keypair, &[])
         .expect("sign mixed parent funding inputs");
     finalize_to_tx(psbt)
@@ -827,11 +848,18 @@ async fn build_v3_multi_anchor_parent(
                 unsigned_tx,
                 parent_fee_rate,
                 operator_wallet::GeneralUtxoPolicy::ConfirmedOnly,
+                operator_wallet::LeaseOwner::ClaimFundingRefill,
             )
             .await
             .expect("fund_v3_transaction (multi-anchor parent)")
     };
-    let mut psbt = funded.psbt;
+    // Commit the lease on the parent's funding inputs, exactly as every production executor
+    // does once it publishes a parent. The inputs stay held until a sync observes the spend.
+    // Without this, they return to the spendable set while the parent is still unbroadcast,
+    // the CPFP child can select one of them, and `submitpackage` rejects the package with
+    // "conflict-in-package".
+    let (mut psbt, funding_lease) = funded.into_parts();
+    funding_lease.commit();
     sign_funding_inputs(&mut psbt, operator_keypair, &[])
         .expect("sign multi-anchor parent funding inputs");
     finalize_to_tx(psbt)

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -43,7 +43,7 @@ use btc_tracker::cpfp::{self, BumpReason, CpfpContext, CpfpHandle, CpfpStrategy,
 use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
 use serial_test::serial;
 use strata_bridge_connectors::{Connector, multi_anchor::MultiAnchor};
-use strata_bridge_exec::cpfp_adapters::{BitcoindCpfpPackageSubmitter, OperatorWalletCpfpAdapter};
+use strata_bridge_exec::cpfp_adapters::{BitcoindCpfpMempool, OperatorWalletCpfpAdapter};
 use tokio::sync::RwLock;
 
 /// Test fee target: well above the bridge protocol floor so the bump path fires.
@@ -334,7 +334,7 @@ async fn cpfp_e2e_against_bitcoind() {
         wallet.clone(),
         operator_pubkey,
     ));
-    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone()));
+    let cpfp_submitter = Arc::new(BitcoindCpfpMempool::new(async_client.clone()));
     let fee_source = Arc::new(FixedFeeSource(
         FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
     ));
@@ -351,7 +351,7 @@ async fn cpfp_e2e_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer,
         max_fee_rate,
-        package_submitter: cpfp_submitter,
+        mempool: cpfp_submitter,
     };
 
     // ── 4. perform_bump → submits [parent, child] package ──────────────────
@@ -512,7 +512,7 @@ async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
         wallet.clone(),
         operator_pubkey,
     ));
-    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone()));
+    let cpfp_submitter = Arc::new(BitcoindCpfpMempool::new(async_client.clone()));
     let fee_source = Arc::new(FixedFeeSource(
         FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
     ));
@@ -529,7 +529,7 @@ async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer,
         max_fee_rate,
-        package_submitter: cpfp_submitter,
+        mempool: cpfp_submitter,
     };
 
     let strategy = CpfpStrategy::ParentTxCombined {
@@ -717,7 +717,7 @@ async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
         wallet.clone(),
         operator_pubkey,
     ));
-    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone()));
+    let cpfp_submitter = Arc::new(BitcoindCpfpMempool::new(async_client.clone()));
     let fee_source = Arc::new(FixedFeeSource(
         FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
     ));
@@ -733,7 +733,7 @@ async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer,
         max_fee_rate,
-        package_submitter: cpfp_submitter,
+        mempool: cpfp_submitter,
     };
 
     let strategy = CpfpStrategy::ParentTxCombined {
@@ -927,7 +927,7 @@ async fn cpfp_e2e_multi_anchor_against_bitcoind() {
         anchor_input_signer,
         wallet_input_signer: test_input_signer(operator_keypair),
         max_fee_rate: FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap(),
-        package_submitter: Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone())),
+        mempool: Arc::new(BitcoindCpfpMempool::new(async_client.clone())),
     };
 
     // ── 5. perform_bump → [parent, child] package via the script path ──────
@@ -988,4 +988,187 @@ async fn cpfp_e2e_multi_anchor_against_bitcoind() {
         confirmed_txids.contains(&child_txid),
         "multi-anchor child must confirm in the same block as the parent"
     );
+}
+
+/// Two watchtowers bump the same `MultiAnchor`, as they do in production.
+///
+/// The first one wins the anchor. The second one must then skip quietly rather than pay to
+/// lose: it reads the spend state of the anchor, sees a package already at target, and returns
+/// without building or signing. Every watchtower of a graph holds a leaf on the same anchor, so
+/// without this the losers rebuild and resubmit on every trigger until the parent confirms.
+///
+/// The test also pins the rejection that bitcoind produces when the check is bypassed. That
+/// string is what `SubmitPackageError::is_replacement_contention` matches, and matching on a
+/// message is only safe while a test holds it against a live node.
+#[tokio::test]
+#[serial]
+async fn cpfp_e2e_multi_anchor_contention_is_quiet() {
+    let (bitcoind, async_client) = setup_bitcoind();
+    let async_client = Arc::new(async_client);
+    let secp = Secp256k1::new();
+    let operator_secret = SecretKey::from_slice(&[7u8; 32]).expect("valid 32-byte scalar");
+    let operator_keypair = Keypair::from_secret_key(&secp, &operator_secret);
+    let (operator_pubkey, _) = operator_keypair.x_only_public_key();
+
+    const N_WATCHTOWERS: u8 = 3;
+    let wt_keypairs: Vec<Keypair> = (0..N_WATCHTOWERS)
+        .map(|i| {
+            let secret = SecretKey::from_slice(&[11 + i; 32]).expect("valid 32-byte scalar");
+            Keypair::from_secret_key(&secp, &secret)
+        })
+        .collect();
+    let wt_pubkeys: Vec<XOnlyPublicKey> = wt_keypairs
+        .iter()
+        .map(|kp| kp.x_only_public_key().0)
+        .collect();
+    let anchor = MultiAnchor::new(Network::Regtest, wt_pubkeys, Amount::from_sat(330));
+
+    let wallet = build_operator_wallet(
+        &bitcoind,
+        operator_pubkey,
+        6,
+        Amount::from_btc(0.5).unwrap(),
+    )
+    .await;
+    let parent_fee_rate = FeeRate::from_sat_per_vb(PARENT_FEE_RATE_SAT_PER_VB).unwrap();
+    let parent =
+        build_v3_multi_anchor_parent(&wallet, operator_keypair, &anchor, parent_fee_rate).await;
+    let anchor_vout = parent
+        .output
+        .iter()
+        .position(|o| o.script_pubkey == anchor.script_pubkey())
+        .expect("multi-anchor output must exist") as u32;
+    let parent_fee = parent_fee_rate
+        .fee_vb(parent.vsize() as u64)
+        .expect("parent fee fits in Amount");
+
+    // One context per watchtower, each signing with its own leaf.
+    let context_for = |slot: usize| {
+        let leaf_script = anchor.leaf_scripts()[slot].clone();
+        let control_block = anchor
+            .spend_info()
+            .control_block(&(leaf_script.clone(), taproot::LeafVersion::TapScript))
+            .expect("control block for the leaf of this watchtower");
+        let ctx = CpfpContext {
+            wallet: Arc::new(OperatorWalletCpfpAdapter::new(
+                wallet.clone(),
+                operator_pubkey,
+            )),
+            multi_anchor_signer: test_untweaked_input_signer(wt_keypairs[slot]),
+            fee_source: Arc::new(FixedFeeSource(
+                FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
+            )),
+            anchor_input_signer: test_input_signer(operator_keypair),
+            wallet_input_signer: test_input_signer(operator_keypair),
+            max_fee_rate: FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap(),
+            mempool: Arc::new(BitcoindCpfpMempool::new(async_client.clone())),
+        };
+        let strategy = CpfpStrategy::MultiAnchorBearing {
+            anchor_vout,
+            leaf_script,
+            control_block,
+            parent_fee,
+        };
+        (ctx, strategy)
+    };
+
+    // Watchtower 0 takes the anchor.
+    let (ctx0, strategy0) = context_for(0);
+    let mut handle0 = CpfpHandle::default();
+    let bumped = cpfp::perform_bump(
+        &ctx0,
+        &parent,
+        strategy0,
+        &mut handle0,
+        FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap(),
+        BumpReason::NewJob,
+    )
+    .await
+    .expect("the first watchtower must win the anchor");
+    assert!(bumped, "the first bump must submit a package");
+
+    // Watchtower 1 now sees the anchor taken at target, and skips.
+    let (ctx1, strategy1) = context_for(1);
+    let mut handle1 = CpfpHandle::default();
+    let bumped = cpfp::perform_bump(
+        &ctx1,
+        &parent,
+        strategy1,
+        &mut handle1,
+        FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap(),
+        BumpReason::NewBlock,
+    )
+    .await
+    .expect("a lost anchor is not an error");
+    assert!(
+        !bumped,
+        "the second watchtower must skip, not submit a package that cannot win"
+    );
+    assert!(
+        handle1.last_child_txid.is_none(),
+        "a skipping watchtower must not build or sign a child"
+    );
+
+    // Pin the rejection that the skip avoids.
+    //
+    // The skip works, so no watchtower reaches the submission any more. Reproduce what one
+    // without the check meets by reporting the anchor as unspent while leaving the submission
+    // real. This is the only way to hold the bitcoind message that
+    // `is_replacement_contention` matches against a live node.
+    let (ctx2, strategy2) = context_for(2);
+    let ctx2 = CpfpContext {
+        wallet: ctx2.wallet,
+        multi_anchor_signer: ctx2.multi_anchor_signer,
+        fee_source: ctx2.fee_source,
+        anchor_input_signer: ctx2.anchor_input_signer,
+        wallet_input_signer: ctx2.wallet_input_signer,
+        max_fee_rate: ctx2.max_fee_rate,
+        mempool: Arc::new(BlindToSpends(BitcoindCpfpMempool::new(
+            async_client.clone(),
+        ))),
+    };
+    let mut handle2 = CpfpHandle::default();
+    let forced = cpfp::perform_bump(
+        &ctx2,
+        &parent,
+        strategy2,
+        &mut handle2,
+        FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap(),
+        BumpReason::NewBlock,
+    )
+    .await;
+
+    let err = forced.expect_err("a same-target child cannot displace the winner");
+    assert!(
+        err.is_replacement_contention(),
+        "a lost race must classify as contention, not as a fault: {err}"
+    );
+}
+
+/// Wraps the real mempool adapter and reports every anchor as unspent.
+///
+/// Submission stays real. Only the pre-build check is blinded, so a bump proceeds to the point
+/// where bitcoind itself rejects it.
+#[derive(Debug)]
+struct BlindToSpends(BitcoindCpfpMempool);
+
+impl cpfp::CpfpMempool for BlindToSpends {
+    fn submit_package(
+        &self,
+        txs: &[Transaction],
+    ) -> impl std::future::Future<
+        Output = Result<
+            btc_tracker::submitpackage::SubmitPackageSummary,
+            btc_tracker::submitpackage::SubmitPackageError,
+        >,
+    > + Send {
+        self.0.submit_package(txs)
+    }
+
+    async fn anchor_spend_state(
+        &self,
+        _anchor: OutPoint,
+    ) -> Result<cpfp::AnchorSpendState, String> {
+        Ok(cpfp::AnchorSpendState::Unspent)
+    }
 }

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -1,0 +1,991 @@
+#![allow(unused_crate_dependencies)]
+//! End-to-end CPFP regression test against a real `bitcoind` (regtest, via `corepc-node`).
+//!
+//! Validates STR-3439 AC2: aggressive CPFP submitted as a `[parent, child]` v3 package is
+//! accepted by `bitcoind`'s `submitpackage` RPC and the package confirms when a block is mined.
+//!
+//! ## TRUC requirement
+//!
+//! Per BIP-431, a v3 child can only spend from a v3 parent. `bitcoind`'s default
+//! `send_to_address` produces a v2 transaction, which submitpackage rejects when paired with
+//! the v3 CPFP child this crate produces. The test therefore builds the parent itself via
+//! `OperatorWallet::fund_v3_transaction`, signs it with the known operator privkey, and uses
+//! that signed v3 transaction as the parent for `perform_bump`.
+//!
+//! ## Signing in the test
+//!
+//! `NativeGeneralWallet` is descriptor-only: it returns unsigned PSBTs. Production code
+//! signs those via secret-service; in this test we sign in-process using the operator's
+//! known keypair (Taproot key-path with BIP-341 tap-tweak). The parent's funding input is
+//! signed in `build_v3_parent` / `build_v3_payout_parent`; the child's inputs (anchor or
+//! payout + wallet funding) are signed by `perform_bump` via the `InputSigner` closures in
+//! `CpfpContext` (here just `test_input_signer`, which signs everything with the operator's
+//! known keypair since both the anchor key and the wallet descriptor key are the same in
+//! the test).
+//!
+//! Test is gated on `bitcoind` being available; it's a `#[serial]` test because `bitcoind`
+//! binds a fixed RPC port (collisions across parallel tests would flake).
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use bdk_bitcoind_rpc::bitcoincore_rpc;
+use bitcoin::{
+    Address, Amount, FeeRate, Network, OutPoint, Psbt, TapSighashType, Transaction, TxOut, Witness,
+    XOnlyPublicKey, absolute,
+    key::{Keypair, Secp256k1, TapTweak},
+    secp256k1::{Message, SecretKey},
+    sighash::{Prevouts, SighashCache},
+    taproot,
+    transaction::Version,
+};
+use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
+use btc_tracker::cpfp::{self, BumpReason, CpfpContext, CpfpHandle, CpfpStrategy, InputSigner};
+use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
+use serial_test::serial;
+use strata_bridge_connectors::{Connector, multi_anchor::MultiAnchor};
+use strata_bridge_exec::cpfp_adapters::{BitcoindCpfpPackageSubmitter, OperatorWalletCpfpAdapter};
+use tokio::sync::RwLock;
+
+/// Test fee target: well above the bridge protocol floor so the bump path fires.
+const TEST_FEE_TARGET: u64 = 20;
+/// Cap (`max_fee_rate`) for the package; well above the target.
+const TEST_FEE_CAP: u64 = 100;
+/// Bridge protocol floor lowered to 1 sat/vB for this test so a 20 sat/vB target unambiguously
+/// triggers the bump.
+const TEST_FLOOR: u64 = 1;
+/// Fee rate used to fund the v3 parent. Independent of the package target — just needs to be
+/// above min-relay so the parent on its own is mempool-valid.
+const PARENT_FEE_RATE_SAT_PER_VB: u64 = 5;
+
+/// `Fixed` fee source that always returns the same rate. Avoids depending on bitcoind's
+/// estimatesmartfee (which returns 0 in a quiet regtest).
+#[derive(Debug)]
+struct FixedFeeSource(FeeRate);
+
+impl cpfp::CpfpFeeSource for FixedFeeSource {
+    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+        let rate = self.0;
+        async move { Ok(rate) }
+    }
+}
+
+/// Boots `bitcoind`, mines coinbase maturity, and returns the node plus an async RPC client.
+fn setup_bitcoind() -> (corepc_node::Node, BitcoinClient) {
+    let bitcoind = corepc_node::Node::with_conf("bitcoind", &corepc_node::Conf::default())
+        .expect("bitcoind must start");
+    let address = bitcoind
+        .client
+        .new_address()
+        .expect("address from bitcoind wallet");
+    bitcoind
+        .client
+        .generate_to_address(101, &address)
+        .expect("mine coinbase maturity");
+
+    let cookie = bitcoind
+        .params
+        .get_cookie_values()
+        .expect("read cookie")
+        .expect("parse cookie");
+    let auth = bitcoind_async_client::Auth::UserPass(cookie.user, cookie.password);
+    let async_client = BitcoinClient::new(bitcoind.rpc_url(), auth, None, None, None)
+        .expect("async rpc client must initialize");
+    (bitcoind, async_client)
+}
+
+/// Spins up a sync `bitcoincore_rpc::Client` against the running node — needed by
+/// `Backend::BitcoinCore` which doesn't accept the async client.
+fn sync_rpc_client(bitcoind: &corepc_node::Node) -> bitcoincore_rpc::Client {
+    let cookie_path = bitcoind.params.cookie_file.clone();
+    let auth = bitcoincore_rpc::Auth::CookieFile(cookie_path);
+    bitcoincore_rpc::Client::new(&bitcoind.rpc_url(), auth).expect("sync rpc client")
+}
+
+/// Asserts — via `getmempoolentry` on the child — that the mempool sees the `[parent, child]`
+/// package paying at least [`TEST_FEE_TARGET`] sat/vB. This is what makes the e2e a *fee* test
+/// rather than just a relay test: a package accepted while underpaying its target (a fee-math
+/// regression) would still pass the mempool-presence and confirmation checks.
+///
+/// The slack is a few absolute sat, not a whole sat/vB. A sat/vB of slack sounds tight but is
+/// worth hundreds of sat on a package this size, which is easily enough to hide a systematic
+/// underpay — an earlier revision of this helper allowed exactly that, and the multi-anchor
+/// case passed only because it was exercised at the single watchtower count that squeaked
+/// under the tolerance. Integer truncation in the fee math is worth well under 1 sat total.
+const PACKAGE_FEE_SLACK_SAT: u64 = 4;
+
+fn assert_package_pays_target(bitcoind: &corepc_node::Node, child_txid: bitcoin::Txid) {
+    use bitcoincore_rpc::RpcApi;
+    let rpc = sync_rpc_client(bitcoind);
+    let entry = rpc
+        .get_mempool_entry(&child_txid)
+        .expect("child must have a mempool entry");
+    // The child's only in-mempool ancestor is the parent, so the ancestor aggregate (child
+    // included) is exactly the package the bump submitted.
+    let ancestor_fee_sat = entry.fees.ancestor.to_sat();
+    let ancestor_vsize = entry.ancestor_size;
+    let required = TEST_FEE_TARGET * ancestor_vsize;
+    assert!(
+        ancestor_fee_sat + PACKAGE_FEE_SLACK_SAT >= required,
+        "package pays {ancestor_fee_sat} sat over {ancestor_vsize} vB = {:.2} sat/vB, \
+         below the {TEST_FEE_TARGET} sat/vB target (needs {required} sat)",
+        ancestor_fee_sat as f64 / ancestor_vsize as f64
+    );
+}
+
+/// Constructs a `NativeGeneralWallet` keyed to `pubkey`, syncs it against `bitcoind`, and
+/// wraps it in an `OperatorWallet`. Sends `funding_utxos` separate UTXOs of `funding_per_utxo`
+/// each to the wallet's address so subsequent fundings (parent + child) draw from distinct
+/// UTXOs without needing intra-test rescans.
+async fn build_operator_wallet(
+    bitcoind: &corepc_node::Node,
+    pubkey: XOnlyPublicKey,
+    funding_utxos: usize,
+    funding_per_utxo: Amount,
+) -> Arc<RwLock<OperatorWallet<NativeGeneralWallet>>> {
+    let backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
+    let backend_clone = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
+    let general_wallet = NativeGeneralWallet::new(pubkey, Network::Regtest, backend);
+    let config = OperatorWalletConfig::new(Amount::from_sat(330), Network::Regtest);
+    let secp = Secp256k1::new();
+    let reserved_secret = SecretKey::from_slice(&[0x42u8; 32]).expect("valid 32-byte scalar");
+    let reserved_keypair = Keypair::from_secret_key(&secp, &reserved_secret);
+    let (reserved_pubkey, _) = reserved_keypair.x_only_public_key();
+    let mut wallet = OperatorWallet::new(
+        general_wallet,
+        reserved_pubkey,
+        config,
+        backend_clone,
+        BTreeSet::new(),
+    );
+
+    let address = Address::p2tr(&secp, pubkey, None, Network::Regtest);
+
+    for _ in 0..funding_utxos {
+        bitcoind
+            .client
+            .send_to_address(&address, funding_per_utxo)
+            .expect("send_to_address");
+    }
+    let miner_addr = bitcoind.client.new_address().expect("address");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine confirmation");
+
+    wallet.sync().await.expect("wallet sync after funding");
+    Arc::new(RwLock::new(wallet))
+}
+
+/// Builds a fully-signed v3 parent transaction with a 330-sat keyed-Taproot anchor output
+/// keyed to `operator_pubkey`. Spends a wallet-selected UTXO; signed in-process with
+/// `operator_keypair`.
+async fn build_v3_parent(
+    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    operator_keypair: Keypair,
+    operator_pubkey: XOnlyPublicKey,
+    parent_fee_rate: FeeRate,
+) -> Transaction {
+    let secp = Secp256k1::new();
+    let anchor_script =
+        Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey();
+    let unsigned_tx = Transaction {
+        version: Version(3),
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            value: Amount::from_sat(330),
+            script_pubkey: anchor_script,
+        }],
+    };
+    let funded = {
+        let mut wallet = wallet.write().await;
+        wallet
+            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .await
+            .expect("fund_v3_transaction (parent)")
+    };
+    let mut psbt = funded.psbt;
+    sign_funding_inputs(&mut psbt, operator_keypair, &[]).expect("sign parent funding inputs");
+    finalize_to_tx(psbt)
+}
+
+/// Signs every PSBT input whose outpoint is NOT in `skip` as Taproot key-path with
+/// `keypair` (BIP-341 tap-tweak with no merkle root), placing the resulting Schnorr signature
+/// in `tap_key_sig`. Requires `witness_utxo` to be set on every input (BDK populates this).
+fn sign_funding_inputs(psbt: &mut Psbt, keypair: Keypair, skip: &[OutPoint]) -> Result<(), String> {
+    let secp = Secp256k1::new();
+    let tweaked = keypair.tap_tweak(&secp, None);
+    let tweaked_keypair = tweaked.to_keypair();
+
+    let prevouts: Vec<TxOut> = psbt
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            input
+                .witness_utxo
+                .clone()
+                .ok_or_else(|| format!("input {i}: witness_utxo not populated"))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let unsigned_tx = psbt.unsigned_tx.clone();
+    let mut cache = SighashCache::new(&unsigned_tx);
+    let prevouts_all = Prevouts::All(&prevouts);
+
+    for i in 0..psbt.inputs.len() {
+        let outpoint = unsigned_tx.input[i].previous_output;
+        if skip.contains(&outpoint) {
+            continue;
+        }
+        let sighash = cache
+            .taproot_key_spend_signature_hash(i, &prevouts_all, TapSighashType::Default)
+            .map_err(|e| format!("input {i}: sighash: {e:?}"))?;
+        let msg = Message::from(sighash);
+        let signature = secp.sign_schnorr_no_aux_rand(&msg, &tweaked_keypair);
+        psbt.inputs[i].tap_key_sig = Some(taproot::Signature {
+            signature,
+            sighash_type: TapSighashType::Default,
+        });
+    }
+    Ok(())
+}
+
+/// Transforms a PSBT with `tap_key_sig` set on every input into a final Transaction by
+/// promoting each `tap_key_sig` to `final_script_witness` and calling `extract_tx`.
+fn finalize_to_tx(mut psbt: Psbt) -> Transaction {
+    for input in &mut psbt.inputs {
+        if input.final_script_witness.is_some() {
+            continue;
+        }
+        if let Some(sig) = input.tap_key_sig.take() {
+            let mut witness = Witness::new();
+            witness.push(sig.to_vec());
+            input.final_script_witness = Some(witness);
+        }
+    }
+    psbt.extract_tx().expect("extract_tx")
+}
+
+/// Builds an [`InputSigner`] that signs a Taproot key-path digest with the test's known
+/// `keypair`, applying BIP-341 tap-tweak with an empty merkle root. In production the
+/// anchor- and wallet-input signers go through different secret-service signers (musig2
+/// signer vs. general-wallet signer) but in this test both keys are the same (`operator_pubkey`
+/// — the wallet's descriptor key AND the anchor's internal key), so one closure suffices.
+fn test_input_signer(keypair: Keypair) -> InputSigner {
+    Arc::new(move |msg: Message| {
+        let kp = keypair;
+        Box::pin(async move {
+            let tweaked = kp.tap_tweak(&Secp256k1::new(), None);
+            let sig = Secp256k1::new().sign_schnorr_no_aux_rand(&msg, &tweaked.to_keypair());
+            Ok(sig)
+        })
+    })
+}
+
+#[tokio::test]
+#[serial]
+async fn cpfp_e2e_against_bitcoind() {
+    let (bitcoind, async_client) = setup_bitcoind();
+    let async_client = Arc::new(async_client);
+
+    // ── 1. Operator key + wallet ───────────────────────────────────────────
+    let secp = Secp256k1::new();
+    let operator_secret = SecretKey::from_slice(&[7u8; 32]).expect("valid 32-byte scalar");
+    let operator_keypair = Keypair::from_secret_key(&secp, &operator_secret);
+    let (operator_pubkey, _) = operator_keypair.x_only_public_key();
+
+    // Fund three separate UTXOs so the parent and the child draw from distinct outputs.
+    // (The wallet leases the parent's selected UTXO after `fund_v3_transaction`; without
+    // additional UTXOs the child would fail at coin selection.)
+    let wallet = build_operator_wallet(
+        &bitcoind,
+        operator_pubkey,
+        3,
+        Amount::from_btc(0.5).unwrap(),
+    )
+    .await;
+
+    // ── 2. Build a fully-signed v3 parent with a keyed-Taproot anchor ──────
+    let parent_fee_rate = FeeRate::from_sat_per_vb(PARENT_FEE_RATE_SAT_PER_VB).unwrap();
+    let parent = build_v3_parent(&wallet, operator_keypair, operator_pubkey, parent_fee_rate).await;
+    assert_eq!(parent.version.0, 3, "parent must be v3 (TRUC)");
+    let parent_txid = parent.compute_txid();
+    let anchor_vout: u32 = parent
+        .output
+        .iter()
+        .position(|o| {
+            o.value == Amount::from_sat(330)
+                && o.script_pubkey
+                    == Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey()
+        })
+        .expect("anchor output must exist on the parent we just built")
+        as u32;
+    let parent_fee = parent_fee_rate
+        .fee_vb(parent.vsize() as u64)
+        .expect("parent fee fits in Amount");
+
+    // ── 3. CpfpContext with real components ────────────────────────────────
+    //
+    // Production wires `OperatorWalletCpfpAdapter` directly (it returns unsigned PSBTs;
+    // perform_bump signs every input via `anchor_input_signer` / `wallet_input_signer`).
+    // No test-only wrapper is needed.
+    let cpfp_wallet = Arc::new(OperatorWalletCpfpAdapter::new(
+        wallet.clone(),
+        operator_pubkey,
+    ));
+    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone()));
+    let fee_source = Arc::new(FixedFeeSource(
+        FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
+    ));
+    let max_fee_rate = FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap();
+    let bridge_protocol_floor = FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap();
+
+    let anchor_input_signer = test_input_signer(operator_keypair);
+    let wallet_input_signer = test_input_signer(operator_keypair);
+
+    let ctx = CpfpContext {
+        wallet: cpfp_wallet,
+        multi_anchor_signer: test_input_signer(operator_keypair),
+        fee_source,
+        anchor_input_signer,
+        wallet_input_signer,
+        max_fee_rate,
+        package_submitter: cpfp_submitter,
+    };
+
+    // ── 4. perform_bump → submits [parent, child] package ──────────────────
+    let strategy = CpfpStrategy::AnchorBearing {
+        anchor_vout,
+        anchor_internal_key: operator_pubkey,
+        parent_fee,
+    };
+    let mut handle = CpfpHandle::default();
+    let bumped = cpfp::perform_bump(
+        &ctx,
+        &parent,
+        strategy,
+        &mut handle,
+        bridge_protocol_floor,
+        BumpReason::NewJob,
+    )
+    .await
+    .expect("perform_bump must succeed end-to-end");
+    assert!(
+        bumped,
+        "expected the bump to fire (target {TEST_FEE_TARGET} sat/vB > floor)"
+    );
+
+    // ── 5. Assert: mempool contains parent + child ─────────────────────────
+    let child_txid = handle.last_child_txid.expect("child txid populated");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&parent_txid)
+        .await
+        .expect("parent must be in mempool or chain");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&child_txid)
+        .await
+        .expect("child must be in mempool");
+
+    assert_package_pays_target(&bitcoind, child_txid);
+
+    // ── 6. Mine a block and assert both confirm in it ──────────────────────
+    //
+    // `bitcoind` is started without `-txindex`, so `getrawtransaction` can't look up
+    // confirmed-and-pruned txs by txid alone. Read the new block directly and assert both
+    // txids are in its txdata.
+    let miner_addr = bitcoind.client.new_address().expect("new address");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine block");
+
+    let tip_height = async_client.get_block_count().await.expect("block count");
+    let tip_hash = async_client
+        .get_block_hash(tip_height)
+        .await
+        .expect("tip hash");
+    let tip_block = async_client.get_block(&tip_hash).await.expect("tip block");
+    let confirmed_txids: BTreeSet<_> = tip_block
+        .txdata
+        .iter()
+        .map(bitcoin::Transaction::compute_txid)
+        .collect();
+    assert!(
+        confirmed_txids.contains(&parent_txid),
+        "parent must confirm in the mined block"
+    );
+    assert!(
+        confirmed_txids.contains(&child_txid),
+        "child must confirm in the same block as parent"
+    );
+}
+
+/// Builds a fully-signed v3 parent whose single output is operator-owned (no anchor) —
+/// mirrors the shape of cooperative_payout / uncontested_payout / unstaking txs that use
+/// [`CpfpStrategy::ParentTxCombined`] in production.
+async fn build_v3_payout_parent(
+    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    operator_keypair: Keypair,
+    operator_pubkey: XOnlyPublicKey,
+    parent_fee_rate: FeeRate,
+    payout_value: Amount,
+) -> Transaction {
+    let secp = Secp256k1::new();
+    let payout_script =
+        Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey();
+    let unsigned_tx = Transaction {
+        version: Version(3),
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            value: payout_value,
+            script_pubkey: payout_script,
+        }],
+    };
+    let funded = {
+        let mut wallet = wallet.write().await;
+        wallet
+            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .await
+            .expect("fund_v3_transaction (payout parent)")
+    };
+    let mut psbt = funded.psbt;
+    sign_funding_inputs(&mut psbt, operator_keypair, &[])
+        .expect("sign payout parent funding inputs");
+    finalize_to_tx(psbt)
+}
+
+/// E2E test for [`CpfpStrategy::ParentTxCombined`]: a v3 parent whose only output is an
+/// operator-owned payout, plus a CPFP child that spends that output (via `add_foreign_utxo`)
+/// + a wallet funding input, drained back to the wallet. Validates that the broken
+/// `manually_selected_only + add_utxo` path (which would fail on a not-yet-broadcast parent)
+/// is no longer in use and that the unified foreign-UTXO machinery in the adapter handles
+/// PayoutCombined correctly against real `bitcoind`.
+#[tokio::test]
+#[serial]
+async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
+    let (bitcoind, async_client) = setup_bitcoind();
+    let async_client = Arc::new(async_client);
+
+    let secp = Secp256k1::new();
+    let operator_secret = SecretKey::from_slice(&[11u8; 32]).expect("valid 32-byte scalar");
+    let operator_keypair = Keypair::from_secret_key(&secp, &operator_secret);
+    let (operator_pubkey, _) = operator_keypair.x_only_public_key();
+
+    // Fund three UTXOs: one funds the payout parent, one funds the CPFP child, one spare.
+    let wallet = build_operator_wallet(
+        &bitcoind,
+        operator_pubkey,
+        3,
+        Amount::from_btc(0.5).unwrap(),
+    )
+    .await;
+
+    // Build a v3 payout parent: single operator-owned output, no anchor. This mirrors the
+    // structure of cooperative_payout / uncontested_payout / unstaking txs in production.
+    let parent_fee_rate = FeeRate::from_sat_per_vb(PARENT_FEE_RATE_SAT_PER_VB).unwrap();
+    let parent = build_v3_payout_parent(
+        &wallet,
+        operator_keypair,
+        operator_pubkey,
+        parent_fee_rate,
+        Amount::from_btc(0.25).unwrap(),
+    )
+    .await;
+    assert_eq!(parent.version.0, 3, "payout parent must be v3 (TRUC)");
+    let parent_txid = parent.compute_txid();
+    let parent_fee = parent_fee_rate
+        .fee_vb(parent.vsize() as u64)
+        .expect("parent fee fits in Amount");
+
+    // The payout outpoint is vout 0 of the parent — the operator-owned output.
+    let payout_outpoint = OutPoint {
+        txid: parent_txid,
+        vout: 0,
+    };
+
+    // CpfpContext, mirroring production wiring. `operator_general_pubkey` passed to the
+    // adapter so it can construct the foreign-UTXO PSBT input with the right
+    // `tap_internal_key` when CPFPing a PayoutCombined parent.
+    let cpfp_wallet = Arc::new(OperatorWalletCpfpAdapter::new(
+        wallet.clone(),
+        operator_pubkey,
+    ));
+    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone()));
+    let fee_source = Arc::new(FixedFeeSource(
+        FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
+    ));
+    let max_fee_rate = FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap();
+    let bridge_protocol_floor = FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap();
+
+    let anchor_input_signer = test_input_signer(operator_keypair);
+    let wallet_input_signer = test_input_signer(operator_keypair);
+
+    let ctx = CpfpContext {
+        wallet: cpfp_wallet,
+        multi_anchor_signer: test_input_signer(operator_keypair),
+        fee_source,
+        anchor_input_signer,
+        wallet_input_signer,
+        max_fee_rate,
+        package_submitter: cpfp_submitter,
+    };
+
+    let strategy = CpfpStrategy::ParentTxCombined {
+        payout_outpoint,
+        parent_fee,
+    };
+    let mut handle = CpfpHandle::default();
+    let bumped = cpfp::perform_bump(
+        &ctx,
+        &parent,
+        strategy,
+        &mut handle,
+        bridge_protocol_floor,
+        BumpReason::NewJob,
+    )
+    .await
+    .expect("perform_bump must succeed end-to-end for ParentTxCombined");
+    assert!(
+        bumped,
+        "expected the bump to fire (target {TEST_FEE_TARGET} sat/vB > floor)"
+    );
+
+    let child_txid = handle.last_child_txid.expect("child txid populated");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&parent_txid)
+        .await
+        .expect("payout parent must be in mempool");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&child_txid)
+        .await
+        .expect("child must be in mempool");
+
+    assert_package_pays_target(&bitcoind, child_txid);
+
+    let miner_addr = bitcoind.client.new_address().expect("new address");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine block");
+
+    let tip_height = async_client.get_block_count().await.expect("block count");
+    let tip_hash = async_client
+        .get_block_hash(tip_height)
+        .await
+        .expect("tip hash");
+    let tip_block = async_client.get_block(&tip_hash).await.expect("tip block");
+    let confirmed_txids: BTreeSet<_> = tip_block
+        .txdata
+        .iter()
+        .map(bitcoin::Transaction::compute_txid)
+        .collect();
+    assert!(
+        confirmed_txids.contains(&parent_txid),
+        "payout parent must confirm in the mined block"
+    );
+    assert!(
+        confirmed_txids.contains(&child_txid),
+        "PayoutCombined child must confirm in the same block as the parent"
+    );
+}
+
+/// Builds a v3 parent shaped like a withdrawal-fulfillment or slash tx: an OP_RETURN-ish
+/// "header" output, a payout output to a non-operator key (the "user" payout / a different
+/// watchtower), and a payout output to the operator's general script (the BDK change / the
+/// calling watchtower's slash share). The third one is the CPFP hook the production helper
+/// would discover via `CpfpKind::InferGeneralPayout`.
+async fn build_v3_mixed_parent(
+    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    operator_keypair: Keypair,
+    operator_pubkey: XOnlyPublicKey,
+    other_pubkey: XOnlyPublicKey,
+    parent_fee_rate: FeeRate,
+    other_value: Amount,
+    operator_value: Amount,
+) -> Transaction {
+    let secp = Secp256k1::new();
+    let operator_script =
+        Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey();
+    let other_script = Address::p2tr(&secp, other_pubkey, None, Network::Regtest).script_pubkey();
+    let unsigned_tx = Transaction {
+        version: Version(3),
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![
+            // vout 0: a non-operator output (the "user payout" or "other watchtower share")
+            TxOut {
+                value: other_value,
+                script_pubkey: other_script,
+            },
+            // vout 1: the operator-owned output (the BDK change / the calling watchtower's
+            // own slash share). This is what `InferGeneralPayout` should discover.
+            TxOut {
+                value: operator_value,
+                script_pubkey: operator_script,
+            },
+        ],
+    };
+    let funded = {
+        let mut wallet = wallet.write().await;
+        wallet
+            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .await
+            .expect("fund_v3_transaction (mixed parent)")
+    };
+    let mut psbt = funded.psbt;
+    sign_funding_inputs(&mut psbt, operator_keypair, &[])
+        .expect("sign mixed parent funding inputs");
+    finalize_to_tx(psbt)
+}
+
+/// E2E test for the `CpfpKind::InferGeneralPayout`-shaped path: a v3 parent with a mix of
+/// operator-owned and non-operator outputs, where the production helper picks the operator
+/// output by script match (no fixed vout). This exercises the WFT / stake-funding-change /
+/// slash classification path against real `bitcoind`.
+#[tokio::test]
+#[serial]
+async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
+    let (bitcoind, async_client) = setup_bitcoind();
+    let async_client = Arc::new(async_client);
+
+    let secp = Secp256k1::new();
+    let operator_secret = SecretKey::from_slice(&[13u8; 32]).expect("valid 32-byte scalar");
+    let operator_keypair = Keypair::from_secret_key(&secp, &operator_secret);
+    let (operator_pubkey, _) = operator_keypair.x_only_public_key();
+
+    // A second key for the non-operator output — simulates the user destination on a WFT
+    // or another watchtower's payout on slash.
+    let other_secret = SecretKey::from_slice(&[99u8; 32]).expect("valid 32-byte scalar");
+    let other_keypair = Keypair::from_secret_key(&secp, &other_secret);
+    let (other_pubkey, _) = other_keypair.x_only_public_key();
+
+    let wallet = build_operator_wallet(
+        &bitcoind,
+        operator_pubkey,
+        3,
+        Amount::from_btc(0.5).unwrap(),
+    )
+    .await;
+
+    let parent_fee_rate = FeeRate::from_sat_per_vb(PARENT_FEE_RATE_SAT_PER_VB).unwrap();
+    let parent = build_v3_mixed_parent(
+        &wallet,
+        operator_keypair,
+        operator_pubkey,
+        other_pubkey,
+        parent_fee_rate,
+        Amount::from_btc(0.1).unwrap(),  // non-operator payout
+        Amount::from_btc(0.15).unwrap(), // operator-owned payout (CPFP hook)
+    )
+    .await;
+    assert_eq!(parent.version.0, 3, "mixed parent must be v3 (TRUC)");
+    let parent_txid = parent.compute_txid();
+    let parent_fee = parent_fee_rate
+        .fee_vb(parent.vsize() as u64)
+        .expect("parent fee fits in Amount");
+
+    // Manually replicate what `first_general_payout_outpoint` does: find vout matching the
+    // operator's P2TR script. In production, `chain::publish_signed_transaction` with
+    // `CpfpKind::InferGeneralPayout` performs this scan; here we do it explicitly so the
+    // test can call `perform_bump` directly with the resolved strategy.
+    let operator_script =
+        Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey();
+    let operator_vout = parent
+        .output
+        .iter()
+        .position(|o| o.script_pubkey == operator_script)
+        .expect("the operator-owned output must be present at some vout")
+        as u32;
+    let payout_outpoint = OutPoint {
+        txid: parent_txid,
+        vout: operator_vout,
+    };
+    // Confirm we found vout 1 (the second output we added) — the "other" payout is at
+    // vout 0, our operator output is at vout 1. If BDK added a change output, it'd be vout
+    // 2+ (but since the parent's total output value already covers most of the input, the
+    // change would also match our script — and `first_general_payout_outpoint` picks the
+    // FIRST match, which is still operator-owned). This confirms the scan returns a valid
+    // operator-owned outpoint.
+    assert_eq!(
+        operator_vout, 1,
+        "operator-owned output must be at vout 1 (the second output we added)"
+    );
+
+    let cpfp_wallet = Arc::new(OperatorWalletCpfpAdapter::new(
+        wallet.clone(),
+        operator_pubkey,
+    ));
+    let cpfp_submitter = Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone()));
+    let fee_source = Arc::new(FixedFeeSource(
+        FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
+    ));
+    let max_fee_rate = FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap();
+    let bridge_protocol_floor = FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap();
+    let anchor_input_signer = test_input_signer(operator_keypair);
+    let wallet_input_signer = test_input_signer(operator_keypair);
+
+    let ctx = CpfpContext {
+        wallet: cpfp_wallet,
+        multi_anchor_signer: test_input_signer(operator_keypair),
+        fee_source,
+        anchor_input_signer,
+        wallet_input_signer,
+        max_fee_rate,
+        package_submitter: cpfp_submitter,
+    };
+
+    let strategy = CpfpStrategy::ParentTxCombined {
+        payout_outpoint,
+        parent_fee,
+    };
+    let mut handle = CpfpHandle::default();
+    let bumped = cpfp::perform_bump(
+        &ctx,
+        &parent,
+        strategy,
+        &mut handle,
+        bridge_protocol_floor,
+        BumpReason::NewJob,
+    )
+    .await
+    .expect("perform_bump must succeed end-to-end for InferGeneralPayout shape");
+    assert!(bumped, "bump must fire at target above floor");
+
+    let child_txid = handle.last_child_txid.expect("child txid populated");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&parent_txid)
+        .await
+        .expect("mixed parent must be in mempool");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&child_txid)
+        .await
+        .expect("InferGeneralPayout child must be in mempool");
+
+    assert_package_pays_target(&bitcoind, child_txid);
+
+    let miner_addr = bitcoind.client.new_address().expect("new address");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine block");
+
+    let tip_height = async_client.get_block_count().await.expect("block count");
+    let tip_hash = async_client
+        .get_block_hash(tip_height)
+        .await
+        .expect("tip hash");
+    let tip_block = async_client.get_block(&tip_hash).await.expect("tip block");
+    let confirmed_txids: BTreeSet<_> = tip_block
+        .txdata
+        .iter()
+        .map(bitcoin::Transaction::compute_txid)
+        .collect();
+    assert!(
+        confirmed_txids.contains(&parent_txid),
+        "mixed parent must confirm in the mined block"
+    );
+    assert!(
+        confirmed_txids.contains(&child_txid),
+        "InferGeneralPayout child must confirm in the same block as the parent"
+    );
+}
+
+/// Builds a fully-signed v3 parent whose 330-sat anchor output is a real [`MultiAnchor`]
+/// connector output — a Taproot script tree with one `<wt_key> OP_CHECKSIG` leaf per
+/// watchtower over an unspendable internal key, exactly as contest / bridge-proof-timeout
+/// transactions carry it in production.
+async fn build_v3_multi_anchor_parent(
+    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    operator_keypair: Keypair,
+    anchor: &MultiAnchor,
+    parent_fee_rate: FeeRate,
+) -> Transaction {
+    let unsigned_tx = Transaction {
+        version: Version(3),
+        lock_time: absolute::LockTime::ZERO,
+        input: vec![],
+        output: vec![anchor.tx_out()],
+    };
+    let funded = {
+        let mut wallet = wallet.write().await;
+        wallet
+            .fund_v3_transaction(unsigned_tx, parent_fee_rate)
+            .await
+            .expect("fund_v3_transaction (multi-anchor parent)")
+    };
+    let mut psbt = funded.psbt;
+    sign_funding_inputs(&mut psbt, operator_keypair, &[])
+        .expect("sign multi-anchor parent funding inputs");
+    finalize_to_tx(psbt)
+}
+
+/// Builds an [`InputSigner`] that signs with the raw (untweaked) keypair — mirroring the
+/// production multi-anchor signer (secret-service `sign_no_tweak`): a Taproot script-path
+/// signature verifies against the key inside the leaf script, so no output-key tweak is
+/// applied.
+fn test_untweaked_input_signer(keypair: Keypair) -> InputSigner {
+    Arc::new(move |msg: Message| {
+        let kp = keypair;
+        Box::pin(async move {
+            let sig = Secp256k1::new().sign_schnorr_no_aux_rand(&msg, &kp);
+            Ok(sig)
+        })
+    })
+}
+
+/// E2E test for the `MultiAnchorBearing` script-path CPFP pipeline against real `bitcoind`.
+///
+/// This is the consensus-level check the unit tests can't provide: the script-path sighash
+/// (leaf-committed), the untweaked leaf signature, and the `[sig, leaf_script,
+/// control_block]` witness ordering are all validated by bitcoind's script interpreter — a
+/// wrong tweak, a wrong leaf hash, or a swapped witness item is an outright package
+/// rejection, not a silently-degraded assertion.
+#[tokio::test]
+#[serial]
+async fn cpfp_e2e_multi_anchor_against_bitcoind() {
+    let (bitcoind, async_client) = setup_bitcoind();
+    let async_client = Arc::new(async_client);
+
+    // ── 1. Keys: funding operator + two watchtowers (we are watchtower 1) ──
+    let secp = Secp256k1::new();
+    let operator_secret = SecretKey::from_slice(&[7u8; 32]).expect("valid 32-byte scalar");
+    let operator_keypair = Keypair::from_secret_key(&secp, &operator_secret);
+    let (operator_pubkey, _) = operator_keypair.x_only_public_key();
+
+    // Seven watchtowers, and we take a middle leaf — not leaf 0 (which an off-by-one that
+    // maps everything to zero would still satisfy) and not the last. The count matters as
+    // much as the index: a deeper tree means a longer control block and so a heavier child,
+    // which is exactly what a size predictor blind to anchor shape gets wrong. An earlier
+    // revision of this test used two watchtowers, the one count shallow enough that the
+    // resulting underpay slipped under the fee assertion.
+    const N_WATCHTOWERS: u8 = 7;
+    const OUR_SLOT: usize = 3;
+    let wt_keypairs: Vec<Keypair> = (0..N_WATCHTOWERS)
+        .map(|i| {
+            let secret = SecretKey::from_slice(&[11 + i; 32]).expect("valid 32-byte scalar");
+            Keypair::from_secret_key(&secp, &secret)
+        })
+        .collect();
+    let wt_pubkeys: Vec<XOnlyPublicKey> = wt_keypairs
+        .iter()
+        .map(|kp| kp.x_only_public_key().0)
+        .collect();
+    let our_wt_keypair = wt_keypairs[OUR_SLOT];
+
+    let anchor = MultiAnchor::new(Network::Regtest, wt_pubkeys, Amount::from_sat(330));
+
+    let wallet = build_operator_wallet(
+        &bitcoind,
+        operator_pubkey,
+        3,
+        Amount::from_btc(0.5).unwrap(),
+    )
+    .await;
+
+    // ── 2. v3 parent bearing the multi-anchor output ───────────────────────
+    let parent_fee_rate = FeeRate::from_sat_per_vb(PARENT_FEE_RATE_SAT_PER_VB).unwrap();
+    let parent =
+        build_v3_multi_anchor_parent(&wallet, operator_keypair, &anchor, parent_fee_rate).await;
+    assert_eq!(parent.version.0, 3, "parent must be v3 (TRUC)");
+    let parent_txid = parent.compute_txid();
+    let anchor_vout = parent
+        .output
+        .iter()
+        .position(|o| o.script_pubkey == anchor.script_pubkey())
+        .expect("multi-anchor output must exist on the parent") as u32;
+    let parent_fee = parent_fee_rate
+        .fee_vb(parent.vsize() as u64)
+        .expect("parent fee fits in Amount");
+
+    // ── 3. Our leaf + control block, as the SM duty would carry them ───────
+    let leaf_script = anchor.leaf_scripts()[OUR_SLOT].clone();
+    let control_block = anchor
+        .spend_info()
+        .control_block(&(leaf_script.clone(), taproot::LeafVersion::TapScript))
+        .expect("control block for our leaf");
+
+    // ── 4. CpfpContext: untweaked signer on the multi-anchor slot ──────────
+    //
+    // The key-path anchor signer is wired to fail: a `MultiAnchorBearing` bump must never
+    // consult it, so any routing regression surfaces as a hard test failure here too.
+    let anchor_input_signer: InputSigner = Arc::new(move |_msg: Message| {
+        Box::pin(async move {
+            Err("anchor_input_signer must not be called for a MultiAnchorBearing bump".to_string())
+        })
+    });
+    let ctx = CpfpContext {
+        wallet: Arc::new(OperatorWalletCpfpAdapter::new(
+            wallet.clone(),
+            operator_pubkey,
+        )),
+        multi_anchor_signer: test_untweaked_input_signer(our_wt_keypair),
+        fee_source: Arc::new(FixedFeeSource(
+            FeeRate::from_sat_per_vb(TEST_FEE_TARGET).unwrap(),
+        )),
+        anchor_input_signer,
+        wallet_input_signer: test_input_signer(operator_keypair),
+        max_fee_rate: FeeRate::from_sat_per_vb(TEST_FEE_CAP).unwrap(),
+        package_submitter: Arc::new(BitcoindCpfpPackageSubmitter::new(async_client.clone())),
+    };
+
+    // ── 5. perform_bump → [parent, child] package via the script path ──────
+    let strategy = CpfpStrategy::MultiAnchorBearing {
+        anchor_vout,
+        leaf_script,
+        control_block,
+        parent_fee,
+    };
+    let mut handle = CpfpHandle::default();
+    let bumped = cpfp::perform_bump(
+        &ctx,
+        &parent,
+        strategy,
+        &mut handle,
+        FeeRate::from_sat_per_vb(TEST_FLOOR).unwrap(),
+        BumpReason::NewJob,
+    )
+    .await
+    .expect("perform_bump must succeed end-to-end for MultiAnchorBearing");
+    assert!(bumped, "bump must fire at target above floor");
+
+    // ── 6. Mempool + package feerate + confirmation ────────────────────────
+    let child_txid = handle.last_child_txid.expect("child txid populated");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&parent_txid)
+        .await
+        .expect("multi-anchor parent must be in mempool");
+    let _ = async_client
+        .get_raw_transaction_verbosity_one(&child_txid)
+        .await
+        .expect("multi-anchor child must be in mempool");
+
+    assert_package_pays_target(&bitcoind, child_txid);
+
+    let miner_addr = bitcoind.client.new_address().expect("new address");
+    bitcoind
+        .client
+        .generate_to_address(1, &miner_addr)
+        .expect("mine block");
+
+    let tip_height = async_client.get_block_count().await.expect("block count");
+    let tip_hash = async_client
+        .get_block_hash(tip_height)
+        .await
+        .expect("tip hash");
+    let tip_block = async_client.get_block(&tip_hash).await.expect("tip block");
+    let confirmed_txids: BTreeSet<_> = tip_block
+        .txdata
+        .iter()
+        .map(bitcoin::Transaction::compute_txid)
+        .collect();
+    assert!(
+        confirmed_txids.contains(&parent_txid),
+        "multi-anchor parent must confirm in the mined block"
+    );
+    assert!(
+        confirmed_txids.contains(&child_txid),
+        "multi-anchor child must confirm in the same block as the parent"
+    );
+}

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -307,6 +307,10 @@ pub enum GraphDuty {
     PublishCounterProofAck {
         /// The signed counterproof ACK transaction to be published.
         signed_counter_proof_ack_tx: Transaction,
+        /// Internal key of the CPFP anchor of that transaction. It belongs to the watchtower
+        /// that this ACK is for. The executor cannot get it from the transaction, because the
+        /// output holds the tweaked key and not the internal key.
+        anchor_key: XOnlyPublicKey,
     },
 
     /// Publish a counterproof NACK on-chain to reject an invalid counterproof.

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -3,7 +3,9 @@
 
 use std::num::NonZero;
 
-use bitcoin::{OutPoint, Transaction, Txid, XOnlyPublicKey, hashes::sha256};
+use bitcoin::{
+    OutPoint, ScriptBuf, Transaction, Txid, XOnlyPublicKey, hashes::sha256, taproot::ControlBlock,
+};
 use musig2::{
     AggNonce,
     secp256k1::{Message, schnorr::Signature},
@@ -21,6 +23,25 @@ use strata_bridge_tx_graph::transactions::{
 };
 use strata_mosaic_client_api::types::CompletedSignatures;
 use zkaleido::ProofReceipt;
+
+/// Script-path CPFP material for a `MultiAnchor` anchor output.
+///
+/// `contest` and `bridge_proof_timeout` carry a `MultiAnchor` — a Taproot script tree with one
+/// `<watchtower_pubkey> OP_CHECKSIG` leaf per watchtower — rather than the bare key-path anchor
+/// every other bridge transaction uses. Bumping one is a script-path spend, so the executor needs
+/// the leaf script and its control block, and which leaf it may satisfy depends on this
+/// operator's slot in *this graph's* watchtower set. That is state-machine knowledge: the
+/// transaction alone does not reveal it, and two operators looking at identical bytes have
+/// different answers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MultiAnchorSpend {
+    /// Index of the anchor output on the parent transaction.
+    pub anchor_vout: u32,
+    /// The leaf script this operator is entitled to satisfy.
+    pub leaf_script: ScriptBuf,
+    /// Control block proving the leaf's membership in the anchor's tree.
+    pub control_block: ControlBlock,
+}
 
 /// The nag duties that can be emitted to remind operators of missing graph signing data.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -248,6 +269,11 @@ pub enum GraphDuty {
     PublishBridgeProofTimeout {
         /// The signed bridge proof timeout transaction to be published.
         signed_timeout_tx: Transaction,
+
+        /// Script-path CPFP material for this operator's watchtower leaf on the timeout's
+        /// `MultiAnchor`, or `None` when this operator owns the graph and therefore holds no
+        /// leaf. `None` means "publish without fee bumping", not an error.
+        cpfp_anchor: Option<MultiAnchorSpend>,
     },
 
     /// Evaluate a bridge proof and, if warranted, generate and publish a counterproof.

--- a/crates/bridge-sm/src/graph/tests/duties.rs
+++ b/crates/bridge-sm/src/graph/tests/duties.rs
@@ -129,6 +129,7 @@ mod tests {
             (
                 GraphDuty::PublishBridgeProofTimeout {
                     signed_timeout_tx: TestGraphTxKind::BridgeProofTimeout.into(),
+                    cpfp_anchor: None,
                 },
                 false,
             ),
@@ -148,6 +149,7 @@ mod tests {
             (
                 GraphDuty::PublishCounterProofAck {
                     signed_counter_proof_ack_tx: TestGraphTxKind::CounterproofAck.into(),
+                    anchor_key: strata_bridge_test_utils::bitcoin::generate_xonly_pubkey(),
                 },
                 false,
             ),

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -7,6 +7,7 @@ pub(super) mod utils;
 
 mod deposit_signal;
 mod duties;
+mod multi_anchor;
 mod notify_new_block;
 mod post_processor;
 mod process_payout;

--- a/crates/bridge-sm/src/graph/tests/multi_anchor.rs
+++ b/crates/bridge-sm/src/graph/tests/multi_anchor.rs
@@ -1,0 +1,132 @@
+//! Tests for resolving the `MultiAnchor` CPFP leaf a given operator may satisfy.
+
+use bitcoin::{opcodes, script, secp256k1::SECP256K1};
+use strata_bridge_connectors::{Connector, ParentTx, prelude::MultiAnchor};
+use strata_bridge_primitives::types::GraphIdx;
+
+use crate::graph::{
+    context::GraphSMCtx,
+    machine::generate_game_graph,
+    tests::{
+        N_TEST_OPERATORS, TEST_DEPOSIT_IDX, TEST_NONPOV_IDX, TEST_POV_IDX, test_deposit_params,
+        test_graph_sm_cfg, test_graph_sm_ctx, test_operator_table,
+    },
+    watchtower::multi_anchor_spend_for_pov,
+};
+
+/// A context for the same graph, but viewed by an operator that does *not* own it.
+fn watchtower_pov_ctx() -> GraphSMCtx {
+    GraphSMCtx {
+        graph_idx: GraphIdx {
+            deposit: TEST_DEPOSIT_IDX,
+            operator: TEST_POV_IDX,
+        },
+        operator_table: test_operator_table(N_TEST_OPERATORS, TEST_NONPOV_IDX),
+        ..test_graph_sm_ctx()
+    }
+}
+
+/// An operator is never a watchtower of its own graph, so it holds no leaf on the anchor and
+/// cannot bump these transactions at all. This is the case executor-side inference could not
+/// express: the transaction bytes are identical whoever is looking at them.
+#[test]
+fn graph_owner_has_no_leaf() {
+    let cfg = test_graph_sm_cfg();
+    let ctx = test_graph_sm_ctx();
+    let game_graph = generate_game_graph(&cfg, &ctx, &test_deposit_params());
+
+    for (label, spend) in [
+        (
+            "contest",
+            multi_anchor_spend_for_pov(
+                &game_graph.contest,
+                ctx.operator_idx(),
+                ctx.operator_table().pov_idx(),
+            ),
+        ),
+        (
+            "bridge_proof_timeout",
+            multi_anchor_spend_for_pov(
+                &game_graph.bridge_proof_timeout,
+                ctx.operator_idx(),
+                ctx.operator_table().pov_idx(),
+            ),
+        ),
+    ] {
+        assert!(
+            spend.is_none(),
+            "{label}: graph owner must not resolve a watchtower leaf"
+        );
+    }
+}
+
+/// A watchtower of the graph resolves the leaf at its own dense slot, and the resolved leaf must
+/// be the one the anchor actually commits to at that index — a mismatch would produce a witness
+/// that fails script validation at broadcast.
+#[test]
+fn watchtower_resolves_its_own_leaf() {
+    let cfg = test_graph_sm_cfg();
+    let owner_ctx = test_graph_sm_ctx();
+    let wt_ctx = watchtower_pov_ctx();
+    let game_graph = generate_game_graph(&cfg, &owner_ctx, &test_deposit_params());
+
+    let expected_slot =
+        crate::graph::watchtower::watchtower_slot_for_operator(TEST_POV_IDX, TEST_NONPOV_IDX)
+            .expect("non-owner maps to a watchtower slot");
+
+    for (label, anchor, spend) in [
+        (
+            "contest",
+            game_graph.contest.cpfp_connector(),
+            multi_anchor_spend_for_pov(
+                &game_graph.contest,
+                wt_ctx.operator_idx(),
+                wt_ctx.operator_table().pov_idx(),
+            ),
+        ),
+        (
+            "bridge_proof_timeout",
+            game_graph.bridge_proof_timeout.cpfp_connector(),
+            multi_anchor_spend_for_pov(
+                &game_graph.bridge_proof_timeout,
+                wt_ctx.operator_idx(),
+                wt_ctx.operator_table().pov_idx(),
+            ),
+        ),
+    ] {
+        let spend = spend.unwrap_or_else(|| panic!("{label}: watchtower must resolve a leaf"));
+        let anchor: &MultiAnchor = anchor;
+
+        // Index agreement is necessary but not sufficient — asserting only that we picked
+        // `leaf_scripts()[slot]` would just restate what the function computes. What actually
+        // matters is that the leaf we will sign commits to *our own* key: a slot/ordering
+        // mismatch would still index in range but hand us another watchtower's leaf, and the
+        // signature would fail script validation at broadcast.
+        let our_key = wt_ctx.operator_table().pov_btc_key().x_only_public_key().0;
+        let expected_leaf = script::Builder::new()
+            .push_slice(our_key.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+        assert_eq!(
+            spend.leaf_script, expected_leaf,
+            "{label}: resolved leaf must commit to this operator's own key"
+        );
+        assert_eq!(
+            spend.leaf_script,
+            anchor.leaf_scripts()[expected_slot],
+            "{label}: and must sit at the slot the state machine computed"
+        );
+
+        // The control block must verify against the anchor's own output key, otherwise the
+        // witness is rejected at broadcast. This is the assertion that would actually catch a
+        // tree/ordering mismatch.
+        assert!(
+            spend.control_block.verify_taproot_commitment(
+                SECP256K1,
+                anchor.spend_info().output_key().to_x_only_public_key(),
+                &spend.leaf_script,
+            ),
+            "{label}: control block must verify against the anchor's output key"
+        );
+    }
+}

--- a/crates/bridge-sm/src/graph/tests/notify_new_block.rs
+++ b/crates/bridge-sm/src/graph/tests/notify_new_block.rs
@@ -4,6 +4,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use musig2::secp256k1::schnorr::Signature;
+    use strata_bridge_connectors::{Connector, ParentTx};
     use strata_bridge_test_utils::bitcoin::generate_txid;
     use strata_bridge_tx_graph::musig_functor::GameFunctor;
 
@@ -866,6 +867,10 @@ mod tests {
         let signatures = mock_game_signatures(&game_graph);
         let sigs = GameFunctor::unpack(signatures.clone(), ctx.watchtower_pubkeys().len())
             .expect("Failed to unpack signatures");
+        let anchor_key = game_graph.counterproofs[watchtower_slot]
+            .counterproof_ack
+            .cpfp_connector()
+            .internal_key();
         let signed_counter_proof_ack_tx = game_graph.counterproofs[watchtower_slot]
             .counterproof_ack
             .clone()
@@ -893,6 +898,7 @@ mod tests {
                 ),
                 expected_duties: vec![GraphDuty::PublishCounterProofAck {
                     signed_counter_proof_ack_tx,
+                    anchor_key,
                 }],
                 expected_signals: vec![],
             },

--- a/crates/bridge-sm/src/graph/tests/notify_new_block.rs
+++ b/crates/bridge-sm/src/graph/tests/notify_new_block.rs
@@ -28,7 +28,7 @@ mod tests {
                 test_graph_sm_cfg, test_graph_sm_ctx, test_graph_summary, test_graph_transition,
                 test_recipient_desc,
             },
-            watchtower::watchtower_slot_for_operator,
+            watchtower::{multi_anchor_spend_for_pov, watchtower_slot_for_operator},
         },
         testing::test_transition,
     };
@@ -253,6 +253,11 @@ mod tests {
             GameFunctor::unpack(signatures.clone(), ctx.watchtower_pubkeys().len())
                 .expect("Failed to unpack signatures")
                 .bridge_proof_timeout;
+        let cpfp_anchor = multi_anchor_spend_for_pov(
+            &game_graph.bridge_proof_timeout,
+            ctx.operator_idx(),
+            ctx.operator_table().pov_idx(),
+        );
         let signed_timeout_tx = game_graph
             .bridge_proof_timeout
             .finalize(bridge_proof_timeout_sigs);
@@ -267,7 +272,10 @@ mod tests {
                     block_height: new_height,
                 }),
                 expected_state: contested_state_with(new_height, signatures),
-                expected_duties: vec![GraphDuty::PublishBridgeProofTimeout { signed_timeout_tx }],
+                expected_duties: vec![GraphDuty::PublishBridgeProofTimeout {
+                    signed_timeout_tx,
+                    cpfp_anchor,
+                }],
                 expected_signals: vec![],
             },
         );
@@ -679,6 +687,13 @@ mod tests {
             GameFunctor::unpack(signatures.clone(), ctx.watchtower_pubkeys().len())
                 .expect("Failed to unpack signatures")
                 .bridge_proof_timeout;
+        // This case drives a non-POV state machine: the POV operator is a *watchtower* of this
+        // graph, not its owner, so it does hold a leaf on the timeout's `MultiAnchor`.
+        let cpfp_anchor = multi_anchor_spend_for_pov(
+            &game_graph.bridge_proof_timeout,
+            ctx.operator_idx(),
+            TEST_NONPOV_IDX,
+        );
         let signed_timeout_tx = game_graph
             .bridge_proof_timeout
             .finalize(bridge_proof_timeout_sigs);
@@ -706,7 +721,10 @@ mod tests {
                     signatures,
                     BTreeMap::new(),
                 ),
-                expected_duties: vec![GraphDuty::PublishBridgeProofTimeout { signed_timeout_tx }],
+                expected_duties: vec![GraphDuty::PublishBridgeProofTimeout {
+                    signed_timeout_tx,
+                    cpfp_anchor,
+                }],
                 expected_signals: vec![],
             },
         );

--- a/crates/bridge-sm/src/graph/transitions/common.rs
+++ b/crates/bridge-sm/src/graph/transitions/common.rs
@@ -12,7 +12,7 @@ use crate::graph::{
     events::NewBlockEvent,
     machine::{GSMOutput, GraphSM, unpack_game},
     state::GraphState,
-    watchtower::watchtower_slot_for_operator,
+    watchtower::{multi_anchor_spend_for_pov, watchtower_slot_for_operator},
 };
 
 impl GraphSM {
@@ -138,12 +138,24 @@ impl GraphSM {
                 // narrowing.
                 if new_block_event.block_height > *contest_block_height + proof_timelock {
                     let (game_graph, sigs) = unpack_game(&cfg, &graph_ctx, graph_data, signatures);
+                    // Resolve our watchtower leaf on the timeout's `MultiAnchor` before
+                    // finalizing. `None` here is legitimate: an operator is never a watchtower of
+                    // its own graph, so when the owner publishes its own timeout there is no leaf
+                    // to satisfy and the transaction goes out without CPFP.
+                    let cpfp_anchor = multi_anchor_spend_for_pov(
+                        &game_graph.bridge_proof_timeout,
+                        graph_ctx.operator_idx(),
+                        graph_ctx.operator_table().pov_idx(),
+                    );
                     let signed_timeout_tx = game_graph
                         .bridge_proof_timeout
                         .finalize(sigs.bridge_proof_timeout);
 
                     return Ok(GSMOutput::with_duties(vec![
-                        GraphDuty::PublishBridgeProofTimeout { signed_timeout_tx },
+                        GraphDuty::PublishBridgeProofTimeout {
+                            signed_timeout_tx,
+                            cpfp_anchor,
+                        },
                     ]));
                 }
 
@@ -255,12 +267,24 @@ impl GraphSM {
                     && new_block_event.block_height > *contest_block_height + proof_timelock
                 {
                     let (game_graph, sigs) = unpack_game(&cfg, &graph_ctx, graph_data, signatures);
+                    // Resolve our watchtower leaf on the timeout's `MultiAnchor` before
+                    // finalizing. `None` here is legitimate: an operator is never a watchtower of
+                    // its own graph, so when the owner publishes its own timeout there is no leaf
+                    // to satisfy and the transaction goes out without CPFP.
+                    let cpfp_anchor = multi_anchor_spend_for_pov(
+                        &game_graph.bridge_proof_timeout,
+                        graph_ctx.operator_idx(),
+                        graph_ctx.operator_table().pov_idx(),
+                    );
                     let signed_timeout_tx = game_graph
                         .bridge_proof_timeout
                         .finalize(sigs.bridge_proof_timeout);
 
                     return Ok(GSMOutput::with_duties(vec![
-                        GraphDuty::PublishBridgeProofTimeout { signed_timeout_tx },
+                        GraphDuty::PublishBridgeProofTimeout {
+                            signed_timeout_tx,
+                            cpfp_anchor,
+                        },
                     ]));
                 }
 

--- a/crates/bridge-sm/src/graph/transitions/common.rs
+++ b/crates/bridge-sm/src/graph/transitions/common.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use musig2::secp256k1::schnorr::Signature;
+use strata_bridge_connectors::{Connector, ParentTx};
 use strata_bridge_primitives::types::BitcoinBlockHeight;
 use strata_bridge_tx_graph::game_graph::DepositParams;
 
@@ -337,6 +338,11 @@ impl GraphSM {
                     )
                 });
 
+                // The anchor key comes from the connector that built the anchor output.
+                let anchor_key = counterproof_graph
+                    .counterproof_ack
+                    .cpfp_connector()
+                    .internal_key();
                 let signed_counter_proof_ack_tx = counterproof_graph
                     .counterproof_ack
                     .clone()
@@ -345,6 +351,7 @@ impl GraphSM {
                 Ok(GSMOutput::with_duties(vec![
                     GraphDuty::PublishCounterProofAck {
                         signed_counter_proof_ack_tx,
+                        anchor_key,
                     },
                 ]))
             }

--- a/crates/bridge-sm/src/graph/watchtower.rs
+++ b/crates/bridge-sm/src/graph/watchtower.rs
@@ -5,7 +5,11 @@
 //! except the owner. These helpers convert between the two numbering
 //! schemes.
 
+use bitcoin::taproot::LeafVersion;
+use strata_bridge_connectors::{Connector, ParentTx, prelude::MultiAnchor};
 use strata_bridge_primitives::types::OperatorIdx;
+
+use crate::graph::duties::MultiAnchorSpend;
 
 /// Maps a zero-based watchtower slot back to the full operator index,
 /// accounting for the graph owner being excluded from the watchtower list.
@@ -37,6 +41,34 @@ pub(crate) const fn watchtower_slot_for_operator(
     } else {
         Some(operator_idx as usize - 1)
     }
+}
+
+/// Resolves the [`MultiAnchorSpend`] this operator may use to bump `tx`.
+///
+/// Returns `None` when the point-of-view operator owns the graph — an operator is never a
+/// watchtower of its own graph, so it holds no leaf and cannot bump these transactions at all.
+/// Callers must treat that as "publish without CPFP" rather than as an error: it is a legitimate
+/// protocol position, reached whenever the owner publishes its own bridge-proof timeout.
+pub(crate) fn multi_anchor_spend_for_pov<T>(
+    tx: &T,
+    graph_owner_idx: OperatorIdx,
+    pov_idx: OperatorIdx,
+) -> Option<MultiAnchorSpend>
+where
+    T: ParentTx<CpfpConnector = MultiAnchor>,
+{
+    let leaf_index = watchtower_slot_for_operator(graph_owner_idx, pov_idx)?;
+    let anchor = tx.cpfp_connector();
+    let leaf_script = anchor.leaf_scripts().into_iter().nth(leaf_index)?;
+    let control_block = anchor
+        .spend_info()
+        .control_block(&(leaf_script.clone(), LeafVersion::TapScript))?;
+
+    Some(MultiAnchorSpend {
+        anchor_vout: tx.cpfp_outpoint().vout,
+        leaf_script,
+        control_block,
+    })
 }
 
 #[cfg(test)]

--- a/crates/bridge-sm/src/stake/duties.rs
+++ b/crates/bridge-sm/src/stake/duties.rs
@@ -27,6 +27,10 @@ pub enum StakeDuty {
         operator_idx: OperatorIdx,
         /// The unsigned stake transaction.
         tx: Transaction,
+        /// Internal key of the CPFP anchor of `tx`. The executor cannot get it from the
+        /// transaction, because the output holds the tweaked key and not the internal key.
+        /// The state machine builds the anchor, so it reports the key with the duty.
+        anchor_key: XOnlyPublicKey,
     },
     /// Publish the nonces for a given operator.
     PublishUnstakingNonces {

--- a/crates/bridge-sm/src/stake/handlers/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/handlers/retry_tick.rs
@@ -1,3 +1,4 @@
+use strata_bridge_connectors::{Connector, ParentTx};
 use strata_bridge_tx_graph::stake_graph::StakeGraph;
 
 use crate::{
@@ -24,6 +25,7 @@ impl StakeSM {
                 vec![StakeDuty::PublishStake {
                     operator_idx: self.context().operator_idx(),
                     tx: stake_graph.stake.as_ref().clone(),
+                    anchor_key: stake_graph.stake.cpfp_connector().internal_key(),
                 }]
             }
             _ => Vec::new(),

--- a/crates/bridge-sm/src/stake/tests/retry_tick.rs
+++ b/crates/bridge-sm/src/stake/tests/retry_tick.rs
@@ -1,5 +1,7 @@
 //! Unit tests for [`StakeSM::process_retry_tick`].
 
+use strata_bridge_connectors::{Connector, ParentTx};
+
 use super::*;
 use crate::stake::{duties::StakeDuty, events::RetryTickEvent, state::StakeState};
 
@@ -18,6 +20,7 @@ fn retry_publish_stake() {
         expected_duties: vec![StakeDuty::PublishStake {
             operator_idx: TEST_POV_IDX,
             tx: stake_graph.stake.as_ref().clone(),
+            anchor_key: stake_graph.stake.cpfp_connector().internal_key(),
         }],
     });
 }

--- a/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/tests/unstaking_partials_received.rs
@@ -1,5 +1,7 @@
 //! Unit tests for [`StakeSM::process_unstaking_partials_received`].
 
+use strata_bridge_connectors::{Connector, ParentTx};
+
 use super::*;
 use crate::stake::{errors::SSMError, events::UnstakingPartialsReceivedEvent, state::StakeState};
 
@@ -92,6 +94,7 @@ fn accept_partials_all_collected_pov() {
         expected_duties: vec![StakeDuty::PublishStake {
             operator_idx: 0,
             tx: TEST_GRAPH.stake.as_ref().clone(),
+            anchor_key: TEST_GRAPH.stake.cpfp_connector().internal_key(),
         }],
         expected_signals: vec![],
     });

--- a/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/unstaking_partials_received.rs
@@ -1,4 +1,5 @@
 use musig2::{aggregate_partial_signatures, verify_partial};
+use strata_bridge_connectors::{Connector, ParentTx};
 use strata_bridge_primitives::key_agg::create_agg_ctx;
 use strata_bridge_tx_graph::{musig_functor::StakeFunctor, stake_graph::StakeGraph};
 
@@ -137,10 +138,12 @@ impl StakeSM {
 
                     if context.operator_idx() == context.operator_table().pov_idx() {
                         let stake_graph = StakeGraph::new(stake_data.expand(*cfg, &context));
+                        let anchor_key = stake_graph.stake.cpfp_connector().internal_key();
                         let stake_tx = stake_graph.stake.as_ref().clone();
                         duties.push(StakeDuty::PublishStake {
                             operator_idx: context.operator_idx(),
                             tx: stake_tx,
+                            anchor_key,
                         });
                     }
 

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -195,19 +195,21 @@ pub enum CpfpWalletError {
 /// What one call to [`perform_bump`] achieved.
 ///
 /// A caller that must decide the fate of a transaction needs more than "no package went
-/// out". A bump that stands down because a competitor's child already covers a shared
-/// anchor proves that the parent is in a mempool, and a bump that skips because no child is
-/// needed proves nothing about the parent at all.
+/// out". A bump that stands down because a live child already holds an output of the
+/// parent proves that the parent is in a mempool, and a bump that skips because no child
+/// is needed proves no publication failure: the next trigger retries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BumpOutcome {
     /// A `[parent, child]` package reached the mempool.
     Submitted,
-    /// No package went out, and the bump observed the parent in a mempool or in a block. A
-    /// competitor's child holds the shared anchor, or the anchor is spent by a confirmed
-    /// transaction.
+    /// No package went out, and the bump observed the parent in a mempool: a live child
+    /// holds an output of this parent.
     ParentIsLive,
-    /// No package went out, and the bump observed nothing about where the parent is. The
-    /// target sits at the protocol floor, or the parent's own fee already meets it.
+    /// No package went out, and the bump saw that a child is not needed: the target sits
+    /// at the protocol floor, the parent's own fee already meets it, a live child already
+    /// meets it, or the output is spent by a confirmed transaction. A failed attempt, or
+    /// a replacement race lost to a conflicting transaction, reports the same outcome; the
+    /// next trigger retries.
     NoChildNeeded,
     /// The parent cannot carry a child at all. Every later bump for it fails the same way, so
     /// the driver stops bumping it and lets the bare paths carry it.
@@ -585,19 +587,25 @@ impl CpfpFeeSource for CachedFeeSource {
     }
 }
 
-/// What already spends a CPFP anchor, if anything.
+/// What already spends the output a CPFP child would spend, if anything.
 ///
-/// A `MultiAnchor` anchor is shared. Every watchtower of the graph holds a leaf on it, and
-/// every one of them bumps the same output. The bump loop reads this state before it builds,
-/// so that a watchtower which has already lost the anchor stops paying to lose it again.
+/// The bump loop probes this state before every build, for every strategy. The probed
+/// output is the anchor for the anchor-bearing strategies, and the payout output for
+/// `ParentTxCombined`.
+///
+/// A `MultiAnchor` anchor is shared: every watchtower of the graph holds a leaf on it, and
+/// every one of them bumps the same output. The probe keeps a watchtower that has already
+/// lost the anchor from paying to lose it again. Every other output is exclusive to this
+/// operator: the spender, if any, is this operator's own prior child or, for a payout
+/// output, a concurrent duty transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnchorSpendState {
-    /// Nothing spends the anchor. This operator can bump.
+    /// Nothing in the mempool spends the output. This operator can bump.
     Unspent,
-    /// A mempool transaction spends the anchor, and its package pays this rate.
+    /// A mempool transaction spends the output, and its package pays this rate.
     SpentInMempool {
         /// Txid of the spending child. The bump loop compares it against its own last
-        /// child. A foreign spender means this operator's child lost the anchor, and the
+        /// child. A foreign spender means this operator's child lost the output, and the
         /// bump loop must release the child's funding leases. Our own spender means the
         /// leases must stay: a release lets a concurrent build double-spend the live
         /// child's funding and evict it.
@@ -605,7 +613,10 @@ pub enum AnchorSpendState {
         /// Package fee rate the spending child's ancestor set pays.
         pkg_fee_rate: FeeRate,
     },
-    /// A confirmed transaction spends the anchor. No child can improve the parent now.
+    /// A confirmed transaction spends the output. No child can improve the parent now.
+    ///
+    /// The mempool-only probe cannot observe a confirmed spend: it reads `Unspent` for one.
+    /// This variant exists for backends with chain visibility.
     Confirmed,
 }
 
@@ -619,11 +630,12 @@ pub trait CpfpMempool: Send + Sync + fmt::Debug {
         Output = Result<submitpackage::SubmitPackageSummary, SubmitPackageError>,
     > + Send;
 
-    /// Reports what already spends `anchor`.
+    /// Reports what already spends `anchor`, the output the bump would spend.
     ///
-    /// The bump loop calls this only for a shared anchor, and treats an error as
-    /// [`AnchorSpendState::Unspent`]. A failed lookup must not stop a bump, because the
-    /// submission itself is the authority on whether the package is acceptable.
+    /// The bump loop calls this before every build, for every strategy, and treats an
+    /// error as [`AnchorSpendState::Unspent`]. A failed lookup must not stop a bump,
+    /// because the submission itself is the authority on whether the package is
+    /// acceptable.
     fn anchor_spend_state(
         &self,
         anchor: OutPoint,
@@ -801,8 +813,10 @@ impl BumpReason {
 /// [`CpfpError`].
 ///
 /// Same-rate calls are a no-op only for [`BumpReason::NewJob`]; reactive reasons
-/// (block/tick/eviction) rebuild the child even at an unchanged target, because a child
-/// evicted by a competing package is invisible to us — see step 4 below.
+/// (block/tick/eviction) rebuild the child at an unchanged target unless the probe
+/// (step 4.5) shows a child already spends the output at a sufficient rate, because a
+/// child evicted by a competing package is invisible to us apart from that probe — see
+/// step 4 below.
 ///
 /// `handle.last_child_lease` takes the new lease as soon as the wallet hands back a funded
 /// child, and not only on success. The handle must own the lease across the fallible steps
@@ -819,7 +833,7 @@ impl BumpReason {
 ///
 /// ## Baseline skips
 ///
-/// Two conditions mean the parent needs no child at all (both return `Ok(false)`):
+/// Two conditions mean the parent needs no child at all (both return `NoChildNeeded`):
 /// - the fee source reports `≤ bridge_protocol_floor` — the presigned parent's protocol-floor fee
 ///   rate is already sufficient;
 /// - the parent's own fee (`strategy.parent_fee()` over its vbytes) already meets the target — a
@@ -892,13 +906,16 @@ where
 
     // ── 4. Skip if we already bumped at this rate (eager only) ──────────────
     //
-    // Reactive bumps (new block / tick / parent eviction) DO rebuild at the same rate:
-    // the previous child may have been silently evicted from the mempool by a competing
-    // replacement, and the only signal we get is the absence of confirmation. A same-rate
-    // resubmission either dedups against the still-present child (`txn-already-in-mempool`
-    // is fine inside `submitpackage`) or, if the rebuilt child differs, gets rejected by
-    // the BIP-125 incremental-fee rule — a logged, harmless failure. We accept that noise
-    // because it's the only way to revive a package whose child is actually gone.
+    // Reactive bumps (new block / tick / parent eviction) DO rebuild at the same rate when
+    // the probe below reports the output unspent: the previous child may have been silently
+    // evicted from the mempool by a competing replacement, and the probe is the only signal
+    // of that. When the probe shows the child still spends the output at a sufficient rate,
+    // step 4.5 skips the build, and the steady-state cost of a reactive attempt is the
+    // probe itself. A same-rate resubmission that does run either dedups against the
+    // still-present child (`txn-already-in-mempool` is fine inside `submitpackage`) or, if
+    // the rebuilt child differs, gets rejected by the BIP-125 incremental-fee rule — a
+    // logged, harmless failure. That is the price of reviving a package whose child is
+    // actually gone.
     if reason.skip_on_same_rate() {
         if let Some(prev) = handle.last_pkg_fee_rate {
             if target <= prev {
@@ -914,73 +931,87 @@ where
         }
     }
 
-    // ── 4.5 Skip when another watchtower already covers a shared anchor ─────
+    // ── 4.5 Probe the output the child would spend ──────────────────────────
     //
-    // Only `MultiAnchorBearing` reaches this check. Every other anchor belongs to one
-    // operator, so nobody else can spend it.
+    // The probe runs before every build, for every strategy. One `gettxspendingprevout`
+    // call answers "is the child still there at a sufficient rate", and the build runs
+    // only when the answer is no.
     //
-    // A `MultiAnchor` output carries one leaf per watchtower, and every watchtower bumps the
-    // same output. Their children conflict, so one wins each round and the rest are rejected.
-    // Without this check the losers rebuild, re-sign, and resubmit on every trigger, for as
-    // long as the parent stays unconfirmed. Each of those attempts costs a signing round trip
-    // and leaves a warning in the log.
+    // The probed output is the one the child would spend. For `MultiAnchorBearing` it is
+    // shared: every watchtower of the graph holds a leaf on it and bumps the same output.
+    // Their children conflict, so one wins each round and the rest are rejected. Without
+    // this probe the losers rebuild, re-sign, and resubmit on every trigger, for as long
+    // as the parent stays unconfirmed. Each of those attempts costs a signing round trip
+    // and leaves a warning in the log. Every other strategy probes an exclusive output:
+    // the spender, if any, is our own prior child or, for a payout output, a concurrent
+    // duty transaction — bounded, because the child's lease holds the payout output out
+    // of selection while the child spends it.
     //
-    // The check is not a lock. Two watchtowers can read `Unspent` in the same instant and both
-    // build. That race is bounded to one round, because the loser observes the winner on the
-    // next trigger. The submission remains the authority, and `perform_bump` still handles a
-    // rejection.
-    if let CpfpStrategy::MultiAnchorBearing { anchor_vout, .. } = &strategy {
-        let anchor = OutPoint {
+    // Steady state is every parent carrying a live child: the probe skips the build, so a
+    // reactive attempt costs the probe and no wallet call. The floor reduction retires
+    // the floor skip of step 3, so this is where the quiet-mempool trigger ends.
+    //
+    // The probe is not a lock. Two builders can read `Unspent` in the same instant and
+    // both build. That race is bounded to one round, because the loser observes the
+    // winner on the next trigger. Submission is the authority, and `perform_bump` still
+    // handles a rejection.
+    let probed = match &strategy {
+        CpfpStrategy::AnchorBearing { anchor_vout, .. }
+        | CpfpStrategy::MultiAnchorBearing { anchor_vout, .. } => OutPoint {
             txid: parent_txid,
             vout: *anchor_vout,
-        };
-        // An error here is not fatal. The lookup is an optimisation, so fall through to the
-        // build and let the submission decide.
-        match ctx.mempool.anchor_spend_state(anchor).await {
-            Ok(AnchorSpendState::SpentInMempool {
-                spender,
-                pkg_fee_rate: existing,
-            }) if existing >= target => {
-                // This skip ends the bump sequence, so the `replacing` hand-over of the
-                // next build never runs. Drop the lease of the last child here instead,
-                // but only when the winning child is not ours. When our own child holds
-                // the anchor at the target, its funding must stay held. A release at that
-                // point lets a concurrent build double-spend the funding and evict our own
-                // child.
-                if handle.last_child_txid != Some(spender) {
-                    handle.last_child_lease = None;
-                    handle.last_child_txid = None;
-                    handle.last_child_fee = None;
-                }
-                debug!(
-                    %parent_txid,
-                    ?target,
-                    ?existing,
-                    %spender,
-                    "anchor already bumped to the target; skipping"
-                );
-                // A child spends this parent's anchor, so the parent is in a mempool.
-                return Ok(BumpOutcome::ParentIsLive);
-            }
-            Ok(AnchorSpendState::Confirmed) => {
-                // The parent is confirmed. If a competitor's child won, this release
-                // frees our dead child's funding. If our child won, its funding is spent
-                // on-chain and the release has one bounded side effect: until the next
-                // sync, `list_unspent` still lists those outpoints, so builds can select
-                // a spent input and be rejected. A sync ends the window.
+        },
+        CpfpStrategy::ParentTxCombined {
+            payout_outpoint, ..
+        } => *payout_outpoint,
+    };
+    // An error here is not fatal. The lookup is an optimisation, so fall through to the
+    // build and let the submission decide.
+    match ctx.mempool.anchor_spend_state(probed).await {
+        Ok(AnchorSpendState::SpentInMempool {
+            spender,
+            pkg_fee_rate: existing,
+        }) if existing >= target => {
+            // This skip ends the bump sequence, so the `replacing` hand-over of the
+            // next build never runs. Drop the lease of the last child here instead,
+            // but only when the winning child is not ours. When our own child holds
+            // the output at the target, its funding must stay held. A release at that
+            // point lets a concurrent build double-spend the funding and evict our own
+            // child.
+            if handle.last_child_txid != Some(spender) {
                 handle.last_child_lease = None;
                 handle.last_child_txid = None;
                 handle.last_child_fee = None;
-                debug!(
-                    %parent_txid,
-                    "anchor already spent by a confirmed transaction; skipping"
-                );
-                return Ok(BumpOutcome::NoChildNeeded);
             }
-            Ok(_) => {}
-            Err(e) => {
-                debug!(%parent_txid, error = %e, "anchor spend lookup failed; building anyway");
-            }
+            debug!(
+                %parent_txid,
+                ?target,
+                ?existing,
+                %spender,
+                "probed output already bumped to the target; skipping"
+            );
+            // A child spends an output of this parent, so the parent is in a mempool.
+            return Ok(BumpOutcome::ParentIsLive);
+        }
+        Ok(AnchorSpendState::Confirmed) => {
+            // A confirmed spend means the winning child's funding is on-chain (our own
+            // child) or our child is dead (a competitor). Either way holding the lease
+            // serves nothing, and the next sync prunes it. The release has one bounded
+            // side effect until that sync: `list_unspent` may still list the spent
+            // outpoint, so a build that selects it is rejected. The rejection is
+            // self-healing.
+            handle.last_child_lease = None;
+            handle.last_child_txid = None;
+            handle.last_child_fee = None;
+            debug!(
+                %parent_txid,
+                "probed output already spent by a confirmed transaction; skipping"
+            );
+            return Ok(BumpOutcome::NoChildNeeded);
+        }
+        Ok(_) => {}
+        Err(e) => {
+            debug!(%parent_txid, error = %e, "anchor spend lookup failed; building anyway");
         }
     }
 
@@ -1381,6 +1412,10 @@ pub(crate) mod tests {
         pub(crate) tx_errors: Mutex<Vec<(Txid, String)>>,
         pub(crate) captured: Mutex<Vec<Vec<Transaction>>>,
         pub(crate) spend_state: Mutex<AnchorSpendState>,
+        /// Error the probe reports, when set.
+        pub(crate) probe_error: Mutex<Option<String>>,
+        /// Every outpoint the probe was asked about, in call order.
+        pub(crate) probed: Mutex<Vec<OutPoint>>,
     }
     impl FakeSubmitter {
         pub(crate) fn ok() -> Self {
@@ -1392,6 +1427,8 @@ pub(crate) mod tests {
                 tx_errors: Mutex::new(Vec::new()),
                 captured: Mutex::new(Vec::new()),
                 spend_state: Mutex::new(AnchorSpendState::Unspent),
+                probe_error: Mutex::new(None),
+                probed: Mutex::new(Vec::new()),
             }
         }
         pub(crate) fn failing(reason: &str) -> Self {
@@ -1400,11 +1437,22 @@ pub(crate) mod tests {
                 tx_errors: Mutex::new(Vec::new()),
                 captured: Mutex::new(Vec::new()),
                 spend_state: Mutex::new(AnchorSpendState::Unspent),
+                probe_error: Mutex::new(None),
+                probed: Mutex::new(Vec::new()),
             }
         }
         pub(crate) fn with_spend_state(self, state: AnchorSpendState) -> Self {
             *self.spend_state.lock().unwrap() = state;
             self
+        }
+        /// Makes the probe fail, so a test exercises the build-on-probe-error path.
+        pub(crate) fn with_failing_probe(self, reason: &str) -> Self {
+            *self.probe_error.lock().unwrap() = Some(reason.to_string());
+            self
+        }
+        /// The outpoints the probe was asked about, in call order.
+        pub(crate) fn probed(&self) -> Vec<OutPoint> {
+            self.probed.lock().unwrap().clone()
         }
         /// Attaches a per-tx error string to the rejection that this fake reports.
         pub(crate) fn with_tx_error(self, txid: Txid, err: &str) -> Self {
@@ -1437,13 +1485,18 @@ pub(crate) mod tests {
         }
 
         /// Reports the configured spend state (default: unspent, so tests exercise the
-        /// build path). The full contention flow is covered end to end against a live
-        /// bitcoind; the unit tests use [`FakeSubmitter::with_spend_state`] to pin the
-        /// lease bookkeeping on the skip paths.
+        /// build path), or the configured probe error. The full contention flow is
+        /// covered end to end against a live bitcoind; the unit tests use
+        /// [`FakeSubmitter::with_spend_state`] to pin the lease bookkeeping on the skip
+        /// paths.
         async fn anchor_spend_state(
             &self,
-            _anchor: OutPoint,
+            anchor: OutPoint,
         ) -> Result<AnchorSpendState, MempoolError> {
+            self.probed.lock().unwrap().push(anchor);
+            if let Some(err) = self.probe_error.lock().unwrap().clone() {
+                return Err(MempoolError(err));
+            }
             Ok(*self.spend_state.lock().unwrap())
         }
     }
@@ -1619,9 +1672,10 @@ pub(crate) mod tests {
         }
     }
 
-    /// A minimal one-leaf `MultiAnchorBearing` strategy. The step-4.5 contention skip is
-    /// gated on this variant, so the lease-release tests need a structurally valid leaf +
-    /// control block even though the skip never spends the anchor.
+    /// A minimal one-leaf `MultiAnchorBearing` strategy. The step-4.5 probe runs for every
+    /// strategy; the contention tests use this variant to cover the shared-anchor path.
+    /// The leaf and control block stay structurally valid even though the skip paths never
+    /// spend the anchor.
     fn multi_anchor_strategy(anchor_key: XOnlyPublicKey) -> CpfpStrategy {
         let leaf = script::Builder::new()
             .push_slice(anchor_key.serialize())
@@ -1847,11 +1901,140 @@ pub(crate) mod tests {
         assert_eq!(
             bumped,
             BumpOutcome::NoChildNeeded,
-            "a spender that left the mempool between the two probe calls is not an \
-             observation of the parent"
+            "a confirmed spend means the parent is in a block, and no child can improve it"
         );
         assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
         assert!(handle.last_child_lease.is_none());
+    }
+
+    /// The probe runs before the build for an exclusive anchor too. Our own child holds
+    /// the anchor at the target: the tick skips without a wallet call, keeps the leases,
+    /// and probes the anchor output of the parent.
+    #[tokio::test]
+    async fn reactive_probe_skips_an_exclusive_anchor_when_our_child_holds_it() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let ours = Txid::from_byte_array([0xAA; 32]);
+        let inputs = [OutPoint::new(Txid::from_byte_array([1; 32]), 0)];
+        let wallet = Arc::new(FakeWallet::failing("skip must not build"));
+        let submitter = Arc::new(
+            FakeSubmitter::failing("skip must not submit").with_spend_state(
+                AnchorSpendState::SpentInMempool {
+                    spender: ours,
+                    pkg_fee_rate: FeeRate::from_sat_per_vb_unchecked(10),
+                },
+            ),
+        );
+        let ctx = contention_context(wallet.clone(), submitter.clone());
+        let mut handle = seeded_handle(&wallet, &inputs, ours);
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("holding the anchor is a skip, not an error");
+        assert_eq!(
+            bumped,
+            BumpOutcome::ParentIsLive,
+            "a child that spends the anchor proves the parent reached the network"
+        );
+        assert!(wallet.released.lock().unwrap().is_empty());
+        assert_eq!(held_by(&handle), inputs.to_vec());
+        assert_eq!(
+            submitter.probed(),
+            vec![OutPoint {
+                txid: parent_txid,
+                vout: 0
+            }],
+            "the probe must ask about the anchor output of the parent"
+        );
+    }
+
+    /// The probe runs before the build for the payout-combined shape too. A child holds
+    /// the payout output at the target: the tick skips without a wallet call, and probes
+    /// the payout outpoint rather than a vout-derived one.
+    #[tokio::test]
+    async fn reactive_probe_skips_a_payout_combined_parent_when_a_child_holds_the_payout() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let ours = Txid::from_byte_array([0xAA; 32]);
+        let payout = OutPoint {
+            txid: parent_txid,
+            vout: 0,
+        };
+        let inputs = [OutPoint::new(Txid::from_byte_array([1; 32]), 0)];
+        let wallet = Arc::new(FakeWallet::failing("skip must not build"));
+        let submitter = Arc::new(
+            FakeSubmitter::failing("skip must not submit").with_spend_state(
+                AnchorSpendState::SpentInMempool {
+                    spender: ours,
+                    pkg_fee_rate: FeeRate::from_sat_per_vb_unchecked(10),
+                },
+            ),
+        );
+        let ctx = contention_context(wallet.clone(), submitter.clone());
+        let mut handle = seeded_handle(&wallet, &inputs, ours);
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            CpfpStrategy::ParentTxCombined {
+                payout_outpoint: payout,
+                parent_fee: Amount::from_sat(220),
+            },
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("holding the payout is a skip, not an error");
+        assert_eq!(bumped, BumpOutcome::ParentIsLive);
+        assert!(wallet.released.lock().unwrap().is_empty());
+        assert_eq!(held_by(&handle), inputs.to_vec());
+        assert_eq!(
+            submitter.probed(),
+            vec![payout],
+            "the probe must ask about the payout outpoint, not a vout-derived one"
+        );
+    }
+
+    /// A probe error is not a stop signal. The ladder treats it as "probe unavailable" and
+    /// builds anyway; the submission is the authority.
+    #[tokio::test]
+    async fn probe_error_builds_anyway() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let wallet = Arc::new(FakeWallet::returning(
+            synthetic_child_psbt(&parent, 0, anchor_key),
+            vec![OutPoint {
+                txid: parent.compute_txid(),
+                vout: 7,
+            }],
+        ));
+        let submitter = Arc::new(FakeSubmitter::ok().with_failing_probe("probe RPC failure"));
+        let ctx = contention_context(wallet.clone(), submitter.clone());
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("a probe failure must not fail the bump");
+        assert_eq!(bumped, BumpOutcome::Submitted);
+        assert_eq!(
+            submitter.captured.lock().unwrap().len(),
+            1,
+            "the build must reach the submission despite the probe error"
+        );
     }
 
     #[tokio::test]

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -137,6 +137,13 @@ pub struct CpfpHandle {
     /// Txid of the child we last broadcast (for tracking / replacement). `None` before the
     /// first bump succeeds.
     pub last_child_txid: Option<Txid>,
+    /// Absolute fee that the most recent child pays. BIP-125 rule 4 requires a
+    /// replacement to pay the replaced fee plus the incremental relay fee over the
+    /// replacement's own size. The builder floors the next child's fee at this value plus
+    /// 1 sat/vB × the new child's vbytes. A small target rise then produces a valid
+    /// replacement. Without the floor, bitcoind rejects each replacement until the target
+    /// rises by a full package-rate step.
+    pub last_child_fee: Option<Amount>,
 }
 
 /// Errors produced by [`perform_bump`].
@@ -166,6 +173,23 @@ pub enum CpfpError {
 }
 
 impl CpfpError {
+    /// Whether the bump held new wallet funding leases when it failed.
+    ///
+    /// True for each failure after the wallet build: the wallet leases `funded.spent`
+    /// during the build, and `perform_bump` records the set in the handle before the step
+    /// that failed. False for failures at or before the build, because a failed build
+    /// restores the pre-bump lease state itself. The driver reads this to decide whether a
+    /// bump whose entry was removed during the bump must release the recorded inputs.
+    pub const fn leased_funding(&self) -> bool {
+        matches!(
+            self,
+            Self::AnchorSigner(_)
+                | Self::WalletSigner(_)
+                | Self::SubmitPackage(_)
+                | Self::PsbtExtract(_)
+        )
+    }
+
     /// Whether this failure is a lost race for a shared anchor rather than a fault.
     ///
     /// See [`SubmitPackageError::is_replacement_contention`]. Callers use it to keep expected
@@ -219,6 +243,11 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
     /// Builds (or rebuilds via RBF) a CPFP child for `parent` under `strategy`, targeting
     /// `target_pkg_fee_rate` on the (parent, child) package.
     ///
+    /// `prior_child_fee` is the absolute fee of the child being replaced, when there is one.
+    /// The wallet must floor the new child's fee at `prior_child_fee + 1 sat/vB × the new
+    /// child's vbytes` (BIP-125 rule 4), or bitcoind rejects the replacement as paying
+    /// insufficient incremental fee.
+    ///
     /// `replacing` is the outpoints of any prior child this rebuild supersedes (released
     /// before re-selection so they can be re-picked or replaced).
     ///
@@ -230,7 +259,19 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
         strategy: CpfpStrategy,
         target_pkg_fee_rate: FeeRate,
         replacing: Option<&[OutPoint]>,
+        prior_child_fee: Option<Amount>,
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send;
+
+    /// Hands `outpoints` back to the wallet's lease bookkeeping without a build.
+    ///
+    /// [`Self::build_cpfp_child`] releases and re-leases through its `replacing` parameter.
+    /// That path only exists while a next build for the same parent is possible. Each path
+    /// that stops the bumps for a parent must call this method instead: a lost shared
+    /// anchor, a parent confirmed through a competitor, a dropped driver entry. Without
+    /// the call, the last child's funding UTXOs stay leased for the process lifetime and
+    /// the spendable balance shrinks. The method must accept outpoints that are not
+    /// currently leased.
+    fn release(&self, outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send;
 }
 
 /// Source of fee-rate estimates used to drive the package target. Defined in this crate
@@ -415,7 +456,16 @@ pub enum AnchorSpendState {
     /// Nothing spends the anchor. This operator can bump.
     Unspent,
     /// A mempool transaction spends the anchor, and its package pays this rate.
-    SpentInMempool(FeeRate),
+    SpentInMempool {
+        /// Txid of the spending child. The bump loop compares it against its own last
+        /// child. A foreign spender means this operator's child lost the anchor, and the
+        /// bump loop must release the child's funding leases. Our own spender means the
+        /// leases must stay: a release lets a concurrent build double-spend the live
+        /// child's funding and evict it.
+        spender: Txid,
+        /// Package fee rate the spending child's ancestor set pays.
+        pkg_fee_rate: FeeRate,
+    },
     /// A confirmed transaction spends the anchor. No child can improve the parent now.
     Confirmed,
 }
@@ -463,8 +513,13 @@ impl CpfpWallet for CpfpDisabled {
         _strategy: CpfpStrategy,
         _target_pkg_fee_rate: FeeRate,
         _replacing: Option<&[OutPoint]>,
+        _prior_child_fee: Option<Amount>,
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
         async { unreachable!("CpfpDisabled::build_cpfp_child should never be called") }
+    }
+
+    fn release(&self, _outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send {
+        async { unreachable!("CpfpDisabled::release should never be called") }
     }
 }
 
@@ -746,16 +801,43 @@ where
         // An error here is not fatal. The lookup is an optimisation, so fall through to the
         // build and let the submission decide.
         match ctx.mempool.anchor_spend_state(anchor).await {
-            Ok(AnchorSpendState::SpentInMempool(existing)) if existing >= target => {
+            Ok(AnchorSpendState::SpentInMempool {
+                spender,
+                pkg_fee_rate: existing,
+            }) if existing >= target => {
+                // This skip ends the bump sequence, so the `replacing` hand-over of the
+                // next build never runs. Release the last child's funding leases here
+                // instead — but only when the winning child is not ours. When our own
+                // child holds the anchor at the target, its funding must stay leased. A
+                // release at that point lets a concurrent build double-spend the funding
+                // and evict our own child.
+                if handle.last_child_txid != Some(spender) && !handle.last_child_inputs.is_empty() {
+                    ctx.wallet.release(&handle.last_child_inputs).await;
+                    handle.last_child_inputs.clear();
+                    handle.last_child_txid = None;
+                    handle.last_child_fee = None;
+                }
                 debug!(
                     %parent_txid,
                     ?target,
                     ?existing,
-                    "another watchtower already bumped this anchor to the target; skipping"
+                    %spender,
+                    "anchor already bumped to the target; skipping"
                 );
                 return Ok(false);
             }
             Ok(AnchorSpendState::Confirmed) => {
+                // The parent is confirmed. If a competitor's child won, this release
+                // frees our dead child's funding. If our child won, its funding is spent
+                // on-chain and the release has one bounded side effect: until the next
+                // sync, `list_unspent` still lists those outpoints, so builds can select
+                // a spent input and be rejected. A sync ends the window.
+                if !handle.last_child_inputs.is_empty() {
+                    ctx.wallet.release(&handle.last_child_inputs).await;
+                    handle.last_child_inputs.clear();
+                    handle.last_child_txid = None;
+                    handle.last_child_fee = None;
+                }
                 debug!(
                     %parent_txid,
                     "anchor already spent by a confirmed transaction; skipping"
@@ -772,9 +854,16 @@ where
     // ── 5. Build the child via the wallet ───────────────────────────────────
     let replacing: Option<&[OutPoint]> =
         (!handle.last_child_inputs.is_empty()).then_some(handle.last_child_inputs.as_slice());
+    // The RBF floor only applies while there is a live child to replace. A prior child
+    // recorded but since evicted (lost anchor race, confirmed competitor) clears the handle
+    // through the release paths, so `last_child_fee` here always describes the mempool
+    // incumbent we are replacing.
+    let prior_child_fee = handle
+        .last_child_fee
+        .filter(|_| handle.last_child_txid.is_some());
     let funded = ctx
         .wallet
-        .build_cpfp_child(parent, strategy.clone(), target, replacing)
+        .build_cpfp_child(parent, strategy.clone(), target, replacing, prior_child_fee)
         .await
         .map_err(CpfpError::Wallet)?;
 
@@ -790,7 +879,13 @@ where
     // Writing it here is safe against the retry path too: `OperatorWallet::build_cpfp_child`
     // releases `replacing` up front and, if selection then fails, re-leases it — so the
     // recorded set is always either currently leased or deliberately handed back.
+    //
+    // Record the fee together with the inputs. The fee is the floor for the next
+    // replacement (BIP-125 rule 4). If submission fails below, the prior child stays in
+    // the mempool and pays less than the recorded fee. The floor is then conservative,
+    // which is safe: the next child pays slightly more than the rule requires.
     handle.last_child_inputs = funded.spent.clone();
+    handle.last_child_fee = funded.psbt.fee().ok();
 
     // ── 6. Sign each input still lacking final_script_witness ─────────────
     //
@@ -834,8 +929,10 @@ where
     if !matches!(strategy, CpfpStrategy::ParentTxCombined { .. }) {
         // The wallet promised to add the anchor as a foreign UTXO; sanity-check that the
         // PSBT actually contains it before signing.
+        // `PsbtExtract`, not `Wallet`: this check runs after the build, so the wallet has
+        // leased the funding inputs, and `CpfpError::leased_funding` must report true.
         let anchor_idx = anchor_input_idx.ok_or_else(|| {
-            CpfpError::Wallet(format!(
+            CpfpError::PsbtExtract(format!(
                 "wallet-built child does not contain expected anchor outpoint for parent {parent_txid}"
             ))
         })?;
@@ -1012,7 +1109,9 @@ pub(crate) mod tests {
     use bitcoin::{
         absolute,
         hashes::Hash,
+        opcodes, script,
         secp256k1::{Keypair, SECP256K1},
+        taproot::{LeafVersion, TaprootBuilder},
         transaction::Version,
         Address, Network, TxIn, XOnlyPublicKey,
     };
@@ -1050,6 +1149,8 @@ pub(crate) mod tests {
         psbt_template: Mutex<Option<Psbt>>,
         spent_template: Vec<OutPoint>,
         error: Option<String>,
+        /// Every outpoint handed back through [`CpfpWallet::release`], in call order.
+        pub(crate) released: Mutex<Vec<OutPoint>>,
     }
     impl FakeWallet {
         pub(crate) fn returning(psbt: Psbt, spent: Vec<OutPoint>) -> Self {
@@ -1057,6 +1158,7 @@ pub(crate) mod tests {
                 psbt_template: Mutex::new(Some(psbt)),
                 spent_template: spent,
                 error: None,
+                released: Mutex::new(Vec::new()),
             }
         }
         pub(crate) fn failing(msg: &str) -> Self {
@@ -1064,6 +1166,7 @@ pub(crate) mod tests {
                 psbt_template: Mutex::new(None),
                 spent_template: Vec::new(),
                 error: Some(msg.to_string()),
+                released: Mutex::new(Vec::new()),
             }
         }
     }
@@ -1074,6 +1177,7 @@ pub(crate) mod tests {
             _strategy: CpfpStrategy,
             _target_pkg_fee_rate: FeeRate,
             _replacing: Option<&[OutPoint]>,
+            _prior_child_fee: Option<Amount>,
         ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
             let err = self.error.clone();
             let psbt = self.psbt_template.lock().unwrap().clone();
@@ -1088,12 +1192,18 @@ pub(crate) mod tests {
                 })
             }
         }
+
+        fn release(&self, outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send {
+            self.released.lock().unwrap().extend_from_slice(outpoints);
+            async {}
+        }
     }
 
     #[derive(Debug)]
     pub(crate) struct FakeSubmitter {
         pub(crate) result: Mutex<Result<SubmitPackageSummary, String>>,
         pub(crate) captured: Mutex<Vec<Vec<Transaction>>>,
+        pub(crate) spend_state: Mutex<AnchorSpendState>,
     }
     impl FakeSubmitter {
         pub(crate) fn ok() -> Self {
@@ -1103,13 +1213,19 @@ pub(crate) mod tests {
                     replaced: Vec::new(),
                 })),
                 captured: Mutex::new(Vec::new()),
+                spend_state: Mutex::new(AnchorSpendState::Unspent),
             }
         }
         pub(crate) fn failing(reason: &str) -> Self {
             Self {
                 result: Mutex::new(Err(reason.to_string())),
                 captured: Mutex::new(Vec::new()),
+                spend_state: Mutex::new(AnchorSpendState::Unspent),
             }
+        }
+        pub(crate) fn with_spend_state(self, state: AnchorSpendState) -> Self {
+            *self.spend_state.lock().unwrap() = state;
+            self
         }
     }
     impl CpfpMempool for FakeSubmitter {
@@ -1135,10 +1251,12 @@ pub(crate) mod tests {
             }
         }
 
-        /// Reports every anchor as unspent, so unit tests exercise the build path. The
-        /// contention skip is covered end to end against a live bitcoind instead.
+        /// Reports the configured spend state (default: unspent, so tests exercise the
+        /// build path). The full contention flow is covered end to end against a live
+        /// bitcoind; the unit tests use [`FakeSubmitter::with_spend_state`] to pin the
+        /// lease bookkeeping on the skip paths.
         async fn anchor_spend_state(&self, _anchor: OutPoint) -> Result<AnchorSpendState, String> {
-            Ok(AnchorSpendState::Unspent)
+            Ok(*self.spend_state.lock().unwrap())
         }
     }
 
@@ -1311,6 +1429,160 @@ pub(crate) mod tests {
             anchor_internal_key: anchor_key,
             parent_fee: Amount::from_sat(220),
         }
+    }
+
+    /// A minimal one-leaf `MultiAnchorBearing` strategy. The step-4.5 contention skip is
+    /// gated on this variant, so the lease-release tests need a structurally valid leaf +
+    /// control block even though the skip never spends the anchor.
+    fn multi_anchor_strategy(anchor_key: XOnlyPublicKey) -> CpfpStrategy {
+        let leaf = script::Builder::new()
+            .push_slice(anchor_key.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(0, leaf.clone())
+            .expect("depth 0 leaf is always valid")
+            .finalize(SECP256K1, anchor_key)
+            .expect("single-leaf tree finalizes");
+        let control_block = spend_info
+            .control_block(&(leaf.clone(), LeafVersion::TapScript))
+            .expect("control block for the only leaf");
+        CpfpStrategy::MultiAnchorBearing {
+            anchor_vout: 0,
+            leaf_script: leaf,
+            control_block,
+            parent_fee: Amount::from_sat(220),
+        }
+    }
+
+    fn seeded_handle(inputs: &[OutPoint], our_child: Txid) -> CpfpHandle {
+        CpfpHandle {
+            last_child_inputs: inputs.to_vec(),
+            last_pkg_fee_rate: Some(FeeRate::from_sat_per_vb_unchecked(3)),
+            last_child_txid: Some(our_child),
+            last_child_fee: Some(Amount::from_sat(500)),
+        }
+    }
+
+    fn contention_context(
+        wallet: Arc<FakeWallet>,
+        submitter: Arc<FakeSubmitter>,
+    ) -> CpfpContext<FakeWallet, FakeFeeSource, FakeSubmitter> {
+        context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(8).unwrap(),
+            )),
+            wallet,
+            submitter,
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        )
+    }
+
+    /// A competitor's child covers the shared anchor at (or above) our target: we stand
+    /// down, and standing down must hand the last child's funding leases back — the next
+    /// build for this parent may never come, and nothing else records those outpoints.
+    #[tokio::test]
+    async fn losing_a_shared_anchor_releases_the_last_childs_funding() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ours = Txid::from_byte_array([0xAA; 32]);
+        let theirs = Txid::from_byte_array([0xBB; 32]);
+        let inputs = [
+            OutPoint::new(Txid::from_byte_array([1; 32]), 0),
+            OutPoint::new(Txid::from_byte_array([2; 32]), 1),
+        ];
+        let wallet = Arc::new(FakeWallet::failing("skip must not build"));
+        let submitter = Arc::new(
+            FakeSubmitter::failing("skip must not submit").with_spend_state(
+                AnchorSpendState::SpentInMempool {
+                    spender: theirs,
+                    pkg_fee_rate: FeeRate::from_sat_per_vb_unchecked(10),
+                },
+            ),
+        );
+        let ctx = contention_context(wallet.clone(), submitter);
+        let mut handle = seeded_handle(&inputs, ours);
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            multi_anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("losing the anchor is a skip, not an error");
+        assert!(!bumped);
+        assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
+        assert!(handle.last_child_inputs.is_empty());
+    }
+
+    /// Our own child holds the anchor at the target. This is the normal state. The leases
+    /// must stay: a release lets a concurrent build double-spend the live child's funding
+    /// and evict our own child.
+    #[tokio::test]
+    async fn our_own_winning_child_keeps_its_funding_leases() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ours = Txid::from_byte_array([0xAA; 32]);
+        let inputs = [OutPoint::new(Txid::from_byte_array([1; 32]), 0)];
+        let wallet = Arc::new(FakeWallet::failing("skip must not build"));
+        let submitter = Arc::new(
+            FakeSubmitter::failing("skip must not submit").with_spend_state(
+                AnchorSpendState::SpentInMempool {
+                    spender: ours,
+                    pkg_fee_rate: FeeRate::from_sat_per_vb_unchecked(10),
+                },
+            ),
+        );
+        let ctx = contention_context(wallet.clone(), submitter);
+        let mut handle = seeded_handle(&inputs, ours);
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            multi_anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("holding the anchor is a skip, not an error");
+        assert!(!bumped);
+        assert!(wallet.released.lock().unwrap().is_empty());
+        assert_eq!(handle.last_child_inputs, inputs.to_vec());
+    }
+
+    /// The anchor is spent by a confirmed transaction: bumping is over for this parent,
+    /// whoever won. Standing down releases the leases; if our own child won, its funding is
+    /// spent on-chain and the release is a harmless no-op ahead of the sync prune.
+    #[tokio::test]
+    async fn a_confirmed_anchor_spend_releases_the_last_childs_funding() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ours = Txid::from_byte_array([0xAA; 32]);
+        let inputs = [OutPoint::new(Txid::from_byte_array([1; 32]), 0)];
+        let wallet = Arc::new(FakeWallet::failing("skip must not build"));
+        let submitter = Arc::new(
+            FakeSubmitter::failing("skip must not submit")
+                .with_spend_state(AnchorSpendState::Confirmed),
+        );
+        let ctx = contention_context(wallet.clone(), submitter);
+        let mut handle = seeded_handle(&inputs, ours);
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            multi_anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("a confirmed spend is a skip, not an error");
+        assert!(!bumped);
+        assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
+        assert!(handle.last_child_inputs.is_empty());
     }
 
     #[tokio::test]

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -151,6 +151,25 @@ pub struct CpfpHandle {
     pub last_child_fee: Option<Amount>,
 }
 
+/// What one call to [`perform_bump`] achieved.
+///
+/// A caller that must decide the fate of a transaction needs more than "no package went
+/// out". A bump that stands down because a competitor's child already covers a shared
+/// anchor proves that the parent is in a mempool, and a bump that skips because no child is
+/// needed proves nothing about the parent at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BumpOutcome {
+    /// A `[parent, child]` package reached the mempool.
+    Submitted,
+    /// No package went out, and the bump observed the parent in a mempool or in a block. A
+    /// competitor's child holds the shared anchor, or the anchor is spent by a confirmed
+    /// transaction.
+    ParentIsLive,
+    /// No package went out, and the bump observed nothing about where the parent is. The
+    /// target sits at the protocol floor, or the parent's own fee already meets it.
+    NoChildNeeded,
+}
+
 /// Errors produced by [`perform_bump`].
 #[derive(Debug, Error)]
 pub enum CpfpError {
@@ -185,6 +204,12 @@ impl CpfpError {
     pub fn is_replacement_contention(&self) -> bool {
         matches!(self, Self::SubmitPackage(e) if e.is_replacement_contention())
     }
+
+    /// Whether the transaction `txid` itself lost a replacement race. See
+    /// [`SubmitPackageError::is_replacement_contention_for`].
+    pub fn is_replacement_contention_for(&self, txid: &Txid) -> bool {
+        matches!(self, Self::SubmitPackage(e) if e.is_replacement_contention_for(txid))
+    }
 }
 
 /// Wallet outpoints that one CPFP child holds.
@@ -204,13 +229,77 @@ pub trait FundingLease: Send + Sync + Debug {
 /// A funded PSBT returned by a wallet handle in [`CpfpContext`].
 #[derive(Debug, Clone)]
 pub struct WalletFundedPsbt {
-    /// The funded child PSBT. Wallet inputs are signed or unsigned per the backend (see
-    /// the [`CpfpWallet`] PSBT-signing contract); the anchor input is always unsigned and
-    /// carries `witness_utxo` plus `tap_internal_key` (key-path) or `tap_scripts`
-    /// (script-path) describing what is being spent.
-    pub psbt: Psbt,
+    /// The funded child PSBT. Wallet inputs are signed or unsigned per the backend. The
+    /// anchor input is always unsigned and carries `witness_utxo` plus `tap_internal_key`
+    /// (key-path) or `tap_scripts` (script-path) describing what is being spent.
+    pub psbt: ChildPsbt,
     /// Holds the wallet outpoints that the child consumes.
     pub lease: Arc<dyn FundingLease>,
+}
+
+/// A PSBT input that breaks the signing contract of [`CpfpWallet`].
+#[derive(Debug, Error)]
+pub enum ChildPsbtError {
+    /// The input carries a signature that is not final. The bump loop signs each input that
+    /// has no final field, so a signature left outside one is lost to that pass.
+    #[error(
+        "input {input_index} carries a signature that is not final; \
+         a backend must finalize each input that it signs"
+    )]
+    UnfinalizedSignature {
+        /// Index of the offending input in the PSBT.
+        input_index: usize,
+    },
+    /// The input carries no spent-output data. The fee of the child, and the sighash of each
+    /// input that still needs a signature, both read the spent outputs.
+    #[error("input {input_index} carries no `witness_utxo` or `non_witness_utxo`")]
+    MissingSpendInfo {
+        /// Index of the offending input in the PSBT.
+        input_index: usize,
+    },
+}
+
+/// A child PSBT that meets the signing contract of [`CpfpWallet`].
+///
+/// [`perform_bump`] signs each input that has no final field (`final_script_witness` or
+/// `final_script_sig`), and it never overwrites a field that is already there. An input that
+/// holds a signature in `tap_key_sig` or `partial_sigs` without a final field therefore gets
+/// signed a second time, and the signature that the backend produced is lost.
+///
+/// The constructor rejects that shape, and it rejects an input without spent-output data:
+/// the fee of the child prices the next RBF floor, and the sighash of each unsigned input
+/// reads the spent outputs. The type carries the proof of both checks.
+#[derive(Debug, Clone)]
+pub struct ChildPsbt(Psbt);
+
+impl ChildPsbt {
+    /// Checks the signing contract and wraps `psbt`.
+    pub fn new(psbt: Psbt) -> Result<Self, ChildPsbtError> {
+        for (input_index, input) in psbt.inputs.iter().enumerate() {
+            if input.witness_utxo.is_none() && input.non_witness_utxo.is_none() {
+                return Err(ChildPsbtError::MissingSpendInfo { input_index });
+            }
+            let signed = input.tap_key_sig.is_some()
+                || !input.partial_sigs.is_empty()
+                || !input.tap_script_sigs.is_empty();
+            let finalized =
+                input.final_script_witness.is_some() || input.final_script_sig.is_some();
+            if signed && !finalized {
+                return Err(ChildPsbtError::UnfinalizedSignature { input_index });
+            }
+        }
+        Ok(Self(psbt))
+    }
+
+    /// The PSBT inside.
+    pub const fn as_psbt(&self) -> &Psbt {
+        &self.0
+    }
+
+    /// Takes the PSBT out for signing and extraction.
+    pub fn into_psbt(self) -> Psbt {
+        self.0
+    }
 }
 
 /// Trait the driver calls to build the next CPFP child.
@@ -236,11 +325,10 @@ pub struct WalletFundedPsbt {
 /// Either way the bump loop never overwrites an existing witness — that contract is what
 /// makes swapping the wallet backend a pure-trait-impl exercise.
 ///
-/// **Signed inputs must be finalized**: the skip check inspects `final_script_witness`,
-/// not `tap_key_sig` or `partial_sigs`. A backend that produces a partially-signed PSBT
-/// with sigs in `tap_key_sig` but no `final_script_witness` will see the bump loop sign
-/// over the top of those partials. Backends MUST finalize their signed inputs before
-/// returning (i.e. produce `final_script_witness` directly).
+/// **Signed inputs must be finalized.** The skip check inspects `final_script_witness`, and
+/// not `tap_key_sig` or `partial_sigs`. [`ChildPsbt::new`] enforces this, so a backend that
+/// leaves a signature outside `final_script_witness` fails at the boundary rather than
+/// losing that signature to a second signing pass.
 pub trait CpfpWallet: Send + Sync + fmt::Debug {
     /// Builds (or rebuilds via RBF) a CPFP child for `parent` under `strategy`, targeting
     /// `target_pkg_fee_rate` on the (parent, child) package.
@@ -649,8 +737,8 @@ impl BumpReason {
 
 /// Drives one CPFP bump attempt for `parent` under `strategy`.
 ///
-/// Returns `Ok(true)` if a package was submitted, `Ok(false)` if the bump was skipped
-/// (see the skip conditions below), and the error variants of [`CpfpError`] otherwise.
+/// Returns the [`BumpOutcome`] that the attempt achieved, or an error variant of
+/// [`CpfpError`].
 ///
 /// Same-rate calls are a no-op only for [`BumpReason::NewJob`]; reactive reasons
 /// (block/tick/eviction) rebuild the child even at an unchanged target, because a child
@@ -683,7 +771,7 @@ pub async fn perform_bump<W, F, P>(
     handle: &mut CpfpHandle,
     bridge_protocol_floor: FeeRate,
     reason: BumpReason,
-) -> Result<bool, CpfpError>
+) -> Result<BumpOutcome, CpfpError>
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
@@ -721,7 +809,7 @@ where
             ?reason,
             "fee source target at or below protocol floor; skipping CPFP child"
         );
-        return Ok(false);
+        return Ok(BumpOutcome::NoChildNeeded);
     }
     // If the parent's own fee already clears the target, a child can't improve the
     // package rate — it would only pay for its own vbytes. Skipping here also avoids a
@@ -738,7 +826,7 @@ where
                 ?reason,
                 "parent fee alone meets target; skipping CPFP child"
             );
-            return Ok(false);
+            return Ok(BumpOutcome::NoChildNeeded);
         }
     }
 
@@ -761,7 +849,7 @@ where
                     ?reason,
                     "target ≤ last bump rate; no-op (avoiding wasted RBF)"
                 );
-                return Ok(false);
+                return Ok(BumpOutcome::NoChildNeeded);
             }
         }
     }
@@ -811,7 +899,8 @@ where
                     %spender,
                     "anchor already bumped to the target; skipping"
                 );
-                return Ok(false);
+                // A child spends this parent's anchor, so the parent is in a mempool.
+                return Ok(BumpOutcome::ParentIsLive);
             }
             Ok(AnchorSpendState::Confirmed) => {
                 // The parent is confirmed. If a competitor's child won, this release
@@ -826,7 +915,7 @@ where
                     %parent_txid,
                     "anchor already spent by a confirmed transaction; skipping"
                 );
-                return Ok(false);
+                return Ok(BumpOutcome::NoChildNeeded);
             }
             Ok(_) => {}
             Err(e) => {
@@ -864,7 +953,7 @@ where
     // the mempool and pays less than the recorded fee. The floor is then conservative,
     // which is safe: the next child pays slightly more than the rule requires.
     handle.last_child_lease = Some(funded.lease);
-    handle.last_child_fee = funded.psbt.fee().ok();
+    handle.last_child_fee = funded.psbt.as_psbt().fee().ok();
 
     // ── 6. Sign each input still lacking final_script_witness ─────────────
     //
@@ -882,7 +971,7 @@ where
     // unsigned PSBTs and every input gets signed below; create-and-sign backends
     // (Fireblocks-style) return wallet funding inputs already signed and only the foreign
     // anchor input unsigned — the skip checks preserve the wallet's signatures.
-    let mut psbt = funded.psbt;
+    let mut psbt = funded.psbt.into_psbt();
     let anchor_outpoint_opt = match &strategy {
         CpfpStrategy::AnchorBearing { anchor_vout, .. }
         | CpfpStrategy::MultiAnchorBearing { anchor_vout, .. } => Some(OutPoint {
@@ -920,7 +1009,9 @@ where
         // backend that happens to hold the musig2 (anchor) key in addition to the general
         // key may pre-sign the anchor input as part of its create-and-sign API. Respect
         // that rather than overwriting.
-        if psbt.inputs[anchor_idx].final_script_witness.is_none() {
+        let anchor_finalized = psbt.inputs[anchor_idx].final_script_witness.is_some()
+            || psbt.inputs[anchor_idx].final_script_sig.is_some();
+        if !anchor_finalized {
             let witness = match &strategy {
                 // Key-path: sign the tweaked output key, witness is the bare signature.
                 CpfpStrategy::AnchorBearing { .. } => {
@@ -968,7 +1059,9 @@ where
     // [`CpfpWallet`] trait contract backend-agnostic: "return a PSBT where any input still
     // without a `final_script_witness` is signable via `wallet_input_signer`."
     for idx in wallet_input_idxs {
-        if psbt.inputs[idx].final_script_witness.is_some() {
+        if psbt.inputs[idx].final_script_witness.is_some()
+            || psbt.inputs[idx].final_script_sig.is_some()
+        {
             continue;
         }
         let sighash = compute_input_sighash(&psbt, idx).map_err(CpfpError::PsbtExtract)?;
@@ -985,9 +1078,9 @@ where
     // Defensive sanity check: every input must have `final_script_witness` set, otherwise
     // `extract_tx` produces a witness-less tx that bitcoind would reject downstream.
     for (i, input) in psbt.inputs.iter().enumerate() {
-        if input.final_script_witness.is_none() {
+        if input.final_script_witness.is_none() && input.final_script_sig.is_none() {
             return Err(CpfpError::PsbtExtract(format!(
-                "PSBT input {i} has no final_script_witness after signing; refusing to extract"
+                "PSBT input {i} is not finalized after signing; refusing to extract"
             )));
         }
     }
@@ -1015,7 +1108,7 @@ where
     handle.last_pkg_fee_rate = Some(target);
     handle.last_child_txid = Some(child_txid);
 
-    Ok(true)
+    Ok(BumpOutcome::Submitted)
 }
 
 /// Computes the BIP-341 **script-path** sighash for one input of a funded child PSBT.
@@ -1198,7 +1291,8 @@ pub(crate) mod tests {
                     return Err(e);
                 }
                 Ok(WalletFundedPsbt {
-                    psbt: psbt.expect("test must seed a psbt template"),
+                    psbt: ChildPsbt::new(psbt.expect("test must seed a psbt template"))
+                        .expect("test psbt must meet the signing contract"),
                     lease,
                 })
             }
@@ -1208,6 +1302,8 @@ pub(crate) mod tests {
     #[derive(Debug)]
     pub(crate) struct FakeSubmitter {
         pub(crate) result: Mutex<Result<SubmitPackageSummary, String>>,
+        /// Per-tx error strings attached to a rejection.
+        pub(crate) tx_errors: Mutex<Vec<(Txid, String)>>,
         pub(crate) captured: Mutex<Vec<Vec<Transaction>>>,
         pub(crate) spend_state: Mutex<AnchorSpendState>,
     }
@@ -1218,6 +1314,7 @@ pub(crate) mod tests {
                     tx_results: Default::default(),
                     replaced: Vec::new(),
                 })),
+                tx_errors: Mutex::new(Vec::new()),
                 captured: Mutex::new(Vec::new()),
                 spend_state: Mutex::new(AnchorSpendState::Unspent),
             }
@@ -1225,12 +1322,18 @@ pub(crate) mod tests {
         pub(crate) fn failing(reason: &str) -> Self {
             Self {
                 result: Mutex::new(Err(reason.to_string())),
+                tx_errors: Mutex::new(Vec::new()),
                 captured: Mutex::new(Vec::new()),
                 spend_state: Mutex::new(AnchorSpendState::Unspent),
             }
         }
         pub(crate) fn with_spend_state(self, state: AnchorSpendState) -> Self {
             *self.spend_state.lock().unwrap() = state;
+            self
+        }
+        /// Attaches a per-tx error string to the rejection that this fake reports.
+        pub(crate) fn with_tx_error(self, txid: Txid, err: &str) -> Self {
+            self.tx_errors.lock().unwrap().push((txid, err.to_string()));
             self
         }
     }
@@ -1246,12 +1349,13 @@ pub(crate) mod tests {
                 Ok(s) => Ok(s.clone()),
                 Err(e) => Err(e.clone()),
             };
+            let tx_errors = self.tx_errors.lock().unwrap().clone();
             async move {
                 match snapshot {
                     Ok(s) => Ok(s),
                     Err(msg) => Err(SubmitPackageError::Rejected {
                         message: msg,
-                        tx_errors: Vec::new(),
+                        tx_errors,
                     }),
                 }
             }
@@ -1461,6 +1565,65 @@ pub(crate) mod tests {
         }
     }
 
+    /// The bump loop signs each input that has no final witness. A backend that leaves a
+    /// signature anywhere else loses it to that second pass, so the boundary rejects the
+    /// shape rather than let the loss reach the chain.
+    #[test]
+    fn a_child_psbt_rejects_a_signature_that_is_not_final() {
+        let (keypair, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let base = synthetic_child_psbt(&parent, 0, key);
+
+        assert!(
+            ChildPsbt::new(base.clone()).is_ok(),
+            "an unsigned child meets the contract"
+        );
+
+        let mut partial = base.clone();
+        partial.inputs[0].tap_key_sig = Some(bitcoin::taproot::Signature {
+            signature: SECP256K1
+                .sign_schnorr_no_aux_rand(&Message::from_digest([7u8; 32]), &keypair),
+            sighash_type: bitcoin::TapSighashType::Default,
+        });
+        let err = ChildPsbt::new(partial).expect_err("a non-final signature must be rejected");
+        assert!(matches!(
+            err,
+            ChildPsbtError::UnfinalizedSignature { input_index: 0 }
+        ));
+
+        let mut finalized = base.clone();
+        finalized.inputs[0].tap_key_sig = Some(bitcoin::taproot::Signature {
+            signature: SECP256K1
+                .sign_schnorr_no_aux_rand(&Message::from_digest([7u8; 32]), &keypair),
+            sighash_type: bitcoin::TapSighashType::Default,
+        });
+        finalized.inputs[0].final_script_witness = Some(bitcoin::Witness::new());
+        assert!(
+            ChildPsbt::new(finalized).is_ok(),
+            "a signature that is final meets the contract"
+        );
+
+        // A legacy input finalizes through `final_script_sig`, with no witness. The bump
+        // loop skips a final field of either kind, so the contract accepts it.
+        let mut legacy = base.clone();
+        legacy.inputs[0].final_script_sig = Some(bitcoin::ScriptBuf::new());
+        assert!(
+            ChildPsbt::new(legacy).is_ok(),
+            "a `final_script_sig` finalization meets the contract"
+        );
+
+        // The fee of the child and the sighash of each unsigned input read the spent
+        // outputs, so an input without them cannot enter the bump loop.
+        let mut missing = base;
+        missing.inputs[0].witness_utxo = None;
+        missing.inputs[0].non_witness_utxo = None;
+        let err = ChildPsbt::new(missing).expect_err("an input without spend info is rejected");
+        assert!(matches!(
+            err,
+            ChildPsbtError::MissingSpendInfo { input_index: 0 }
+        ));
+    }
+
     fn seeded_handle(wallet: &FakeWallet, inputs: &[OutPoint], our_child: Txid) -> CpfpHandle {
         CpfpHandle {
             last_child_lease: Some(wallet.lease(inputs.to_vec())),
@@ -1529,7 +1692,11 @@ pub(crate) mod tests {
         )
         .await
         .expect("losing the anchor is a skip, not an error");
-        assert!(!bumped);
+        assert_eq!(
+            bumped,
+            BumpOutcome::ParentIsLive,
+            "a child that spends the anchor proves the parent reached the network"
+        );
         assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
         assert!(handle.last_child_lease.is_none());
     }
@@ -1564,7 +1731,11 @@ pub(crate) mod tests {
         )
         .await
         .expect("holding the anchor is a skip, not an error");
-        assert!(!bumped);
+        assert_eq!(
+            bumped,
+            BumpOutcome::ParentIsLive,
+            "a child that spends the anchor proves the parent reached the network"
+        );
         assert!(wallet.released.lock().unwrap().is_empty());
         assert_eq!(held_by(&handle), inputs.to_vec());
     }
@@ -1595,7 +1766,12 @@ pub(crate) mod tests {
         )
         .await
         .expect("a confirmed spend is a skip, not an error");
-        assert!(!bumped);
+        assert_eq!(
+            bumped,
+            BumpOutcome::NoChildNeeded,
+            "a spender that left the mempool between the two probe calls is not an \
+             observation of the parent"
+        );
         assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
         assert!(handle.last_child_lease.is_none());
     }
@@ -1627,7 +1803,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("at-floor must succeed-skip");
-        assert!(!bumped);
+        assert_eq!(bumped, BumpOutcome::NoChildNeeded);
         assert!(handle.last_pkg_fee_rate.is_none());
     }
 
@@ -1667,7 +1843,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("overpaying parent must succeed-skip");
-        assert!(!bumped);
+        assert_eq!(bumped, BumpOutcome::NoChildNeeded);
         assert!(handle.last_pkg_fee_rate.is_none());
     }
 
@@ -1699,7 +1875,7 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
-        assert!(!bumped);
+        assert_eq!(bumped, BumpOutcome::NoChildNeeded);
     }
 
     #[tokio::test]
@@ -1740,8 +1916,9 @@ pub(crate) mod tests {
             )
             .await
             .unwrap_or_else(|e| panic!("reactive bump ({reason:?}) must succeed: {e}"));
-            assert!(
+            assert_eq!(
                 bumped,
+                BumpOutcome::Submitted,
                 "reactive bump ({reason:?}) must rebuild at same rate"
             );
         }
@@ -1781,7 +1958,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("happy path must submit");
-        assert!(bumped);
+        assert_eq!(bumped, BumpOutcome::Submitted);
 
         // handle is updated
         assert_eq!(
@@ -1825,7 +2002,7 @@ pub(crate) mod tests {
         )
         .await
         .unwrap();
-        assert!(bumped);
+        assert_eq!(bumped, BumpOutcome::Submitted);
         assert_eq!(
             handle.last_pkg_fee_rate,
             Some(FeeRate::from_sat_per_vb(20).unwrap())
@@ -1975,7 +2152,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("presigned-wallet-input path must submit without invoking wallet signer");
-        assert!(bumped);
+        assert_eq!(bumped, BumpOutcome::Submitted);
 
         // The submitted child's funding-input witness must still be the sentinel — proves
         // perform_bump didn't overwrite it.
@@ -2027,7 +2204,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("presigned-anchor path must submit without invoking anchor signer");
-        assert!(bumped);
+        assert_eq!(bumped, BumpOutcome::Submitted);
 
         let captured = submitter.captured.lock().unwrap();
         let child = &captured[0][1];
@@ -2103,7 +2280,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("ParentTxCombined happy path must submit");
-        assert!(bumped);
+        assert_eq!(bumped, BumpOutcome::Submitted);
 
         assert_eq!(
             handle.last_pkg_fee_rate,
@@ -2399,7 +2576,7 @@ pub(crate) mod tests {
         )
         .await
         .expect("script-path bump must succeed");
-        assert!(submitted);
+        assert_eq!(submitted, BumpOutcome::Submitted);
         assert_eq!(held_by(&handle), wallet_funding);
 
         let packages = submitter.captured.lock().unwrap();

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -45,7 +45,7 @@ use bitcoin::{
 };
 use thiserror::Error;
 use tokio::task::JoinHandle;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::submitpackage::{self, SubmitPackageError};
 
@@ -163,6 +163,16 @@ pub enum CpfpError {
     /// caller-provided signature (anchor) by the time we get here.
     #[error("psbt extract: {0}")]
     PsbtExtract(String),
+}
+
+impl CpfpError {
+    /// Whether this failure is a lost race for a shared anchor rather than a fault.
+    ///
+    /// See [`SubmitPackageError::is_replacement_contention`]. Callers use it to keep expected
+    /// contention out of the warning stream.
+    pub fn is_replacement_contention(&self) -> bool {
+        matches!(self, Self::SubmitPackage(e) if e.is_replacement_contention())
+    }
 }
 
 /// A funded PSBT returned by a wallet handle in [`CpfpContext`].
@@ -395,8 +405,23 @@ impl CpfpFeeSource for CachedFeeSource {
     }
 }
 
-/// Submits a `[parent, child]` package via the configured RPC.
-pub trait CpfpPackageSubmitter: Send + Sync + fmt::Debug {
+/// What already spends a CPFP anchor, if anything.
+///
+/// A `MultiAnchor` anchor is shared. Every watchtower of the graph holds a leaf on it, and
+/// every one of them bumps the same output. The bump loop reads this state before it builds,
+/// so that a watchtower which has already lost the anchor stops paying to lose it again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorSpendState {
+    /// Nothing spends the anchor. This operator can bump.
+    Unspent,
+    /// A mempool transaction spends the anchor, and its package pays this rate.
+    SpentInMempool(FeeRate),
+    /// A confirmed transaction spends the anchor. No child can improve the parent now.
+    Confirmed,
+}
+
+/// The bitcoind mempool operations that the bump loop needs.
+pub trait CpfpMempool: Send + Sync + fmt::Debug {
     /// Forwards to bitcoind's `submitpackage` RPC; returns the typed summary.
     fn submit_package(
         &self,
@@ -404,6 +429,16 @@ pub trait CpfpPackageSubmitter: Send + Sync + fmt::Debug {
     ) -> impl std::future::Future<
         Output = Result<submitpackage::SubmitPackageSummary, SubmitPackageError>,
     > + Send;
+
+    /// Reports what already spends `anchor`.
+    ///
+    /// The bump loop calls this only for a shared anchor, and treats an error as
+    /// [`AnchorSpendState::Unspent`]. A failed lookup must not stop a bump, because the
+    /// submission itself is the authority on whether the package is acceptable.
+    fn anchor_spend_state(
+        &self,
+        anchor: OutPoint,
+    ) -> impl std::future::Future<Output = Result<AnchorSpendState, String>> + Send;
 }
 
 /// Zero-sized placeholder that implements every CPFP trait but panics if any method is ever
@@ -441,7 +476,7 @@ impl CpfpFeeSource for CpfpDisabled {
 }
 
 #[expect(clippy::manual_async_fn, reason = "see CpfpWallet impl above")]
-impl CpfpPackageSubmitter for CpfpDisabled {
+impl CpfpMempool for CpfpDisabled {
     fn submit_package(
         &self,
         _txs: &[Transaction],
@@ -449,6 +484,13 @@ impl CpfpPackageSubmitter for CpfpDisabled {
         Output = Result<submitpackage::SubmitPackageSummary, SubmitPackageError>,
     > + Send {
         async { unreachable!("CpfpDisabled::submit_package should never be called") }
+    }
+
+    fn anchor_spend_state(
+        &self,
+        _anchor: OutPoint,
+    ) -> impl std::future::Future<Output = Result<AnchorSpendState, String>> + Send {
+        async { unreachable!("CpfpDisabled::anchor_spend_state should never be called") }
     }
 }
 
@@ -462,7 +504,7 @@ pub struct CpfpContext<W, F, P>
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     /// Wallet that constructs the child PSBT. The PSBT comes back **unsigned**: bridge
     /// wallets are descriptor-only (no key material in the BDK wallet), so the funding
@@ -494,14 +536,14 @@ where
     pub max_fee_rate: FeeRate,
     /// Submits `[parent, child]` packages via bitcoind. Wrapper around the
     /// [`submitpackage::submit_package`] helper.
-    pub package_submitter: Arc<P>,
+    pub mempool: Arc<P>,
 }
 
 impl<W, F, P> Clone for CpfpContext<W, F, P>
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     fn clone(&self) -> Self {
         Self {
@@ -511,7 +553,7 @@ where
             multi_anchor_signer: self.multi_anchor_signer.clone(),
             wallet_input_signer: self.wallet_input_signer.clone(),
             max_fee_rate: self.max_fee_rate,
-            package_submitter: self.package_submitter.clone(),
+            mempool: self.mempool.clone(),
         }
     }
 }
@@ -520,7 +562,7 @@ impl<W, F, P> Debug for CpfpContext<W, F, P>
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CpfpContext")
@@ -529,7 +571,7 @@ where
             .field("anchor_input_signer", &"<closure>")
             .field("wallet_input_signer", &"<closure>")
             .field("max_fee_rate", &self.max_fee_rate)
-            .field("package_submitter", &self.package_submitter)
+            .field("mempool", &self.mempool)
             .finish()
     }
 }
@@ -602,7 +644,7 @@ pub async fn perform_bump<W, F, P>(
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     let parent_txid = parent.compute_txid();
 
@@ -677,6 +719,52 @@ where
                     "target ≤ last bump rate; no-op (avoiding wasted RBF)"
                 );
                 return Ok(false);
+            }
+        }
+    }
+
+    // ── 4.5 Skip when another watchtower already covers a shared anchor ─────
+    //
+    // Only `MultiAnchorBearing` reaches this check. Every other anchor belongs to one
+    // operator, so nobody else can spend it.
+    //
+    // A `MultiAnchor` output carries one leaf per watchtower, and every watchtower bumps the
+    // same output. Their children conflict, so one wins each round and the rest are rejected.
+    // Without this check the losers rebuild, re-sign, and resubmit on every trigger, for as
+    // long as the parent stays unconfirmed. Each of those attempts costs a signing round trip
+    // and leaves a warning in the log.
+    //
+    // The check is not a lock. Two watchtowers can read `Unspent` in the same instant and both
+    // build. That race is bounded to one round, because the loser observes the winner on the
+    // next trigger. The submission remains the authority, and `perform_bump` still handles a
+    // rejection.
+    if let CpfpStrategy::MultiAnchorBearing { anchor_vout, .. } = &strategy {
+        let anchor = OutPoint {
+            txid: parent_txid,
+            vout: *anchor_vout,
+        };
+        // An error here is not fatal. The lookup is an optimisation, so fall through to the
+        // build and let the submission decide.
+        match ctx.mempool.anchor_spend_state(anchor).await {
+            Ok(AnchorSpendState::SpentInMempool(existing)) if existing >= target => {
+                debug!(
+                    %parent_txid,
+                    ?target,
+                    ?existing,
+                    "another watchtower already bumped this anchor to the target; skipping"
+                );
+                return Ok(false);
+            }
+            Ok(AnchorSpendState::Confirmed) => {
+                debug!(
+                    %parent_txid,
+                    "anchor already spent by a confirmed transaction; skipping"
+                );
+                return Ok(false);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                debug!(%parent_txid, error = %e, "anchor spend lookup failed; building anyway");
             }
         }
     }
@@ -832,10 +920,7 @@ where
     let child_txid = child.compute_txid();
 
     // ── 8. submit_package([parent, child]) ──────────────────────────────────
-    let summary = ctx
-        .package_submitter
-        .submit_package(&[parent.clone(), child])
-        .await?;
+    let summary = ctx.mempool.submit_package(&[parent.clone(), child]).await?;
 
     info!(
         %parent_txid,
@@ -1027,7 +1112,7 @@ pub(crate) mod tests {
             }
         }
     }
-    impl CpfpPackageSubmitter for FakeSubmitter {
+    impl CpfpMempool for FakeSubmitter {
         fn submit_package(
             &self,
             txs: &[Transaction],
@@ -1048,6 +1133,12 @@ pub(crate) mod tests {
                     }),
                 }
             }
+        }
+
+        /// Reports every anchor as unspent, so unit tests exercise the build path. The
+        /// contention skip is covered end to end against a live bitcoind instead.
+        async fn anchor_spend_state(&self, _anchor: OutPoint) -> Result<AnchorSpendState, String> {
+            Ok(AnchorSpendState::Unspent)
         }
     }
 
@@ -1197,7 +1288,7 @@ pub(crate) mod tests {
     where
         F: CpfpFeeSource + 'static,
         W: CpfpWallet + 'static,
-        P: CpfpPackageSubmitter + 'static,
+        P: CpfpMempool + 'static,
     {
         CpfpContext {
             wallet,
@@ -1206,7 +1297,7 @@ pub(crate) mod tests {
             anchor_input_signer: anchor_signer,
             wallet_input_signer: wallet_signer,
             max_fee_rate,
-            package_submitter: submitter,
+            mempool: submitter,
         }
     }
 
@@ -2001,7 +2092,7 @@ pub(crate) mod tests {
             multi_anchor_signer: fake_input_signer_const(0xAA),
             wallet_input_signer: fake_input_signer_const(0xBB),
             max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
-            package_submitter: submitter.clone(),
+            mempool: submitter.clone(),
         };
         let strategy = CpfpStrategy::MultiAnchorBearing {
             anchor_vout: 0,

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -1,0 +1,2049 @@
+//! CPFP package construction + aggressive RBF for [`TxDriver`](crate::tx_driver::TxDriver).
+//!
+//! Bridge presigned transactions pay a protocol-floor fee rate (`fee::FEE_RATE = 2 sat/vB`).
+//! On any non-trivial network load they get evicted from the mempool before confirming. To drive
+//! them to confirmation we build a CPFP child that lifts the **package** (parent + child) fee
+//! rate to whatever the fee source reports as the current target, RBF'ing the child on each
+//! new block. Package fee accounting only — the child's per-vB rate can far exceed the operator's
+//! `max_fee_rate` as long as the package average doesn't.
+//!
+//! ## Design summary
+//!
+//! - [`CpfpStrategy`] tells the driver how to derive a CPFP child for a given parent kind.
+//! - [`CpfpContext`] bundles the dependencies the bump loop needs (wallet, fee source, anchor
+//!   signer, max fee rate, package submitter).
+//! - [`perform_bump`] is the single source of truth for the bump loop: it queries the fee source,
+//!   builds the child via the wallet, signs the anchor input via the operator's secret service
+//!   (through a caller-provided closure), and submits `[parent, child]` via
+//!   [`submit_package`](crate::submitpackage::submit_package).
+//! - Termination is driven by the parent confirming (the existing mempool-event branch in
+//!   `TxDriver` notifies the wait-condition listener). The bump function itself is stateless per
+//!   call — it carries the last-attempted rate and last-child-funding-inputs through the
+//!   [`CpfpHandle`] state owned by the driver.
+//!
+//! ## What's intentionally NOT here
+//!
+//! - This module does not own ZMQ subscriptions; that's the driver's job.
+//! - This module does not retry on its own — each `perform_bump` is one attempt. The driver
+//!   re-calls on the next trigger (mempool eviction or new block).
+//! - This module does not escalate past `max_fee_rate`. Cap-and-warn per the operator's policy.
+
+use std::{
+    fmt::{self, Debug},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use bitcoin::{
+    secp256k1::{schnorr::Signature, Message},
+    sighash::{Prevouts, SighashCache},
+    taproot::{ControlBlock, LeafVersion, TapLeafHash},
+    Amount, FeeRate, OutPoint, Psbt, ScriptBuf, TapSighashType, Transaction, TxOut, Txid, Witness,
+};
+use thiserror::Error;
+use tokio::task::JoinHandle;
+use tracing::{info, warn};
+
+use crate::submitpackage::{self, SubmitPackageError};
+
+/// Configures how the driver derives a CPFP child for a particular parent transaction.
+///
+/// Not `Copy`: [`Self::MultiAnchorBearing`] carries the leaf script and control block needed for
+/// a script-path spend.
+#[derive(Debug, Clone)]
+pub enum CpfpStrategy {
+    /// Parent carries a keyed-Taproot anchor at `parent.output[anchor_vout]`. The child is
+    /// constructed via the wallet's CPFP-anchor pathway and spends the anchor + one funding
+    /// input.
+    AnchorBearing {
+        /// Index of the anchor output on `parent`.
+        anchor_vout: u32,
+        /// The internal x-only key the anchor was constructed from. Passed through to the
+        /// wallet so it can populate the PSBT's `tap_internal_key` for downstream signing.
+        anchor_internal_key: bitcoin::XOnlyPublicKey,
+        /// Caller-known fee already paid by `parent`. The wallet uses this together with
+        /// parent vbytes and the package target to compute the implied child fee.
+        parent_fee: Amount,
+    },
+    /// Parent has a spendable payout output keyed to an operator-controlled key
+    /// (cooperative payout, uncontested payout, contested payout, counterproof nack,
+    /// unstaking). The child consumes that output via the same `add_foreign_utxo`
+    /// machinery used for `AnchorBearing` anchors — the payout outpoint is foreign to
+    /// BDK at the time we build the child (the parent hasn't been broadcast yet; we
+    /// submit `[parent, child]` as a v3 package), so it can't be auto-selected from the
+    /// wallet's UTXO set.
+    ///
+    /// The bump loop signs the payout input via [`CpfpContext::wallet_input_signer`] —
+    /// not [`CpfpContext::anchor_input_signer`] — because the operator's general-wallet
+    /// signer holds the key (the bridge assumes payouts are keyed to the operator's
+    /// `payout_descriptor`, which resolves to the general-wallet P2TR; see the doc on
+    /// [`crate::cpfp::InputSigner`] for the dispatch table).
+    ParentTxCombined {
+        /// The payout outpoint that the child will spend.
+        payout_outpoint: OutPoint,
+        /// Caller-known fee already paid by `parent`.
+        parent_fee: Amount,
+    },
+    /// Parent carries a multi-leaf Taproot anchor at `parent.output[anchor_vout]` — one
+    /// `<watchtower_pubkey> OP_CHECKSIG` leaf per watchtower, so any watchtower can bump it.
+    /// Used by `contest` and `bridge_proof_timeout`.
+    ///
+    /// Unlike [`Self::AnchorBearing`] this is a **script-path** spend: the witness is
+    /// `[signature, leaf_script, control_block]` and the signature is *untweaked* (the leaf is
+    /// satisfied directly, not the tweaked output key). The bump loop signs it via
+    /// [`CpfpContext::multi_anchor_signer`], not [`CpfpContext::anchor_input_signer`].
+    ///
+    /// The caller supplies `leaf_script` and `control_block` because reconstructing them
+    /// requires the graph's watchtower key set and our slot within it — knowledge that lives in
+    /// the state machine, not here. `btc-tracker` deliberately stays free of any dependency on
+    /// the connector types.
+    MultiAnchorBearing {
+        /// Index of the anchor output on `parent`.
+        anchor_vout: u32,
+        /// The leaf script this operator is entitled to satisfy.
+        leaf_script: ScriptBuf,
+        /// Control block proving `leaf_script`'s membership in the anchor's tree.
+        control_block: ControlBlock,
+        /// Caller-known fee already paid by `parent`.
+        parent_fee: Amount,
+    },
+}
+
+impl CpfpStrategy {
+    /// Returns the `parent_fee` carried by every variant.
+    pub const fn parent_fee(&self) -> Amount {
+        match self {
+            Self::AnchorBearing { parent_fee, .. }
+            | Self::ParentTxCombined { parent_fee, .. }
+            | Self::MultiAnchorBearing { parent_fee, .. } => *parent_fee,
+        }
+    }
+}
+
+/// Per-parent state the driver carries between bump attempts.
+#[derive(Debug, Default, Clone)]
+pub struct CpfpHandle {
+    /// Outpoints spent by the most recent child the driver broadcast (excluding the anchor
+    /// itself). Released back to the wallet before the next bump so the same outpoints can
+    /// be re-selected for the replacement child, then re-leased to whatever the new child
+    /// actually consumes.
+    pub last_child_inputs: Vec<OutPoint>,
+    /// Package fee rate the driver last targeted. Used to skip noop bumps when the fee source
+    /// hasn't moved upward.
+    pub last_pkg_fee_rate: Option<FeeRate>,
+    /// Txid of the child we last broadcast (for tracking / replacement). `None` before the
+    /// first bump succeeds.
+    pub last_child_txid: Option<Txid>,
+}
+
+/// Errors produced by [`perform_bump`].
+#[derive(Debug, Error)]
+pub enum CpfpError {
+    /// The fee source lookup failed. The bump is skipped; the next trigger will retry.
+    #[error("fee source: {0}")]
+    FeeSource(String),
+    /// The wallet rejected the child build (insufficient funds, anchor out of range, ...).
+    #[error("wallet build_cpfp_child: {0}")]
+    Wallet(String),
+    /// The anchor input signer returned an error. The bump is skipped; the next trigger
+    /// will retry. Per design, secret-service hiccups don't escalate from the bump loop.
+    #[error("anchor signer: {0}")]
+    AnchorSigner(String),
+    /// A wallet funding-input signer returned an error. Treated the same as
+    /// [`Self::AnchorSigner`] — skip + retry.
+    #[error("wallet input signer: {0}")]
+    WalletSigner(String),
+    /// `submitpackage` returned a non-success outcome. Logged + bump skipped.
+    #[error("submit_package: {0}")]
+    SubmitPackage(#[from] SubmitPackageError),
+    /// PSBT finalization failed — every input must be either signed (funding) or have a
+    /// caller-provided signature (anchor) by the time we get here.
+    #[error("psbt extract: {0}")]
+    PsbtExtract(String),
+}
+
+/// A funded PSBT returned by a wallet handle in [`CpfpContext`].
+#[derive(Debug, Clone)]
+pub struct WalletFundedPsbt {
+    /// The funded child PSBT. Wallet inputs are signed or unsigned per the backend (see
+    /// the [`CpfpWallet`] PSBT-signing contract); the anchor input is always unsigned and
+    /// carries `witness_utxo` plus `tap_internal_key` (key-path) or `tap_scripts`
+    /// (script-path) describing what is being spent.
+    pub psbt: Psbt,
+    /// Wallet outpoints consumed by the child (not including the anchor).
+    pub spent: Vec<OutPoint>,
+}
+
+/// Trait the driver calls to build the next CPFP child.
+///
+/// Decouples [`crate::tx_driver::TxDriver`] from `operator-wallet` so this crate stays at the
+/// bottom of the dependency graph. The actual wallet handle in `bridge-exec` implements this
+/// trait against `Arc<RwLock<OperatorWallet<G>>>`.
+///
+/// # PSBT-signing contract
+///
+/// The returned PSBT may be fully unsigned, partially signed, or fully signed — whatever
+/// the wallet backend produces. [`perform_bump`] inspects each PSBT input's
+/// `final_script_witness` and only signs the ones still unsigned (anchor input via
+/// [`CpfpContext::anchor_input_signer`], everything else via
+/// [`CpfpContext::wallet_input_signer`]). Two patterns are supported:
+///
+/// - **Descriptor-only wallets** (e.g. `NativeGeneralWallet`): no key material in the wallet,
+///   returned PSBT is fully unsigned, every input gets signed by the bump loop.
+/// - **Create-and-sign backends** (e.g. Fireblocks): wallet selects UTXOs and signs the funding
+///   inputs in one API call, returned PSBT has wallet inputs already signed and only the foreign
+///   anchor input unsigned. The bump loop fills in the anchor signature.
+///
+/// Either way the bump loop never overwrites an existing witness — that contract is what
+/// makes swapping the wallet backend a pure-trait-impl exercise.
+///
+/// **Signed inputs must be finalized**: the skip check inspects `final_script_witness`,
+/// not `tap_key_sig` or `partial_sigs`. A backend that produces a partially-signed PSBT
+/// with sigs in `tap_key_sig` but no `final_script_witness` will see the bump loop sign
+/// over the top of those partials. Backends MUST finalize their signed inputs before
+/// returning (i.e. produce `final_script_witness` directly).
+pub trait CpfpWallet: Send + Sync + fmt::Debug {
+    /// Builds (or rebuilds via RBF) a CPFP child for `parent` under `strategy`, targeting
+    /// `target_pkg_fee_rate` on the (parent, child) package.
+    ///
+    /// `replacing` is the outpoints of any prior child this rebuild supersedes (released
+    /// before re-selection so they can be re-picked or replaced).
+    ///
+    /// See the trait-level "PSBT-signing contract" for what the returned PSBT must look
+    /// like with respect to per-input `final_script_witness`.
+    fn build_cpfp_child(
+        &self,
+        parent: &Transaction,
+        strategy: CpfpStrategy,
+        target_pkg_fee_rate: FeeRate,
+        replacing: Option<&[OutPoint]>,
+    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send;
+}
+
+/// Source of fee-rate estimates used to drive the package target. Defined in this crate
+/// (rather than reusing a wallet- or executor-side abstraction) so `btc-tracker` stays at
+/// the bottom of the dependency graph; callers implement it for their estimator of choice.
+///
+/// In production the live estimator is wrapped in a [`CachedFeeSource`] so the bump loop
+/// reads from a hot atomic instead of hitting the network per call. The tracker refreshes
+/// it in the background on `refresh_interval`.
+pub trait CpfpFeeSource: Send + Sync + fmt::Debug {
+    /// Returns the current sat/vB target for the next block.
+    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send;
+}
+
+/// Boxed future returned by an [`InputSigner`]; pinned + Send so it can fly across the
+/// driver's tokio task boundary.
+pub type InputSignFut =
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<Signature, String>> + Send>>;
+
+/// Signs one BIP-341 key-path Taproot input by computing a Schnorr signature over the
+/// caller-supplied sighash. Used by [`perform_bump`] in two distinct roles:
+///
+/// 1. As [`CpfpContext::anchor_input_signer`] — signs the anchor input of an `AnchorBearing` child
+///    with the key the parent's anchor was constructed from. In the bridge this is the operator's
+///    musig2-signer pubkey (the "btc key" from the operator table), which `KeyedAnchor::new` is fed
+///    in `tx-graph::transactions::{claim,stake,unstaking_intent,counterproof,counterproof_ack}`.
+///    Caveat: counterproof / counterproof_ack nominally key their anchors to a *watchtower* pubkey,
+///    but today the bridge identifies watchtower keys with musig2 keys (see the comment in
+///    `bin/strata-bridge/src/mode/services/operator_wallet.rs` near `watchtower_keys`); if the two
+///    sets ever diverge, this signer + the matching [`crate::cpfp::CpfpStrategy`] inference layer
+///    need to grow a per-anchor-kind dispatch.
+///
+/// 2. As [`CpfpContext::wallet_input_signer`] — signs every funding input the wallet selected. In
+///    the bridge this is the operator's general-wallet pubkey (the `tr()` descriptor key of
+///    `NativeGeneralWallet`), which holds the UTXOs the child consumes.
+///
+/// Both roles call `sign(digest, None)` on a `SchnorrSigner` (from `secret-service-proto`)
+/// — the `None` tweak applies the BIP-341 tap-tweak with an empty merkle root, matching how
+/// the corresponding outputs were constructed (keyed-Taproot, no script tree).
+pub type InputSigner = Arc<dyn Fn(Message) -> InputSignFut + Send + Sync>;
+
+/// A [`CpfpFeeSource`] that caches the most recent estimate in a shared atomic, refreshed in
+/// the background by a tokio task at a configurable interval.
+///
+/// Wraps any underlying [`CpfpFeeSource`] (typically the live `bridge-exec::fees::FeeSource`
+/// going to Bitcoin Core or mempool.space). Reads from the cache are constant-time —
+/// `estimate()` returns the latest cached value without I/O, so the bump loop in
+/// [`TxDriver`](crate::tx_driver::TxDriver) can poll it on a fast timer without rate-limiting
+/// the underlying source.
+///
+/// ## Initialization semantics
+///
+/// [`CachedFeeSource::spawn`] performs the first refresh synchronously and returns an error
+/// if it fails. This is intentional: the bridge cannot start CPFP-bumping if the fee source
+/// is unreachable at boot. Subsequent refresh failures are logged but the prior cached value
+/// is retained — a transient network blip doesn't blank the cache.
+///
+/// ## Drop behaviour
+///
+/// The background task is aborted when the `CachedFeeSource` is dropped. The task itself
+/// runs an infinite loop; tokio's `JoinHandle::abort` cancels it cleanly. In tests this
+/// ensures one test's tracker doesn't leak into the next.
+pub struct CachedFeeSource {
+    cached_sat_per_kwu: Arc<AtomicU64>,
+    /// Monotonic-millis-since-spawn of the most recent successful refresh. Stored as
+    /// milliseconds elapsed from a process-start anchor [`Instant`] so it fits in `u64`
+    /// and avoids wall-clock skew. Inspected via [`Self::seconds_since_last_refresh`] —
+    /// callers can use that to decide how much to trust the cached value when bumping.
+    last_refresh_unix_ms: Arc<AtomicU64>,
+    /// Anchor point for the `last_refresh_unix_ms` clock. Same instant for the duration
+    /// of the [`CachedFeeSource`]'s lifetime.
+    spawn_anchor: std::time::Instant,
+    task: JoinHandle<()>,
+}
+
+impl Debug for CachedFeeSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kwu = self.cached_sat_per_kwu.load(Ordering::Relaxed);
+        f.debug_struct("CachedFeeSource")
+            .field("cached_sat_per_kwu", &kwu)
+            .field(
+                "seconds_since_last_refresh",
+                &self.seconds_since_last_refresh(),
+            )
+            .field("task_finished", &self.task.is_finished())
+            .finish()
+    }
+}
+
+impl Drop for CachedFeeSource {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl CachedFeeSource {
+    /// Performs one initial refresh from `underlying`, spawns a background task that re-polls
+    /// every `refresh_interval`, and returns a `CachedFeeSource` whose `estimate()` reads from
+    /// the cached atomic.
+    pub async fn spawn<U>(underlying: Arc<U>, refresh_interval: Duration) -> Result<Self, String>
+    where
+        U: CpfpFeeSource + 'static,
+    {
+        let spawn_anchor = std::time::Instant::now();
+        let initial = underlying.estimate().await?;
+        let cached_sat_per_kwu = Arc::new(AtomicU64::new(initial.to_sat_per_kwu()));
+        // Stamp the initial refresh time so `seconds_since_last_refresh()` returns ~0 right
+        // after `spawn()` returns; otherwise the AtomicU64 would still be 0 and the elapsed
+        // calc would report the time since `spawn_anchor` instead.
+        let initial_elapsed_ms = spawn_anchor.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        let last_refresh_unix_ms = Arc::new(AtomicU64::new(initial_elapsed_ms));
+        let cache_clone = cached_sat_per_kwu.clone();
+        let last_refresh_clone = last_refresh_unix_ms.clone();
+        let task = tokio::task::spawn(async move {
+            let mut tick = tokio::time::interval(refresh_interval);
+            // `interval` fires immediately on first tick; we already have the initial value so
+            // burn that tick before entering the refresh loop.
+            tick.tick().await;
+            loop {
+                tick.tick().await;
+                match underlying.estimate().await {
+                    Ok(rate) => {
+                        cache_clone.store(rate.to_sat_per_kwu(), Ordering::Relaxed);
+                        let elapsed =
+                            spawn_anchor.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                        last_refresh_clone.store(elapsed, Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "fee-rate refresh failed; retaining last cached value"
+                        );
+                    }
+                }
+            }
+        });
+        Ok(Self {
+            cached_sat_per_kwu,
+            last_refresh_unix_ms,
+            spawn_anchor,
+            task,
+        })
+    }
+
+    /// Returns the most recently cached fee rate without I/O.
+    pub fn current(&self) -> FeeRate {
+        FeeRate::from_sat_per_kwu(self.cached_sat_per_kwu.load(Ordering::Relaxed))
+    }
+
+    /// Returns the number of seconds since the cache was last *successfully* refreshed.
+    /// Returns 0 for the initial refresh in [`Self::spawn`]. Lets callers decide how much
+    /// to trust the cached value — e.g., the bump loop could log a warning when the cache
+    /// is older than several refresh intervals (indicating the underlying source has been
+    /// failing).
+    pub fn seconds_since_last_refresh(&self) -> u64 {
+        let last_ms = self.last_refresh_unix_ms.load(Ordering::Relaxed);
+        let now_ms = self
+            .spawn_anchor
+            .elapsed()
+            .as_millis()
+            .min(u64::MAX as u128) as u64;
+        now_ms.saturating_sub(last_ms) / 1_000
+    }
+}
+
+impl CpfpFeeSource for CachedFeeSource {
+    /// Returns the cached value. Never returns `Err` — refresh failures are logged at the
+    /// background task and the prior value is retained.
+    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+        let value = self.current();
+        async move { Ok(value) }
+    }
+}
+
+/// Submits a `[parent, child]` package via the configured RPC.
+pub trait CpfpPackageSubmitter: Send + Sync + fmt::Debug {
+    /// Forwards to bitcoind's `submitpackage` RPC; returns the typed summary.
+    fn submit_package(
+        &self,
+        txs: &[Transaction],
+    ) -> impl std::future::Future<
+        Output = Result<submitpackage::SubmitPackageSummary, SubmitPackageError>,
+    > + Send;
+}
+
+/// Zero-sized placeholder that implements every CPFP trait but panics if any method is ever
+/// called. Used by [`crate::tx_driver::TxDriver::new`] (the no-CPFP path) to satisfy the
+/// generic bounds on [`crate::tx_driver::TxDriver::with_cpfp`] when `cpfp_ctx` is `None`.
+///
+/// The driver task only invokes the trait methods when `cpfp_ctx.is_some()`, so the
+/// `unreachable!()` arms are safe by construction.
+#[derive(Debug, Clone, Copy)]
+pub struct CpfpDisabled;
+
+// The trait signatures use the explicit `-> impl Future + Send` form to express the `Send`
+// bound on the returned future. The `async fn` desugaring infers `Send`-ness from the body —
+// which for these unreachable placeholders is still `Send`, but mirroring the trait's
+// signature shape keeps the impl visually paired with the trait definition. Suppress
+// `manual_async_fn` on each impl below accordingly.
+#[expect(clippy::manual_async_fn, reason = "mirror AFIT trait signature shape")]
+impl CpfpWallet for CpfpDisabled {
+    fn build_cpfp_child(
+        &self,
+        _parent: &Transaction,
+        _strategy: CpfpStrategy,
+        _target_pkg_fee_rate: FeeRate,
+        _replacing: Option<&[OutPoint]>,
+    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
+        async { unreachable!("CpfpDisabled::build_cpfp_child should never be called") }
+    }
+}
+
+#[expect(clippy::manual_async_fn, reason = "see CpfpWallet impl above")]
+impl CpfpFeeSource for CpfpDisabled {
+    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+        async { unreachable!("CpfpDisabled::estimate should never be called") }
+    }
+}
+
+#[expect(clippy::manual_async_fn, reason = "see CpfpWallet impl above")]
+impl CpfpPackageSubmitter for CpfpDisabled {
+    fn submit_package(
+        &self,
+        _txs: &[Transaction],
+    ) -> impl std::future::Future<
+        Output = Result<submitpackage::SubmitPackageSummary, SubmitPackageError>,
+    > + Send {
+        async { unreachable!("CpfpDisabled::submit_package should never be called") }
+    }
+}
+
+/// Bundle of dependencies the bump loop needs.
+///
+/// Owned by [`TxDriver`](crate::tx_driver::TxDriver) (inside the spawned task's closure) when
+/// CPFP is enabled; passed by reference into [`perform_bump`]. Cheap to clone — every field
+/// is either `Copy` or `Arc`-wrapped, so the manual [`Clone`] impl on this type doesn't
+/// require `W: Clone`/`F: Clone`/`P: Clone` (the derived `Clone` would).
+pub struct CpfpContext<W, F, P>
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    /// Wallet that constructs the child PSBT. The PSBT comes back **unsigned**: bridge
+    /// wallets are descriptor-only (no key material in the BDK wallet), so the funding
+    /// inputs must be signed downstream via [`Self::wallet_input_signer`].
+    pub wallet: Arc<W>,
+    /// Source of the current package fee-rate target.
+    pub fee_source: Arc<F>,
+    /// Signs the **anchor input** of `AnchorBearing` children — the foreign-key input
+    /// that the parent's CPFP anchor pins to. Bound to the operator's musig2-signer
+    /// pubkey in production (see [`InputSigner`] doc). Not called for `ParentTxCombined`.
+    pub anchor_input_signer: InputSigner,
+    /// Signs the **script-path anchor input** of [`CpfpStrategy::MultiAnchorBearing`] children
+    /// (`contest`, `bridge_proof_timeout`).
+    ///
+    /// Distinct from [`Self::anchor_input_signer`] because a script-path spend satisfies the leaf
+    /// directly: the signature must be made with the raw key, *not* BIP-341 tap-tweaked. In the
+    /// bridge this is the operator's musig2 signer used untweaked — the same key and mode
+    /// `publish_contest` already uses to sign the contest transaction's own input.
+    pub multi_anchor_signer: InputSigner,
+    /// Signs every **wallet-selected funding input** the child consumes. Bound to the
+    /// operator's general-wallet-signer pubkey in production. Called once per non-anchor
+    /// input by [`perform_bump`]; closure may be invoked sequentially many times, so it
+    /// should be cheap to retain a strong reference to (typically just an `Arc` to the
+    /// secret-service handle).
+    pub wallet_input_signer: InputSigner,
+    /// Cap on the package-level fee rate. The bump loop clamps the fee source's reported
+    /// target to this and warns when clamping kicks in. Per design, exceeding this is an
+    /// operator policy decision: we don't escalate.
+    pub max_fee_rate: FeeRate,
+    /// Submits `[parent, child]` packages via bitcoind. Wrapper around the
+    /// [`submitpackage::submit_package`] helper.
+    pub package_submitter: Arc<P>,
+}
+
+impl<W, F, P> Clone for CpfpContext<W, F, P>
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            wallet: self.wallet.clone(),
+            fee_source: self.fee_source.clone(),
+            anchor_input_signer: self.anchor_input_signer.clone(),
+            multi_anchor_signer: self.multi_anchor_signer.clone(),
+            wallet_input_signer: self.wallet_input_signer.clone(),
+            max_fee_rate: self.max_fee_rate,
+            package_submitter: self.package_submitter.clone(),
+        }
+    }
+}
+
+impl<W, F, P> Debug for CpfpContext<W, F, P>
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CpfpContext")
+            .field("wallet", &self.wallet)
+            .field("fee_source", &self.fee_source)
+            .field("anchor_input_signer", &"<closure>")
+            .field("wallet_input_signer", &"<closure>")
+            .field("max_fee_rate", &self.max_fee_rate)
+            .field("package_submitter", &self.package_submitter)
+            .finish()
+    }
+}
+
+/// Why the bump loop is being invoked. Controls the `target ≤ last bump rate` skip:
+/// eager bumps (after broadcasting a new parent) skip; trigger-driven bumps (new block,
+/// timer tick, parent mempool eviction) **do not**, because they may be reacting to the
+/// previous child being purged with no parent-side event to clue us in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BumpReason {
+    /// First bump for a freshly-broadcast parent. Skip if the fee source hasn't moved
+    /// above the last rate — the fresh parent's protocol-floor fee is already a baseline.
+    NewJob,
+    /// A new block arrived. Always (re)build the child to keep mempool presence even at
+    /// the same fee rate.
+    NewBlock,
+    /// The shared CPFP refresh tick fired. Same policy as [`Self::NewBlock`].
+    Tick,
+    /// The driver observed the parent leaving the mempool (eviction event). Always
+    /// (re)attempt to push the package back in.
+    ParentEvicted,
+}
+
+impl BumpReason {
+    /// Whether the bump should skip on `target ≤ last_pkg_fee_rate`. Eager (`NewJob`)
+    /// bumps skip to avoid wasted RBF; reactive bumps always rebuild.
+    pub const fn skip_on_same_rate(self) -> bool {
+        matches!(self, Self::NewJob)
+    }
+}
+
+/// Drives one CPFP bump attempt for `parent` under `strategy`.
+///
+/// Returns `Ok(true)` if a package was submitted, `Ok(false)` if the bump was skipped
+/// (see the skip conditions below), and the error variants of [`CpfpError`] otherwise.
+///
+/// Same-rate calls are a no-op only for [`BumpReason::NewJob`]; reactive reasons
+/// (block/tick/eviction) rebuild the child even at an unchanged target, because a child
+/// evicted by a competing package is invisible to us — see step 4 below.
+///
+/// `handle.last_child_inputs` is updated as soon as the wallet hands back a funded child —
+/// **not** only on success — because the wallet leases those inputs at that point and the next
+/// call is the only thing that can release them (it passes them back as `replacing`). Returning
+/// early from any later step without recording them would strand the leases permanently.
+/// `handle.last_pkg_fee_rate` and `handle.last_child_txid` describe what actually reached the
+/// mempool, so those advance only on success.
+///
+/// ## Cap-and-warn at `max_fee_rate`
+///
+/// When the fee source reports above `ctx.max_fee_rate`, the target is clamped and a warning
+/// is logged. The bump proceeds at the cap. If the fee source's target remains above the cap
+/// on subsequent calls, this is steady-state — operator's `max_fee_rate` is the most they're
+/// willing to pay.
+///
+/// ## Baseline skips
+///
+/// Two conditions mean the parent needs no child at all (both return `Ok(false)`):
+/// - the fee source reports `≤ bridge_protocol_floor` — the presigned parent's protocol-floor fee
+///   rate is already sufficient;
+/// - the parent's own fee (`strategy.parent_fee()` over its vbytes) already meets the target — a
+///   child cannot improve the package rate, it would only pay for its own vbytes.
+pub async fn perform_bump<W, F, P>(
+    ctx: &CpfpContext<W, F, P>,
+    parent: &Transaction,
+    strategy: CpfpStrategy,
+    handle: &mut CpfpHandle,
+    bridge_protocol_floor: FeeRate,
+    reason: BumpReason,
+) -> Result<bool, CpfpError>
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    let parent_txid = parent.compute_txid();
+
+    // ── 1. Query the fee source ─────────────────────────────────────────────
+    let estimated = ctx
+        .fee_source
+        .estimate()
+        .await
+        .map_err(CpfpError::FeeSource)?;
+
+    // ── 2. Clamp to max_fee_rate, warn if clamping kicked in ────────────────
+    let target = if estimated > ctx.max_fee_rate {
+        warn!(
+            %parent_txid,
+            estimated = ?estimated,
+            cap = ?ctx.max_fee_rate,
+            "fee source target exceeds max_fee_rate; clamping to cap (operator policy)"
+        );
+        ctx.max_fee_rate
+    } else {
+        estimated
+    };
+
+    // ── 3. Baseline skips: parent already sufficient on its own ─────────────
+    if target <= bridge_protocol_floor {
+        // Quiet by default — this fires on every bump tick for every parent in a quiet
+        // mempool. `trace!` so it's still recoverable with -vvv.
+        tracing::trace!(
+            %parent_txid,
+            ?target,
+            ?reason,
+            "fee source target at or below protocol floor; skipping CPFP child"
+        );
+        return Ok(false);
+    }
+    // If the parent's own fee already clears the target, a child can't improve the
+    // package rate — it would only pay for its own vbytes. Skipping here also avoids a
+    // wallet corner: a child asked to cover nothing but itself can end up selecting no
+    // funding input at all and failing on a below-dust drain output.
+    let parent_vbytes = u64::try_from(parent.vsize()).expect("tx vsize fits in u64");
+    if let Some(parent_target_fee) = target.fee_vb(parent_vbytes) {
+        if strategy.parent_fee() >= parent_target_fee {
+            tracing::trace!(
+                %parent_txid,
+                ?target,
+                parent_fee = %strategy.parent_fee(),
+                parent_vbytes,
+                ?reason,
+                "parent fee alone meets target; skipping CPFP child"
+            );
+            return Ok(false);
+        }
+    }
+
+    // ── 4. Skip if we already bumped at this rate (eager only) ──────────────
+    //
+    // Reactive bumps (new block / tick / parent eviction) DO rebuild at the same rate:
+    // the previous child may have been silently evicted from the mempool by a competing
+    // replacement, and the only signal we get is the absence of confirmation. A same-rate
+    // resubmission either dedups against the still-present child (`txn-already-in-mempool`
+    // is fine inside `submitpackage`) or, if the rebuilt child differs, gets rejected by
+    // the BIP-125 incremental-fee rule — a logged, harmless failure. We accept that noise
+    // because it's the only way to revive a package whose child is actually gone.
+    if reason.skip_on_same_rate() {
+        if let Some(prev) = handle.last_pkg_fee_rate {
+            if target <= prev {
+                info!(
+                    %parent_txid,
+                    ?target,
+                    last = ?prev,
+                    ?reason,
+                    "target ≤ last bump rate; no-op (avoiding wasted RBF)"
+                );
+                return Ok(false);
+            }
+        }
+    }
+
+    // ── 5. Build the child via the wallet ───────────────────────────────────
+    let replacing: Option<&[OutPoint]> =
+        (!handle.last_child_inputs.is_empty()).then_some(handle.last_child_inputs.as_slice());
+    let funded = ctx
+        .wallet
+        .build_cpfp_child(parent, strategy.clone(), target, replacing)
+        .await
+        .map_err(CpfpError::Wallet)?;
+
+    // Record the newly-leased funding inputs NOW, before any of the fallible steps below.
+    //
+    // `build_cpfp_child` leases `funded.spent` on the way out. Every step between here and
+    // submission can fail (anchor signer, wallet signer, sighash, PSBT extraction, package
+    // rejection), and until this handle carries the inputs, the next bump computes
+    // `replacing = None` and the wallet is never told to let them go — so a single transient
+    // signer or RPC blip stranded those UTXOs for the lifetime of the process, and repeated
+    // failures progressively starved the general wallet of spendable inputs.
+    //
+    // Writing it here is safe against the retry path too: `OperatorWallet::build_cpfp_child`
+    // releases `replacing` up front and, if selection then fails, re-leases it — so the
+    // recorded set is always either currently leased or deliberately handed back.
+    handle.last_child_inputs = funded.spent.clone();
+
+    // ── 6. Sign each input still lacking final_script_witness ─────────────
+    //
+    // The wallet's PSBT may be fully unsigned, partially signed, or fully signed (see
+    // [`CpfpWallet`]'s "PSBT-signing contract" doc). We inspect each input's
+    // `final_script_witness` and only sign the ones that are still unsigned:
+    //
+    // - For `AnchorBearing`: at most one anchor input (foreign, signed via `anchor_input_signer`) +
+    //   N wallet funding inputs (signed via `wallet_input_signer`).
+    // - For `ParentTxCombined`: all inputs are operator-controlled outputs (the payout output +
+    //   wallet funding inputs); every still-unsigned one goes through `wallet_input_signer`. No
+    //   anchor signer is invoked.
+    //
+    // Backends matter here: descriptor-only wallets (NativeGeneralWallet) return fully
+    // unsigned PSBTs and every input gets signed below; create-and-sign backends
+    // (Fireblocks-style) return wallet funding inputs already signed and only the foreign
+    // anchor input unsigned — the skip checks preserve the wallet's signatures.
+    let mut psbt = funded.psbt;
+    let anchor_outpoint_opt = match &strategy {
+        CpfpStrategy::AnchorBearing { anchor_vout, .. }
+        | CpfpStrategy::MultiAnchorBearing { anchor_vout, .. } => Some(OutPoint {
+            txid: parent_txid,
+            vout: *anchor_vout,
+        }),
+        CpfpStrategy::ParentTxCombined { .. } => None,
+    };
+
+    let (anchor_input_idx, wallet_input_idxs): (Option<usize>, Vec<usize>) = {
+        let mut anchor = None;
+        let mut wallet = Vec::with_capacity(psbt.inputs.len());
+        for (i, txin) in psbt.unsigned_tx.input.iter().enumerate() {
+            if Some(txin.previous_output) == anchor_outpoint_opt {
+                anchor = Some(i);
+            } else {
+                wallet.push(i);
+            }
+        }
+        (anchor, wallet)
+    };
+
+    if !matches!(strategy, CpfpStrategy::ParentTxCombined { .. }) {
+        // The wallet promised to add the anchor as a foreign UTXO; sanity-check that the
+        // PSBT actually contains it before signing.
+        let anchor_idx = anchor_input_idx.ok_or_else(|| {
+            CpfpError::Wallet(format!(
+                "wallet-built child does not contain expected anchor outpoint for parent {parent_txid}"
+            ))
+        })?;
+        // Same skip-if-already-signed semantics as the wallet-input loop below: a wallet
+        // backend that happens to hold the musig2 (anchor) key in addition to the general
+        // key may pre-sign the anchor input as part of its create-and-sign API. Respect
+        // that rather than overwriting.
+        if psbt.inputs[anchor_idx].final_script_witness.is_none() {
+            let witness = match &strategy {
+                // Key-path: sign the tweaked output key, witness is the bare signature.
+                CpfpStrategy::AnchorBearing { .. } => {
+                    let sighash =
+                        compute_input_sighash(&psbt, anchor_idx).map_err(CpfpError::PsbtExtract)?;
+                    let sig = (ctx.anchor_input_signer)(Message::from(sighash))
+                        .await
+                        .map_err(CpfpError::AnchorSigner)?;
+                    let mut witness = Witness::new();
+                    witness.push(sig.as_ref());
+                    witness
+                }
+                // Script-path: the sighash commits to the leaf, the signature is untweaked,
+                // and the witness carries the leaf script and control block after it.
+                CpfpStrategy::MultiAnchorBearing {
+                    leaf_script,
+                    control_block,
+                    ..
+                } => {
+                    let sighash = compute_script_path_sighash(&psbt, anchor_idx, leaf_script)
+                        .map_err(CpfpError::PsbtExtract)?;
+                    let sig = (ctx.multi_anchor_signer)(Message::from(sighash))
+                        .await
+                        .map_err(CpfpError::AnchorSigner)?;
+                    let mut witness = Witness::new();
+                    witness.push(sig.as_ref());
+                    witness.push(leaf_script.to_bytes());
+                    witness.push(control_block.serialize());
+                    witness
+                }
+                CpfpStrategy::ParentTxCombined { .. } => {
+                    unreachable!("guarded by the enclosing `if`")
+                }
+            };
+            psbt.inputs[anchor_idx].final_script_witness = Some(witness);
+        }
+    }
+
+    // Skip inputs that the wallet already signed. `NativeGeneralWallet` returns fully-unsigned
+    // PSBTs (it's descriptor-only and has no key material), so every wallet input goes through
+    // `wallet_input_signer` below. A Fireblocks-style backend typically does create-and-sign in
+    // one API call, leaving the funding inputs already-signed and only the foreign anchor
+    // input unsigned — for that case we MUST NOT re-sign and clobber the wallet's witness with
+    // one computed against a key the wallet doesn't actually control. The skip makes the
+    // [`CpfpWallet`] trait contract backend-agnostic: "return a PSBT where any input still
+    // without a `final_script_witness` is signable via `wallet_input_signer`."
+    for idx in wallet_input_idxs {
+        if psbt.inputs[idx].final_script_witness.is_some() {
+            continue;
+        }
+        let sighash = compute_input_sighash(&psbt, idx).map_err(CpfpError::PsbtExtract)?;
+        let sig = (ctx.wallet_input_signer)(Message::from(sighash))
+            .await
+            .map_err(CpfpError::WalletSigner)?;
+        let mut witness = Witness::new();
+        witness.push(sig.as_ref());
+        psbt.inputs[idx].final_script_witness = Some(witness);
+    }
+
+    // ── 7. Finalize PSBT → child Transaction ───────────────────────────────
+    //
+    // Defensive sanity check: every input must have `final_script_witness` set, otherwise
+    // `extract_tx` produces a witness-less tx that bitcoind would reject downstream.
+    for (i, input) in psbt.inputs.iter().enumerate() {
+        if input.final_script_witness.is_none() {
+            return Err(CpfpError::PsbtExtract(format!(
+                "PSBT input {i} has no final_script_witness after signing; refusing to extract"
+            )));
+        }
+    }
+    let child = psbt
+        .extract_tx()
+        .map_err(|e| CpfpError::PsbtExtract(format!("{e:?}")))?;
+    let child_txid = child.compute_txid();
+
+    // ── 8. submit_package([parent, child]) ──────────────────────────────────
+    let summary = ctx
+        .package_submitter
+        .submit_package(&[parent.clone(), child])
+        .await?;
+
+    info!(
+        %parent_txid,
+        %child_txid,
+        ?target,
+        replaced = ?summary.replaced,
+        "submitted CPFP package"
+    );
+
+    // ── 9. Update handle ────────────────────────────────────────────────────
+    //
+    // `last_child_inputs` was already recorded right after funding (see above) so a failure
+    // anywhere in between still hands the leases back on the next bump. The remaining two
+    // fields describe what is actually in the mempool, so they only advance on success.
+    handle.last_pkg_fee_rate = Some(target);
+    handle.last_child_txid = Some(child_txid);
+
+    Ok(true)
+}
+
+/// Computes the BIP-341 **script-path** sighash for one input of a funded child PSBT.
+///
+/// Differs from [`compute_input_sighash`] in that the message commits to the specific leaf being
+/// satisfied (via its [`TapLeafHash`]), so a signature made for one leaf cannot be replayed
+/// against another. Used for [`CpfpStrategy::MultiAnchorBearing`] anchors, whose leaves are
+/// `<watchtower_pubkey> OP_CHECKSIG`.
+fn compute_script_path_sighash(
+    psbt: &Psbt,
+    input_idx: usize,
+    leaf_script: &ScriptBuf,
+) -> Result<bitcoin::TapSighash, String> {
+    let prevouts: Vec<TxOut> = psbt
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            input
+                .witness_utxo
+                .clone()
+                .ok_or_else(|| format!("PSBT input {i}: witness_utxo not populated"))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let leaf_hash = TapLeafHash::from_script(leaf_script, LeafVersion::TapScript);
+    let mut cache = SighashCache::new(&psbt.unsigned_tx);
+    cache
+        .taproot_script_spend_signature_hash(
+            input_idx,
+            &Prevouts::All(&prevouts),
+            leaf_hash,
+            TapSighashType::Default,
+        )
+        .map_err(|e| format!("script-path sighash compute (input {input_idx}): {e:?}"))
+}
+
+/// Computes the BIP-341 key-path Taproot sighash for one input of a funded child PSBT.
+///
+/// Uses [`TapSighashType::Default`] (sighash byte omitted from the witness; signature is the
+/// bare 64-byte Schnorr signature). Requires every PSBT input to have `witness_utxo`
+/// populated — BDK populates these on every wallet-selected input, and the anchor adapter
+/// populates it for the foreign anchor input.
+fn compute_input_sighash(psbt: &Psbt, input_idx: usize) -> Result<bitcoin::TapSighash, String> {
+    let prevouts: Vec<TxOut> = psbt
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(i, input)| {
+            input
+                .witness_utxo
+                .clone()
+                .ok_or_else(|| format!("PSBT input {i}: witness_utxo not populated"))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let mut cache = SighashCache::new(&psbt.unsigned_tx);
+    cache
+        .taproot_key_spend_signature_hash(
+            input_idx,
+            &Prevouts::All(&prevouts),
+            TapSighashType::Default,
+        )
+        .map_err(|e| format!("sighash compute (input {input_idx}): {e:?}"))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::sync::Mutex;
+
+    use bitcoin::{
+        absolute,
+        hashes::Hash,
+        secp256k1::{Keypair, SECP256K1},
+        transaction::Version,
+        Address, Network, TxIn, XOnlyPublicKey,
+    };
+
+    use super::*;
+    use crate::submitpackage::SubmitPackageSummary;
+
+    // ── Test doubles ─────────────────────────────────────────────────────────
+
+    #[derive(Debug)]
+    pub(crate) struct FakeFeeSource {
+        rate: Mutex<Result<FeeRate, String>>,
+    }
+    impl FakeFeeSource {
+        pub(crate) fn returning(rate: FeeRate) -> Self {
+            Self {
+                rate: Mutex::new(Ok(rate)),
+            }
+        }
+        fn failing() -> Self {
+            Self {
+                rate: Mutex::new(Err("fake fee source failure".to_string())),
+            }
+        }
+    }
+    impl CpfpFeeSource for FakeFeeSource {
+        fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+            let r = self.rate.lock().unwrap().clone();
+            async move { r }
+        }
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct FakeWallet {
+        psbt_template: Mutex<Option<Psbt>>,
+        spent_template: Vec<OutPoint>,
+        error: Option<String>,
+    }
+    impl FakeWallet {
+        pub(crate) fn returning(psbt: Psbt, spent: Vec<OutPoint>) -> Self {
+            Self {
+                psbt_template: Mutex::new(Some(psbt)),
+                spent_template: spent,
+                error: None,
+            }
+        }
+        pub(crate) fn failing(msg: &str) -> Self {
+            Self {
+                psbt_template: Mutex::new(None),
+                spent_template: Vec::new(),
+                error: Some(msg.to_string()),
+            }
+        }
+    }
+    impl CpfpWallet for FakeWallet {
+        fn build_cpfp_child(
+            &self,
+            _parent: &Transaction,
+            _strategy: CpfpStrategy,
+            _target_pkg_fee_rate: FeeRate,
+            _replacing: Option<&[OutPoint]>,
+        ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
+            let err = self.error.clone();
+            let psbt = self.psbt_template.lock().unwrap().clone();
+            let spent = self.spent_template.clone();
+            async move {
+                if let Some(e) = err {
+                    return Err(e);
+                }
+                Ok(WalletFundedPsbt {
+                    psbt: psbt.expect("test must seed a psbt template"),
+                    spent,
+                })
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct FakeSubmitter {
+        pub(crate) result: Mutex<Result<SubmitPackageSummary, String>>,
+        pub(crate) captured: Mutex<Vec<Vec<Transaction>>>,
+    }
+    impl FakeSubmitter {
+        pub(crate) fn ok() -> Self {
+            Self {
+                result: Mutex::new(Ok(SubmitPackageSummary {
+                    tx_results: Default::default(),
+                    replaced: Vec::new(),
+                })),
+                captured: Mutex::new(Vec::new()),
+            }
+        }
+        pub(crate) fn failing(reason: &str) -> Self {
+            Self {
+                result: Mutex::new(Err(reason.to_string())),
+                captured: Mutex::new(Vec::new()),
+            }
+        }
+    }
+    impl CpfpPackageSubmitter for FakeSubmitter {
+        fn submit_package(
+            &self,
+            txs: &[Transaction],
+        ) -> impl std::future::Future<Output = Result<SubmitPackageSummary, SubmitPackageError>> + Send
+        {
+            self.captured.lock().unwrap().push(txs.to_vec());
+            let snapshot: Result<SubmitPackageSummary, String> = match &*self.result.lock().unwrap()
+            {
+                Ok(s) => Ok(s.clone()),
+                Err(e) => Err(e.clone()),
+            };
+            async move {
+                match snapshot {
+                    Ok(s) => Ok(s),
+                    Err(msg) => Err(SubmitPackageError::Rejected {
+                        message: msg,
+                        tx_errors: Vec::new(),
+                    }),
+                }
+            }
+        }
+    }
+
+    pub(crate) fn fake_input_signer_ok() -> InputSigner {
+        Arc::new(|_msg: Message| {
+            Box::pin(async move {
+                // Schnorr signature is 64 bytes; bytes don't have to verify for unit tests of
+                // the bump-loop control flow.
+                let sig = Signature::from_slice(&[7u8; 64]).expect("64 bytes is a valid sig");
+                Ok::<_, String>(sig)
+            })
+        })
+    }
+
+    pub(crate) fn fake_input_signer_failing(message: &'static str) -> InputSigner {
+        Arc::new(move |_msg: Message| {
+            let m = message.to_string();
+            Box::pin(async move { Err(m) })
+        })
+    }
+
+    // ── Test fixtures ────────────────────────────────────────────────────────
+
+    pub(crate) fn test_keypair_and_xonly() -> (Keypair, XOnlyPublicKey) {
+        let kp = Keypair::from_seckey_slice(SECP256K1, &[5u8; 32]).unwrap();
+        let (x, _parity) = kp.x_only_public_key();
+        (kp, x)
+    }
+
+    /// Build a synthetic parent with a keyed-Taproot anchor at vout 0.
+    pub(crate) fn synthetic_parent(
+        anchor_internal_key: XOnlyPublicKey,
+        anchor_value: Amount,
+    ) -> Transaction {
+        let addr = Address::p2tr(SECP256K1, anchor_internal_key, None, Network::Regtest);
+        Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: anchor_value,
+                script_pubkey: addr.script_pubkey(),
+            }],
+        }
+    }
+
+    /// Build a synthetic child PSBT with the right shape: anchor input + funding input + change.
+    /// Inputs carry only `witness_utxo` (+ `tap_internal_key` on the anchor); `perform_bump`
+    /// is responsible for signing both inputs via its caller-provided signers.
+    pub(crate) fn synthetic_child_psbt(
+        parent: &Transaction,
+        anchor_vout: u32,
+        anchor_internal_key: XOnlyPublicKey,
+    ) -> Psbt {
+        let anchor_outpoint = OutPoint {
+            txid: parent.compute_txid(),
+            vout: anchor_vout,
+        };
+        let funding_outpoint = OutPoint {
+            txid: bitcoin::Txid::from_slice(&[1u8; 32]).unwrap(),
+            vout: 0,
+        };
+        let wallet_script = Address::p2tr(
+            SECP256K1,
+            test_keypair_and_xonly().1,
+            None,
+            Network::Regtest,
+        )
+        .script_pubkey();
+        let child_tx = Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![
+                TxIn {
+                    previous_output: anchor_outpoint,
+                    ..Default::default()
+                },
+                TxIn {
+                    previous_output: funding_outpoint,
+                    ..Default::default()
+                },
+            ],
+            output: vec![TxOut {
+                value: Amount::from_sat(49_500),
+                script_pubkey: wallet_script.clone(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(child_tx).expect("unsigned tx must convert");
+        psbt.inputs[0].witness_utxo = Some(parent.output[anchor_vout as usize].clone());
+        psbt.inputs[0].tap_internal_key = Some(anchor_internal_key);
+        psbt.inputs[1].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: wallet_script,
+        });
+        psbt
+    }
+
+    /// Build a synthetic child PSBT for the `ParentTxCombined` shape: payout input + funding
+    /// input + change. Both inputs carry only `witness_utxo`; `perform_bump` signs them via
+    /// `wallet_input_signer`.
+    fn synthetic_parent_combined_child_psbt(
+        payout_outpoint: OutPoint,
+        wallet_script: bitcoin::ScriptBuf,
+    ) -> Psbt {
+        let funding_outpoint = OutPoint {
+            txid: bitcoin::Txid::from_slice(&[2u8; 32]).unwrap(),
+            vout: 0,
+        };
+        let child_tx = Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![
+                TxIn {
+                    previous_output: payout_outpoint,
+                    ..Default::default()
+                },
+                TxIn {
+                    previous_output: funding_outpoint,
+                    ..Default::default()
+                },
+            ],
+            output: vec![TxOut {
+                value: Amount::from_sat(99_000),
+                script_pubkey: wallet_script.clone(),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(child_tx).expect("unsigned tx must convert");
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: wallet_script.clone(),
+        });
+        psbt.inputs[1].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: wallet_script,
+        });
+        psbt
+    }
+
+    fn context<F, W, P>(
+        fee_source: Arc<F>,
+        wallet: Arc<W>,
+        submitter: Arc<P>,
+        anchor_signer: InputSigner,
+        wallet_signer: InputSigner,
+        max_fee_rate: FeeRate,
+    ) -> CpfpContext<W, F, P>
+    where
+        F: CpfpFeeSource + 'static,
+        W: CpfpWallet + 'static,
+        P: CpfpPackageSubmitter + 'static,
+    {
+        CpfpContext {
+            wallet,
+            fee_source,
+            multi_anchor_signer: anchor_signer.clone(),
+            anchor_input_signer: anchor_signer,
+            wallet_input_signer: wallet_signer,
+            max_fee_rate,
+            package_submitter: submitter,
+        }
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    pub(crate) const PROTOCOL_FLOOR: FeeRate = FeeRate::from_sat_per_vb_unchecked(2);
+
+    pub(crate) fn anchor_strategy(anchor_key: XOnlyPublicKey) -> CpfpStrategy {
+        CpfpStrategy::AnchorBearing {
+            anchor_vout: 0,
+            anchor_internal_key: anchor_key,
+            parent_fee: Amount::from_sat(220),
+        }
+    }
+
+    #[tokio::test]
+    async fn bump_skipped_when_target_at_or_below_floor() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(2).unwrap(),
+            )),
+            Arc::new(FakeWallet::failing(
+                "wallet must not be called when skipping",
+            )),
+            Arc::new(FakeSubmitter::failing("submitter must not be called")),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("at-floor must succeed-skip");
+        assert!(!bumped);
+        assert!(handle.last_pkg_fee_rate.is_none());
+    }
+
+    #[tokio::test]
+    async fn bump_skipped_when_parent_fee_alone_meets_target() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        // Target is above the floor, and the reason is reactive so the step-4 same-rate
+        // skip can't fire — the only thing standing between perform_bump and the failing
+        // wallet is the parent-fee baseline skip.
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(5).unwrap(),
+            )),
+            Arc::new(FakeWallet::failing(
+                "wallet must not be called when the parent alone clears the target",
+            )),
+            Arc::new(FakeSubmitter::failing("submitter must not be called")),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let overpaying = CpfpStrategy::AnchorBearing {
+            anchor_vout: 0,
+            anchor_internal_key: anchor_key,
+            // Far more than 5 sat/vB over any plausible parent vsize.
+            parent_fee: Amount::from_sat(50_000),
+        };
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            overpaying,
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await
+        .expect("overpaying parent must succeed-skip");
+        assert!(!bumped);
+        assert!(handle.last_pkg_fee_rate.is_none());
+    }
+
+    #[tokio::test]
+    async fn eager_bump_skipped_when_target_not_above_last_rate() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(5).unwrap(),
+            )),
+            Arc::new(FakeWallet::failing("wallet must not be called")),
+            Arc::new(FakeSubmitter::failing("submitter must not be called")),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle {
+            last_pkg_fee_rate: Some(FeeRate::from_sat_per_vb(5).unwrap()),
+            ..Default::default()
+        };
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .unwrap();
+        assert!(!bumped);
+    }
+
+    #[tokio::test]
+    async fn reactive_bump_rebuilds_even_at_same_rate() {
+        // Regression for B3 (reviewer finding): when only the child is evicted, no
+        // parent-side eviction event fires; the timer/block tick must rebuild even at the
+        // same package fee rate to keep the child resident in the mempool.
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+        let submitter = Arc::new(FakeSubmitter::ok());
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(5).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            submitter.clone(),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(50).unwrap(),
+        );
+        let mut handle = CpfpHandle {
+            last_pkg_fee_rate: Some(FeeRate::from_sat_per_vb(5).unwrap()),
+            ..Default::default()
+        };
+        for reason in [
+            BumpReason::NewBlock,
+            BumpReason::Tick,
+            BumpReason::ParentEvicted,
+        ] {
+            let bumped = perform_bump(
+                &ctx,
+                &parent,
+                anchor_strategy(anchor_key),
+                &mut handle,
+                PROTOCOL_FLOOR,
+                reason,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("reactive bump ({reason:?}) must succeed: {e}"));
+            assert!(
+                bumped,
+                "reactive bump ({reason:?}) must rebuild at same rate"
+            );
+        }
+        assert_eq!(submitter.captured.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn happy_path_submits_package_and_updates_handle() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+        let wallet_funding = vec![OutPoint {
+            txid: bitcoin::Txid::from_slice(&[1u8; 32]).unwrap(),
+            vout: 0,
+        }];
+
+        let submitter = Arc::new(FakeSubmitter::ok());
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, wallet_funding.clone())),
+            submitter.clone(),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(50).unwrap(),
+        );
+
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("happy path must submit");
+        assert!(bumped);
+
+        // handle is updated
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(10).unwrap())
+        );
+        assert_eq!(handle.last_child_inputs, wallet_funding);
+        assert!(handle.last_child_txid.is_some());
+
+        // submitter received [parent, child]
+        let captured = submitter.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].len(), 2);
+        assert_eq!(captured[0][0].compute_txid(), parent.compute_txid());
+    }
+
+    #[tokio::test]
+    async fn target_above_cap_is_clamped() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(100).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            Arc::new(FakeSubmitter::ok()),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .unwrap();
+        assert!(bumped);
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(20).unwrap())
+        );
+    }
+
+    #[tokio::test]
+    async fn fee_source_failure_surfaces() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let ctx = context(
+            Arc::new(FakeFeeSource::failing()),
+            Arc::new(FakeWallet::failing("wallet must not be called")),
+            Arc::new(FakeSubmitter::failing("submitter must not be called")),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let err = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CpfpError::FeeSource(_)));
+        assert!(handle.last_pkg_fee_rate.is_none());
+    }
+
+    #[tokio::test]
+    async fn anchor_signer_failure_surfaces() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            Arc::new(FakeSubmitter::failing(
+                "must not be called when signer fails",
+            )),
+            fake_input_signer_failing("anchor sign boom"),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let err = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CpfpError::AnchorSigner(_)));
+        assert!(handle.last_pkg_fee_rate.is_none());
+    }
+
+    #[tokio::test]
+    async fn wallet_input_signer_failure_surfaces() {
+        // Regression for B2: every non-anchor input must be signed via wallet_input_signer.
+        // Failure there must propagate (not silently produce a witness-less tx).
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            Arc::new(FakeSubmitter::failing(
+                "must not be called when signer fails",
+            )),
+            fake_input_signer_ok(),
+            fake_input_signer_failing("wallet sign boom"),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let err = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, CpfpError::WalletSigner(_)),
+            "expected WalletSigner; got {err:?}"
+        );
+        assert!(handle.last_pkg_fee_rate.is_none());
+    }
+
+    #[tokio::test]
+    async fn presigned_wallet_inputs_are_not_re_signed() {
+        // Backend-agnostic CpfpWallet contract: if `build_cpfp_child` returns a PSBT
+        // whose wallet inputs are ALREADY signed (the create-and-sign pattern that
+        // Fireblocks-like backends follow), perform_bump MUST NOT overwrite the witness.
+        // Use a wallet_input_signer that panics if called — the test passes only if
+        // perform_bump skips signing for the pre-signed input.
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let mut psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+        // Pre-populate the funding input's witness with a sentinel — this is what a
+        // create-and-sign backend would have done. perform_bump must respect it.
+        let sentinel = Signature::from_slice(&[0x42u8; 64]).expect("64 bytes");
+        let mut sentinel_witness = Witness::new();
+        sentinel_witness.push(sentinel.as_ref());
+        psbt.inputs[1].final_script_witness = Some(sentinel_witness.clone());
+
+        let panicking_wallet_signer: InputSigner = Arc::new(|_msg: Message| {
+            Box::pin(async move {
+                panic!("wallet_input_signer must NOT be called for already-signed inputs")
+            })
+        });
+
+        let submitter = Arc::new(FakeSubmitter::ok());
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            submitter.clone(),
+            fake_input_signer_ok(),
+            panicking_wallet_signer,
+            FeeRate::from_sat_per_vb(50).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("presigned-wallet-input path must submit without invoking wallet signer");
+        assert!(bumped);
+
+        // The submitted child's funding-input witness must still be the sentinel — proves
+        // perform_bump didn't overwrite it.
+        let captured = submitter.captured.lock().unwrap();
+        let child = &captured[0][1];
+        assert_eq!(
+            child.input[1].witness, sentinel_witness,
+            "presigned wallet-input witness must survive perform_bump unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn presigned_anchor_input_is_not_re_signed() {
+        // Same contract for the anchor input — supports backends that hold the musig2 key
+        // alongside the general key (e.g. an operator who puts ALL keys in Fireblocks).
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let mut psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+        let sentinel = Signature::from_slice(&[0x37u8; 64]).expect("64 bytes");
+        let mut sentinel_witness = Witness::new();
+        sentinel_witness.push(sentinel.as_ref());
+        psbt.inputs[0].final_script_witness = Some(sentinel_witness.clone());
+
+        let panicking_anchor_signer: InputSigner = Arc::new(|_msg: Message| {
+            Box::pin(async move {
+                panic!("anchor_input_signer must NOT be called for an already-signed anchor")
+            })
+        });
+
+        let submitter = Arc::new(FakeSubmitter::ok());
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            submitter.clone(),
+            panicking_anchor_signer,
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(50).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("presigned-anchor path must submit without invoking anchor signer");
+        assert!(bumped);
+
+        let captured = submitter.captured.lock().unwrap();
+        let child = &captured[0][1];
+        assert_eq!(
+            child.input[0].witness, sentinel_witness,
+            "presigned anchor witness must survive perform_bump unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn parent_tx_combined_happy_path_no_anchor_signer_call() {
+        // ParentTxCombined parents have no foreign-key input. The bump loop must:
+        // (a) build the child via the wallet (which signs everything itself),
+        // (b) NOT invoke the anchor signer,
+        // (c) submit the package as usual.
+        //
+        // We assert (b) by supplying an anchor signer that panics if called — the test would
+        // panic instead of pass if the bump loop incorrectly entered the AnchorBearing path.
+        let wallet_script = Address::p2tr(
+            SECP256K1,
+            test_keypair_and_xonly().1,
+            None,
+            Network::Regtest,
+        )
+        .script_pubkey();
+        let payout_outpoint = OutPoint {
+            txid: bitcoin::Txid::from_slice(&[42u8; 32]).unwrap(),
+            vout: 1,
+        };
+        // The "parent" is a dummy v3 tx — its content doesn't matter for ParentTxCombined,
+        // since the wallet builds the child against the payout outpoint directly.
+        let parent = Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: wallet_script.clone(),
+            }],
+        };
+        let psbt = synthetic_parent_combined_child_psbt(payout_outpoint, wallet_script);
+
+        let panicking_anchor_signer: InputSigner = Arc::new(|_msg: Message| {
+            Box::pin(async move {
+                panic!("anchor signer must NOT be called for ParentTxCombined strategies");
+            })
+        });
+
+        let submitter = Arc::new(FakeSubmitter::ok());
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, vec![payout_outpoint])),
+            submitter.clone(),
+            panicking_anchor_signer,
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(50).unwrap(),
+        );
+
+        let mut handle = CpfpHandle::default();
+        let strategy = CpfpStrategy::ParentTxCombined {
+            payout_outpoint,
+            parent_fee: Amount::from_sat(300),
+        };
+        let bumped = perform_bump(
+            &ctx,
+            &parent,
+            strategy,
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("ParentTxCombined happy path must submit");
+        assert!(bumped);
+
+        assert_eq!(
+            handle.last_pkg_fee_rate,
+            Some(FeeRate::from_sat_per_vb(10).unwrap())
+        );
+        assert!(handle.last_child_txid.is_some());
+
+        // submitter received [parent, child]
+        let captured = submitter.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].len(), 2);
+        assert_eq!(captured[0][0].compute_txid(), parent.compute_txid());
+    }
+
+    #[tokio::test]
+    async fn cached_fee_source_returns_initial_value() {
+        let underlying = Arc::new(FakeFeeSource::returning(
+            FeeRate::from_sat_per_vb(7).unwrap(),
+        ));
+        let cache = CachedFeeSource::spawn(underlying, Duration::from_secs(60))
+            .await
+            .expect("initial refresh must succeed");
+        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(7).unwrap());
+        // Trait impl returns the same.
+        let via_trait = cache.estimate().await.unwrap();
+        assert_eq!(via_trait, FeeRate::from_sat_per_vb(7).unwrap());
+    }
+
+    #[tokio::test]
+    async fn cached_fee_source_propagates_initial_refresh_error() {
+        let underlying = Arc::new(FakeFeeSource::failing());
+        let result = CachedFeeSource::spawn(underlying, Duration::from_secs(60)).await;
+        assert!(result.is_err(), "initial refresh failure must propagate");
+    }
+
+    /// Fee source whose result can be swapped mid-test, for exercising the background
+    /// refresh loop of [`CachedFeeSource`].
+    #[derive(Debug)]
+    struct FlippableFeeSource {
+        inner: Mutex<Result<FeeRate, String>>,
+    }
+    impl CpfpFeeSource for FlippableFeeSource {
+        fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+            let r = self.inner.lock().unwrap().clone();
+            async move { r }
+        }
+    }
+
+    #[tokio::test]
+    async fn cached_fee_source_retains_stale_value_when_refresh_fails() {
+        // Initial refresh succeeds at 10 sat/vB; flip the underlying to fail; wait past a
+        // few 5 ms refresh intervals (real time — the refresh loop runs on a spawned task);
+        // the cache must still report the original 10 sat/vB.
+        let flippable = Arc::new(FlippableFeeSource {
+            inner: Mutex::new(Ok(FeeRate::from_sat_per_vb(10).unwrap())),
+        });
+        let cache = CachedFeeSource::spawn(flippable.clone(), Duration::from_millis(5))
+            .await
+            .unwrap();
+        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(10).unwrap());
+
+        // Flip underlying to failing.
+        *flippable.inner.lock().unwrap() = Err("transient blip".to_string());
+        // Wait long enough for a refresh attempt to complete.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Cache still reports 10.
+        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(10).unwrap());
+    }
+
+    #[tokio::test]
+    async fn cached_fee_source_picks_up_refreshed_value() {
+        // Same shape as the previous test, but the underlying flips to a new value.
+        let flippable = Arc::new(FlippableFeeSource {
+            inner: Mutex::new(Ok(FeeRate::from_sat_per_vb(5).unwrap())),
+        });
+        let cache = CachedFeeSource::spawn(flippable.clone(), Duration::from_millis(5))
+            .await
+            .unwrap();
+        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(5).unwrap());
+
+        *flippable.inner.lock().unwrap() = Ok(FeeRate::from_sat_per_vb(30).unwrap());
+        // Allow a few refresh ticks to fire.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(cache.current(), FeeRate::from_sat_per_vb(30).unwrap());
+    }
+
+    #[tokio::test]
+    async fn submitpackage_failure_surfaces() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, Vec::new())),
+            Arc::new(FakeSubmitter::failing("package-not-valid")),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(20).unwrap(),
+        );
+        let mut handle = CpfpHandle::default();
+        let err = perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CpfpError::SubmitPackage(_)));
+        assert!(handle.last_pkg_fee_rate.is_none());
+    }
+
+    /// Regression: a bump that dies *after* the wallet funded the child must still leave the
+    /// funding inputs recorded on the handle.
+    ///
+    /// `build_cpfp_child` leases `funded.spent` on the way out, and the only thing that can ever
+    /// hand those back is a subsequent bump passing them as `replacing`. Recording them only on
+    /// the success path meant any rejection stranded the UTXOs for the process lifetime, and
+    /// repeated failures walked the general wallet down to nothing.
+    ///
+    /// Exercised at both ends of the fallible stretch: package rejection (last step) and a
+    /// wallet-signer failure (first step).
+    #[tokio::test]
+    async fn failure_after_funding_still_records_leases_for_release() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let wallet_funding = vec![OutPoint {
+            txid: parent.compute_txid(),
+            vout: 7,
+        }];
+
+        for (label, submitter, wallet_signer) in [
+            (
+                "package rejected",
+                Arc::new(FakeSubmitter::failing("package-not-valid")),
+                fake_input_signer_ok(),
+            ),
+            (
+                "wallet signer failed",
+                Arc::new(FakeSubmitter::ok()),
+                fake_input_signer_failing("signer offline"),
+            ),
+        ] {
+            let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+            let ctx = context(
+                Arc::new(FakeFeeSource::returning(
+                    FeeRate::from_sat_per_vb(10).unwrap(),
+                )),
+                Arc::new(FakeWallet::returning(psbt, wallet_funding.clone())),
+                submitter,
+                fake_input_signer_ok(),
+                wallet_signer,
+                FeeRate::from_sat_per_vb(20).unwrap(),
+            );
+            let mut handle = CpfpHandle::default();
+            let result = perform_bump(
+                &ctx,
+                &parent,
+                anchor_strategy(anchor_key),
+                &mut handle,
+                PROTOCOL_FLOOR,
+                BumpReason::NewJob,
+            )
+            .await;
+
+            assert!(result.is_err(), "{label}: expected the bump to fail");
+            // Nothing reached the mempool, so these must not advance.
+            assert!(
+                handle.last_pkg_fee_rate.is_none(),
+                "{label}: fee rate must not advance on failure"
+            );
+            assert!(
+                handle.last_child_txid.is_none(),
+                "{label}: child txid must not advance on failure"
+            );
+            // But the leased inputs must be recorded, so the next bump releases them.
+            assert_eq!(
+                handle.last_child_inputs, wallet_funding,
+                "{label}: leased funding inputs must be recorded for release"
+            );
+        }
+    }
+
+    /// A constant-byte signer whose output is recognisable in the final witness, so a test can
+    /// prove *which* signer produced a given signature rather than only that signing happened.
+    fn fake_input_signer_const(byte: u8) -> InputSigner {
+        Arc::new(move |_msg: Message| {
+            Box::pin(async move {
+                Ok::<_, String>(
+                    Signature::from_slice(&[byte; 64]).expect("64 bytes is a valid sig"),
+                )
+            })
+        })
+    }
+
+    /// The script-path (`MultiAnchorBearing`) bump must (a) route the anchor input through the
+    /// dedicated `multi_anchor_signer` — NOT the tap-tweaked key-path signer — and (b) emit the
+    /// BIP-341 script-path witness stack `[signature, leaf_script, control_block]` in exactly
+    /// that order. A wrong signer or a reordered stack produces a transaction that fails script
+    /// validation at broadcast, on the time-critical contest path, with no local signal.
+    ///
+    /// Sentinels make routing observable: the key-path signer errors if invoked at all, and the
+    /// multi-anchor signer returns a recognisable constant signature that is then asserted
+    /// byte-for-byte in the captured child.
+    #[tokio::test]
+    async fn multi_anchor_bump_routes_untweaked_signer_and_orders_witness() {
+        use bitcoin::taproot::TaprootBuilder;
+
+        // Two watchtower-style leaves; ours is leaf 0. Assembled directly with TaprootBuilder
+        // because btc-tracker deliberately doesn't depend on the connector crate.
+        let (_, our_key) = test_keypair_and_xonly();
+        let derived_key = |seed: u8| {
+            let sk = bitcoin::secp256k1::SecretKey::from_slice(&[seed; 32]).expect("valid scalar");
+            bitcoin::secp256k1::Keypair::from_secret_key(SECP256K1, &sk)
+                .x_only_public_key()
+                .0
+        };
+        let other_key = derived_key(0x11);
+        let leaf = |key: XOnlyPublicKey| {
+            bitcoin::script::Builder::new()
+                .push_slice(key.serialize())
+                .push_opcode(bitcoin::opcodes::all::OP_CHECKSIG)
+                .into_script()
+        };
+        let our_leaf = leaf(our_key);
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(1, our_leaf.clone())
+            .expect("depth 1 is valid")
+            .add_leaf(1, leaf(other_key))
+            .expect("depth 1 is valid")
+            .finalize(SECP256K1, derived_key(0x22))
+            .expect("tree finalizes");
+        let control_block = spend_info
+            .control_block(&(our_leaf.clone(), bitcoin::taproot::LeafVersion::TapScript))
+            .expect("leaf is in the tree");
+        let anchor_spk = bitcoin::ScriptBuf::new_p2tr_tweaked(spend_info.output_key());
+
+        let parent = Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![TxOut {
+                value: Amount::from_sat(330),
+                script_pubkey: anchor_spk,
+            }],
+        };
+        // The synthetic child spends parent:0 (the anchor) + one wallet funding input; the
+        // internal key it stamps on input 0 is irrelevant to the script-path branch.
+        let psbt = synthetic_child_psbt(&parent, 0, our_key);
+        let wallet_funding = vec![OutPoint {
+            txid: parent.compute_txid(),
+            vout: 9,
+        }];
+
+        let submitter = Arc::new(FakeSubmitter::ok());
+        let ctx = CpfpContext {
+            wallet: Arc::new(FakeWallet::returning(psbt, wallet_funding.clone())),
+            fee_source: Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            // Key-path signer must never fire for a script-path anchor: if it does, the bump
+            // errors and the assertions below fail loudly.
+            anchor_input_signer: fake_input_signer_failing(
+                "key-path anchor signer must not be called for MultiAnchorBearing",
+            ),
+            multi_anchor_signer: fake_input_signer_const(0xAA),
+            wallet_input_signer: fake_input_signer_const(0xBB),
+            max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
+            package_submitter: submitter.clone(),
+        };
+        let strategy = CpfpStrategy::MultiAnchorBearing {
+            anchor_vout: 0,
+            leaf_script: our_leaf.clone(),
+            control_block: control_block.clone(),
+            parent_fee: Amount::from_sat(200),
+        };
+        let mut handle = CpfpHandle::default();
+        let submitted = perform_bump(
+            &ctx,
+            &parent,
+            strategy,
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect("script-path bump must succeed");
+        assert!(submitted);
+        assert_eq!(handle.last_child_inputs, wallet_funding);
+
+        let packages = submitter.captured.lock().unwrap();
+        let child = &packages[0][1];
+
+        // Anchor input: exactly the BIP-341 script-path stack, in order, signed by the
+        // multi-anchor sentinel.
+        let anchor_witness: Vec<&[u8]> = child.input[0].witness.iter().collect();
+        assert_eq!(
+            anchor_witness.len(),
+            3,
+            "script-path witness must be [sig, leaf_script, control_block]"
+        );
+        assert_eq!(
+            anchor_witness[0], &[0xAA; 64],
+            "anchor signature must come from multi_anchor_signer, not the key-path signer"
+        );
+        assert_eq!(anchor_witness[1], our_leaf.as_bytes());
+        assert_eq!(anchor_witness[2], control_block.serialize().as_slice());
+
+        // Wallet funding input stays a bare key-path spend via the wallet signer.
+        let wallet_witness: Vec<&[u8]> = child.input[1].witness.iter().collect();
+        assert_eq!(wallet_witness.len(), 1);
+        assert_eq!(wallet_witness[0], &[0xBB; 64]);
+    }
+}

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -151,6 +151,47 @@ pub struct CpfpHandle {
     pub last_child_fee: Option<Amount>,
 }
 
+/// A fee source could not produce an estimate.
+///
+/// Every cause is transient: the network, the RPC, and the explorer all recover. The type
+/// names the boundary, so a call site cannot pass one boundary's error where another belongs.
+#[derive(Debug, Clone, Error)]
+#[error("fee source: {0}")]
+pub struct FeeSourceError(pub String);
+
+/// A mempool query could not complete.
+///
+/// The bump loop treats each cause the same and falls through to the build, so the type
+/// carries a message rather than a classification.
+#[derive(Debug, Clone, Error)]
+#[error("mempool: {0}")]
+pub struct MempoolError(pub String);
+
+/// An input signer could not produce a signature.
+///
+/// The bump skips and the next trigger retries. A secret-service fault does not escalate out
+/// of the bump loop.
+#[derive(Debug, Clone, Error)]
+#[error("{0}")]
+pub struct SignerError(pub String);
+
+/// Why a wallet could not build a CPFP child.
+///
+/// The two cases lead to different driver behaviour, so the boundary reports which one it is
+/// rather than one message that the driver has to read.
+#[derive(Debug, Error)]
+pub enum CpfpWalletError {
+    /// The parent cannot carry a child, whatever the wallet does. Its anchor is not where the
+    /// strategy says, or the wallet cannot spend it. A signed parent does not change shape, so
+    /// every later attempt fails at the same step.
+    #[error("parent cannot carry a child: {0}")]
+    Unbumpable(String),
+    /// The wallet could not fund a child now. Funds arrive, the chain moves, and a later
+    /// attempt can pass.
+    #[error("{0}")]
+    Transient(String),
+}
+
 /// What one call to [`perform_bump`] achieved.
 ///
 /// A caller that must decide the fate of a transaction needs more than "no package went
@@ -168,25 +209,28 @@ pub enum BumpOutcome {
     /// No package went out, and the bump observed nothing about where the parent is. The
     /// target sits at the protocol floor, or the parent's own fee already meets it.
     NoChildNeeded,
+    /// The parent cannot carry a child at all. Every later bump for it fails the same way, so
+    /// the driver stops bumping it and lets the bare paths carry it.
+    Unbumpable,
 }
 
 /// Errors produced by [`perform_bump`].
 #[derive(Debug, Error)]
 pub enum CpfpError {
     /// The fee source lookup failed. The bump is skipped; the next trigger will retry.
-    #[error("fee source: {0}")]
-    FeeSource(String),
-    /// The wallet rejected the child build (insufficient funds, anchor out of range, ...).
+    #[error("{0}")]
+    FeeSource(#[from] FeeSourceError),
+    /// The wallet rejected the child build.
     #[error("wallet build_cpfp_child: {0}")]
-    Wallet(String),
+    Wallet(#[from] CpfpWalletError),
     /// The anchor input signer returned an error. The bump is skipped; the next trigger
     /// will retry. Per design, secret-service hiccups don't escalate from the bump loop.
     #[error("anchor signer: {0}")]
-    AnchorSigner(String),
+    AnchorSigner(SignerError),
     /// A wallet funding-input signer returned an error. Treated the same as
     /// [`Self::AnchorSigner`] — skip + retry.
     #[error("wallet input signer: {0}")]
-    WalletSigner(String),
+    WalletSigner(SignerError),
     /// `submitpackage` returned a non-success outcome. Logged + bump skipped.
     #[error("submit_package: {0}")]
     SubmitPackage(#[from] SubmitPackageError),
@@ -197,6 +241,14 @@ pub enum CpfpError {
 }
 
 impl CpfpError {
+    /// Whether every later bump for this parent fails the same way.
+    ///
+    /// A parent whose anchor is not where the strategy says never becomes bumpable, so the
+    /// driver stops rather than rebuild, re-sign, and resubmit on every block and tick.
+    pub const fn is_unbumpable(&self) -> bool {
+        matches!(self, Self::Wallet(CpfpWalletError::Unbumpable(_)))
+    }
+
     /// Whether this failure is a lost race for a shared anchor rather than a fault.
     ///
     /// See [`SubmitPackageError::is_replacement_contention`]. Callers use it to keep expected
@@ -352,7 +404,7 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
         target_pkg_fee_rate: FeeRate,
         replacing: Option<&dyn FundingLease>,
         prior_child_fee: Option<Amount>,
-    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send;
+    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, CpfpWalletError>> + Send;
 }
 
 /// Source of fee-rate estimates used to drive the package target. Defined in this crate
@@ -364,13 +416,14 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
 /// it in the background on `refresh_interval`.
 pub trait CpfpFeeSource: Send + Sync + fmt::Debug {
     /// Returns the current sat/vB target for the next block.
-    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send;
+    fn estimate(&self)
+        -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send;
 }
 
 /// Boxed future returned by an [`InputSigner`]; pinned + Send so it can fly across the
 /// driver's tokio task boundary.
 pub type InputSignFut =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Result<Signature, String>> + Send>>;
+    std::pin::Pin<Box<dyn std::future::Future<Output = Result<Signature, SignerError>> + Send>>;
 
 /// Signs one BIP-341 key-path Taproot input by computing a Schnorr signature over the
 /// caller-supplied sighash. Used by [`perform_bump`] in two distinct roles:
@@ -452,7 +505,10 @@ impl CachedFeeSource {
     /// Performs one initial refresh from `underlying`, spawns a background task that re-polls
     /// every `refresh_interval`, and returns a `CachedFeeSource` whose `estimate()` reads from
     /// the cached atomic.
-    pub async fn spawn<U>(underlying: Arc<U>, refresh_interval: Duration) -> Result<Self, String>
+    pub async fn spawn<U>(
+        underlying: Arc<U>,
+        refresh_interval: Duration,
+    ) -> Result<Self, FeeSourceError>
     where
         U: CpfpFeeSource + 'static,
     {
@@ -521,7 +577,9 @@ impl CachedFeeSource {
 impl CpfpFeeSource for CachedFeeSource {
     /// Returns the cached value. Never returns `Err` — refresh failures are logged at the
     /// background task and the prior value is retained.
-    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+    fn estimate(
+        &self,
+    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
         let value = self.current();
         async move { Ok(value) }
     }
@@ -569,7 +627,7 @@ pub trait CpfpMempool: Send + Sync + fmt::Debug {
     fn anchor_spend_state(
         &self,
         anchor: OutPoint,
-    ) -> impl std::future::Future<Output = Result<AnchorSpendState, String>> + Send;
+    ) -> impl std::future::Future<Output = Result<AnchorSpendState, MempoolError>> + Send;
 }
 
 /// Zero-sized placeholder that implements every CPFP trait but panics if any method is ever
@@ -595,14 +653,16 @@ impl CpfpWallet for CpfpDisabled {
         _target_pkg_fee_rate: FeeRate,
         _replacing: Option<&dyn FundingLease>,
         _prior_child_fee: Option<Amount>,
-    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
+    ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, CpfpWalletError>> + Send {
         async { unreachable!("CpfpDisabled::build_cpfp_child should never be called") }
     }
 }
 
 #[expect(clippy::manual_async_fn, reason = "see CpfpWallet impl above")]
 impl CpfpFeeSource for CpfpDisabled {
-    fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+    fn estimate(
+        &self,
+    ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
         async { unreachable!("CpfpDisabled::estimate should never be called") }
     }
 }
@@ -621,7 +681,7 @@ impl CpfpMempool for CpfpDisabled {
     fn anchor_spend_state(
         &self,
         _anchor: OutPoint,
-    ) -> impl std::future::Future<Output = Result<AnchorSpendState, String>> + Send {
+    ) -> impl std::future::Future<Output = Result<AnchorSpendState, MempoolError>> + Send {
         async { unreachable!("CpfpDisabled::anchor_spend_state should never be called") }
     }
 }
@@ -936,8 +996,7 @@ where
     let funded = ctx
         .wallet
         .build_cpfp_child(parent, strategy.clone(), target, replacing, prior_child_fee)
-        .await
-        .map_err(CpfpError::Wallet)?;
+        .await?;
 
     // Take the new lease into the handle NOW, before any of the fallible steps below.
     //
@@ -1196,7 +1255,7 @@ pub(crate) mod tests {
 
     #[derive(Debug)]
     pub(crate) struct FakeFeeSource {
-        rate: Mutex<Result<FeeRate, String>>,
+        rate: Mutex<Result<FeeRate, FeeSourceError>>,
     }
     impl FakeFeeSource {
         pub(crate) fn returning(rate: FeeRate) -> Self {
@@ -1206,12 +1265,14 @@ pub(crate) mod tests {
         }
         fn failing() -> Self {
             Self {
-                rate: Mutex::new(Err("fake fee source failure".to_string())),
+                rate: Mutex::new(Err(FeeSourceError("fake fee source failure".into()))),
             }
         }
     }
     impl CpfpFeeSource for FakeFeeSource {
-        fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+        fn estimate(
+            &self,
+        ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
             let r = self.rate.lock().unwrap().clone();
             async move { r }
         }
@@ -1245,7 +1306,7 @@ pub(crate) mod tests {
     pub(crate) struct FakeWallet {
         psbt_template: Mutex<Option<Psbt>>,
         spent_template: Vec<OutPoint>,
-        error: Option<String>,
+        error: Option<CpfpWalletError>,
         /// Outpoints of every lease that has dropped, in drop order.
         pub(crate) released: Arc<Mutex<Vec<OutPoint>>>,
     }
@@ -1262,7 +1323,17 @@ pub(crate) mod tests {
             Self {
                 psbt_template: Mutex::new(None),
                 spent_template: Vec::new(),
-                error: Some(msg.to_string()),
+                error: Some(CpfpWalletError::Transient(msg.to_string())),
+                released: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        /// A wallet that reports a parent which can never carry a child.
+        pub(crate) fn unbumpable(msg: &str) -> Self {
+            Self {
+                psbt_template: Mutex::new(None),
+                spent_template: Vec::new(),
+                error: Some(CpfpWalletError::Unbumpable(msg.to_string())),
                 released: Arc::new(Mutex::new(Vec::new())),
             }
         }
@@ -1282,8 +1353,12 @@ pub(crate) mod tests {
             _target_pkg_fee_rate: FeeRate,
             _replacing: Option<&dyn FundingLease>,
             _prior_child_fee: Option<Amount>,
-        ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
-            let err = self.error.clone();
+        ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, CpfpWalletError>> + Send
+        {
+            let err = self.error.as_ref().map(|e| match e {
+                CpfpWalletError::Unbumpable(m) => CpfpWalletError::Unbumpable(m.clone()),
+                CpfpWalletError::Transient(m) => CpfpWalletError::Transient(m.clone()),
+            });
             let psbt = self.psbt_template.lock().unwrap().clone();
             let lease = self.lease(self.spent_template.clone());
             async move {
@@ -1365,7 +1440,10 @@ pub(crate) mod tests {
         /// build path). The full contention flow is covered end to end against a live
         /// bitcoind; the unit tests use [`FakeSubmitter::with_spend_state`] to pin the
         /// lease bookkeeping on the skip paths.
-        async fn anchor_spend_state(&self, _anchor: OutPoint) -> Result<AnchorSpendState, String> {
+        async fn anchor_spend_state(
+            &self,
+            _anchor: OutPoint,
+        ) -> Result<AnchorSpendState, MempoolError> {
             Ok(*self.spend_state.lock().unwrap())
         }
     }
@@ -1376,7 +1454,7 @@ pub(crate) mod tests {
                 // Schnorr signature is 64 bytes; bytes don't have to verify for unit tests of
                 // the bump-loop control flow.
                 let sig = Signature::from_slice(&[7u8; 64]).expect("64 bytes is a valid sig");
-                Ok::<_, String>(sig)
+                Ok::<_, SignerError>(sig)
             })
         })
     }
@@ -1384,7 +1462,7 @@ pub(crate) mod tests {
     pub(crate) fn fake_input_signer_failing(message: &'static str) -> InputSigner {
         Arc::new(move |_msg: Message| {
             let m = message.to_string();
-            Box::pin(async move { Err(m) })
+            Box::pin(async move { Err(SignerError(m)) })
         })
     }
 
@@ -2320,10 +2398,12 @@ pub(crate) mod tests {
     /// refresh loop of [`CachedFeeSource`].
     #[derive(Debug)]
     struct FlippableFeeSource {
-        inner: Mutex<Result<FeeRate, String>>,
+        inner: Mutex<Result<FeeRate, FeeSourceError>>,
     }
     impl CpfpFeeSource for FlippableFeeSource {
-        fn estimate(&self) -> impl std::future::Future<Output = Result<FeeRate, String>> + Send {
+        fn estimate(
+            &self,
+        ) -> impl std::future::Future<Output = Result<FeeRate, FeeSourceError>> + Send {
             let r = self.inner.lock().unwrap().clone();
             async move { r }
         }
@@ -2343,7 +2423,7 @@ pub(crate) mod tests {
         assert_eq!(cache.current(), FeeRate::from_sat_per_vb(10).unwrap());
 
         // Flip underlying to failing.
-        *flippable.inner.lock().unwrap() = Err("transient blip".to_string());
+        *flippable.inner.lock().unwrap() = Err(FeeSourceError("transient blip".into()));
         // Wait long enough for a refresh attempt to complete.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -2477,7 +2557,7 @@ pub(crate) mod tests {
     fn fake_input_signer_const(byte: u8) -> InputSigner {
         Arc::new(move |_msg: Message| {
             Box::pin(async move {
-                Ok::<_, String>(
+                Ok::<_, SignerError>(
                     Signature::from_slice(&[byte; 64]).expect("64 bytes is a valid sig"),
                 )
             })

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -139,10 +139,14 @@ pub struct CpfpHandle {
     /// Package fee rate the driver last targeted. Used to skip noop bumps when the fee source
     /// hasn't moved upward.
     pub last_pkg_fee_rate: Option<FeeRate>,
-    /// Txid of the child we last broadcast (for tracking / replacement). `None` before the
-    /// first bump succeeds.
+    /// Txid of the child we last accepted into the mempool, for tracking and
+    /// replacement. `None` before the first accepted bump.
     pub last_child_txid: Option<Txid>,
-    /// Absolute fee that the most recent child pays. BIP-125 rule 4 requires a
+    /// Absolute fee that the most recent child pays. Set only when the package is
+    /// accepted into the mempool (step 9 of the bump), together with `last_child_txid`:
+    /// a rejected candidate must not become the floor, because the replacement floor
+    /// derived from it is not re-clamped against the target's max rate.
+    /// BIP-125 rule 4 requires a
     /// replacement to pay the replaced fee plus the incremental relay fee over the
     /// replacement's own size. The builder floors the next child's fee at this value plus
     /// 1 sat/vB × the new child's vbytes. A small target rise then produces a valid
@@ -1017,10 +1021,13 @@ where
 
     // ── 5. Build the child via the wallet ───────────────────────────────────
     let replacing: Option<&dyn FundingLease> = handle.last_child_lease.as_deref();
-    // The RBF floor only applies while there is a live child to replace. A prior child
-    // recorded but since evicted (lost anchor race, confirmed competitor) clears the handle
-    // through the release paths, so `last_child_fee` here always describes the mempool
-    // incumbent we are replacing.
+    // The RBF floor only applies while there is a child to replace. Only accepted
+    // submissions record `last_child_fee` (step 9), so a rejected candidate never feeds
+    // the floor. A prior child that lost the anchor race or was confirmed away clears
+    // the handle through the release paths. A child evicted by fee pressure is not
+    // probe-visible, so in that one case the floor still holds the dead child's fee and
+    // is conservative: the next child pays the dead child's fee plus its own
+    // incremental relay fee, which is a valid replacement fee.
     let prior_child_fee = handle
         .last_child_fee
         .filter(|_| handle.last_child_txid.is_some());
@@ -1038,12 +1045,15 @@ where
     // `replacing`. This assignment also drops the lease of the child that the new child
     // supersedes, once the caller writes the handle back.
     //
-    // Record the fee together with the lease. The fee is the floor for the next
-    // replacement (BIP-125 rule 4). If submission fails below, the prior child stays in
-    // the mempool and pays less than the recorded fee. The floor is then conservative,
-    // which is safe: the next child pays slightly more than the rule requires.
+    // The fee is captured but NOT recorded yet: it is the floor for the next replacement
+    // (BIP-125 rule 4) and must describe a child that is actually in the mempool. A
+    // rejected candidate must not set the floor — the floor is not re-clamped against
+    // the target's max rate, and submitpackage disables the Core fee guard, so
+    // recording a rejected fee would let failed submissions ratchet the package above
+    // the operator's cap, one failed tick at a time. The fee advances with
+    // `last_child_txid`, on acceptance only (step 9).
     handle.last_child_lease = Some(funded.lease);
-    handle.last_child_fee = funded.psbt.as_psbt().fee().ok();
+    let child_fee = funded.psbt.as_psbt().fee().ok();
 
     // ── 6. Sign each input still lacking final_script_witness ─────────────
     //
@@ -1193,10 +1203,13 @@ where
     // ── 9. Update handle ────────────────────────────────────────────────────
     //
     // The lease was already recorded right after funding (see above) so a failure
-    // anywhere in between still hands the leases back on the next bump. The remaining two
-    // fields describe what is actually in the mempool, so they only advance on success.
+    // anywhere in between still hands the leases back on the next bump. The remaining
+    // fields describe what is actually in the mempool, so they only advance on
+    // acceptance: a rejected candidate sets neither the floor fee nor the incumbent
+    // txid, and the wallet derives the next replacement floor from `last_child_fee`.
     handle.last_pkg_fee_rate = Some(target);
     handle.last_child_txid = Some(child_txid);
+    handle.last_child_fee = child_fee;
 
     Ok(BumpOutcome::Submitted)
 }
@@ -2234,6 +2247,58 @@ pub(crate) mod tests {
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0].len(), 2);
         assert_eq!(captured[0][0].compute_txid(), parent.compute_txid());
+    }
+
+    /// A rejected candidate is not the incumbent: a failed submission advances neither
+    /// the floor fee nor the child txid. Recording the rejected fee would let the next
+    /// build floor itself on it, and the floor is not re-clamped against the target's
+    /// max rate — sustained failures would ratchet the package above the operator's cap.
+    #[tokio::test]
+    async fn a_rejected_candidate_does_not_advance_the_floor() {
+        let (_, anchor_key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(anchor_key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, anchor_key);
+        let wallet_funding = vec![OutPoint {
+            txid: bitcoin::Txid::from_slice(&[1u8; 32]).unwrap(),
+            vout: 0,
+        }];
+
+        let submitter = Arc::new(FakeSubmitter::failing("min relay fee not met"));
+        let ctx = context(
+            Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            Arc::new(FakeWallet::returning(psbt, wallet_funding.clone())),
+            submitter.clone(),
+            fake_input_signer_ok(),
+            fake_input_signer_ok(),
+            FeeRate::from_sat_per_vb(50).unwrap(),
+        );
+
+        let mut handle = CpfpHandle::default();
+        perform_bump(
+            &ctx,
+            &parent,
+            anchor_strategy(anchor_key),
+            &mut handle,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+        )
+        .await
+        .expect_err("a failing submitter must surface the error");
+
+        assert!(
+            handle.last_child_txid.is_none(),
+            "a rejected candidate is not the incumbent"
+        );
+        assert!(
+            handle.last_child_fee.is_none(),
+            "a rejected candidate must not set the replacement floor"
+        );
+        assert!(handle.last_pkg_fee_rate.is_none());
+        // The lease still covers the built child's funding: the next bump hands it back
+        // or passes it as the replacement lease.
+        assert_eq!(held_by(&handle), wallet_funding);
     }
 
     #[tokio::test]

--- a/crates/btc-tracker/src/cpfp.rs
+++ b/crates/btc-tracker/src/cpfp.rs
@@ -18,8 +18,8 @@
 //!   [`submit_package`](crate::submitpackage::submit_package).
 //! - Termination is driven by the parent confirming (the existing mempool-event branch in
 //!   `TxDriver` notifies the wait-condition listener). The bump function itself is stateless per
-//!   call — it carries the last-attempted rate and last-child-funding-inputs through the
-//!   [`CpfpHandle`] state owned by the driver.
+//!   call — it carries the last-attempted rate and the lease on the last child's funding inputs
+//!   through the [`CpfpHandle`] state owned by the driver.
 //!
 //! ## What's intentionally NOT here
 //!
@@ -126,11 +126,16 @@ impl CpfpStrategy {
 /// Per-parent state the driver carries between bump attempts.
 #[derive(Debug, Default, Clone)]
 pub struct CpfpHandle {
-    /// Outpoints spent by the most recent child the driver broadcast (excluding the anchor
-    /// itself). Released back to the wallet before the next bump so the same outpoints can
-    /// be re-selected for the replacement child, then re-leased to whatever the new child
-    /// actually consumes.
-    pub last_child_inputs: Vec<OutPoint>,
+    /// Lease on the funding inputs of the most recent child that the wallet built.
+    ///
+    /// The wallet frees the inputs when the last clone of this value drops. Every path that
+    /// stops the bumps for a parent therefore frees the inputs by dropping the handle, and no
+    /// path needs an explicit release call.
+    ///
+    /// The value is an [`Arc`] because the driver clones the handle to run a bump without the
+    /// entries lock held. The clone keeps the lease alive for the length of the bump. The
+    /// write-back that replaces the handle then drops the last clone of the superseded lease.
+    pub last_child_lease: Option<Arc<dyn FundingLease>>,
     /// Package fee rate the driver last targeted. Used to skip noop bumps when the fee source
     /// hasn't moved upward.
     pub last_pkg_fee_rate: Option<FeeRate>,
@@ -173,23 +178,6 @@ pub enum CpfpError {
 }
 
 impl CpfpError {
-    /// Whether the bump held new wallet funding leases when it failed.
-    ///
-    /// True for each failure after the wallet build: the wallet leases `funded.spent`
-    /// during the build, and `perform_bump` records the set in the handle before the step
-    /// that failed. False for failures at or before the build, because a failed build
-    /// restores the pre-bump lease state itself. The driver reads this to decide whether a
-    /// bump whose entry was removed during the bump must release the recorded inputs.
-    pub const fn leased_funding(&self) -> bool {
-        matches!(
-            self,
-            Self::AnchorSigner(_)
-                | Self::WalletSigner(_)
-                | Self::SubmitPackage(_)
-                | Self::PsbtExtract(_)
-        )
-    }
-
     /// Whether this failure is a lost race for a shared anchor rather than a fault.
     ///
     /// See [`SubmitPackageError::is_replacement_contention`]. Callers use it to keep expected
@@ -197,6 +185,20 @@ impl CpfpError {
     pub fn is_replacement_contention(&self) -> bool {
         matches!(self, Self::SubmitPackage(e) if e.is_replacement_contention())
     }
+}
+
+/// Wallet outpoints that one CPFP child holds.
+///
+/// The wallet frees the outpoints when this value drops, so the driver keeps the value for
+/// as long as the child can still enter a mempool. This is what removes the release call from
+/// every path that stops the bumps for a parent.
+///
+/// The trait keeps `btc-tracker` free of a dependency on the wallet crate. The bridge
+/// implements it in `bridge-exec` over the lease type of `operator-wallet`.
+pub trait FundingLease: Send + Sync + Debug {
+    /// The outpoints that this lease holds. The anchor input is not one of them, unless the
+    /// output that the child spends belongs to the wallet.
+    fn outpoints(&self) -> &[OutPoint];
 }
 
 /// A funded PSBT returned by a wallet handle in [`CpfpContext`].
@@ -207,8 +209,8 @@ pub struct WalletFundedPsbt {
     /// carries `witness_utxo` plus `tap_internal_key` (key-path) or `tap_scripts`
     /// (script-path) describing what is being spent.
     pub psbt: Psbt,
-    /// Wallet outpoints consumed by the child (not including the anchor).
-    pub spent: Vec<OutPoint>,
+    /// Holds the wallet outpoints that the child consumes.
+    pub lease: Arc<dyn FundingLease>,
 }
 
 /// Trait the driver calls to build the next CPFP child.
@@ -248,8 +250,10 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
     /// child's vbytes` (BIP-125 rule 4), or bitcoind rejects the replacement as paying
     /// insufficient incremental fee.
     ///
-    /// `replacing` is the outpoints of any prior child this rebuild supersedes (released
-    /// before re-selection so they can be re-picked or replaced).
+    /// `replacing` is the lease of a prior child that this rebuild supersedes. Input
+    /// selection must keep its outpoints available, so that the replacement can spend them
+    /// again. The lease stays valid across the call: a failed build leaves it with the same
+    /// outpoints, and the driver drops it once the new child supersedes the old one.
     ///
     /// See the trait-level "PSBT-signing contract" for what the returned PSBT must look
     /// like with respect to per-input `final_script_witness`.
@@ -258,20 +262,9 @@ pub trait CpfpWallet: Send + Sync + fmt::Debug {
         parent: &Transaction,
         strategy: CpfpStrategy,
         target_pkg_fee_rate: FeeRate,
-        replacing: Option<&[OutPoint]>,
+        replacing: Option<&dyn FundingLease>,
         prior_child_fee: Option<Amount>,
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send;
-
-    /// Hands `outpoints` back to the wallet's lease bookkeeping without a build.
-    ///
-    /// [`Self::build_cpfp_child`] releases and re-leases through its `replacing` parameter.
-    /// That path only exists while a next build for the same parent is possible. Each path
-    /// that stops the bumps for a parent must call this method instead: a lost shared
-    /// anchor, a parent confirmed through a competitor, a dropped driver entry. Without
-    /// the call, the last child's funding UTXOs stay leased for the process lifetime and
-    /// the spendable balance shrinks. The method must accept outpoints that are not
-    /// currently leased.
-    fn release(&self, outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send;
 }
 
 /// Source of fee-rate estimates used to drive the package target. Defined in this crate
@@ -512,14 +505,10 @@ impl CpfpWallet for CpfpDisabled {
         _parent: &Transaction,
         _strategy: CpfpStrategy,
         _target_pkg_fee_rate: FeeRate,
-        _replacing: Option<&[OutPoint]>,
+        _replacing: Option<&dyn FundingLease>,
         _prior_child_fee: Option<Amount>,
     ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
         async { unreachable!("CpfpDisabled::build_cpfp_child should never be called") }
-    }
-
-    fn release(&self, _outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send {
-        async { unreachable!("CpfpDisabled::release should never be called") }
     }
 }
 
@@ -667,10 +656,9 @@ impl BumpReason {
 /// (block/tick/eviction) rebuild the child even at an unchanged target, because a child
 /// evicted by a competing package is invisible to us — see step 4 below.
 ///
-/// `handle.last_child_inputs` is updated as soon as the wallet hands back a funded child —
-/// **not** only on success — because the wallet leases those inputs at that point and the next
-/// call is the only thing that can release them (it passes them back as `replacing`). Returning
-/// early from any later step without recording them would strand the leases permanently.
+/// `handle.last_child_lease` takes the new lease as soon as the wallet hands back a funded
+/// child, and not only on success. The handle must own the lease across the fallible steps
+/// that follow. A drop at one of those steps frees inputs that a live child still spends.
 /// `handle.last_pkg_fee_rate` and `handle.last_child_txid` describe what actually reached the
 /// mempool, so those advance only on success.
 ///
@@ -806,14 +794,13 @@ where
                 pkg_fee_rate: existing,
             }) if existing >= target => {
                 // This skip ends the bump sequence, so the `replacing` hand-over of the
-                // next build never runs. Release the last child's funding leases here
-                // instead — but only when the winning child is not ours. When our own
-                // child holds the anchor at the target, its funding must stay leased. A
-                // release at that point lets a concurrent build double-spend the funding
-                // and evict our own child.
-                if handle.last_child_txid != Some(spender) && !handle.last_child_inputs.is_empty() {
-                    ctx.wallet.release(&handle.last_child_inputs).await;
-                    handle.last_child_inputs.clear();
+                // next build never runs. Drop the lease of the last child here instead,
+                // but only when the winning child is not ours. When our own child holds
+                // the anchor at the target, its funding must stay held. A release at that
+                // point lets a concurrent build double-spend the funding and evict our own
+                // child.
+                if handle.last_child_txid != Some(spender) {
+                    handle.last_child_lease = None;
                     handle.last_child_txid = None;
                     handle.last_child_fee = None;
                 }
@@ -832,12 +819,9 @@ where
                 // on-chain and the release has one bounded side effect: until the next
                 // sync, `list_unspent` still lists those outpoints, so builds can select
                 // a spent input and be rejected. A sync ends the window.
-                if !handle.last_child_inputs.is_empty() {
-                    ctx.wallet.release(&handle.last_child_inputs).await;
-                    handle.last_child_inputs.clear();
-                    handle.last_child_txid = None;
-                    handle.last_child_fee = None;
-                }
+                handle.last_child_lease = None;
+                handle.last_child_txid = None;
+                handle.last_child_fee = None;
                 debug!(
                     %parent_txid,
                     "anchor already spent by a confirmed transaction; skipping"
@@ -852,8 +836,7 @@ where
     }
 
     // ── 5. Build the child via the wallet ───────────────────────────────────
-    let replacing: Option<&[OutPoint]> =
-        (!handle.last_child_inputs.is_empty()).then_some(handle.last_child_inputs.as_slice());
+    let replacing: Option<&dyn FundingLease> = handle.last_child_lease.as_deref();
     // The RBF floor only applies while there is a live child to replace. A prior child
     // recorded but since evicted (lost anchor race, confirmed competitor) clears the handle
     // through the release paths, so `last_child_fee` here always describes the mempool
@@ -867,24 +850,20 @@ where
         .await
         .map_err(CpfpError::Wallet)?;
 
-    // Record the newly-leased funding inputs NOW, before any of the fallible steps below.
+    // Take the new lease into the handle NOW, before any of the fallible steps below.
     //
-    // `build_cpfp_child` leases `funded.spent` on the way out. Every step between here and
-    // submission can fail (anchor signer, wallet signer, sighash, PSBT extraction, package
-    // rejection), and until this handle carries the inputs, the next bump computes
-    // `replacing = None` and the wallet is never told to let them go — so a single transient
-    // signer or RPC blip stranded those UTXOs for the lifetime of the process, and repeated
-    // failures progressively starved the general wallet of spendable inputs.
+    // The lease frees its outpoints when the last clone drops. Every step between here and
+    // submission can fail: the anchor signer, the wallet signer, the sighash, the PSBT
+    // extraction, and the package submission. The handle must own the lease across all of
+    // them, so that the caller's write-back keeps it and the next bump passes it as
+    // `replacing`. This assignment also drops the lease of the child that the new child
+    // supersedes, once the caller writes the handle back.
     //
-    // Writing it here is safe against the retry path too: `OperatorWallet::build_cpfp_child`
-    // releases `replacing` up front and, if selection then fails, re-leases it — so the
-    // recorded set is always either currently leased or deliberately handed back.
-    //
-    // Record the fee together with the inputs. The fee is the floor for the next
+    // Record the fee together with the lease. The fee is the floor for the next
     // replacement (BIP-125 rule 4). If submission fails below, the prior child stays in
     // the mempool and pays less than the recorded fee. The floor is then conservative,
     // which is safe: the next child pays slightly more than the rule requires.
-    handle.last_child_inputs = funded.spent.clone();
+    handle.last_child_lease = Some(funded.lease);
     handle.last_child_fee = funded.psbt.fee().ok();
 
     // ── 6. Sign each input still lacking final_script_witness ─────────────
@@ -929,8 +908,9 @@ where
     if !matches!(strategy, CpfpStrategy::ParentTxCombined { .. }) {
         // The wallet promised to add the anchor as a foreign UTXO; sanity-check that the
         // PSBT actually contains it before signing.
-        // `PsbtExtract`, not `Wallet`: this check runs after the build, so the wallet has
-        // leased the funding inputs, and `CpfpError::leased_funding` must report true.
+        // `PsbtExtract`, not `Wallet`: this check runs after the build, and the handle
+        // already owns the lease on the funding inputs. The caller's write-back keeps that
+        // lease, or drops it and frees the inputs.
         let anchor_idx = anchor_input_idx.ok_or_else(|| {
             CpfpError::PsbtExtract(format!(
                 "wallet-built child does not contain expected anchor outpoint for parent {parent_txid}"
@@ -1029,7 +1009,7 @@ where
 
     // ── 9. Update handle ────────────────────────────────────────────────────
     //
-    // `last_child_inputs` was already recorded right after funding (see above) so a failure
+    // The lease was already recorded right after funding (see above) so a failure
     // anywhere in between still hands the leases back on the next bump. The remaining two
     // fields describe what is actually in the mempool, so they only advance on success.
     handle.last_pkg_fee_rate = Some(target);
@@ -1144,13 +1124,37 @@ pub(crate) mod tests {
         }
     }
 
+    /// A lease that appends its outpoints to a shared log when it drops.
+    ///
+    /// The tests read that log to make sure that each path which stops the bumps returns the
+    /// funding inputs of the last child. A production lease returns them to the wallet. This
+    /// one records the same event.
+    #[derive(Debug)]
+    pub(crate) struct FakeLease {
+        outpoints: Vec<OutPoint>,
+        released: Arc<Mutex<Vec<OutPoint>>>,
+    }
+    impl FundingLease for FakeLease {
+        fn outpoints(&self) -> &[OutPoint] {
+            &self.outpoints
+        }
+    }
+    impl Drop for FakeLease {
+        fn drop(&mut self) {
+            self.released
+                .lock()
+                .unwrap()
+                .extend_from_slice(&self.outpoints);
+        }
+    }
+
     #[derive(Debug)]
     pub(crate) struct FakeWallet {
         psbt_template: Mutex<Option<Psbt>>,
         spent_template: Vec<OutPoint>,
         error: Option<String>,
-        /// Every outpoint handed back through [`CpfpWallet::release`], in call order.
-        pub(crate) released: Mutex<Vec<OutPoint>>,
+        /// Outpoints of every lease that has dropped, in drop order.
+        pub(crate) released: Arc<Mutex<Vec<OutPoint>>>,
     }
     impl FakeWallet {
         pub(crate) fn returning(psbt: Psbt, spent: Vec<OutPoint>) -> Self {
@@ -1158,7 +1162,7 @@ pub(crate) mod tests {
                 psbt_template: Mutex::new(Some(psbt)),
                 spent_template: spent,
                 error: None,
-                released: Mutex::new(Vec::new()),
+                released: Arc::new(Mutex::new(Vec::new())),
             }
         }
         pub(crate) fn failing(msg: &str) -> Self {
@@ -1166,8 +1170,15 @@ pub(crate) mod tests {
                 psbt_template: Mutex::new(None),
                 spent_template: Vec::new(),
                 error: Some(msg.to_string()),
-                released: Mutex::new(Vec::new()),
+                released: Arc::new(Mutex::new(Vec::new())),
             }
+        }
+        /// Builds a lease over `outpoints` that reports its own drop to this wallet.
+        pub(crate) fn lease(&self, outpoints: Vec<OutPoint>) -> Arc<dyn FundingLease> {
+            Arc::new(FakeLease {
+                outpoints,
+                released: Arc::clone(&self.released),
+            })
         }
     }
     impl CpfpWallet for FakeWallet {
@@ -1176,26 +1187,21 @@ pub(crate) mod tests {
             _parent: &Transaction,
             _strategy: CpfpStrategy,
             _target_pkg_fee_rate: FeeRate,
-            _replacing: Option<&[OutPoint]>,
+            _replacing: Option<&dyn FundingLease>,
             _prior_child_fee: Option<Amount>,
         ) -> impl std::future::Future<Output = Result<WalletFundedPsbt, String>> + Send {
             let err = self.error.clone();
             let psbt = self.psbt_template.lock().unwrap().clone();
-            let spent = self.spent_template.clone();
+            let lease = self.lease(self.spent_template.clone());
             async move {
                 if let Some(e) = err {
                     return Err(e);
                 }
                 Ok(WalletFundedPsbt {
                     psbt: psbt.expect("test must seed a psbt template"),
-                    spent,
+                    lease,
                 })
             }
-        }
-
-        fn release(&self, outpoints: &[OutPoint]) -> impl std::future::Future<Output = ()> + Send {
-            self.released.lock().unwrap().extend_from_slice(outpoints);
-            async {}
         }
     }
 
@@ -1455,13 +1461,22 @@ pub(crate) mod tests {
         }
     }
 
-    fn seeded_handle(inputs: &[OutPoint], our_child: Txid) -> CpfpHandle {
+    fn seeded_handle(wallet: &FakeWallet, inputs: &[OutPoint], our_child: Txid) -> CpfpHandle {
         CpfpHandle {
-            last_child_inputs: inputs.to_vec(),
+            last_child_lease: Some(wallet.lease(inputs.to_vec())),
             last_pkg_fee_rate: Some(FeeRate::from_sat_per_vb_unchecked(3)),
             last_child_txid: Some(our_child),
             last_child_fee: Some(Amount::from_sat(500)),
         }
+    }
+
+    /// The outpoints that the handle's lease holds, or an empty vector when it holds none.
+    fn held_by(handle: &CpfpHandle) -> Vec<OutPoint> {
+        handle
+            .last_child_lease
+            .as_deref()
+            .map(|lease| lease.outpoints().to_vec())
+            .unwrap_or_default()
     }
 
     fn contention_context(
@@ -1503,7 +1518,7 @@ pub(crate) mod tests {
             ),
         );
         let ctx = contention_context(wallet.clone(), submitter);
-        let mut handle = seeded_handle(&inputs, ours);
+        let mut handle = seeded_handle(&wallet, &inputs, ours);
         let bumped = perform_bump(
             &ctx,
             &parent,
@@ -1516,7 +1531,7 @@ pub(crate) mod tests {
         .expect("losing the anchor is a skip, not an error");
         assert!(!bumped);
         assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
-        assert!(handle.last_child_inputs.is_empty());
+        assert!(handle.last_child_lease.is_none());
     }
 
     /// Our own child holds the anchor at the target. This is the normal state. The leases
@@ -1538,7 +1553,7 @@ pub(crate) mod tests {
             ),
         );
         let ctx = contention_context(wallet.clone(), submitter);
-        let mut handle = seeded_handle(&inputs, ours);
+        let mut handle = seeded_handle(&wallet, &inputs, ours);
         let bumped = perform_bump(
             &ctx,
             &parent,
@@ -1551,7 +1566,7 @@ pub(crate) mod tests {
         .expect("holding the anchor is a skip, not an error");
         assert!(!bumped);
         assert!(wallet.released.lock().unwrap().is_empty());
-        assert_eq!(handle.last_child_inputs, inputs.to_vec());
+        assert_eq!(held_by(&handle), inputs.to_vec());
     }
 
     /// The anchor is spent by a confirmed transaction: bumping is over for this parent,
@@ -1569,7 +1584,7 @@ pub(crate) mod tests {
                 .with_spend_state(AnchorSpendState::Confirmed),
         );
         let ctx = contention_context(wallet.clone(), submitter);
-        let mut handle = seeded_handle(&inputs, ours);
+        let mut handle = seeded_handle(&wallet, &inputs, ours);
         let bumped = perform_bump(
             &ctx,
             &parent,
@@ -1582,7 +1597,7 @@ pub(crate) mod tests {
         .expect("a confirmed spend is a skip, not an error");
         assert!(!bumped);
         assert_eq!(*wallet.released.lock().unwrap(), inputs.to_vec());
-        assert!(handle.last_child_inputs.is_empty());
+        assert!(handle.last_child_lease.is_none());
     }
 
     #[tokio::test]
@@ -1773,7 +1788,7 @@ pub(crate) mod tests {
             handle.last_pkg_fee_rate,
             Some(FeeRate::from_sat_per_vb(10).unwrap())
         );
-        assert_eq!(handle.last_child_inputs, wallet_funding);
+        assert_eq!(held_by(&handle), wallet_funding);
         assert!(handle.last_child_txid.is_some());
 
         // submitter received [parent, child]
@@ -2273,7 +2288,8 @@ pub(crate) mod tests {
             );
             // But the leased inputs must be recorded, so the next bump releases them.
             assert_eq!(
-                handle.last_child_inputs, wallet_funding,
+                held_by(&handle),
+                wallet_funding,
                 "{label}: leased funding inputs must be recorded for release"
             );
         }
@@ -2384,7 +2400,7 @@ pub(crate) mod tests {
         .await
         .expect("script-path bump must succeed");
         assert!(submitted);
-        assert_eq!(handle.last_child_inputs, wallet_funding);
+        assert_eq!(held_by(&handle), wallet_funding);
 
         let packages = submitter.captured.lock().unwrap();
         let child = &packages[0][1];

--- a/crates/btc-tracker/src/lib.rs
+++ b/crates/btc-tracker/src/lib.rs
@@ -7,8 +7,10 @@
 pub mod client;
 pub mod config;
 mod constants;
+pub mod cpfp;
 pub mod event;
 mod state_machine;
+pub mod submitpackage;
 pub mod tx_driver;
 
 // Re-exports

--- a/crates/btc-tracker/src/submitpackage.rs
+++ b/crates/btc-tracker/src/submitpackage.rs
@@ -99,6 +99,21 @@ impl SubmitPackageError {
             Self::Rpc(_) => false,
         }
     }
+
+    /// Whether the package member `txid` itself lost a replacement race.
+    ///
+    /// The per-tx entries key on the members of the submitted package, so this reports which
+    /// of the package's own transactions bitcoind declined. A rejection on the child means a
+    /// transaction in the mempool spends one of the child's inputs. A rejection on the parent
+    /// means a conflict with the parent itself is in the mempool, and the parent is not.
+    pub fn is_replacement_contention_for(&self, txid: &Txid) -> bool {
+        match self {
+            Self::Rejected { tx_errors, .. } => tx_errors
+                .iter()
+                .any(|(t, err)| t == txid && err.contains(REPLACEMENT_CONTENTION_MARKER)),
+            Self::Rpc(_) => false,
+        }
+    }
 }
 
 /// Substring that bitcoind uses when it declines a replacement for paying too little.

--- a/crates/btc-tracker/src/submitpackage.rs
+++ b/crates/btc-tracker/src/submitpackage.rs
@@ -1,0 +1,510 @@
+//! Typed wrapper around `bitcoind`'s `submitpackage` RPC.
+//!
+//! `bitcoind-async-client`'s `Reader::submit_package` returns a `corepc-types::SubmitPackage`
+//! struct whose `package_msg: String` carries the package-level outcome ("success" iff every
+//! tx in the package was accepted into or already present in the mempool). This wrapper turns
+//! that into a typed result so call sites can pattern-match on outcomes rather than string-compare.
+//!
+//! Used by [`crate::tx_driver`] when broadcasting `[parent, child]` v3 1P1C CPFP packages.
+
+use std::collections::BTreeMap;
+
+use bitcoin::{Amount, Transaction, Txid, Wtxid};
+use bitcoind_async_client::{
+    corepc_types::model::{SubmitPackage, SubmitPackageTxResult},
+    error::ClientError,
+    traits::Broadcaster,
+    types::BroadcastOptions,
+};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// `bitcoind` returns this string in `package_msg` iff every transaction in the package was
+/// accepted into the mempool (or was already present).
+const PACKAGE_MSG_SUCCESS: &str = "success";
+
+/// Successful `submitpackage` outcome — every transaction in the package was either newly
+/// accepted into the mempool or already present.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubmitPackageSummary {
+    /// Per-transaction result keyed by [`Txid`]. Tracks which submitted txs were accepted vs.
+    /// already-in-mempool, plus per-tx fee/vsize where bitcoind reported them.
+    pub tx_results: BTreeMap<Txid, TxOutcome>,
+    /// `[Txid]`s of any in-mempool transactions that this package's submission replaced via
+    /// RBF. Used by callers tracking RBF lineage (typically just the prior CPFP child).
+    pub replaced: Vec<Txid>,
+}
+
+/// Per-transaction outcome inside a successful package submission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxOutcome {
+    /// Sigops-adjusted virtual size, when bitcoind reports one.
+    pub vsize: Option<u32>,
+    /// Base fee + effective fee rate when bitcoind reports them. `effective_fee_rate` is
+    /// `None` for transactions that were already in the mempool.
+    pub fees: Option<TxFees>,
+    /// `Some(wtxid)` if bitcoind ignored this submission because a different witness for the
+    /// same txid was already in the mempool. Callers may use this as a signal that a prior
+    /// broadcast won the race.
+    pub conflicting_wtxid: Option<Wtxid>,
+}
+
+/// Fee/fee-rate details bitcoind reports per accepted transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TxFees {
+    /// Base fee in sats.
+    pub base_fee: bitcoin::Amount,
+    /// Effective fee rate (`None` if the transaction was already in the mempool — no rate was
+    /// computed because the tx wasn't newly accepted).
+    pub effective_fee_rate: Option<bitcoin::FeeRate>,
+}
+
+/// Errors produced by [`submit_package`].
+#[derive(Debug, Error)]
+pub enum SubmitPackageError {
+    /// The RPC call itself failed (network, auth, deserialization, etc).
+    #[error("submitpackage rpc: {0}")]
+    Rpc(#[from] ClientError),
+    /// `bitcoind` returned a non-success `package_msg`. Carries the message and any per-tx
+    /// rejection reasons it reported. Typical causes: package-level policy violations
+    /// (`package-not-valid`, `package-fee-too-low`), or RBF rule failures
+    /// (`replacement-adds-unconfirmed`, `insufficient-fee`).
+    #[error("submitpackage rejected: {message}")]
+    Rejected {
+        /// The raw `package_msg` from bitcoind.
+        message: String,
+        /// Per-tx error strings when bitcoind reported any. Empty if the rejection was
+        /// purely at the package level.
+        tx_errors: Vec<(Txid, String)>,
+    },
+}
+
+/// Computes the `maxburnamount` guard for a whole package submission.
+///
+/// Mirrors the per-transaction logic the tx-driver applies to bare rebroadcasts, lifted to
+/// package scope: bitcoind applies the guard to the submission as a whole, so we take the
+/// largest valued `OP_RETURN` output across every transaction in the package. Bridge txs carry
+/// SPS-50 header outputs, and any that hold value would otherwise trip bitcoind's burn guard
+/// and get the entire package rejected.
+///
+/// Returns `None` when no transaction in the package has a valued `OP_RETURN`, which leaves
+/// bitcoind on its defaults.
+fn package_broadcast_options(txs: &[Transaction]) -> Option<BroadcastOptions> {
+    let max_burn_amount = txs
+        .iter()
+        .flat_map(|tx| tx.output.iter())
+        .filter(|output| output.value > Amount::ZERO && output.script_pubkey.is_op_return())
+        .map(|output| output.value)
+        .max()?;
+
+    Some(BroadcastOptions {
+        max_burn_amount: Some(max_burn_amount),
+        ..Default::default()
+    })
+}
+
+/// Submits a transaction package via the `submitpackage` RPC.
+///
+/// Returns [`Ok`] only when bitcoind reports `package_msg == "success"`, which means every
+/// transaction in `txs` is now in the mempool (either newly accepted or already present
+/// before submission).
+///
+/// On any other outcome — RPC failure, package rejection, per-tx rejection — returns
+/// [`SubmitPackageError`]. Per-tx error strings are surfaced verbatim in `tx_errors`.
+///
+/// # Notes
+///
+/// * Bitcoin Core's `submitpackage` expects the transactions in topological order (parent before
+///   child). Callers must ensure this; this wrapper does not reorder.
+/// * The `replaced_transactions` field of bitcoind's response is surfaced in
+///   [`SubmitPackageSummary::replaced`]. Callers using this wrapper for RBF will typically find
+///   their prior CPFP child's txid here.
+pub async fn submit_package<B: Broadcaster + ?Sized>(
+    client: &B,
+    txs: &[Transaction],
+) -> Result<SubmitPackageSummary, SubmitPackageError> {
+    debug!(
+        count = txs.len(),
+        first_txid = ?txs.first().map(Transaction::compute_txid),
+        "submitting package via submitpackage rpc"
+    );
+    let response = client
+        .submit_package(txs, package_broadcast_options(txs))
+        .await?;
+
+    if response.package_msg != PACKAGE_MSG_SUCCESS {
+        let tx_errors = collect_tx_errors(&response);
+        warn!(
+            package_msg = %response.package_msg,
+            n_tx_errors = tx_errors.len(),
+            "submitpackage was rejected by bitcoind"
+        );
+        return Err(SubmitPackageError::Rejected {
+            message: response.package_msg,
+            tx_errors,
+        });
+    }
+
+    Ok(summarize_success(response))
+}
+
+/// Walks `tx_results` and pulls out any per-tx `error` strings, keyed by the public [`Txid`].
+fn collect_tx_errors(response: &SubmitPackage) -> Vec<(Txid, String)> {
+    response
+        .tx_results
+        .values()
+        .filter_map(|res: &SubmitPackageTxResult| {
+            res.error.as_ref().map(|err| (res.txid, err.clone()))
+        })
+        .collect()
+}
+
+/// Builds the typed summary from a successful response.
+fn summarize_success(response: SubmitPackage) -> SubmitPackageSummary {
+    let tx_results = response
+        .tx_results
+        .into_values()
+        .map(|res| {
+            let outcome = TxOutcome {
+                vsize: res.vsize,
+                fees: res.fees.map(|f| TxFees {
+                    base_fee: f.base_fee,
+                    effective_fee_rate: f.effective_fee_rate,
+                }),
+                conflicting_wtxid: res.other_wtxid,
+            };
+            (res.txid, outcome)
+        })
+        .collect();
+    SubmitPackageSummary {
+        tx_results,
+        replaced: response.replaced_transactions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use bitcoin::{
+        absolute, hashes::Hash, transaction::Version, Amount, Transaction, TxOut, Wtxid,
+    };
+    use bitcoind_async_client::{
+        corepc_types::model::{SubmitPackage, SubmitPackageTxResult, SubmitPackageTxResultFees},
+        error::ClientError,
+        ClientResult,
+    };
+
+    use super::*;
+
+    /// Stub [`Broadcaster`] that returns a configured `submit_package` response. Other methods
+    /// panic — fee-source / tx-driver tests have their own seams.
+    #[derive(Debug)]
+    struct MockBroadcaster {
+        response: ClientResult<SubmitPackage>,
+        captured_options: Mutex<Vec<Option<BroadcastOptions>>>,
+    }
+
+    impl Broadcaster for MockBroadcaster {
+        async fn send_raw_transaction(
+            &self,
+            _tx: &Transaction,
+            _options: Option<BroadcastOptions>,
+        ) -> ClientResult<Txid> {
+            unimplemented!("not used by submit_package tests")
+        }
+
+        async fn test_mempool_accept(
+            &self,
+            _tx: &Transaction,
+        ) -> ClientResult<bitcoind_async_client::corepc_types::model::TestMempoolAccept> {
+            unimplemented!("not used by submit_package tests")
+        }
+
+        async fn submit_package(
+            &self,
+            _txs: &[Transaction],
+            options: Option<BroadcastOptions>,
+        ) -> ClientResult<SubmitPackage> {
+            self.captured_options.lock().unwrap().push(options);
+            self.response.clone()
+        }
+    }
+
+    fn dummy_tx(lock_time_seed: u32) -> Transaction {
+        Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::from_consensus(lock_time_seed),
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::from_sat(330),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        }
+    }
+
+    fn success_response(parent: &Transaction, child: &Transaction) -> SubmitPackage {
+        let parent_txid = parent.compute_txid();
+        let child_txid = child.compute_txid();
+        let parent_wtxid = parent.compute_wtxid();
+        let child_wtxid = child.compute_wtxid();
+        let mut tx_results = BTreeMap::new();
+        tx_results.insert(
+            parent_wtxid,
+            SubmitPackageTxResult {
+                txid: parent_txid,
+                other_wtxid: None,
+                vsize: Some(110),
+                fees: Some(SubmitPackageTxResultFees {
+                    base_fee: Amount::from_sat(220),
+                    effective_fee_rate: bitcoin::FeeRate::from_sat_per_vb(2),
+                    effective_includes: vec![parent_wtxid],
+                }),
+                error: None,
+            },
+        );
+        tx_results.insert(
+            child_wtxid,
+            SubmitPackageTxResult {
+                txid: child_txid,
+                other_wtxid: None,
+                vsize: Some(150),
+                fees: Some(SubmitPackageTxResultFees {
+                    base_fee: Amount::from_sat(2_000),
+                    effective_fee_rate: bitcoin::FeeRate::from_sat_per_vb(15),
+                    effective_includes: vec![child_wtxid],
+                }),
+                error: None,
+            },
+        );
+        SubmitPackage {
+            package_msg: "success".to_string(),
+            tx_results,
+            replaced_transactions: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn success_returns_summary_with_per_tx_outcomes() {
+        let parent = dummy_tx(0);
+        let child = dummy_tx(1);
+        let response = success_response(&parent, &child);
+        let client = MockBroadcaster {
+            response: Ok(response),
+            captured_options: Mutex::new(Vec::new()),
+        };
+
+        let summary = submit_package(&client, &[parent.clone(), child.clone()])
+            .await
+            .expect("success response must produce Ok");
+
+        assert_eq!(summary.tx_results.len(), 2);
+        assert!(summary.tx_results.contains_key(&parent.compute_txid()));
+        assert!(summary.tx_results.contains_key(&child.compute_txid()));
+        assert!(summary.replaced.is_empty());
+
+        let parent_outcome = &summary.tx_results[&parent.compute_txid()];
+        assert_eq!(parent_outcome.vsize, Some(110));
+        assert_eq!(
+            parent_outcome.fees.as_ref().map(|f| f.base_fee),
+            Some(Amount::from_sat(220))
+        );
+        assert!(parent_outcome.conflicting_wtxid.is_none());
+    }
+
+    #[tokio::test]
+    async fn success_reports_replaced_transactions() {
+        let parent = dummy_tx(0);
+        let child = dummy_tx(1);
+        let replaced_child = Txid::from_slice(&[7u8; 32]).unwrap();
+        let mut response = success_response(&parent, &child);
+        response.replaced_transactions = vec![replaced_child];
+
+        let client = MockBroadcaster {
+            response: Ok(response),
+            captured_options: Mutex::new(Vec::new()),
+        };
+        let summary = submit_package(&client, &[parent, child]).await.unwrap();
+        assert_eq!(summary.replaced, vec![replaced_child]);
+    }
+
+    #[tokio::test]
+    async fn package_level_rejection_surfaces_as_rejected() {
+        let parent = dummy_tx(0);
+        let child = dummy_tx(1);
+        let response = SubmitPackage {
+            package_msg: "package-not-valid".to_string(),
+            tx_results: BTreeMap::new(),
+            replaced_transactions: vec![],
+        };
+        let client = MockBroadcaster {
+            response: Ok(response),
+            captured_options: Mutex::new(Vec::new()),
+        };
+
+        let err = submit_package(&client, &[parent, child])
+            .await
+            .expect_err("non-success package_msg must be an error");
+        match err {
+            SubmitPackageError::Rejected { message, tx_errors } => {
+                assert_eq!(message, "package-not-valid");
+                assert!(tx_errors.is_empty());
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn per_tx_rejection_surfaces_in_tx_errors() {
+        let parent = dummy_tx(0);
+        let child = dummy_tx(1);
+        let parent_txid = parent.compute_txid();
+        let child_wtxid = child.compute_wtxid();
+        let parent_wtxid = parent.compute_wtxid();
+        let mut tx_results = BTreeMap::new();
+        tx_results.insert(
+            parent_wtxid,
+            SubmitPackageTxResult {
+                txid: parent_txid,
+                other_wtxid: None,
+                vsize: None,
+                fees: None,
+                error: Some("bad-txns-in-mempool".to_string()),
+            },
+        );
+        tx_results.insert(
+            child_wtxid,
+            SubmitPackageTxResult {
+                txid: child.compute_txid(),
+                other_wtxid: None,
+                vsize: None,
+                fees: None,
+                error: None,
+            },
+        );
+        let response = SubmitPackage {
+            package_msg: "package-mempool-error".to_string(),
+            tx_results,
+            replaced_transactions: vec![],
+        };
+        let client = MockBroadcaster {
+            response: Ok(response),
+            captured_options: Mutex::new(Vec::new()),
+        };
+
+        let err = submit_package(&client, &[parent, child]).await.unwrap_err();
+        match err {
+            SubmitPackageError::Rejected { tx_errors, .. } => {
+                assert_eq!(tx_errors.len(), 1);
+                assert_eq!(tx_errors[0].0, parent_txid);
+                assert_eq!(tx_errors[0].1, "bad-txns-in-mempool");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rpc_failure_surfaces_as_rpc() {
+        let parent = dummy_tx(0);
+        let client = MockBroadcaster {
+            response: Err(ClientError::Request("boom".to_string())),
+            captured_options: Mutex::new(Vec::new()),
+        };
+        let err = submit_package(&client, &[parent]).await.unwrap_err();
+        assert!(matches!(err, SubmitPackageError::Rpc(_)));
+    }
+
+    #[tokio::test]
+    async fn conflicting_wtxid_propagated_into_outcome() {
+        let parent = dummy_tx(0);
+        let child = dummy_tx(1);
+        let parent_txid = parent.compute_txid();
+        let other_wtxid = Wtxid::from_slice(&[9u8; 32]).unwrap();
+        let parent_wtxid = parent.compute_wtxid();
+        let child_wtxid = child.compute_wtxid();
+        let mut tx_results = BTreeMap::new();
+        tx_results.insert(
+            parent_wtxid,
+            SubmitPackageTxResult {
+                txid: parent_txid,
+                other_wtxid: Some(other_wtxid),
+                vsize: Some(110),
+                fees: None,
+                error: None,
+            },
+        );
+        tx_results.insert(
+            child_wtxid,
+            SubmitPackageTxResult {
+                txid: child.compute_txid(),
+                other_wtxid: None,
+                vsize: Some(150),
+                fees: None,
+                error: None,
+            },
+        );
+        let response = SubmitPackage {
+            package_msg: "success".to_string(),
+            tx_results,
+            replaced_transactions: vec![],
+        };
+        let client = MockBroadcaster {
+            response: Ok(response),
+            captured_options: Mutex::new(Vec::new()),
+        };
+        let summary = submit_package(&client, &[parent.clone(), child])
+            .await
+            .unwrap();
+        assert_eq!(
+            summary.tx_results[&parent_txid].conflicting_wtxid,
+            Some(other_wtxid)
+        );
+    }
+
+    /// The package-level `maxburnamount` guard is what lets packages containing valued
+    /// SPS-50 `OP_RETURN` outputs (e.g. a slash parent) through bitcoind's burn protection.
+    /// Deleting `package_broadcast_options` compiles fine and every response-mapping test
+    /// still passes — this pins the actual option bitcoind receives.
+    #[tokio::test]
+    async fn valued_op_return_sets_max_burn_amount() {
+        use bitcoin::{opcodes, script, Amount};
+
+        let mut burn_tx = dummy_tx(7);
+        burn_tx.output.push(bitcoin::TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: script::Builder::new()
+                .push_opcode(opcodes::all::OP_RETURN)
+                .push_slice([0xAB; 8])
+                .into_script(),
+        });
+        let plain_tx = dummy_tx(8);
+
+        let client = MockBroadcaster {
+            response: Ok(success_response(&burn_tx, &plain_tx)),
+            captured_options: Mutex::new(Vec::new()),
+        };
+
+        submit_package(&client, &[burn_tx.clone(), plain_tx.clone()])
+            .await
+            .expect("mocked success");
+        let first_options = client.captured_options.lock().unwrap()[0].clone();
+        assert_eq!(
+            first_options
+                .expect("valued OP_RETURN must produce options")
+                .max_burn_amount,
+            Some(Amount::from_sat(1_000)),
+            "guard must cover the largest valued OP_RETURN in the package"
+        );
+
+        // And a package with no valued OP_RETURN must leave bitcoind on its defaults.
+        let other_plain = dummy_tx(9);
+        let client = MockBroadcaster {
+            response: Ok(success_response(&plain_tx, &other_plain)),
+            captured_options: Mutex::new(Vec::new()),
+        };
+        submit_package(&client, &[plain_tx, other_plain])
+            .await
+            .expect("mocked success");
+        assert!(client.captured_options.lock().unwrap()[0].is_none());
+    }
+}

--- a/crates/btc-tracker/src/submitpackage.rs
+++ b/crates/btc-tracker/src/submitpackage.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeMap;
 
-use bitcoin::{Amount, Transaction, Txid, Wtxid};
+use bitcoin::{Amount, FeeRate, Transaction, Txid, Wtxid};
 use bitcoind_async_client::{
     corepc_types::model::{SubmitPackage, SubmitPackageTxResult},
     error::ClientError,
@@ -117,19 +117,27 @@ const REPLACEMENT_CONTENTION_MARKER: &str = "rejecting replacement";
 /// SPS-50 header outputs, and any that hold value would otherwise trip bitcoind's burn guard
 /// and get the entire package rejected.
 ///
-/// Returns `None` when no transaction in the package has a valued `OP_RETURN`, which leaves
-/// bitcoind on its defaults.
+/// Always returns options: the fee-rate cap is disabled unconditionally, and
+/// `max_burn_amount` is set when some transaction in the package has a valued `OP_RETURN`.
+///
+/// The cap is disabled for a structural reason. bitcoind applies its default `maxfeerate`
+/// (0.10 BTC/kvB) to each transaction individually. A CPFP child concentrates the whole
+/// package's fee into its own few vbytes, so its individual rate is near `target ×
+/// package_vbytes / child_vbytes` — a large multiple of each target the bump loop sets. A
+/// per-transaction guard on the child alone rejects well-formed high-ratio packages. The
+/// bump loop already caps the package price: `max_fee_rate` clamps the target before the
+/// build. Zero turns the bitcoind check off.
 fn package_broadcast_options(txs: &[Transaction]) -> Option<BroadcastOptions> {
     let max_burn_amount = txs
         .iter()
         .flat_map(|tx| tx.output.iter())
         .filter(|output| output.value > Amount::ZERO && output.script_pubkey.is_op_return())
         .map(|output| output.value)
-        .max()?;
+        .max();
 
     Some(BroadcastOptions {
-        max_burn_amount: Some(max_burn_amount),
-        ..Default::default()
+        max_burn_amount,
+        max_fee_rate: Some(FeeRate::ZERO),
     })
 }
 
@@ -520,16 +528,24 @@ mod tests {
         submit_package(&client, &[burn_tx.clone(), plain_tx.clone()])
             .await
             .expect("mocked success");
-        let first_options = client.captured_options.lock().unwrap()[0].clone();
+        let first_options = client.captured_options.lock().unwrap()[0]
+            .clone()
+            .expect("options are always set");
         assert_eq!(
-            first_options
-                .expect("valued OP_RETURN must produce options")
-                .max_burn_amount,
+            first_options.max_burn_amount,
             Some(Amount::from_sat(1_000)),
             "guard must cover the largest valued OP_RETURN in the package"
         );
+        assert_eq!(
+            first_options.max_fee_rate,
+            Some(bitcoin::FeeRate::ZERO),
+            "the per-transaction fee cap must be disabled"
+        );
 
-        // And a package with no valued OP_RETURN must leave bitcoind on its defaults.
+        // A package with no valued OP_RETURN still disables the fee cap. A CPFP child
+        // concentrates the whole package's fee into its own few vbytes, and the default
+        // per-transaction `maxfeerate` rejects such well-formed high-ratio packages. Burn
+        // stays on its default.
         let other_plain = dummy_tx(9);
         let client = MockBroadcaster {
             response: Ok(success_response(&plain_tx, &other_plain)),
@@ -538,6 +554,10 @@ mod tests {
         submit_package(&client, &[plain_tx, other_plain])
             .await
             .expect("mocked success");
-        assert!(client.captured_options.lock().unwrap()[0].is_none());
+        let plain_options = client.captured_options.lock().unwrap()[0]
+            .clone()
+            .expect("options are always set");
+        assert_eq!(plain_options.max_burn_amount, None);
+        assert_eq!(plain_options.max_fee_rate, Some(bitcoin::FeeRate::ZERO));
     }
 }

--- a/crates/btc-tracker/src/submitpackage.rs
+++ b/crates/btc-tracker/src/submitpackage.rs
@@ -79,6 +79,36 @@ pub enum SubmitPackageError {
     },
 }
 
+impl SubmitPackageError {
+    /// Whether this rejection means that a competing transaction already holds one of our
+    /// inputs, and our replacement does not pay enough more to displace it.
+    ///
+    /// A shared `MultiAnchor` produces this outcome by design. Every watchtower of the graph
+    /// bumps the same anchor, all of them target the same market rate, and only the first one
+    /// gets in. The rest read this error on every trigger for as long as the parent stays
+    /// unconfirmed. That is expected contention rather than a fault, so callers log it quietly
+    /// and keep a real failure visible.
+    ///
+    /// bitcoind reports it per transaction, in the form
+    /// `insufficient fee, rejecting replacement <txid>, not enough additional fees to relay`.
+    pub fn is_replacement_contention(&self) -> bool {
+        match self {
+            Self::Rejected { tx_errors, .. } => tx_errors
+                .iter()
+                .any(|(_, err)| err.contains(REPLACEMENT_CONTENTION_MARKER)),
+            Self::Rpc(_) => false,
+        }
+    }
+}
+
+/// Substring that bitcoind uses when it declines a replacement for paying too little.
+///
+/// Matching on a message is brittle in general. It is the only signal available here, because
+/// `submitpackage` reports per-transaction outcomes as free text. The e2e test
+/// `cpfp_e2e_multi_anchor_contention_is_quiet` pins the real string against a live bitcoind, so
+/// a change upstream fails a test rather than silently restoring the log noise.
+const REPLACEMENT_CONTENTION_MARKER: &str = "rejecting replacement";
+
 /// Computes the `maxburnamount` guard for a whole package submission.
 ///
 /// Mirrors the per-transaction logic the tx-driver applies to bare rebroadcasts, lifted to
@@ -134,15 +164,18 @@ pub async fn submit_package<B: Broadcaster + ?Sized>(
 
     if response.package_msg != PACKAGE_MSG_SUCCESS {
         let tx_errors = collect_tx_errors(&response);
-        warn!(
-            package_msg = %response.package_msg,
-            n_tx_errors = tx_errors.len(),
-            "submitpackage was rejected by bitcoind"
-        );
-        return Err(SubmitPackageError::Rejected {
+        let rejection = SubmitPackageError::Rejected {
             message: response.package_msg,
             tx_errors,
-        });
+        };
+        // Expected contention on a shared anchor is not a fault. Keep it out of the warning
+        // stream, so that a genuine rejection stays visible there.
+        if rejection.is_replacement_contention() {
+            debug!(error = %rejection, "submitpackage lost a race for a shared anchor");
+        } else {
+            warn!(error = %rejection, "submitpackage was rejected by bitcoind");
+        }
+        return Err(rejection);
     }
 
     Ok(summarize_success(response))

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -36,8 +36,8 @@ use tracing::{debug, error, info, warn};
 use crate::{
     client::{BtcNotifyClient, Connected},
     cpfp::{
-        self, BumpReason, CpfpContext, CpfpDisabled, CpfpFeeSource, CpfpHandle, CpfpMempool,
-        CpfpStrategy, CpfpWallet,
+        self, BumpOutcome, BumpReason, CpfpContext, CpfpDisabled, CpfpFeeSource, CpfpHandle,
+        CpfpMempool, CpfpStrategy, CpfpWallet,
     },
     event::{TxEvent, TxStatus},
 };
@@ -302,7 +302,7 @@ async fn bump_parent<W, F, P>(
     mark: &Arc<AtomicBool>,
     bridge_protocol_floor: FeeRate,
     reason: cpfp::BumpReason,
-) -> bool
+) -> BumpOutcome
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
@@ -321,7 +321,7 @@ where
         ))
     });
     let Some((parent, strategy, mut handle)) = snapshot else {
-        return false;
+        return BumpOutcome::NoChildNeeded;
     };
     let result = cpfp::perform_bump(
         ctx,
@@ -354,21 +354,29 @@ where
     drop(guard);
 
     match result {
-        Ok(submitted) => {
-            if submitted {
+        Ok(outcome) => {
+            if outcome == BumpOutcome::Submitted {
                 debug!(%parent_txid, ?reason, "CPFP bump submitted");
             }
-            submitted
+            outcome
+        }
+        Err(e) if e.is_replacement_contention_for(&parent_txid) => {
+            // The parent itself lost a replacement race: a transaction that conflicts with
+            // the parent is in the mempool, and the parent is not. Nothing more is known.
+            debug!(%parent_txid, ?reason, "parent lost a replacement race to a conflicting transaction");
+            BumpOutcome::NoChildNeeded
         }
         Err(e) if e.is_replacement_contention() => {
-            // Another watchtower holds this shared anchor and our child does not pay enough
-            // more to displace it. Expected on every trigger until the parent confirms.
+            // The child lost the race. The usual incumbent is another watchtower's child on
+            // a shared anchor, or this operator's own prior child under BIP-125 rule 4.
+            // Both spend an output of this parent, so the parent is in a mempool. Expected
+            // on every trigger until the parent confirms.
             debug!(%parent_txid, ?reason, "CPFP bump lost the race for a shared anchor");
-            false
+            BumpOutcome::ParentIsLive
         }
         Err(e) => {
             warn!(%parent_txid, error = %e, ?reason, "CPFP bump failed; will retry on next trigger");
-            false
+            BumpOutcome::NoChildNeeded
         }
     }
 }
@@ -404,32 +412,38 @@ enum BumpFollowUp {
 }
 
 impl BumpFollowUp {
-    /// Runs the follow-up for a bump that submitted no package.
-    async fn on_declined(
+    /// Runs the follow-up for `outcome`.
+    ///
+    /// [`BumpOutcome::ParentIsLive`] counts as a success for every follow-up. No package went
+    /// out, and the parent is in a mempool or in a block, so a bare resubmission is waste and
+    /// a failure report to the carried job is wrong.
+    async fn apply(
         self,
         parents: &Parents,
         parent_txid: Txid,
+        outcome: BumpOutcome,
         mark: Option<&Arc<AtomicBool>>,
     ) {
+        let parent_reached_network =
+            matches!(outcome, BumpOutcome::Submitted | BumpOutcome::ParentIsLive);
         match self {
             Self::None => {}
             Self::ResubmitBare(rpc_client, rawtx) => {
-                resubmit_bare(&rpc_client, &rawtx, parent_txid).await;
+                if !parent_reached_network {
+                    resubmit_bare(&rpc_client, &rawtx, parent_txid).await;
+                }
             }
             Self::CarryJob {
                 err,
                 listener,
                 created,
             } => {
-                fail_carried_job(parents, parent_txid, &err, listener, created, mark).await;
+                if parent_reached_network {
+                    attach_listener(parents, parent_txid, listener).await;
+                } else {
+                    fail_carried_job(parents, parent_txid, &err, listener, created, mark).await;
+                }
             }
-        }
-    }
-
-    /// Runs the follow-up for a bump that put a package in the mempool.
-    async fn on_submitted(self, parents: &Parents, parent_txid: Txid) {
-        if let Self::CarryJob { listener, .. } = self {
-            attach_listener(parents, parent_txid, listener).await;
         }
     }
 }
@@ -521,7 +535,10 @@ where
     P: CpfpMempool + 'static,
 {
     let Some(guard) = take_bump_mark(parents, parent_txid).await else {
-        follow_up.on_declined(parents, parent_txid, None).await;
+        // No bump ran, so nothing was learned about the parent.
+        follow_up
+            .apply(parents, parent_txid, BumpOutcome::NoChildNeeded, None)
+            .await;
         return None;
     };
     Some(tokio::spawn({
@@ -556,7 +573,7 @@ async fn run_bump<W, F, P>(
     F: CpfpFeeSource + 'static,
     P: CpfpMempool + 'static,
 {
-    let submitted = bump_parent(
+    let outcome = bump_parent(
         ctx,
         parents,
         parent_txid,
@@ -565,13 +582,9 @@ async fn run_bump<W, F, P>(
         reason,
     )
     .await;
-    if submitted {
-        follow_up.on_submitted(parents, parent_txid).await;
-    } else {
-        follow_up
-            .on_declined(parents, parent_txid, Some(guard.mark()))
-            .await;
-    }
+    follow_up
+        .apply(parents, parent_txid, outcome, Some(guard.mark()))
+        .await;
 }
 
 /// Spawns one task that bumps every parent that can take a bump, one after another.
@@ -1517,7 +1530,11 @@ mod cpfp_lifecycle_tests {
             )
             .await;
 
-            assert_eq!(submitted, expect_submit, "stage = {stage:?}");
+            assert_eq!(
+                submitted == BumpOutcome::Submitted,
+                expect_submit,
+                "stage = {stage:?}"
+            );
             assert_eq!(
                 submitter.captured.lock().unwrap().len(),
                 usize::from(expect_submit),
@@ -1558,7 +1575,11 @@ mod cpfp_lifecycle_tests {
         )
         .await;
 
-        assert!(!submitted, "rejected package must not report submission");
+        assert_ne!(
+            submitted,
+            BumpOutcome::Submitted,
+            "rejected package must not report submission"
+        );
         let map = parents.lock().await;
         let cpfp = map[&parent_txid].cpfp.as_ref().expect("cpfp state");
         assert_eq!(
@@ -1598,7 +1619,7 @@ mod cpfp_lifecycle_tests {
         )
         .await;
 
-        assert!(!submitted);
+        assert_ne!(submitted, BumpOutcome::Submitted);
         assert!(parents.lock().await.is_empty());
     }
 
@@ -1801,6 +1822,47 @@ mod cpfp_lifecycle_tests {
             1,
             "the carried caller joins the record once the package lands"
         );
+    }
+
+    /// The contention outcome depends on which package member lost the race. A rejection on
+    /// the parent means a conflicting transaction is in the mempool and the parent is not.
+    /// A rejection on the child means the incumbent spends an output of the parent, so the
+    /// parent is in a mempool.
+    #[tokio::test]
+    async fn contention_on_the_parent_itself_is_not_proof_of_life() {
+        use bitcoin::hashes::Hash;
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let funding = vec![OutPoint {
+            txid: parent_txid,
+            vout: 7,
+        }];
+        let marker = "insufficient fee, rejecting replacement";
+
+        for (rejected, expected) in [
+            (parent_txid, BumpOutcome::NoChildNeeded),
+            (Txid::from_byte_array([0xEE; 32]), BumpOutcome::ParentIsLive),
+        ] {
+            let ctx = test_ctx(
+                FakeWallet::returning(synthetic_child_psbt(&parent, 0, key), funding.clone()),
+                FakeSubmitter::failing("package rbf failure").with_tx_error(rejected, marker),
+            );
+            let (parents, mark) = parents_with(
+                parent_txid,
+                test_record(parent.clone(), key, Stage::Unconfirmed),
+            );
+            let outcome = bump_parent(
+                &ctx,
+                &parents,
+                parent_txid,
+                &mark,
+                PROTOCOL_FLOOR,
+                BumpReason::Tick,
+            )
+            .await;
+            assert_eq!(outcome, expected, "rejected member = {rejected}");
+        }
     }
 
     /// The per-parent mark stops a second trigger from bumping a parent whose bump is still

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -237,18 +237,12 @@ where
     )
     .await;
     if !submitted && inserted {
-        // The bump can lease funding inputs and then fail (funding succeeded, a later
-        // step did not). This removal deletes the last record of those leases, so release
-        // them here. The child never reached the mempool, the inputs stay live, and the
-        // sync prune keeps a lease on a live outpoint forever.
+        // The removed entry drops the lease of its last child, which frees the funding
+        // inputs of a child that never reached a mempool.
         //
         // Remove only an entry that this call inserted. A pre-existing entry belongs to
         // an earlier job that still waits on it, and its reactive bumps continue.
-        if let Some(entry) = entries.lock().await.remove(&txid) {
-            if !entry.handle.last_child_inputs.is_empty() {
-                ctx.wallet.release(&entry.handle.last_child_inputs).await;
-            }
-        }
+        entries.lock().await.remove(&txid);
     }
     submitted
 }
@@ -296,7 +290,7 @@ async fn resubmit_bare(rpc_client: &BitcoinClient, rawtx: &Transaction, evicted_
 /// callers serialize through the driver's single `active_bump_task` slot. The new-job
 /// caller does not share that slot, so it gates itself on the slot's state before it
 /// bumps: two concurrent bumps of one entry snapshot the same handle, and the later
-/// write-back clobbers the earlier one's `last_child_inputs`.
+/// write-back clobbers the lease that the earlier one took.
 async fn bump_one_entry<W, F, P>(
     ctx: &CpfpContext<W, F, P>,
     entries: &CpfpEntries,
@@ -331,29 +325,16 @@ where
     // Write the updated handle back if the entry still exists and is awake. Two other
     // cases exist, and both mean an event arm settled this parent during the bump:
     //
-    // - Entry gone: the parent was buried and the removal released the map handle.
-    // - Entry dormant: the parent was mined and the Mined arm took and released the map handle. A
-    //   write-back here re-records inputs that the Mined release already handed back, and the
-    //   burial release then strips them a second time — after a concurrent build has re-acquired
-    //   them.
+    // - Entry gone: the parent was buried and the removal dropped the map handle.
+    // - Entry dormant: the parent was mined, and the Mined arm cleared the lease of the map handle.
     //
-    // In both cases this local handle holds the only record of the inputs that this bump
-    // leased, so release them — but only when this bump leased. A bump that did not reach
-    // the build (floor skip, fee-source error, or a failed build, which restores its own
-    // lease state) leaves `last_child_inputs` with the pre-bump set, and the event arm
-    // released that set already from its own copy. A second release of the pre-bump set
-    // can strip a lease that a concurrent new-job build acquired in between.
-    let bump_leased = match &result {
-        Ok(submitted) => *submitted,
-        Err(e) => e.leased_funding(),
-    };
+    // Neither case needs a release call. The local handle drops at the end of this function.
+    // When this bump built a child, the local handle owns the only clone of that lease, and
+    // the drop frees the inputs. When it did not, the local handle holds a clone of the
+    // lease that the map still owns, and the drop frees nothing.
     match entries.lock().await.get_mut(&parent_txid) {
         Some(entry) if !entry.dormant => entry.handle = handle,
-        _ => {
-            if bump_leased && !handle.last_child_inputs.is_empty() {
-                ctx.wallet.release(&handle.last_child_inputs).await;
-            }
-        }
+        _ => {}
     }
     match result {
         Ok(true) => {
@@ -386,7 +367,7 @@ where
 /// The insert is get-or-create. A duplicate drive job for a parent that already has an
 /// entry keeps the live handle and only refreshes the parent and strategy. The duty retry
 /// tick re-emits publishes while the SM waits for burial, and the handle's
-/// `last_child_inputs` is the only record of the wallet leases. The insert also runs
+/// `last_child_lease` is the only record of the wallet leases. The insert also runs
 /// *before* the bump. The reverse order (bump into a private entry, insert after) opens a
 /// write-back race: a concurrent batch bump of the same parent leases fresh funding and
 /// records it in the map, and a late insert then overwrites that record with a stale
@@ -758,7 +739,7 @@ impl TxDriver {
                                     // The eviction bump shares the block/tick arms' single
                                     // in-flight slot. Two concurrent bumps of one entry would
                                     // snapshot the same handle and the later write-back would
-                                    // clobber the earlier one's `last_child_inputs`,
+                                    // clobber the lease that the earlier one took,
                                     // stranding the loser's wallet leases — the exact failure
                                     // `perform_bump`'s eager lease recording exists to
                                     // prevent. Spawning (rather than bumping inline) also
@@ -824,8 +805,8 @@ impl TxDriver {
                                 // CPFP lifecycle against confirmation depth:
                                 //
                                 // - Mined: stop the bumps (a confirmed parent needs no
-                                //   child), release the child's funding leases, and keep
-                                //   the entry dormant. Each production caller waits for
+                                //   child), drop the lease of the child, and keep the
+                                //   entry dormant. Each production caller waits for
                                 //   burial. A reorg between mined and buried returns the
                                 //   parent to the mempool (`Mempool`) or evicts it
                                 //   (`Unknown`), and the bumps must resume then. A removal
@@ -834,29 +815,21 @@ impl TxDriver {
                                 //   of a floor-rate parent, no mempool accepts it under
                                 //   fee pressure, and the duty never completes.
                                 // - Mempool: the reorg case. Wake the entry.
-                                // - Buried: final. Remove the entry.
+                                // - Buried: final. Remove the entry, which drops any lease
+                                //   that the Mined arm did not already drop.
                                 //
-                                // The lease release runs at mined time and again, without
-                                // effect, at burial. If the parent confirmed through a
-                                // competitor's child, the release frees our dead child's
-                                // funding. If our own child confirmed, its funding is
-                                // spent on-chain — see the release note in `perform_bump`
-                                // step 4.5 for the bounded side effect. A woken entry
-                                // starts from an empty handle and leases fresh funding on
-                                // its next bump.
+                                // If the parent confirmed through a competitor's child,
+                                // the drop frees our dead child's funding. If our own
+                                // child confirmed, its funding is spent on chain — see the
+                                // release note in `perform_bump` step 4.5 for the bounded
+                                // side effect. A woken entry starts from an empty handle
+                                // and takes a fresh lease on its next bump.
                                 match event.status {
                                     TxStatus::Mined { .. } => {
-                                        let released = {
-                                            let mut entries = cpfp_entries.lock().await;
-                                            entries.get_mut(&txid).map(|entry| {
-                                                entry.dormant = true;
-                                                std::mem::take(&mut entry.handle)
-                                            })
-                                        };
-                                        if let (Some(ctx), Some(handle)) = (cpfp_ctx.as_ref(), released) {
-                                            if !handle.last_child_inputs.is_empty() {
-                                                ctx.wallet.release(&handle.last_child_inputs).await;
-                                            }
+                                        let mut entries = cpfp_entries.lock().await;
+                                        if let Some(entry) = entries.get_mut(&txid) {
+                                            entry.dormant = true;
+                                            entry.handle = CpfpHandle::default();
                                         }
                                     }
                                     TxStatus::Mempool => {
@@ -868,12 +841,7 @@ impl TxDriver {
                                         }
                                     }
                                     TxStatus::Buried { .. } => {
-                                        let removed = cpfp_entries.lock().await.remove(&txid);
-                                        if let (Some(ctx), Some(entry)) = (cpfp_ctx.as_ref(), removed) {
-                                            if !entry.handle.last_child_inputs.is_empty() {
-                                                ctx.wallet.release(&entry.handle.last_child_inputs).await;
-                                            }
-                                        }
+                                        cpfp_entries.lock().await.remove(&txid);
                                     }
                                     TxStatus::Unknown => {}
                                 }
@@ -1481,7 +1449,13 @@ mod cpfp_lifecycle_tests {
         assert!(!submitted, "rejected package must not report submission");
         let map = entries.lock().await;
         assert_eq!(
-            map[&parent_txid].handle.last_child_inputs, funding,
+            map[&parent_txid]
+                .handle
+                .last_child_lease
+                .as_deref()
+                .expect("the entry must hold a lease")
+                .outpoints(),
+            funding,
             "leased funding inputs must be written back even though submission failed"
         );
         assert!(
@@ -1576,7 +1550,13 @@ mod cpfp_lifecycle_tests {
         assert!(submitted);
         let map = entries.lock().await;
         assert_eq!(
-            map[&parent_txid].handle.last_child_inputs, funding,
+            map[&parent_txid]
+                .handle
+                .last_child_lease
+                .as_deref()
+                .expect("the entry must hold a lease")
+                .outpoints(),
+            funding,
             "the surviving entry must carry the bump's lease state"
         );
     }

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -360,6 +360,15 @@ where
             }
             outcome
         }
+        Err(e) if e.is_unbumpable() => {
+            error!(
+                %parent_txid,
+                error = %e,
+                ?reason,
+                "parent cannot carry a CPFP child; stopping the bumps for it"
+            );
+            BumpOutcome::Unbumpable
+        }
         Err(e) if e.is_replacement_contention_for(&parent_txid) => {
             // The parent itself lost a replacement race: a transaction that conflicts with
             // the parent is in the mempool, and the parent is not. Nothing more is known.
@@ -585,6 +594,15 @@ async fn run_bump<W, F, P>(
     follow_up
         .apply(parents, parent_txid, outcome, Some(guard.mark()))
         .await;
+    if outcome == BumpOutcome::Unbumpable {
+        // Drop the CPFP state of a record that the follow-up left in place. Its listeners
+        // still wait on this transaction, and the eviction path still puts it back bare.
+        // The follow-up runs first, because a carried job proves its ownership of the
+        // record through the mark that lives in the CPFP state.
+        if let Some(record) = parents.lock().await.get_mut(&parent_txid) {
+            record.cpfp = None;
+        }
+    }
 }
 
 /// Spawns one task that bumps every parent that can take a bump, one after another.
@@ -1824,6 +1842,48 @@ mod cpfp_lifecycle_tests {
         );
     }
 
+    /// An unbumpable parent that entered through a failed bare broadcast must go completely.
+    /// The package was its only route into a mempool, so the record that its job created is
+    /// removed, and its caller hears the broadcast error.
+    #[tokio::test]
+    async fn an_unbumpable_carried_job_still_removes_its_record() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::unbumpable("anchor vout 9 out of range"),
+            FakeSubmitter::failing("submitter must not be called"),
+        ));
+        let (parents, _mark) =
+            parents_with(parent_txid, test_record(parent, key, Stage::Unconfirmed));
+        let (listener, receiver) = never_listener();
+
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+            BumpFollowUp::CarryJob {
+                err: ClientError::Other("bare broadcast rejected".into()),
+                listener,
+                created: true,
+            },
+        )
+        .await
+        .expect("a bumpable record must spawn a bump");
+        task.await.expect("the bump task must not panic");
+
+        assert!(
+            parents.lock().await.is_empty(),
+            "the record must go with the job that created it"
+        );
+        assert!(
+            matches!(receiver.await, Ok(Err(DriveErr::PublishFailed(_)))),
+            "the caller must hear the broadcast error"
+        );
+    }
+
     /// The contention outcome depends on which package member lost the race. A rejection on
     /// the parent means a conflicting transaction is in the mempool and the parent is not.
     /// A rejection on the child means the incumbent spends an output of the parent, so the
@@ -1863,6 +1923,42 @@ mod cpfp_lifecycle_tests {
             .await;
             assert_eq!(outcome, expected, "rejected member = {rejected}");
         }
+    }
+
+    /// A parent whose anchor the wallet cannot spend never becomes bumpable. The driver drops
+    /// its CPFP state, so no later block or tick rebuilds, re-signs, and resubmits for it.
+    /// The record stays, because its callers still wait on the transaction.
+    #[tokio::test]
+    async fn an_unbumpable_parent_loses_its_cpfp_state() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::unbumpable("anchor vout 9 out of range"),
+            FakeSubmitter::failing("submitter must not be called"),
+        ));
+        let (parents, _mark) =
+            parents_with(parent_txid, test_record(parent, key, Stage::Unconfirmed));
+
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+            BumpFollowUp::None,
+        )
+        .await
+        .expect("a bumpable record must spawn a bump");
+        task.await.expect("the bump task must not panic");
+
+        let map = parents.lock().await;
+        let record = map.get(&parent_txid).expect("the record must survive");
+        assert!(
+            record.cpfp.is_none(),
+            "an unbumpable parent must lose its CPFP state"
+        );
+        assert!(!record.is_bumpable(), "and it must not take another bump");
     }
 
     /// The per-parent mark stops a second trigger from bumping a parent whose bump is still

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -33,8 +33,8 @@ use tracing::{debug, error, info, warn};
 use crate::{
     client::{BtcNotifyClient, Connected},
     cpfp::{
-        self, BumpReason, CpfpContext, CpfpDisabled, CpfpFeeSource, CpfpHandle,
-        CpfpPackageSubmitter, CpfpStrategy, CpfpWallet,
+        self, BumpReason, CpfpContext, CpfpDisabled, CpfpFeeSource, CpfpHandle, CpfpMempool,
+        CpfpStrategy, CpfpWallet,
     },
     event::{TxEvent, TxStatus},
 };
@@ -187,7 +187,7 @@ async fn bump_all_entries<W, F, P>(
 ) where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     let txids: Vec<Txid> = entries.lock().await.keys().copied().collect();
     for parent_txid in txids {
@@ -220,7 +220,7 @@ async fn fallback_package_submit<W, F, P>(
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     let txid = parent.compute_txid();
     let submitted =
@@ -289,7 +289,7 @@ async fn bump_one_entry<W, F, P>(
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     // Snapshot under a brief lock; the slow bump runs without the entries mutex held.
     let snapshot = entries
@@ -322,6 +322,12 @@ where
             // Target at or below floor; expected in a quiet mempool.
             false
         }
+        Err(e) if e.is_replacement_contention() => {
+            // Another watchtower holds this shared anchor and our child does not pay enough
+            // more to displace it. Expected on every trigger until the parent confirms.
+            debug!(%parent_txid, ?reason, "CPFP bump lost the race for a shared anchor");
+            false
+        }
         Err(e) => {
             warn!(%parent_txid, error = %e, ?reason, "CPFP bump failed; will retry on next trigger");
             false
@@ -351,7 +357,7 @@ async fn register_cpfp_entry_and_bump<W, F, P>(
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
-    P: CpfpPackageSubmitter + 'static,
+    P: CpfpMempool + 'static,
 {
     let txid = parent.compute_txid();
     let mut entry = CpfpEntry {
@@ -436,7 +442,7 @@ impl TxDriver {
     where
         W: CpfpWallet + 'static,
         F: CpfpFeeSource + 'static,
-        P: CpfpPackageSubmitter + 'static,
+        P: CpfpMempool + 'static,
     {
         let new_jobs = unbounded_channel::<TxDriveJob>();
         let new_jobs_sender = new_jobs.0;
@@ -1214,7 +1220,7 @@ mod cpfp_lifecycle_tests {
             multi_anchor_signer: fake_input_signer_ok(),
             wallet_input_signer: fake_input_signer_ok(),
             max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
-            package_submitter: Arc::new(submitter),
+            mempool: Arc::new(submitter),
         }
     }
 

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -361,7 +361,10 @@ where
             outcome
         }
         Err(e) if e.is_unbumpable() => {
-            error!(
+            // `warn!`, not `error!`: a re-driven job re-arms the bumps for this parent, so a
+            // persistent Unbumpable parent would log at `error!` once per duty retry. The
+            // bare paths keep carrying the parent in the meantime.
+            warn!(
                 %parent_txid,
                 error = %e,
                 ?reason,
@@ -780,13 +783,13 @@ impl TxDriver {
             let mut active_tx_subs = SelectAll::<Abortable<Subscription<TxEvent>>>::new();
             let parents: Parents = Arc::new(Mutex::new(HashMap::new()));
             // Timer that fires every `bump_check_interval`. Note the cost model: tick is a
-            // reactive `BumpReason`, so parents whose target sits ABOVE the protocol floor
-            // are fully rebuilt every tick (wallet build + sign + submitpackage that either
-            // dedups against the live child or bounces off the BIP-125 incremental-fee rule)
-            // — deliberate, because a silently-evicted child is invisible and the tick is
-            // what revives it. The walk is only cheap in the quiet-mempool steady state,
-            // where the floor / parent-fee baseline skips return `Ok(false)` before any
-            // wallet call.
+            // reactive `BumpReason`, so it does not take the step-4 same-rate skip. A parent
+            // whose probe (step 4.5) reports a live child at a sufficient rate costs one
+            // probe and no wallet call. A parent whose probe reports the output unspent is
+            // fully rebuilt (wallet build + sign + submitpackage) — deliberate, because a
+            // silently-evicted child is invisible and the tick is what revives it. The walk
+            // is only cheap in the quiet-mempool steady state, where the floor / parent-fee
+            // baseline skips return `NoChildNeeded` before any wallet call.
             let mut bump_tick = tokio::time::interval(bump_check_interval);
             // `Interval::tick` fires immediately on first call. Burn it so the first effective
             // bump tick is one full interval after construction.

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -514,7 +514,7 @@ async fn take_bump_mark(parents: &Parents, parent_txid: Txid) -> Option<BumpGuar
 /// cannot take one still runs `follow_up`, so an evicted parent goes back into the mempool
 /// even when another trigger holds the mark.
 ///
-/// Spawning is not an optimisation. `perform_bump` takes the operator wallet's write lock,
+/// Spawning is not an optimisation. `perform_bump` takes the operator wallet's read lock,
 /// and a duty can hold that lock while it awaits `TxDriver::drive`. A bump awaited inside the
 /// driver's select loop therefore deadlocks: the driver waits for the wallet, the duty waits
 /// for a status event that only the driver can deliver, and neither side can proceed.
@@ -589,7 +589,7 @@ async fn run_bump<W, F, P>(
 
 /// Spawns one task that bumps every parent that can take a bump, one after another.
 ///
-/// The bumps run one at a time. Each one takes the operator wallet's write lock, so a
+/// The bumps run one at a time. Each one takes the operator wallet's lock, so a
 /// parallel fan-out puts every other user of the wallet behind the whole batch. Each parent
 /// keeps its own mark, so a parent that another trigger is already bumping is skipped and the
 /// rest of the batch continues.
@@ -986,8 +986,8 @@ impl TxDriver {
                         // On each new block, walk every tracked parent and spawn a bump for
                         // each one that can take it. Spawned (not inline) so the driver
                         // returns to its select! immediately, and because a bump takes the
-                        // operator wallet's write lock — see `spawn_bump` for why an inline
-                        // bump deadlocks.
+                        // operator wallet's lock — see `spawn_bump` for why an inline bump
+                        // deadlocks.
                         if let Some(ctx) = cpfp_ctx.as_ref() {
                             spawn_batch_bump(ctx, &parents, bridge_protocol_floor, BumpReason::NewBlock).await;
                         }

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -161,6 +161,11 @@ struct CpfpEntry {
     parent: Transaction,
     strategy: CpfpStrategy,
     handle: CpfpHandle,
+    /// True while the parent is mined but not yet buried. A dormant entry is not bumped —
+    /// a confirmed parent needs no child — but it is kept, because a reorg between mined
+    /// and buried puts the parent back in (or out of) the mempool, and bumping must resume
+    /// then. Removal happens only at burial, when the callers' own wait conditions resolve.
+    dormant: bool,
 }
 
 /// Shared CPFP state across the driver task and the spawned bump tasks. `Arc<Mutex>` so
@@ -222,19 +227,28 @@ where
     F: CpfpFeeSource + 'static,
     P: CpfpMempool + 'static,
 {
-    let txid = parent.compute_txid();
-    let submitted =
-        match register_cpfp_entry_and_bump(ctx, entries, parent, strategy, bridge_protocol_floor)
-            .await
-        {
-            Ok(submitted) => submitted,
-            Err(e) => {
-                warn!(%txid, error = %e, "CPFP fallback after bare-broadcast failure also failed");
-                false
+    let (txid, inserted) = upsert_cpfp_entry(entries, parent, strategy).await;
+    let submitted = bump_one_entry(
+        ctx,
+        entries,
+        txid,
+        bridge_protocol_floor,
+        BumpReason::NewJob,
+    )
+    .await;
+    if !submitted && inserted {
+        // The bump can lease funding inputs and then fail (funding succeeded, a later
+        // step did not). This removal deletes the last record of those leases, so release
+        // them here. The child never reached the mempool, the inputs stay live, and the
+        // sync prune keeps a lease on a live outpoint forever.
+        //
+        // Remove only an entry that this call inserted. A pre-existing entry belongs to
+        // an earlier job that still waits on it, and its reactive bumps continue.
+        if let Some(entry) = entries.lock().await.remove(&txid) {
+            if !entry.handle.last_child_inputs.is_empty() {
+                ctx.wallet.release(&entry.handle.last_child_inputs).await;
             }
-        };
-    if !submitted {
-        entries.lock().await.remove(&txid);
+        }
     }
     submitted
 }
@@ -249,7 +263,10 @@ async fn resubmit_bare(rpc_client: &BitcoinClient, rawtx: &Transaction, evicted_
             info!(%txid, "resubmitted transaction successfully");
         }
         Err(err) => {
-            error!(%evicted_txid, %err, "could not resubmit transaction");
+            // `warn`, not `error`: a floor-rate parent evicted under fee pressure is
+            // rejected here on each attempt by design, and the CPFP path (next block or
+            // tick) is what actually recovers it. An error level buries real faults.
+            warn!(%evicted_txid, %err, "could not resubmit transaction");
             // TODO: <https://alpenlabs.atlassian.net/browse/STR-2690>
             // Analyze the reported error and classify the submission
             // failure mode.
@@ -274,11 +291,12 @@ async fn resubmit_bare(rpc_client: &BitcoinClient, rawtx: &Transaction, evicted_
 /// the floor would strand the leases (see the lease-recording note on
 /// [`cpfp::perform_bump`]).
 ///
-/// Shared by the batch walker above and the eviction arm of the driver loop, so both paths
-/// bump with identical snapshot / write-back discipline. Callers serialize through the
-/// driver's single `active_bump_task` slot — two concurrent bumps of the same entry would
-/// snapshot the same handle and the later write-back would clobber the earlier one's
-/// `last_child_inputs`.
+/// Shared by the batch walker, the eviction arm, and the new-job registration, so every
+/// path bumps with identical snapshot / write-back discipline. The batch and eviction
+/// callers serialize through the driver's single `active_bump_task` slot. The new-job
+/// caller does not share that slot, so it gates itself on the slot's state before it
+/// bumps: two concurrent bumps of one entry snapshot the same handle, and the later
+/// write-back clobbers the earlier one's `last_child_inputs`.
 async fn bump_one_entry<W, F, P>(
     ctx: &CpfpContext<W, F, P>,
     entries: &CpfpEntries,
@@ -296,9 +314,10 @@ where
         .lock()
         .await
         .get(&parent_txid)
+        .filter(|e| !e.dormant)
         .map(|e| (e.parent.clone(), e.strategy.clone(), e.handle.clone()));
     let Some((parent, strategy, mut handle)) = snapshot else {
-        return false; // entry confirmed / removed since the caller looked
+        return false; // entry removed, or dormant (parent mined; awaiting burial)
     };
     let result = cpfp::perform_bump(
         ctx,
@@ -309,9 +328,32 @@ where
         reason,
     )
     .await;
-    // Write back the updated handle if the entry still exists.
-    if let Some(entry) = entries.lock().await.get_mut(&parent_txid) {
-        entry.handle = handle;
+    // Write the updated handle back if the entry still exists and is awake. Two other
+    // cases exist, and both mean an event arm settled this parent during the bump:
+    //
+    // - Entry gone: the parent was buried and the removal released the map handle.
+    // - Entry dormant: the parent was mined and the Mined arm took and released the map handle. A
+    //   write-back here re-records inputs that the Mined release already handed back, and the
+    //   burial release then strips them a second time — after a concurrent build has re-acquired
+    //   them.
+    //
+    // In both cases this local handle holds the only record of the inputs that this bump
+    // leased, so release them — but only when this bump leased. A bump that did not reach
+    // the build (floor skip, fee-source error, or a failed build, which restores its own
+    // lease state) leaves `last_child_inputs` with the pre-bump set, and the event arm
+    // released that set already from its own copy. A second release of the pre-bump set
+    // can strip a lease that a concurrent new-job build acquired in between.
+    let bump_leased = match &result {
+        Ok(submitted) => *submitted,
+        Err(e) => e.leased_funding(),
+    };
+    match entries.lock().await.get_mut(&parent_txid) {
+        Some(entry) if !entry.dormant => entry.handle = handle,
+        _ => {
+            if bump_leased && !handle.last_child_inputs.is_empty() {
+                ctx.wallet.release(&handle.last_child_inputs).await;
+            }
+        }
     }
     match result {
         Ok(true) => {
@@ -335,47 +377,77 @@ where
     }
 }
 
-/// Inserts a [`CpfpEntry`] for `parent` into the shared entries map and runs one initial
-/// `NewJob` bump. Used by the new-job arm in three places: after a successful bare
-/// broadcast, when the parent is already in the mempool at job arrival, and as a
-/// fallback when bare broadcast fails (so a properly-priced child can carry an
-/// underpriced parent in via `submitpackage`).
+/// Inserts (or refreshes) a [`CpfpEntry`] for `parent`, then runs one initial `NewJob` bump
+/// through [`bump_one_entry`], sharing its snapshot / write-back discipline. Used by the
+/// new-job arm in three places: after a successful bare broadcast, when the parent is
+/// already in the mempool at job arrival, and as a fallback when bare broadcast fails (so a
+/// properly-priced child can carry an underpriced parent in via `submitpackage`).
 ///
-/// Returns the bump outcome: `Ok(true)` means a `[parent, child]` package was actually
-/// submitted (relevant for the fallback caller — the parent is now in the mempool);
-/// `Ok(false)` means the bump was skipped (one of [`perform_bump`]'s skip conditions:
-/// target at or below the floor, parent fee already at target, or — for eager bumps —
-/// target not above the last submitted rate); `Err` is a build/sign/submit failure. The
-/// entry is inserted regardless, so reactive bumps on block / tick / eviction will retry.
+/// The insert is get-or-create. A duplicate drive job for a parent that already has an
+/// entry keeps the live handle and only refreshes the parent and strategy. The duty retry
+/// tick re-emits publishes while the SM waits for burial, and the handle's
+/// `last_child_inputs` is the only record of the wallet leases. The insert also runs
+/// *before* the bump. The reverse order (bump into a private entry, insert after) opens a
+/// write-back race: a concurrent batch bump of the same parent leases fresh funding and
+/// records it in the map, and a late insert then overwrites that record with a stale
+/// handle. The leases are lost.
+///
+/// Returns whether a `[parent, child]` package was actually submitted (relevant for the
+/// fallback caller — the parent is then in the mempool). Failures are logged inside
+/// [`bump_one_entry`]; reactive bumps on block / tick / eviction retry regardless.
 async fn register_cpfp_entry_and_bump<W, F, P>(
     ctx: &CpfpContext<W, F, P>,
     entries: &CpfpEntries,
     parent: Transaction,
     strategy: CpfpStrategy,
     bridge_protocol_floor: FeeRate,
-) -> Result<bool, cpfp::CpfpError>
+) -> bool
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
     P: CpfpMempool + 'static,
 {
-    let txid = parent.compute_txid();
-    let mut entry = CpfpEntry {
-        parent,
-        strategy,
-        handle: CpfpHandle::default(),
-    };
-    let result = cpfp::perform_bump(
+    let (txid, _) = upsert_cpfp_entry(entries, parent, strategy).await;
+    bump_one_entry(
         ctx,
-        &entry.parent,
-        entry.strategy.clone(),
-        &mut entry.handle,
+        entries,
+        txid,
         bridge_protocol_floor,
-        BumpReason::NewJob,
+        cpfp::BumpReason::NewJob,
     )
-    .await;
-    entries.lock().await.insert(txid, entry);
-    result
+    .await
+}
+
+/// Inserts a [`CpfpEntry`] for `parent`, or refreshes the parent and strategy of an
+/// existing entry while its handle (the lease record) stays live. Returns the parent txid
+/// and whether the call inserted a new entry.
+async fn upsert_cpfp_entry(
+    entries: &CpfpEntries,
+    parent: Transaction,
+    strategy: CpfpStrategy,
+) -> (Txid, bool) {
+    let txid = parent.compute_txid();
+    let mut entries = entries.lock().await;
+    let inserted = match entries.get_mut(&txid) {
+        Some(existing) => {
+            existing.parent = parent;
+            existing.strategy = strategy;
+            false
+        }
+        None => {
+            entries.insert(
+                txid,
+                CpfpEntry {
+                    parent,
+                    strategy,
+                    handle: CpfpHandle::default(),
+                    dormant: false,
+                },
+            );
+            true
+        }
+    };
+    (txid, inserted)
 }
 
 /// System for driving a signed transaction to confirmation.
@@ -539,16 +611,27 @@ impl TxDriver {
                                 // The first bump runs here too so a deeply-underpriced
                                 // resident parent gets a fresh package immediately.
                                 if let (Some(ctx), Some(strategy)) = (cpfp_ctx.as_ref(), job_cpfp) {
-                                    if let Err(e) = register_cpfp_entry_and_bump(
-                                        ctx.as_ref(),
-                                        &cpfp_entries,
-                                        job_parent,
-                                        strategy,
-                                        bridge_protocol_floor,
-                                    )
-                                    .await
-                                    {
-                                        warn!(%txid, error = %e, "initial CPFP bump for already-known parent failed; will retry on next trigger");
+                                    // The eager bump must not run next to an in-flight
+                                    // batch or eviction bump: two concurrent bumps of one
+                                    // entry snapshot the same handle, and the later
+                                    // write-back clobbers the earlier one's lease record.
+                                    // The entry registers either way; the next trigger
+                                    // bumps it. Failures are logged inside
+                                    // `bump_one_entry`.
+                                    if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
+                                        let (registered_txid, _) =
+                                            upsert_cpfp_entry(&cpfp_entries, job_parent, strategy)
+                                                .await;
+                                        debug!(%registered_txid, "bump slot busy; CPFP entry registered without an eager bump");
+                                    } else {
+                                        register_cpfp_entry_and_bump(
+                                            ctx.as_ref(),
+                                            &cpfp_entries,
+                                            job_parent,
+                                            strategy,
+                                            bridge_protocol_floor,
+                                        )
+                                        .await;
                                     }
                                 }
                             }
@@ -576,16 +659,27 @@ impl TxDriver {
                                 // below the floor mean the presigned parent's own rate is
                                 // sufficient; the helper's `perform_bump` skips internally.
                                 if let (Some(ctx), Some(strategy)) = (cpfp_ctx.as_ref(), job_cpfp) {
-                                    if let Err(e) = register_cpfp_entry_and_bump(
-                                        ctx.as_ref(),
-                                        &cpfp_entries,
-                                        job_parent,
-                                        strategy,
-                                        bridge_protocol_floor,
-                                    )
-                                    .await
-                                    {
-                                        warn!(%txid, error = %e, "initial CPFP bump failed; will retry on next trigger");
+                                    // The eager bump must not run next to an in-flight
+                                    // batch or eviction bump: two concurrent bumps of one
+                                    // entry snapshot the same handle, and the later
+                                    // write-back clobbers the earlier one's lease record.
+                                    // The entry registers either way; the next trigger
+                                    // bumps it. Failures are logged inside
+                                    // `bump_one_entry`.
+                                    if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
+                                        let (registered_txid, _) =
+                                            upsert_cpfp_entry(&cpfp_entries, job_parent, strategy)
+                                                .await;
+                                        debug!(%registered_txid, "bump slot busy; CPFP entry registered without an eager bump");
+                                    } else {
+                                        register_cpfp_entry_and_bump(
+                                            ctx.as_ref(),
+                                            &cpfp_entries,
+                                            job_parent,
+                                            strategy,
+                                            bridge_protocol_floor,
+                                        )
+                                        .await;
                                     }
                                 }
                             },
@@ -642,8 +736,24 @@ impl TxDriver {
                                 // re-submit as a package — that's the canonical bump path on
                                 // mempool eviction. Otherwise fall back to bare resubmission
                                 // (legacy behaviour preserved for non-CPFP callers).
-                                let has_cpfp_entry = cpfp_ctx.is_some()
-                                    && cpfp_entries.lock().await.contains_key(&evicted_txid);
+                                let has_cpfp_entry = cpfp_ctx.is_some() && {
+                                    let mut entries = cpfp_entries.lock().await;
+                                    match entries.get_mut(&evicted_txid) {
+                                        Some(entry) => {
+                                            // A dormant entry means the parent was mined. An
+                                            // eviction event for it means a reorg dropped
+                                            // the parent from its block and from the
+                                            // mempool. That is the situation the bumps
+                                            // exist for. Wake the entry.
+                                            if entry.dormant {
+                                                info!(%evicted_txid, "mined parent evicted after a reorg; resuming CPFP bumps");
+                                                entry.dormant = false;
+                                            }
+                                            true
+                                        }
+                                        None => false,
+                                    }
+                                };
                                 if let (Some(ctx), true) = (cpfp_ctx.as_ref(), has_cpfp_entry) {
                                     // The eviction bump shares the block/tick arms' single
                                     // in-flight slot. Two concurrent bumps of one entry would
@@ -655,12 +765,14 @@ impl TxDriver {
                                     // keeps the driver select loop responsive through the
                                     // build + sign + submitpackage round-trip.
                                     if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
-                                        // Safe to skip entirely: the in-flight batch calls
-                                        // `submitpackage([parent, child])` for this entry,
-                                        // which reintroduces the evicted parent by
-                                        // construction; failing that, the next block or tick
-                                        // retries.
-                                        debug!(%evicted_txid, "skipping eviction bump: in-flight bump batch will resubmit the package");
+                                        // The in-flight batch snapshotted its txid list at
+                                        // its start. It can miss this entry (registered
+                                        // after the snapshot) or it can have walked past
+                                        // this txid already. Neither case resubmits the
+                                        // evicted parent. Resubmit the bare parent now; the
+                                        // next block or tick rebuilds the child on top.
+                                        debug!(%evicted_txid, "bump slot busy; resubmitting evicted parent bare until the next trigger");
+                                        resubmit_bare(&rpc_client, &event.rawtx, evicted_txid).await;
                                     } else {
                                         let ctx = ctx.clone();
                                         let entries = cpfp_entries.clone();
@@ -709,11 +821,61 @@ impl TxDriver {
                                         }
                                     }));
                                 active_jobs = active_jobs.merge(leftovers);
-                                // If this event represents confirmation (mined/buried), the
-                                // parent has landed on chain — drop its CPFP state so we stop
-                                // bumping. Mempool events leave the entry alone.
-                                if matches!(event.status, TxStatus::Mined { .. } | TxStatus::Buried { .. }) {
-                                    cpfp_entries.lock().await.remove(&txid);
+                                // CPFP lifecycle against confirmation depth:
+                                //
+                                // - Mined: stop the bumps (a confirmed parent needs no
+                                //   child), release the child's funding leases, and keep
+                                //   the entry dormant. Each production caller waits for
+                                //   burial. A reorg between mined and buried returns the
+                                //   parent to the mempool (`Mempool`) or evicts it
+                                //   (`Unknown`), and the bumps must resume then. A removal
+                                //   here makes the parent unbumpable for the rest of the
+                                //   wait: the eviction arm falls back to a bare resubmit
+                                //   of a floor-rate parent, no mempool accepts it under
+                                //   fee pressure, and the duty never completes.
+                                // - Mempool: the reorg case. Wake the entry.
+                                // - Buried: final. Remove the entry.
+                                //
+                                // The lease release runs at mined time and again, without
+                                // effect, at burial. If the parent confirmed through a
+                                // competitor's child, the release frees our dead child's
+                                // funding. If our own child confirmed, its funding is
+                                // spent on-chain — see the release note in `perform_bump`
+                                // step 4.5 for the bounded side effect. A woken entry
+                                // starts from an empty handle and leases fresh funding on
+                                // its next bump.
+                                match event.status {
+                                    TxStatus::Mined { .. } => {
+                                        let released = {
+                                            let mut entries = cpfp_entries.lock().await;
+                                            entries.get_mut(&txid).map(|entry| {
+                                                entry.dormant = true;
+                                                std::mem::take(&mut entry.handle)
+                                            })
+                                        };
+                                        if let (Some(ctx), Some(handle)) = (cpfp_ctx.as_ref(), released) {
+                                            if !handle.last_child_inputs.is_empty() {
+                                                ctx.wallet.release(&handle.last_child_inputs).await;
+                                            }
+                                        }
+                                    }
+                                    TxStatus::Mempool => {
+                                        if let Some(entry) = cpfp_entries.lock().await.get_mut(&txid) {
+                                            if entry.dormant {
+                                                info!(%txid, "parent reorged back into the mempool; resuming CPFP bumps");
+                                                entry.dormant = false;
+                                            }
+                                        }
+                                    }
+                                    TxStatus::Buried { .. } => {
+                                        let removed = cpfp_entries.lock().await.remove(&txid);
+                                        if let (Some(ctx), Some(entry)) = (cpfp_ctx.as_ref(), removed) {
+                                            if !entry.handle.last_child_inputs.is_empty() {
+                                                ctx.wallet.release(&entry.handle.last_child_inputs).await;
+                                            }
+                                        }
+                                    }
+                                    TxStatus::Unknown => {}
                                 }
                             }
                         }
@@ -1224,6 +1386,62 @@ mod cpfp_lifecycle_tests {
         }
     }
 
+    /// A dormant entry (parent mined, burial pending) is not bumped. The wallet and the
+    /// mempool must not be called: a confirmed parent needs no child. The same entry with
+    /// `dormant = false` submits, so the skip is the only difference under test.
+    #[tokio::test]
+    async fn bump_one_entry_skips_dormant_entries() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let funding = vec![OutPoint {
+            txid: parent_txid,
+            vout: 7,
+        }];
+        let make_entry = |dormant: bool| CpfpEntry {
+            parent: parent.clone(),
+            strategy: anchor_strategy(key),
+            handle: CpfpHandle::default(),
+            dormant,
+        };
+
+        for (dormant, expect_submit) in [(true, false), (false, true)] {
+            let submitter = Arc::new(FakeSubmitter::ok());
+            let ctx = CpfpContext {
+                wallet: Arc::new(FakeWallet::returning(
+                    synthetic_child_psbt(&parent, 0, key),
+                    funding.clone(),
+                )),
+                fee_source: Arc::new(FakeFeeSource::returning(
+                    FeeRate::from_sat_per_vb(10).unwrap(),
+                )),
+                anchor_input_signer: fake_input_signer_ok(),
+                multi_anchor_signer: fake_input_signer_ok(),
+                wallet_input_signer: fake_input_signer_ok(),
+                max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
+                mempool: submitter.clone(),
+            };
+            let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::from([(
+                parent_txid,
+                make_entry(dormant),
+            )])));
+            let submitted = bump_one_entry(
+                &ctx,
+                &entries,
+                parent_txid,
+                crate::cpfp::tests::PROTOCOL_FLOOR,
+                BumpReason::Tick,
+            )
+            .await;
+            assert_eq!(submitted, expect_submit, "dormant = {dormant}");
+            assert_eq!(
+                submitter.captured.lock().unwrap().len(),
+                usize::from(expect_submit),
+                "dormant = {dormant}"
+            );
+        }
+    }
+
     /// Even a failed bump must land its handle back in the entries map: `perform_bump` records
     /// the freshly-leased funding inputs on the handle as soon as the wallet returns, and the
     /// next bump can only release them if that update survives into the map.
@@ -1247,6 +1465,7 @@ mod cpfp_lifecycle_tests {
                 parent: parent.clone(),
                 strategy: anchor_strategy(key),
                 handle: CpfpHandle::default(),
+                dormant: false,
             },
         )])));
 

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -1,12 +1,15 @@
 //! This module implements a system that will accept signed transactions and ensure they are posted
 //! to the blockchain within a reasonable time.
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 use algebra::{
     monoid::{self, Monoid},
     semigroup::Semigroup,
 };
-use bitcoin::{Amount, Transaction, Txid};
+use bitcoin::{Amount, FeeRate, Transaction, Txid};
 use bitcoind_async_client::{
     error::ClientError,
     traits::{Broadcaster, Reader},
@@ -18,14 +21,21 @@ use strata_bridge_primitives::subscription::Subscription;
 use thiserror::Error;
 use tokio::{
     select,
-    sync::mpsc::{unbounded_channel, UnboundedSender},
+    sync::{
+        mpsc::{unbounded_channel, UnboundedSender},
+        Mutex,
+    },
     task::JoinHandle,
 };
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     client::{BtcNotifyClient, Connected},
+    cpfp::{
+        self, BumpReason, CpfpContext, CpfpDisabled, CpfpFeeSource, CpfpHandle,
+        CpfpPackageSubmitter, CpfpStrategy, CpfpWallet,
+    },
     event::{TxEvent, TxStatus},
 };
 
@@ -51,6 +61,11 @@ struct TxDriveJob {
 
     /// The channel that we should publish on when the job is done.
     respond_on: oneshot::Sender<Result<(), DriveErr>>,
+
+    /// Optional CPFP strategy. When present, the driver builds (and replaces on each new
+    /// block / mempool eviction) a CPFP child to lift the package fee rate toward the fee
+    /// source's target. Disabled for non-CPFP txs.
+    cpfp: Option<CpfpStrategy>,
 }
 
 impl TxDriveJob {
@@ -101,7 +116,8 @@ impl Monoid for TxJobHeap {
 }
 
 impl From<TxDriveJob> for TxJobHeap {
-    /// Converts a TxDriveJob into a TxJobHeap with a single job in it.
+    /// Converts a TxDriveJob into a TxJobHeap with a single job in it. Discards `cpfp` —
+    /// CPFP-specific state lives in a parallel map keyed on the parent txid.
     fn from(job: TxDriveJob) -> Self {
         let mut heap = BTreeMap::new();
         heap.insert(job.tx.compute_txid(), vec![(job.condition, job.respond_on)]);
@@ -121,6 +137,239 @@ fn broadcast_options(tx: &Transaction) -> Option<BroadcastOptions> {
         max_burn_amount: Some(max_burn_amount),
         ..Default::default()
     })
+}
+
+/// Sentinel bump-tick interval used by [`TxDriver::new`] (no-CPFP path). The bump arm
+/// inside the driver's select loop fires on this cadence but immediately short-circuits
+/// when `cpfp_ctx` is `None`, so a long interval keeps the no-CPFP path effectively idle.
+const NO_CPFP_BUMP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Default bridge protocol-floor fee rate used by [`TxDriver::new`] (no-CPFP path). MUST
+/// equal `strata_bridge_tx_graph::fee::FEE_RATE_SAT_PER_VB` — but `btc-tracker` cannot
+/// depend on `tx-graph` (layering), so the value is duplicated here with a grep-anchorable
+/// const name. If `FEE_RATE_SAT_PER_VB` ever changes, search for `DEFAULT_PROTOCOL_FLOOR`
+/// to find and update this. Production (CPFP-enabled) calls [`TxDriver::with_cpfp`] and
+/// passes `fee::FEE_RATE` directly, so this only affects the legacy no-CPFP constructor.
+const DEFAULT_PROTOCOL_FLOOR: FeeRate = FeeRate::from_sat_per_vb_unchecked(2);
+
+/// Per-parent CPFP state. Keyed on parent txid in the shared `CpfpEntries` map.
+///
+/// Holds the parent transaction (needed for re-building children on bump), its strategy, and
+/// the [`CpfpHandle`] tracking the most recent child's funding inputs and package rate.
+#[derive(Clone)]
+struct CpfpEntry {
+    parent: Transaction,
+    strategy: CpfpStrategy,
+    handle: CpfpHandle,
+}
+
+/// Shared CPFP state across the driver task and the spawned bump tasks. `Arc<Mutex>` so
+/// reactive bump tasks (new block, timer tick) can run concurrently with the driver loop —
+/// the driver task isn't blocked waiting on N×submitpackage RPCs.
+type CpfpEntries = Arc<Mutex<HashMap<Txid, CpfpEntry>>>;
+
+/// Walks every entry in `entries` and runs one `perform_bump` per entry under `reason`.
+///
+/// **Lock discipline.** Snapshots the keys + each entry (cloning parent/strategy/handle)
+/// under a brief lock so the slow `perform_bump` call runs WITHOUT the entries mutex held.
+/// On completion, re-acquires the lock to write back the updated handle, IF the entry still
+/// exists (it may have been removed in the meantime, e.g. the parent confirmed). This means
+/// new-job insertions and confirm-removals are never blocked by an in-flight bump batch.
+///
+/// Spawned as a separate tokio task by the driver's block/tick select! arms so the driver
+/// returns to its select! immediately. Within this task, bumps are serial — they share the
+/// wallet's `RwLock::write()` anyway, so additional intra-batch concurrency wouldn't help.
+async fn bump_all_entries<W, F, P>(
+    ctx: Arc<CpfpContext<W, F, P>>,
+    entries: CpfpEntries,
+    bridge_protocol_floor: FeeRate,
+    reason: cpfp::BumpReason,
+) where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    let txids: Vec<Txid> = entries.lock().await.keys().copied().collect();
+    for parent_txid in txids {
+        bump_one_entry(
+            ctx.as_ref(),
+            &entries,
+            parent_txid,
+            bridge_protocol_floor,
+            reason,
+        )
+        .await;
+    }
+}
+
+/// Fallback for a parent whose bare broadcast was rejected: register a CPFP entry and try to
+/// carry the parent into the mempool inside a `[parent, child]` package. Returns whether the
+/// package was actually submitted.
+///
+/// On any non-submission outcome the just-registered entry is removed again. The caller is
+/// about to fail the job and drop its subscription, so the confirm-removal path in the event
+/// arm could never fire for this txid — an orphaned entry would be bumped on every block and
+/// tick forever, churning wallet leases for a parent that never reached the mempool.
+async fn fallback_package_submit<W, F, P>(
+    ctx: &CpfpContext<W, F, P>,
+    entries: &CpfpEntries,
+    parent: Transaction,
+    strategy: CpfpStrategy,
+    bridge_protocol_floor: FeeRate,
+) -> bool
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    let txid = parent.compute_txid();
+    let submitted =
+        match register_cpfp_entry_and_bump(ctx, entries, parent, strategy, bridge_protocol_floor)
+            .await
+        {
+            Ok(submitted) => submitted,
+            Err(e) => {
+                warn!(%txid, error = %e, "CPFP fallback after bare-broadcast failure also failed");
+                false
+            }
+        };
+    if !submitted {
+        entries.lock().await.remove(&txid);
+    }
+    submitted
+}
+
+/// Bare (non-package) resubmission of an evicted transaction, preserving the pre-CPFP
+/// driver behaviour for parents without a CPFP entry and as the fallback when a bump
+/// declines to submit.
+async fn resubmit_bare(rpc_client: &BitcoinClient, rawtx: &Transaction, evicted_txid: Txid) {
+    let options = broadcast_options(rawtx);
+    match rpc_client.send_raw_transaction(rawtx, options).await {
+        Ok(txid) => {
+            info!(%txid, "resubmitted transaction successfully");
+        }
+        Err(err) => {
+            error!(%evicted_txid, %err, "could not resubmit transaction");
+            // TODO: <https://alpenlabs.atlassian.net/browse/STR-2690>
+            // Analyze the reported error and classify the submission
+            // failure mode.
+            //
+            // 1. It failed because one or more of the inputs is double
+            // spent.
+            // 2. It failed because the fee didn't exceed the purge
+            // rate.
+            // 3. If failed because the transaction has already
+            // re-entered the mempool automatically upon reorg.
+        }
+    }
+}
+
+/// Runs one `perform_bump` for the entry at `parent_txid`, writing the updated handle back
+/// if the entry still exists. Returns whether a `[parent, child]` package was actually
+/// submitted. No-op returning `false` when the entry has vanished (parent confirmed and was
+/// removed between the caller's look-up and ours).
+///
+/// The handle is written back **even when the bump fails**: `perform_bump` records the
+/// child's funding inputs as soon as the wallet leases them, and dropping that update on
+/// the floor would strand the leases (see the lease-recording note on
+/// [`cpfp::perform_bump`]).
+///
+/// Shared by the batch walker above and the eviction arm of the driver loop, so both paths
+/// bump with identical snapshot / write-back discipline. Callers serialize through the
+/// driver's single `active_bump_task` slot — two concurrent bumps of the same entry would
+/// snapshot the same handle and the later write-back would clobber the earlier one's
+/// `last_child_inputs`.
+async fn bump_one_entry<W, F, P>(
+    ctx: &CpfpContext<W, F, P>,
+    entries: &CpfpEntries,
+    parent_txid: Txid,
+    bridge_protocol_floor: FeeRate,
+    reason: cpfp::BumpReason,
+) -> bool
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    // Snapshot under a brief lock; the slow bump runs without the entries mutex held.
+    let snapshot = entries
+        .lock()
+        .await
+        .get(&parent_txid)
+        .map(|e| (e.parent.clone(), e.strategy.clone(), e.handle.clone()));
+    let Some((parent, strategy, mut handle)) = snapshot else {
+        return false; // entry confirmed / removed since the caller looked
+    };
+    let result = cpfp::perform_bump(
+        ctx,
+        &parent,
+        strategy,
+        &mut handle,
+        bridge_protocol_floor,
+        reason,
+    )
+    .await;
+    // Write back the updated handle if the entry still exists.
+    if let Some(entry) = entries.lock().await.get_mut(&parent_txid) {
+        entry.handle = handle;
+    }
+    match result {
+        Ok(true) => {
+            debug!(%parent_txid, ?reason, "CPFP bump submitted");
+            true
+        }
+        Ok(false) => {
+            // Target at or below floor; expected in a quiet mempool.
+            false
+        }
+        Err(e) => {
+            warn!(%parent_txid, error = %e, ?reason, "CPFP bump failed; will retry on next trigger");
+            false
+        }
+    }
+}
+
+/// Inserts a [`CpfpEntry`] for `parent` into the shared entries map and runs one initial
+/// `NewJob` bump. Used by the new-job arm in three places: after a successful bare
+/// broadcast, when the parent is already in the mempool at job arrival, and as a
+/// fallback when bare broadcast fails (so a properly-priced child can carry an
+/// underpriced parent in via `submitpackage`).
+///
+/// Returns the bump outcome: `Ok(true)` means a `[parent, child]` package was actually
+/// submitted (relevant for the fallback caller — the parent is now in the mempool);
+/// `Ok(false)` means the bump was skipped (one of [`perform_bump`]'s skip conditions:
+/// target at or below the floor, parent fee already at target, or — for eager bumps —
+/// target not above the last submitted rate); `Err` is a build/sign/submit failure. The
+/// entry is inserted regardless, so reactive bumps on block / tick / eviction will retry.
+async fn register_cpfp_entry_and_bump<W, F, P>(
+    ctx: &CpfpContext<W, F, P>,
+    entries: &CpfpEntries,
+    parent: Transaction,
+    strategy: CpfpStrategy,
+    bridge_protocol_floor: FeeRate,
+) -> Result<bool, cpfp::CpfpError>
+where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpPackageSubmitter + 'static,
+{
+    let txid = parent.compute_txid();
+    let mut entry = CpfpEntry {
+        parent,
+        strategy,
+        handle: CpfpHandle::default(),
+    };
+    let result = cpfp::perform_bump(
+        ctx,
+        &entry.parent,
+        entry.strategy.clone(),
+        &mut entry.handle,
+        bridge_protocol_floor,
+        BumpReason::NewJob,
+    )
+    .await;
+    entries.lock().await.insert(txid, entry);
+    result
 }
 
 /// System for driving a signed transaction to confirmation.
@@ -144,16 +393,89 @@ impl TxDriverHealthHandle {
 }
 
 impl TxDriver {
-    /// Initializes the TxDriver.
+    /// Initializes the TxDriver without CPFP fee-bumping. Behaves identically to the original
+    /// driver: broadcasts transactions, watches for confirmation, no aggressive bump on
+    /// eviction or new blocks. The bump-tick interval is set to a long sentinel duration
+    /// (one hour) since no CPFP context is configured — the timer arm fires but the inner
+    /// `cpfp_ctx` check short-circuits.
     pub async fn new(zmq_client: BtcNotifyClient<Connected>, rpc_client: BitcoinClient) -> Self {
+        Self::with_cpfp::<CpfpDisabled, CpfpDisabled, CpfpDisabled>(
+            zmq_client,
+            rpc_client,
+            None,
+            DEFAULT_PROTOCOL_FLOOR,
+            NO_CPFP_BUMP_INTERVAL,
+        )
+        .await
+    }
+
+    /// Initializes the TxDriver with CPFP fee-bumping enabled. When `cpfp_ctx` is `Some`, jobs
+    /// submitted via [`Self::drive_with_cpfp`] carry a [`CpfpStrategy`], and the driver:
+    ///
+    /// * On mempool eviction (per-tx ZMQ `Unknown` event): re-queries the fee source, rebuilds the
+    ///   child via the wallet, RBF-submits `[parent, child]` as a package.
+    /// * On each new block (block-event branch): walks every active CPFP parent that hasn't
+    ///   confirmed and runs the same bump path.
+    ///
+    /// `bridge_protocol_floor` is the bridge presigned-tx fee rate (typically 2 sat/vB). When
+    /// the fee source target is at or below this floor, the bump is a no-op — the presigned
+    /// parent's own fee already meets the network's needs.
+    ///
+    /// `bump_check_interval` is the cadence at which the driver polls its cached fee rate
+    /// and bumps any active CPFP parent whose package rate is below the new target. The
+    /// fee source itself is refreshed in the background by [`crate::cpfp::CachedFeeSource`]
+    /// at its own cadence; this knob controls how often the driver consumes that cache.
+    /// Defaults to 30 seconds in practice.
+    pub async fn with_cpfp<W, F, P>(
+        zmq_client: BtcNotifyClient<Connected>,
+        rpc_client: BitcoinClient,
+        cpfp_ctx: Option<CpfpContext<W, F, P>>,
+        bridge_protocol_floor: FeeRate,
+        bump_check_interval: std::time::Duration,
+    ) -> Self
+    where
+        W: CpfpWallet + 'static,
+        F: CpfpFeeSource + 'static,
+        P: CpfpPackageSubmitter + 'static,
+    {
         let new_jobs = unbounded_channel::<TxDriveJob>();
         let new_jobs_sender = new_jobs.0;
         let mut block_subscription = zmq_client.subscribe_blocks().await;
+
+        // The CPFP context is shared via `Arc` so block/tick spawned tasks can capture it
+        // by value without forcing `CpfpContext` itself to be Clone-friendly across an
+        // ever-cloning hot path.
+        let cpfp_ctx = cpfp_ctx.map(Arc::new);
 
         let driver = tokio::task::spawn(async move {
             let mut new_jobs_receiver_stream = UnboundedReceiverStream::new(new_jobs.1);
             let mut active_tx_subs = SelectAll::<Subscription<TxEvent>>::new();
             let mut active_jobs = TxJobHeap::empty();
+            // CPFP state for active parents, keyed on parent txid. Populated when a job
+            // arrives with `Some(cpfp_strategy)`, cleared when the parent confirms (the
+            // mined/buried branch below). `Arc<Mutex<>>` so spawned bump tasks can take
+            // a brief lock without blocking the driver loop on long bump RPCs (S1 fix —
+            // see `bump_all_entries` for the lock discipline).
+            let cpfp_entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+            // Handle of the currently in-flight `bump_all_entries` task, if any. New
+            // block/tick triggers skip spawning if the previous batch hasn't finished —
+            // prevents fan-out pile-up under sustained slowness (slow RPC, contended wallet
+            // lock) which would otherwise queue stale-snapshot tasks behind each other and
+            // re-trigger benign-but-noisy `release(prior)` warnings. The next tick will
+            // pick up freshly-evolved state once the previous task drains.
+            let mut active_bump_task: Option<JoinHandle<()>> = None;
+            // Timer that fires every `bump_check_interval`. Note the cost model: tick is a
+            // reactive `BumpReason`, so entries whose target sits ABOVE the protocol floor
+            // are fully rebuilt every tick (wallet build + sign + submitpackage that either
+            // dedups against the live child or bounces off the BIP-125 incremental-fee rule)
+            // — deliberate, because a silently-evicted child is invisible and the tick is
+            // what revives it. The walk is only cheap in the quiet-mempool steady state,
+            // where the floor / parent-fee baseline skips return `Ok(false)` before any
+            // wallet call.
+            let mut bump_tick = tokio::time::interval(bump_check_interval);
+            // `Interval::tick` fires immediately on first call. Burn it so the first effective
+            // bump tick is one full interval after construction.
+            bump_tick.tick().await;
             loop {
                 select! {
                     Some(job) = new_jobs_receiver_stream.next().fuse() => {
@@ -200,7 +522,29 @@ impl TxDriver {
                                 // Handle the race where the relevant event may already have
                                 // happened before the subscription is established.
                                 active_tx_subs.push(tx_sub);
+                                let job_parent = job.tx.clone();
+                                let job_cpfp = job.cpfp.clone();
                                 active_jobs = active_jobs.merge(job.into());
+
+                                // Register CPFP for an already-resident parent. Without
+                                // this, parents broadcast in a prior incarnation that are
+                                // still in the mempool when the driver comes back up would
+                                // never be re-bumped on block / tick / eviction events.
+                                // The first bump runs here too so a deeply-underpriced
+                                // resident parent gets a fresh package immediately.
+                                if let (Some(ctx), Some(strategy)) = (cpfp_ctx.as_ref(), job_cpfp) {
+                                    if let Err(e) = register_cpfp_entry_and_bump(
+                                        ctx.as_ref(),
+                                        &cpfp_entries,
+                                        job_parent,
+                                        strategy,
+                                        bridge_protocol_floor,
+                                    )
+                                    .await
+                                    {
+                                        warn!(%txid, error = %e, "initial CPFP bump for already-known parent failed; will retry on next trigger");
+                                    }
+                                }
                             }
 
                             continue;
@@ -216,49 +560,126 @@ impl TxDriver {
                                 // is to add the subscription at the top and then remove them if the submission errors
                                 // but removing a subscription from a `SelectAll` is not straightforward.
                                 active_tx_subs.push(tx_sub);
+                                let job_parent = job.tx.clone();
+                                let job_cpfp = job.cpfp.clone();
                                 active_jobs = active_jobs.merge(job.into());
+
+                                // Eager initial bump: if CPFP is configured and the fee
+                                // source's target is above the protocol floor, build and
+                                // submit a CPFP child as a package right now. Targets at or
+                                // below the floor mean the presigned parent's own rate is
+                                // sufficient; the helper's `perform_bump` skips internally.
+                                if let (Some(ctx), Some(strategy)) = (cpfp_ctx.as_ref(), job_cpfp) {
+                                    if let Err(e) = register_cpfp_entry_and_bump(
+                                        ctx.as_ref(),
+                                        &cpfp_entries,
+                                        job_parent,
+                                        strategy,
+                                        bridge_protocol_floor,
+                                    )
+                                    .await
+                                    {
+                                        warn!(%txid, error = %e, "initial CPFP bump failed; will retry on next trigger");
+                                    }
+                                }
                             },
                             Err(err) => {
-                                // TODO: <https://alpenlabs.atlassian.net/browse/STR-2688>
-                                // If we have not hit the mempool purge rate, CPFP using the
-                                // anchor from the start and retry as a package.
-                                //
+                                // Bare broadcast failed. Most commonly the parent's own fee
+                                // rate is below the mempool's minimum and a CPFP child can
+                                // carry it in via `submitpackage` (package validation is
+                                // more lenient than single-tx acceptance). If CPFP is
+                                // configured, try that fallback before surfacing the error.
                                 // TODO: <https://alpenlabs.atlassian.net/browse/STR-2689>
-                                // Distinguish invalid transactions and notify the job submitter
-                                // instead of treating them like fee-bumping work.
-                                // For now, we just inform the caller until we add fee-bumping
-                                // support.
-                                error!(%txid, tx=?rawtx_rpc_client, %err, "could not submit transaction");
-                                // send feedback to the job submitter
-                                if job.respond_on.send(Err(DriveErr::PublishFailed(err))).is_err() {
-                                    error!("could not send error response to job submitter");
+                                // Distinguish invalid transactions and notify the job
+                                // submitter directly instead of attempting fee bumping.
+                                let job_parent = job.tx.clone();
+                                let job_cpfp = job.cpfp.clone();
+                                let pkg_submitted = if let (Some(ctx), Some(strategy)) =
+                                    (cpfp_ctx.as_ref(), job_cpfp)
+                                {
+                                    warn!(%txid, %err, "bare broadcast failed; attempting CPFP package fallback");
+                                    fallback_package_submit(
+                                        ctx.as_ref(),
+                                        &cpfp_entries,
+                                        job_parent,
+                                        strategy,
+                                        bridge_protocol_floor,
+                                    )
+                                    .await
+                                } else {
+                                    false
+                                };
+
+                                if pkg_submitted {
+                                    info!(%txid, "parent reached mempool via CPFP package fallback");
+                                    active_tx_subs.push(tx_sub);
+                                    active_jobs = active_jobs.merge(job.into());
+                                } else {
+                                    // `fallback_package_submit` has already removed any entry
+                                    // it registered — nothing here can observe this parent
+                                    // confirming once the job is failed.
+                                    error!(%txid, tx=?rawtx_rpc_client, %err, "could not submit transaction");
+                                    // send feedback to the job submitter
+                                    if job.respond_on.send(Err(DriveErr::PublishFailed(err))).is_err() {
+                                        error!("could not send error response to job submitter");
+                                    }
                                 }
                             }
                         }
                     }
                     Some(event) = active_tx_subs.next().fuse() => {
+                        let evicted_txid = event.rawtx.compute_txid();
                         match event.status {
                             TxStatus::Unknown => {
-                                // Transaction has been evicted, resubmit and see what happens
-                                let options = broadcast_options(&event.rawtx);
-                                match rpc_client.send_raw_transaction(&event.rawtx, options).await {
-                                    Ok(txid) => {
-                                        /* NOOP, we good fam */
-                                        info!(%txid, "resubmitted transaction successfully");
+                                // Transaction has been evicted. If this parent has CPFP
+                                // enabled, rebuild the child at the current fee target and
+                                // re-submit as a package — that's the canonical bump path on
+                                // mempool eviction. Otherwise fall back to bare resubmission
+                                // (legacy behaviour preserved for non-CPFP callers).
+                                let has_cpfp_entry = cpfp_ctx.is_some()
+                                    && cpfp_entries.lock().await.contains_key(&evicted_txid);
+                                if let (Some(ctx), true) = (cpfp_ctx.as_ref(), has_cpfp_entry) {
+                                    // The eviction bump shares the block/tick arms' single
+                                    // in-flight slot. Two concurrent bumps of one entry would
+                                    // snapshot the same handle and the later write-back would
+                                    // clobber the earlier one's `last_child_inputs`,
+                                    // stranding the loser's wallet leases — the exact failure
+                                    // `perform_bump`'s eager lease recording exists to
+                                    // prevent. Spawning (rather than bumping inline) also
+                                    // keeps the driver select loop responsive through the
+                                    // build + sign + submitpackage round-trip.
+                                    if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
+                                        // Safe to skip entirely: the in-flight batch calls
+                                        // `submitpackage([parent, child])` for this entry,
+                                        // which reintroduces the evicted parent by
+                                        // construction; failing that, the next block or tick
+                                        // retries.
+                                        debug!(%evicted_txid, "skipping eviction bump: in-flight bump batch will resubmit the package");
+                                    } else {
+                                        let ctx = ctx.clone();
+                                        let entries = cpfp_entries.clone();
+                                        let floor = bridge_protocol_floor;
+                                        let rawtx = event.rawtx.clone();
+                                        let rpc_client = rpc_client.clone();
+                                        active_bump_task = Some(tokio::spawn(async move {
+                                            let submitted = bump_one_entry(
+                                                ctx.as_ref(),
+                                                &entries,
+                                                evicted_txid,
+                                                floor,
+                                                BumpReason::ParentEvicted,
+                                            )
+                                            .await;
+                                            if !submitted {
+                                                // Bump declined (target at floor) or failed;
+                                                // keep the legacy behaviour of at least
+                                                // putting the bare parent back.
+                                                resubmit_bare(&rpc_client, &rawtx, evicted_txid).await;
+                                            }
+                                        }));
                                     }
-                                    Err(err) => {
-                                        error!(txid=%event.rawtx.compute_txid(), %err, "could not resubmit transaction");
-                                        // TODO: <https://alpenlabs.atlassian.net/browse/STR-2690>
-                                        // Analyze the reported error and classify the submission
-                                        // failure mode.
-                                        //
-                                        // 1. It failed because one or more of the inputs is double
-                                        // spent.
-                                        // 2. It failed because the fee didn't exceed the purge
-                                        // rate.
-                                        // 3. If failed because the transaction has already
-                                        // re-entered the mempool automatically upon reorg.
-                                    }
+                                } else {
+                                    resubmit_bare(&rpc_client, &event.rawtx, evicted_txid).await;
                                 }
                             }
                             _ => {
@@ -282,13 +703,51 @@ impl TxDriver {
                                         }
                                     }));
                                 active_jobs = active_jobs.merge(leftovers);
+                                // If this event represents confirmation (mined/buried), the
+                                // parent has landed on chain — drop its CPFP state so we stop
+                                // bumping. Mempool events leave the entry alone.
+                                if matches!(event.status, TxStatus::Mined { .. } | TxStatus::Buried { .. }) {
+                                    cpfp_entries.lock().await.remove(&txid);
+                                }
                             }
                         }
 
                     }
                     _block = block_subscription.next().fuse() => {
-                        // TODO: <https://alpenlabs.atlassian.net/browse/STR-2691>
-                        // Compare against deadlines and CPFP using the anchor where needed.
+                        // On each new block, spawn a task that walks every CPFP parent and
+                        // runs a bump. Spawned (not inline) so the driver returns to its
+                        // select! immediately — new jobs and ZMQ events aren't blocked even
+                        // if there are many entries or the bumps stall on a slow RPC. See
+                        // `bump_all_entries` for the lock-discipline details, and
+                        // `active_bump_task` above for the fan-out guard rationale.
+                        if let Some(ctx) = cpfp_ctx.as_ref() {
+                            if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
+                                debug!("skipping new-block bump: previous bump batch still running");
+                            } else {
+                                let ctx = ctx.clone();
+                                let entries = cpfp_entries.clone();
+                                let floor = bridge_protocol_floor;
+                                active_bump_task = Some(tokio::spawn(async move {
+                                    bump_all_entries(ctx, entries, floor, BumpReason::NewBlock).await;
+                                }));
+                            }
+                        }
+                    }
+                    _ = bump_tick.tick().fuse() => {
+                        // Periodic timer-driven bump — same shape as the new-block arm, with
+                        // the same in-flight guard.
+                        if let Some(ctx) = cpfp_ctx.as_ref() {
+                            if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
+                                debug!("skipping tick bump: previous bump batch still running");
+                            } else {
+                                let ctx = ctx.clone();
+                                let entries = cpfp_entries.clone();
+                                let floor = bridge_protocol_floor;
+                                active_bump_task = Some(tokio::spawn(async move {
+                                    bump_all_entries(ctx, entries, floor, BumpReason::Tick).await;
+                                }));
+                            }
+                        }
                     }
                 }
             }
@@ -300,11 +759,38 @@ impl TxDriver {
         }
     }
 
-    /// Instructs the TxDriver to drive a new transaction to confirmation.
+    /// Instructs the TxDriver to drive a new transaction to confirmation without CPFP.
     pub async fn drive(
         &self,
         tx: Transaction,
         condition: impl Fn(&TxStatus) -> bool + Send + 'static,
+    ) -> Result<(), DriveErr> {
+        self.drive_inner(tx, condition, None).await
+    }
+
+    /// Instructs the TxDriver to drive a new transaction to confirmation with CPFP
+    /// fee-bumping. The driver builds the initial child immediately (unless the fee source
+    /// reports at or below the bridge protocol floor), then RBFs the child on each new block
+    /// or mempool eviction until the parent confirms or the operator's `max_fee_rate` cap is
+    /// reached.
+    ///
+    /// Requires the driver to have been initialized via [`Self::with_cpfp`] with a non-`None`
+    /// [`CpfpContext`]. If CPFP wasn't configured at construction time, this method behaves
+    /// the same as [`Self::drive`].
+    pub async fn drive_with_cpfp(
+        &self,
+        tx: Transaction,
+        cpfp: CpfpStrategy,
+        condition: impl Fn(&TxStatus) -> bool + Send + 'static,
+    ) -> Result<(), DriveErr> {
+        self.drive_inner(tx, condition, Some(cpfp)).await
+    }
+
+    async fn drive_inner(
+        &self,
+        tx: Transaction,
+        condition: impl Fn(&TxStatus) -> bool + Send + 'static,
+        cpfp: Option<CpfpStrategy>,
     ) -> Result<(), DriveErr> {
         let (sender, receiver) = oneshot::channel();
         self.new_jobs_sender
@@ -312,6 +798,7 @@ impl TxDriver {
                 tx,
                 condition: Box::new(condition),
                 respond_on: sender,
+                cpfp,
             })
             .map_err(|_| DriveErr::DriverAborted)?;
         receiver
@@ -329,6 +816,17 @@ impl TxDriver {
 }
 
 impl Drop for TxDriver {
+    /// Aborts the main driver task. Note that any in-flight `bump_all_entries` task spawned
+    /// by the block / tick arms is **detached** — its `JoinHandle` was stored in the driver
+    /// task's local `active_bump_task` slot, which is dropped (not awaited) along with the
+    /// driver task itself. The detached bump task continues running on the runtime until it
+    /// finishes its current pass over `cpfp_entries`. At process shutdown the runtime tears
+    /// the task down regardless; for graceful in-process restart of `TxDriver`, a brief race
+    /// with the previous instance's bump task is possible (each call holds the wallet lock
+    /// per-bump, releases between, and the entries map is per-`TxDriver` so the old task
+    /// operates on its own snapshot). Acceptable for current call patterns; if mid-process
+    /// `TxDriver` lifecycle ever becomes load-bearing, expose a `shutdown(self)` that awaits
+    /// the active bump task before aborting the driver task.
     fn drop(&mut self) {
         self.driver.abort();
     }
@@ -682,5 +1180,179 @@ mod e2e_tests {
         info!("OP_RETURN burn transaction appeared in mempool");
 
         Ok(())
+    }
+}
+
+/// Unit tests for the driver's CPFP entry-lifecycle plumbing, using the shared fakes from
+/// [`crate::cpfp::tests`]. The full driver loop needs a live bitcoind (see `e2e_tests`); these
+/// pin the helpers the loop is built from, which is where the audit found the lifecycle gaps.
+#[cfg(test)]
+mod cpfp_lifecycle_tests {
+    use std::collections::HashMap;
+
+    use bitcoin::{Amount, OutPoint};
+
+    use super::*;
+    use crate::cpfp::{
+        tests::{
+            anchor_strategy, fake_input_signer_ok, synthetic_child_psbt, synthetic_parent,
+            test_keypair_and_xonly, FakeFeeSource, FakeSubmitter, FakeWallet, PROTOCOL_FLOOR,
+        },
+        CpfpContext,
+    };
+
+    fn test_ctx(
+        wallet: FakeWallet,
+        submitter: FakeSubmitter,
+    ) -> CpfpContext<FakeWallet, FakeFeeSource, FakeSubmitter> {
+        CpfpContext {
+            wallet: Arc::new(wallet),
+            fee_source: Arc::new(FakeFeeSource::returning(
+                FeeRate::from_sat_per_vb(10).unwrap(),
+            )),
+            anchor_input_signer: fake_input_signer_ok(),
+            multi_anchor_signer: fake_input_signer_ok(),
+            wallet_input_signer: fake_input_signer_ok(),
+            max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
+            package_submitter: Arc::new(submitter),
+        }
+    }
+
+    /// Even a failed bump must land its handle back in the entries map: `perform_bump` records
+    /// the freshly-leased funding inputs on the handle as soon as the wallet returns, and the
+    /// next bump can only release them if that update survives into the map.
+    #[tokio::test]
+    async fn bump_one_entry_writes_handle_back_on_submit_failure() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let funding = vec![OutPoint {
+            txid: parent_txid,
+            vout: 7,
+        }];
+        let psbt = synthetic_child_psbt(&parent, 0, key);
+        let ctx = test_ctx(
+            FakeWallet::returning(psbt, funding.clone()),
+            FakeSubmitter::failing("package-not-valid"),
+        );
+        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::from([(
+            parent_txid,
+            CpfpEntry {
+                parent: parent.clone(),
+                strategy: anchor_strategy(key),
+                handle: CpfpHandle::default(),
+            },
+        )])));
+
+        let submitted = bump_one_entry(
+            &ctx,
+            &entries,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+        )
+        .await;
+
+        assert!(!submitted, "rejected package must not report submission");
+        let map = entries.lock().await;
+        assert_eq!(
+            map[&parent_txid].handle.last_child_inputs, funding,
+            "leased funding inputs must be written back even though submission failed"
+        );
+        assert!(
+            map[&parent_txid].handle.last_child_txid.is_none(),
+            "nothing reached the mempool, so the child txid must not advance"
+        );
+    }
+
+    /// A vanished entry (parent confirmed between look-up and bump) is a quiet no-op — in
+    /// particular the wallet must never be asked to fund a child for it.
+    #[tokio::test]
+    async fn bump_one_entry_is_noop_when_entry_vanished() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let ctx = test_ctx(
+            FakeWallet::failing("wallet must not be called for a vanished entry"),
+            FakeSubmitter::failing("submitter must not be called either"),
+        );
+        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+
+        let submitted = bump_one_entry(
+            &ctx,
+            &entries,
+            parent.compute_txid(),
+            PROTOCOL_FLOOR,
+            BumpReason::NewBlock,
+        )
+        .await;
+
+        assert!(!submitted);
+        assert!(entries.lock().await.is_empty());
+    }
+
+    /// The bare-broadcast fallback must not leave an orphaned entry behind when the package
+    /// submission fails too: the caller is about to fail the job and drop its subscription, so
+    /// nothing could ever remove the entry, and it would be re-bumped forever.
+    #[tokio::test]
+    async fn failed_fallback_leaves_no_orphan_entry() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let psbt = synthetic_child_psbt(&parent, 0, key);
+        let ctx = test_ctx(
+            FakeWallet::returning(
+                psbt,
+                vec![OutPoint {
+                    txid: parent.compute_txid(),
+                    vout: 7,
+                }],
+            ),
+            FakeSubmitter::failing("package-not-valid"),
+        );
+        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+
+        let submitted = fallback_package_submit(
+            &ctx,
+            &entries,
+            parent.clone(),
+            anchor_strategy(key),
+            PROTOCOL_FLOOR,
+        )
+        .await;
+
+        assert!(!submitted);
+        assert!(
+            entries.lock().await.is_empty(),
+            "failed fallback must remove the entry it registered"
+        );
+    }
+
+    /// The successful fallback keeps its entry — the job survives, its subscription is pushed,
+    /// and the confirm-removal path owns the entry from here.
+    #[tokio::test]
+    async fn successful_fallback_keeps_entry_for_future_bumps() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let funding = vec![OutPoint {
+            txid: parent_txid,
+            vout: 7,
+        }];
+        let psbt = synthetic_child_psbt(&parent, 0, key);
+        let ctx = test_ctx(
+            FakeWallet::returning(psbt, funding.clone()),
+            FakeSubmitter::ok(),
+        );
+        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+
+        let submitted =
+            fallback_package_submit(&ctx, &entries, parent, anchor_strategy(key), PROTOCOL_FLOOR)
+                .await;
+
+        assert!(submitted);
+        let map = entries.lock().await;
+        assert_eq!(
+            map[&parent_txid].handle.last_child_inputs, funding,
+            "the surviving entry must carry the bump's lease state"
+        );
     }
 }

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -1,14 +1,13 @@
 //! This module implements a system that will accept signed transactions and ensure they are posted
 //! to the blockchain within a reasonable time.
 use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
-use algebra::{
-    monoid::{self, Monoid},
-    semigroup::Semigroup,
-};
 use bitcoin::{Amount, FeeRate, Transaction, Txid};
 use bitcoind_async_client::{
     error::ClientError,
@@ -16,7 +15,11 @@ use bitcoind_async_client::{
     types::BroadcastOptions,
     Client as BitcoinClient,
 };
-use futures::{channel::oneshot, stream::SelectAll, FutureExt, StreamExt};
+use futures::{
+    channel::oneshot,
+    stream::{abortable, AbortHandle, Abortable, SelectAll},
+    FutureExt, StreamExt,
+};
 use strata_bridge_primitives::subscription::Subscription;
 use thiserror::Error;
 use tokio::{
@@ -49,6 +52,12 @@ pub enum DriveErr {
     /// Indicates that the transaction could not be published.
     #[error("could not publish transaction: {0}")]
     PublishFailed(ClientError),
+
+    /// The transaction reached burial before the caller's condition was true. The driver
+    /// stops tracking a transaction at burial, so the condition can never become true after
+    /// this point.
+    #[error("transaction was buried before the wait condition was met")]
+    ConditionUnmet,
 }
 
 /// This is the minimal description of a request to drive a transaction.
@@ -80,51 +89,6 @@ type TxSubscriberSet = Vec<(
     oneshot::Sender<Result<(), DriveErr>>,
 )>;
 
-/// The TxJobHeap is a map from [`Txid`]s to the corresponding [`Transaction`] and a list of
-/// listeners for the results.
-struct TxJobHeap(BTreeMap<Txid, TxSubscriberSet>);
-impl TxJobHeap {
-    /// Removes all jobs associated with a given [`Transaction`] and returns the job details.
-    fn remove(&mut self, txid: &Txid) -> Option<TxSubscriberSet> {
-        self.0.remove(txid)
-    }
-}
-
-/// The Semigroup impl for TxJobHeap merges heaps so that all listeners are notified but the
-/// representation is always minimally encoded.
-impl Semigroup for TxJobHeap {
-    fn merge(self, other: Self) -> Self {
-        let mut a = self.0;
-        let b = other.0;
-        for (k, v) in b {
-            match a.get_mut(&k) {
-                Some(responders) => responders.extend(v),
-                None => {
-                    a.insert(k, v);
-                }
-            }
-        }
-        TxJobHeap(a)
-    }
-}
-
-/// The Monoid impl for TxJobHeap yields a heap that contains no transactions it is trying to drive.
-impl Monoid for TxJobHeap {
-    fn empty() -> TxJobHeap {
-        TxJobHeap(BTreeMap::new())
-    }
-}
-
-impl From<TxDriveJob> for TxJobHeap {
-    /// Converts a TxDriveJob into a TxJobHeap with a single job in it. Discards `cpfp` —
-    /// CPFP-specific state lives in a parallel map keyed on the parent txid.
-    fn from(job: TxDriveJob) -> Self {
-        let mut heap = BTreeMap::new();
-        heap.insert(job.tx.compute_txid(), vec![(job.condition, job.respond_on)]);
-        TxJobHeap(heap)
-    }
-}
-
 fn broadcast_options(tx: &Transaction) -> Option<BroadcastOptions> {
     let max_burn_amount = tx
         .output
@@ -152,104 +116,151 @@ const NO_CPFP_BUMP_INTERVAL: std::time::Duration = std::time::Duration::from_sec
 /// passes `fee::FEE_RATE` directly, so this only affects the legacy no-CPFP constructor.
 const DEFAULT_PROTOCOL_FLOOR: FeeRate = FeeRate::from_sat_per_vb_unchecked(2);
 
-/// Per-parent CPFP state. Keyed on parent txid in the shared `CpfpEntries` map.
+/// How far the driver has seen a transaction advance.
 ///
-/// Holds the parent transaction (needed for re-building children on bump), its strategy, and
-/// the [`CpfpHandle`] tracking the most recent child's funding inputs and package rate.
-#[derive(Clone)]
-struct CpfpEntry {
-    parent: Transaction,
+/// The stage and the presence of a record together give three states: bumping, waiting for
+/// burial, and gone. The stage field holds the first two, and each event arm sets it
+/// directly. The third is the absence of a record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    /// Not in a block. CPFP bumps run.
+    Unconfirmed,
+    /// In a block, not yet buried. CPFP bumps stop, because a confirmed parent needs no
+    /// child. The record stays: a reorg returns the transaction to [`Self::Unconfirmed`] and
+    /// the bumps must resume then. A removal at this point makes the parent unbumpable for
+    /// the rest of the wait, and a floor-rate parent that no mempool accepts never confirms.
+    Mined,
+}
+
+/// Marks one parent as having a bump in flight, and clears the mark when it drops.
+///
+/// The bump task owns the guard, so the mark clears when the task ends by any route,
+/// including a panic. A flag that a task sets and clears by hand stays set after a panic, and
+/// no later bump for that parent can start.
+#[derive(Debug)]
+struct BumpGuard(Arc<AtomicBool>);
+
+impl BumpGuard {
+    /// The mark that this guard holds. Two records for one txid hold different marks, so
+    /// pointer identity tells a bump whether the record it started on is still the one there.
+    const fn mark(&self) -> &Arc<AtomicBool> {
+        &self.0
+    }
+}
+
+impl Drop for BumpGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
+
+/// CPFP state for one parent.
+#[derive(Debug)]
+struct CpfpState {
     strategy: CpfpStrategy,
     handle: CpfpHandle,
-    /// True while the parent is mined but not yet buried. A dormant entry is not bumped —
-    /// a confirmed parent needs no child — but it is kept, because a reorg between mined
-    /// and buried puts the parent back in (or out of) the mempool, and bumping must resume
-    /// then. Removal happens only at burial, when the callers' own wait conditions resolve.
-    dormant: bool,
+    /// Whether a bump for this parent is in flight.
+    ///
+    /// One bump per parent at a time. Two concurrent bumps take a snapshot of the same
+    /// handle, and the later write-back drops the lease of the live child. The mark is per
+    /// parent, so a slow bump for one parent does not stop the bumps for every other parent,
+    /// and no trigger has to fall back to a degraded path.
+    bumping: Arc<AtomicBool>,
 }
 
-/// Shared CPFP state across the driver task and the spawned bump tasks. `Arc<Mutex>` so
-/// reactive bump tasks (new block, timer tick) can run concurrently with the driver loop —
-/// the driver task isn't blocked waiting on N×submitpackage RPCs.
-type CpfpEntries = Arc<Mutex<HashMap<Txid, CpfpEntry>>>;
+impl CpfpState {
+    /// A fresh state for `strategy`, with no child built yet.
+    fn new(strategy: CpfpStrategy) -> Self {
+        Self {
+            strategy,
+            handle: CpfpHandle::default(),
+            bumping: Arc::new(AtomicBool::new(false)),
+        }
+    }
 
-/// Walks every entry in `entries` and runs one `perform_bump` per entry under `reason`.
-///
-/// **Lock discipline.** Snapshots the keys + each entry (cloning parent/strategy/handle)
-/// under a brief lock so the slow `perform_bump` call runs WITHOUT the entries mutex held.
-/// On completion, re-acquires the lock to write back the updated handle, IF the entry still
-/// exists (it may have been removed in the meantime, e.g. the parent confirmed). This means
-/// new-job insertions and confirm-removals are never blocked by an in-flight bump batch.
-///
-/// Spawned as a separate tokio task by the driver's block/tick select! arms so the driver
-/// returns to its select! immediately. Within this task, bumps are serial — they share the
-/// wallet's `RwLock::write()` anyway, so additional intra-batch concurrency wouldn't help.
-async fn bump_all_entries<W, F, P>(
-    ctx: Arc<CpfpContext<W, F, P>>,
-    entries: CpfpEntries,
-    bridge_protocol_floor: FeeRate,
-    reason: cpfp::BumpReason,
-) where
-    W: CpfpWallet + 'static,
-    F: CpfpFeeSource + 'static,
-    P: CpfpMempool + 'static,
-{
-    let txids: Vec<Txid> = entries.lock().await.keys().copied().collect();
-    for parent_txid in txids {
-        bump_one_entry(
-            ctx.as_ref(),
-            &entries,
-            parent_txid,
-            bridge_protocol_floor,
-            reason,
-        )
-        .await;
+    /// Marks a bump as in flight and returns the guard that clears the mark. Returns `None`
+    /// when a bump is already running for this parent.
+    fn start_bump(&self) -> Option<BumpGuard> {
+        self.bumping
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| BumpGuard(Arc::clone(&self.bumping)))
+    }
+
+    /// Whether a bump for this parent is in flight.
+    fn is_bumping(&self) -> bool {
+        self.bumping.load(Ordering::Acquire)
     }
 }
 
-/// Fallback for a parent whose bare broadcast was rejected: register a CPFP entry and try to
-/// carry the parent into the mempool inside a `[parent, child]` package. Returns whether the
-/// package was actually submitted.
+/// Everything the driver tracks for one transaction that it drives.
 ///
-/// On any non-submission outcome the just-registered entry is removed again. The caller is
-/// about to fail the job and drop its subscription, so the confirm-removal path in the event
-/// arm could never fire for this txid — an orphaned entry would be bumped on every block and
-/// tick forever, churning wallet leases for a parent that never reached the mempool.
-async fn fallback_package_submit<W, F, P>(
-    ctx: &CpfpContext<W, F, P>,
-    entries: &CpfpEntries,
-    parent: Transaction,
-    strategy: CpfpStrategy,
-    bridge_protocol_floor: FeeRate,
-) -> bool
-where
-    W: CpfpWallet + 'static,
-    F: CpfpFeeSource + 'static,
-    P: CpfpMempool + 'static,
-{
-    let (txid, inserted) = upsert_cpfp_entry(entries, parent, strategy).await;
-    let submitted = bump_one_entry(
-        ctx,
-        entries,
-        txid,
-        bridge_protocol_floor,
-        BumpReason::NewJob,
-    )
-    .await;
-    if !submitted && inserted {
-        // The removed entry drops the lease of its last child, which frees the funding
-        // inputs of a child that never reached a mempool.
-        //
-        // Remove only an entry that this call inserted. A pre-existing entry belongs to
-        // an earlier job that still waits on it, and its reactive bumps continue.
-        entries.lock().await.remove(&txid);
-    }
-    submitted
+/// The listeners, the ZMQ subscription, and the CPFP state share one lifetime, so they share
+/// one record. A single removal ends the subscription and drops the lease of the last CPFP
+/// child together, and it answers each listener that is still waiting.
+///
+/// Separate structures keyed on the same txid give each event arm three things to keep
+/// consistent. Any arm that updates two of the three leaks the third.
+struct ParentRecord {
+    /// The transaction. A bump uses it to rebuild the child.
+    tx: Transaction,
+    /// Callers that wait for a status condition.
+    listeners: TxSubscriberSet,
+    stage: Stage,
+    /// `None` when the caller asked for no CPFP.
+    cpfp: Option<CpfpState>,
+    /// Ends the ZMQ subscription of this transaction.
+    ///
+    /// [`SelectAll`] has no removal method, so each subscription enters it through
+    /// [`futures::stream::abortable`]. An abort ends that stream, and `SelectAll` drops it on
+    /// the next poll. Without a way to end it, each driven transaction holds one entry in
+    /// `SelectAll` for the lifetime of the process.
+    ///
+    /// The client keeps its own sender and filter until an event matches the predicate again
+    /// and the send fails. A buried transaction produces no further match, so that side is
+    /// not freed here.
+    subscription: AbortHandle,
 }
 
-/// Bare (non-package) resubmission of an evicted transaction, preserving the pre-CPFP
-/// driver behaviour for parents without a CPFP entry and as the fallback when a bump
-/// declines to submit.
+impl ParentRecord {
+    /// Answers every listener whose condition `status` satisfies, and keeps the rest.
+    fn notify(&mut self, status: &TxStatus) {
+        let waiting = std::mem::take(&mut self.listeners);
+        self.listeners = waiting
+            .into_iter()
+            .filter_map(|(condition, respond_on)| {
+                if condition(status) {
+                    let _ = respond_on.send(Ok(()));
+                    None
+                } else {
+                    Some((condition, respond_on))
+                }
+            })
+            .collect();
+    }
+
+    /// Whether a bump can run for this parent now.
+    fn is_bumpable(&self) -> bool {
+        self.stage == Stage::Unconfirmed
+            && self.cpfp.as_ref().is_some_and(|cpfp| !cpfp.is_bumping())
+    }
+}
+
+/// The transactions that the driver drives, keyed on txid.
+///
+/// `Arc<Mutex>` so a spawned bump task can take a brief lock without blocking the driver loop
+/// through a wallet build, a signing round trip, and a `submitpackage` call.
+type Parents = Arc<Mutex<HashMap<Txid, ParentRecord>>>;
+
+/// Whether `record` is the one whose CPFP state holds `mark`.
+fn holds_mark(record: Option<&ParentRecord>, mark: &Arc<AtomicBool>) -> bool {
+    record
+        .and_then(|record| record.cpfp.as_ref())
+        .is_some_and(|cpfp| Arc::ptr_eq(&cpfp.bumping, mark))
+}
+
+/// Bare (non-package) resubmission of an evicted transaction. This is the path for a parent
+/// without CPFP, and the fallback when a bump submits no package.
 async fn resubmit_bare(rpc_client: &BitcoinClient, rawtx: &Transaction, evicted_txid: Txid) {
     let options = broadcast_options(rawtx);
     match rpc_client.send_raw_transaction(rawtx, options).await {
@@ -275,26 +286,20 @@ async fn resubmit_bare(rpc_client: &BitcoinClient, rawtx: &Transaction, evicted_
     }
 }
 
-/// Runs one `perform_bump` for the entry at `parent_txid`, writing the updated handle back
-/// if the entry still exists. Returns whether a `[parent, child]` package was actually
-/// submitted. No-op returning `false` when the entry has vanished (parent confirmed and was
-/// removed between the caller's look-up and ours).
+/// Runs one `perform_bump` for `parent_txid` and writes the updated handle back.
 ///
-/// The handle is written back **even when the bump fails**: `perform_bump` records the
-/// child's funding inputs as soon as the wallet leases them, and dropping that update on
-/// the floor would strand the leases (see the lease-recording note on
-/// [`cpfp::perform_bump`]).
+/// Returns whether a `[parent, child]` package reached the mempool. Returns `false` when the
+/// record is gone, or when its stage is no longer `Unconfirmed`. An event arm settles the
+/// parent that way between the caller's look-up and this one.
 ///
-/// Shared by the batch walker, the eviction arm, and the new-job registration, so every
-/// path bumps with identical snapshot / write-back discipline. The batch and eviction
-/// callers serialize through the driver's single `active_bump_task` slot. The new-job
-/// caller does not share that slot, so it gates itself on the slot's state before it
-/// bumps: two concurrent bumps of one entry snapshot the same handle, and the later
-/// write-back clobbers the lease that the earlier one took.
-async fn bump_one_entry<W, F, P>(
+/// The handle is written back **even when the bump fails**. `perform_bump` takes the lease on
+/// the new child's funding inputs before the steps that can fail. The write-back keeps that
+/// lease for the next attempt.
+async fn bump_parent<W, F, P>(
     ctx: &CpfpContext<W, F, P>,
-    entries: &CpfpEntries,
+    parents: &Parents,
     parent_txid: Txid,
+    mark: &Arc<AtomicBool>,
     bridge_protocol_floor: FeeRate,
     reason: cpfp::BumpReason,
 ) -> bool
@@ -303,15 +308,20 @@ where
     F: CpfpFeeSource + 'static,
     P: CpfpMempool + 'static,
 {
-    // Snapshot under a brief lock; the slow bump runs without the entries mutex held.
-    let snapshot = entries
-        .lock()
-        .await
-        .get(&parent_txid)
-        .filter(|e| !e.dormant)
-        .map(|e| (e.parent.clone(), e.strategy.clone(), e.handle.clone()));
+    // Snapshot under a brief lock. The slow bump runs without the parents mutex held.
+    let snapshot = parents.lock().await.get(&parent_txid).and_then(|record| {
+        if record.stage != Stage::Unconfirmed {
+            return None;
+        }
+        let cpfp = record.cpfp.as_ref()?;
+        Some((
+            record.tx.clone(),
+            cpfp.strategy.clone(),
+            cpfp.handle.clone(),
+        ))
+    });
     let Some((parent, strategy, mut handle)) = snapshot else {
-        return false; // entry removed, or dormant (parent mined; awaiting burial)
+        return false;
     };
     let result = cpfp::perform_bump(
         ctx,
@@ -322,28 +332,33 @@ where
         reason,
     )
     .await;
-    // Write the updated handle back if the entry still exists and is awake. Two other
-    // cases exist, and both mean an event arm settled this parent during the bump:
-    //
-    // - Entry gone: the parent was buried and the removal dropped the map handle.
-    // - Entry dormant: the parent was mined, and the Mined arm cleared the lease of the map handle.
+
+    // Write the updated handle back while the record is still bumpable. A record that has
+    // gone or reached `Mined` means an event arm settled this parent during the bump.
     //
     // Neither case needs a release call. The local handle drops at the end of this function.
-    // When this bump built a child, the local handle owns the only clone of that lease, and
-    // the drop frees the inputs. When it did not, the local handle holds a clone of the
-    // lease that the map still owns, and the drop frees nothing.
-    match entries.lock().await.get_mut(&parent_txid) {
-        Some(entry) if !entry.dormant => entry.handle = handle,
-        _ => {}
-    }
-    match result {
-        Ok(true) => {
-            debug!(%parent_txid, ?reason, "CPFP bump submitted");
-            true
+    // When this bump built a child, the local handle owns the only clone of that lease and
+    // the drop frees the inputs. When the write-back is skipped, the removal or the `Mined`
+    // arm already dropped the record's clone, so the drop frees those inputs as well. That is
+    // correct for a parent that is gone or mined.
+    let mut guard = parents.lock().await;
+    if holds_mark(guard.get(&parent_txid), mark) {
+        if let Some(record) = guard.get_mut(&parent_txid) {
+            if record.stage == Stage::Unconfirmed {
+                if let Some(cpfp) = record.cpfp.as_mut() {
+                    cpfp.handle = handle;
+                }
+            }
         }
-        Ok(false) => {
-            // Target at or below floor; expected in a quiet mempool.
-            false
+    }
+    drop(guard);
+
+    match result {
+        Ok(submitted) => {
+            if submitted {
+                debug!(%parent_txid, ?reason, "CPFP bump submitted");
+            }
+            submitted
         }
         Err(e) if e.is_replacement_contention() => {
             // Another watchtower holds this shared anchor and our child does not pay enough
@@ -358,77 +373,298 @@ where
     }
 }
 
-/// Inserts (or refreshes) a [`CpfpEntry`] for `parent`, then runs one initial `NewJob` bump
-/// through [`bump_one_entry`], sharing its snapshot / write-back discipline. Used by the
-/// new-job arm in three places: after a successful bare broadcast, when the parent is
-/// already in the mempool at job arrival, and as a fallback when bare broadcast fails (so a
-/// properly-priced child can carry an underpriced parent in via `submitpackage`).
+/// One caller waiting for a status condition.
+type Listener = (
+    Box<dyn Fn(&TxStatus) -> bool + Send>,
+    oneshot::Sender<Result<(), DriveErr>>,
+);
+
+/// What a bump task does with the result of its bump.
+enum BumpFollowUp {
+    /// Nothing. The next trigger retries.
+    None,
+    /// Put the bare parent back when the bump submits no package. The eviction path needs
+    /// this: a declined bump leaves the parent in no mempool at all.
+    ResubmitBare(BitcoinClient, Transaction),
+    /// Carry one job whose bare broadcast failed. The package is its only route into a
+    /// mempool, so this job hears the result directly.
+    CarryJob {
+        /// The error that the bare broadcast reported.
+        err: ClientError,
+        /// The caller of the failed job. It stays outside the record until the result is
+        /// known, so a failure answers this caller alone. Other callers of the same
+        /// transaction have their own jobs, and a broadcast failure here says nothing about
+        /// those.
+        listener: Listener,
+        /// Whether the registration of this job created the record. A record that already
+        /// existed belongs to an earlier job that still waits on it, and a failure here must
+        /// not remove it.
+        created: bool,
+    },
+}
+
+impl BumpFollowUp {
+    /// Runs the follow-up for a bump that submitted no package.
+    async fn on_declined(
+        self,
+        parents: &Parents,
+        parent_txid: Txid,
+        mark: Option<&Arc<AtomicBool>>,
+    ) {
+        match self {
+            Self::None => {}
+            Self::ResubmitBare(rpc_client, rawtx) => {
+                resubmit_bare(&rpc_client, &rawtx, parent_txid).await;
+            }
+            Self::CarryJob {
+                err,
+                listener,
+                created,
+            } => {
+                fail_carried_job(parents, parent_txid, &err, listener, created, mark).await;
+            }
+        }
+    }
+
+    /// Runs the follow-up for a bump that put a package in the mempool.
+    async fn on_submitted(self, parents: &Parents, parent_txid: Txid) {
+        if let Self::CarryJob { listener, .. } = self {
+            attach_listener(parents, parent_txid, listener).await;
+        }
+    }
+}
+
+/// Adds `listener` to the record for `parent_txid`, or answers it when the record is gone.
+async fn attach_listener(parents: &Parents, parent_txid: Txid, listener: Listener) {
+    if let Some(record) = parents.lock().await.get_mut(&parent_txid) {
+        record.listeners.push(listener);
+        return;
+    }
+    // The record went at burial, so the transaction is deep in the chain and no further
+    // event can arrive for it.
+    let _ = listener.1.send(Err(DriveErr::ConditionUnmet));
+}
+
+/// Reports a failed bare broadcast to the one job that made it.
 ///
-/// The insert is get-or-create. A duplicate drive job for a parent that already has an
-/// entry keeps the live handle and only refreshes the parent and strategy. The duty retry
-/// tick re-emits publishes while the SM waits for burial, and the handle's
-/// `last_child_lease` is the only record of the wallet leases. The insert also runs
-/// *before* the bump. The reverse order (bump into a private entry, insert after) opens a
-/// write-back race: a concurrent batch bump of the same parent leases fresh funding and
-/// records it in the map, and a late insert then overwrites that record with a stale
-/// handle. The leases are lost.
+/// Removes the record only when this job created it. A record that an earlier job created is
+/// still driving that job's transaction, and a later job's broadcast failure says nothing
+/// about it.
+async fn fail_carried_job(
+    parents: &Parents,
+    parent_txid: Txid,
+    err: &ClientError,
+    listener: Listener,
+    created: bool,
+    mark: Option<&Arc<AtomicBool>>,
+) {
+    let mut guard = parents.lock().await;
+    // The parent reached a block through another route, such as a package that another
+    // watchtower submitted. Keep waiting on it instead of reporting a failure.
+    if guard
+        .get(&parent_txid)
+        .is_some_and(|record| record.stage == Stage::Mined)
+    {
+        if let Some(record) = guard.get_mut(&parent_txid) {
+            record.listeners.push(listener);
+        }
+        return;
+    }
+    let is_ours = created && mark.is_some_and(|mark| holds_mark(guard.get(&parent_txid), mark));
+    if is_ours {
+        if let Some(record) = guard.remove(&parent_txid) {
+            record.subscription.abort();
+        }
+    }
+    drop(guard);
+    let _ = listener.1.send(Err(DriveErr::PublishFailed(err.clone())));
+}
+
+/// Takes the bump mark for `parent_txid` when that parent can take a bump now.
 ///
-/// Returns whether a `[parent, child]` package was actually submitted (relevant for the
-/// fallback caller — the parent is then in the mempool). Failures are logged inside
-/// [`bump_one_entry`]; reactive bumps on block / tick / eviction retry regardless.
-async fn register_cpfp_entry_and_bump<W, F, P>(
-    ctx: &CpfpContext<W, F, P>,
-    entries: &CpfpEntries,
-    parent: Transaction,
-    strategy: CpfpStrategy,
+/// The mark is taken under the records lock, so two triggers cannot both start a bump for one
+/// parent.
+async fn take_bump_mark(parents: &Parents, parent_txid: Txid) -> Option<BumpGuard> {
+    let guard = parents.lock().await;
+    match guard.get(&parent_txid) {
+        Some(record) if record.stage == Stage::Unconfirmed => {
+            record.cpfp.as_ref().and_then(CpfpState::start_bump)
+        }
+        _ => None,
+    }
+}
+
+/// Spawns one bump for `parent_txid` after it takes that parent's bump mark.
+///
+/// Returns the task handle, or `None` when the parent cannot take a bump now. A parent that
+/// cannot take one still runs `follow_up`, so an evicted parent goes back into the mempool
+/// even when another trigger holds the mark.
+///
+/// Spawning is not an optimisation. `perform_bump` takes the operator wallet's write lock,
+/// and a duty can hold that lock while it awaits `TxDriver::drive`. A bump awaited inside the
+/// driver's select loop therefore deadlocks: the driver waits for the wallet, the duty waits
+/// for a status event that only the driver can deliver, and neither side can proceed.
+///
+/// The mark prevents a fault, not duplicate work. Two bumps of one parent take a snapshot of
+/// the same handle, and the later write-back drops the lease of the live child.
+async fn spawn_bump<W, F, P>(
+    ctx: &Arc<CpfpContext<W, F, P>>,
+    parents: &Parents,
+    parent_txid: Txid,
     bridge_protocol_floor: FeeRate,
-) -> bool
+    reason: cpfp::BumpReason,
+    follow_up: BumpFollowUp,
+) -> Option<JoinHandle<()>>
 where
     W: CpfpWallet + 'static,
     F: CpfpFeeSource + 'static,
     P: CpfpMempool + 'static,
 {
-    let (txid, _) = upsert_cpfp_entry(entries, parent, strategy).await;
-    bump_one_entry(
-        ctx,
-        entries,
-        txid,
-        bridge_protocol_floor,
-        cpfp::BumpReason::NewJob,
-    )
-    .await
+    let Some(guard) = take_bump_mark(parents, parent_txid).await else {
+        follow_up.on_declined(parents, parent_txid, None).await;
+        return None;
+    };
+    Some(tokio::spawn({
+        let ctx = ctx.clone();
+        let parents = parents.clone();
+        async move {
+            run_bump(
+                ctx.as_ref(),
+                &parents,
+                parent_txid,
+                bridge_protocol_floor,
+                reason,
+                follow_up,
+                guard,
+            )
+            .await;
+        }
+    }))
 }
 
-/// Inserts a [`CpfpEntry`] for `parent`, or refreshes the parent and strategy of an
-/// existing entry while its handle (the lease record) stays live. Returns the parent txid
-/// and whether the call inserted a new entry.
-async fn upsert_cpfp_entry(
-    entries: &CpfpEntries,
-    parent: Transaction,
-    strategy: CpfpStrategy,
-) -> (Txid, bool) {
-    let txid = parent.compute_txid();
-    let mut entries = entries.lock().await;
-    let inserted = match entries.get_mut(&txid) {
-        Some(existing) => {
-            existing.parent = parent;
-            existing.strategy = strategy;
+/// Runs one bump under `guard` and then its follow-up.
+async fn run_bump<W, F, P>(
+    ctx: &CpfpContext<W, F, P>,
+    parents: &Parents,
+    parent_txid: Txid,
+    bridge_protocol_floor: FeeRate,
+    reason: cpfp::BumpReason,
+    follow_up: BumpFollowUp,
+    guard: BumpGuard,
+) where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpMempool + 'static,
+{
+    let submitted = bump_parent(
+        ctx,
+        parents,
+        parent_txid,
+        guard.mark(),
+        bridge_protocol_floor,
+        reason,
+    )
+    .await;
+    if submitted {
+        follow_up.on_submitted(parents, parent_txid).await;
+    } else {
+        follow_up
+            .on_declined(parents, parent_txid, Some(guard.mark()))
+            .await;
+    }
+}
+
+/// Spawns one task that bumps every parent that can take a bump, one after another.
+///
+/// The bumps run one at a time. Each one takes the operator wallet's write lock, so a
+/// parallel fan-out puts every other user of the wallet behind the whole batch. Each parent
+/// keeps its own mark, so a parent that another trigger is already bumping is skipped and the
+/// rest of the batch continues.
+async fn spawn_batch_bump<W, F, P>(
+    ctx: &Arc<CpfpContext<W, F, P>>,
+    parents: &Parents,
+    bridge_protocol_floor: FeeRate,
+    reason: cpfp::BumpReason,
+) where
+    W: CpfpWallet + 'static,
+    F: CpfpFeeSource + 'static,
+    P: CpfpMempool + 'static,
+{
+    let txids: Vec<Txid> = parents
+        .lock()
+        .await
+        .iter()
+        .filter(|(_, record)| record.is_bumpable())
+        .map(|(txid, _)| *txid)
+        .collect();
+    if txids.is_empty() {
+        return;
+    }
+    let ctx = ctx.clone();
+    let parents = parents.clone();
+    tokio::spawn(async move {
+        for parent_txid in txids {
+            let Some(guard) = take_bump_mark(&parents, parent_txid).await else {
+                continue;
+            };
+            run_bump(
+                ctx.as_ref(),
+                &parents,
+                parent_txid,
+                bridge_protocol_floor,
+                reason,
+                BumpFollowUp::None,
+                guard,
+            )
+            .await;
+        }
+    });
+}
+
+/// Inserts a record for `job`, or merges the job into the record that already tracks its
+/// transaction.
+///
+/// A duplicate drive job keeps the live CPFP state of the existing record, including the
+/// lease of the last child. The duty retry tick re-emits publishes while the state machine
+/// waits for burial. A fresh record there drops that lease and strands its inputs.
+async fn upsert_parent(
+    parents: &Parents,
+    tx: Transaction,
+    cpfp: Option<CpfpStrategy>,
+    subscription: AbortHandle,
+    listener: Option<Listener>,
+) -> bool {
+    let txid = tx.compute_txid();
+    let mut guard = parents.lock().await;
+    match guard.get_mut(&txid) {
+        Some(record) => {
+            record.tx = tx;
+            record.listeners.extend(listener);
+            if let Some(strategy) = cpfp {
+                match record.cpfp.as_mut() {
+                    Some(cpfp) => cpfp.strategy = strategy,
+                    None => record.cpfp = Some(CpfpState::new(strategy)),
+                }
+            }
+            // The record already owns a subscription for this transaction. End the second
+            // one, so `SelectAll` drops it on the next poll.
+            subscription.abort();
             false
         }
         None => {
-            entries.insert(
+            guard.insert(
                 txid,
-                CpfpEntry {
-                    parent,
-                    strategy,
-                    handle: CpfpHandle::default(),
-                    dormant: false,
+                ParentRecord {
+                    tx,
+                    listeners: listener.into_iter().collect(),
+                    stage: Stage::Unconfirmed,
+                    cpfp: cpfp.map(CpfpState::new),
+                    subscription,
                 },
             );
             true
         }
-    };
-    (txid, inserted)
+    }
 }
 
 /// System for driving a signed transaction to confirmation.
@@ -508,23 +744,12 @@ impl TxDriver {
 
         let driver = tokio::task::spawn(async move {
             let mut new_jobs_receiver_stream = UnboundedReceiverStream::new(new_jobs.1);
-            let mut active_tx_subs = SelectAll::<Subscription<TxEvent>>::new();
-            let mut active_jobs = TxJobHeap::empty();
-            // CPFP state for active parents, keyed on parent txid. Populated when a job
-            // arrives with `Some(cpfp_strategy)`, cleared when the parent confirms (the
-            // mined/buried branch below). `Arc<Mutex<>>` so spawned bump tasks can take
-            // a brief lock without blocking the driver loop on long bump RPCs (S1 fix —
-            // see `bump_all_entries` for the lock discipline).
-            let cpfp_entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
-            // Handle of the currently in-flight `bump_all_entries` task, if any. New
-            // block/tick triggers skip spawning if the previous batch hasn't finished —
-            // prevents fan-out pile-up under sustained slowness (slow RPC, contended wallet
-            // lock) which would otherwise queue stale-snapshot tasks behind each other and
-            // re-trigger benign-but-noisy `release(prior)` warnings. The next tick will
-            // pick up freshly-evolved state once the previous task drains.
-            let mut active_bump_task: Option<JoinHandle<()>> = None;
+            // Each subscription enters through `abortable`, so the record that owns it can
+            // end it. `SelectAll` drops a stream that finishes.
+            let mut active_tx_subs = SelectAll::<Abortable<Subscription<TxEvent>>>::new();
+            let parents: Parents = Arc::new(Mutex::new(HashMap::new()));
             // Timer that fires every `bump_check_interval`. Note the cost model: tick is a
-            // reactive `BumpReason`, so entries whose target sits ABOVE the protocol floor
+            // reactive `BumpReason`, so parents whose target sits ABOVE the protocol floor
             // are fully rebuilt every tick (wallet build + sign + submitpackage that either
             // dedups against the live child or bounces off the BIP-125 incremental-fee rule)
             // — deliberate, because a silently-evicted child is invisible and the tick is
@@ -538,12 +763,14 @@ impl TxDriver {
             loop {
                 select! {
                     Some(job) = new_jobs_receiver_stream.next().fuse() => {
-                        let rawtx_filter = job.tx.clone();
-                        let rawtx_rpc_client = job.tx.clone();
                         let txid = job.tx.compute_txid();
-                        let tx_sub = zmq_client.subscribe_transactions(
-                            move |tx| tx == &rawtx_filter
-                        ).await;
+                        let rawtx = job.tx.clone();
+                        let rawtx_filter = job.tx.clone();
+                        let (subscription, abort) = abortable(
+                            zmq_client
+                                .subscribe_transactions(move |tx| tx == &rawtx_filter)
+                                .await,
+                        );
 
                         if let Ok(tx_data) = rpc_client.get_raw_transaction_verbosity_one(&txid).await {
                             let num_confirmations = tx_data.confirmations.unwrap_or(0);
@@ -574,94 +801,33 @@ impl TxDriver {
                                 if job.respond_on.send(Ok(())).is_err() {
                                     error!("could not send response to job submitter");
                                 }
+                                abort.abort();
                             } else {
-                                // if the condition is not met, we still need to add the job
-                                // to the active jobs so that we can notify it later.
+                                // The node already knows this transaction. Track it, so this
+                                // caller hears about later status changes, and so CPFP bumps
+                                // resume for a parent that an earlier incarnation broadcast
+                                // and that is still in the mempool.
                                 // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2687>
                                 // Handle the race where the relevant event may already have
                                 // happened before the subscription is established.
-                                active_tx_subs.push(tx_sub);
-                                let job_parent = job.tx.clone();
-                                let job_cpfp = job.cpfp.clone();
-                                active_jobs = active_jobs.merge(job.into());
-
-                                // Register CPFP for an already-resident parent. Without
-                                // this, parents broadcast in a prior incarnation that are
-                                // still in the mempool when the driver comes back up would
-                                // never be re-bumped on block / tick / eviction events.
-                                // The first bump runs here too so a deeply-underpriced
-                                // resident parent gets a fresh package immediately.
-                                if let (Some(ctx), Some(strategy)) = (cpfp_ctx.as_ref(), job_cpfp) {
-                                    // The eager bump must not run next to an in-flight
-                                    // batch or eviction bump: two concurrent bumps of one
-                                    // entry snapshot the same handle, and the later
-                                    // write-back clobbers the earlier one's lease record.
-                                    // The entry registers either way; the next trigger
-                                    // bumps it. Failures are logged inside
-                                    // `bump_one_entry`.
-                                    if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
-                                        let (registered_txid, _) =
-                                            upsert_cpfp_entry(&cpfp_entries, job_parent, strategy)
-                                                .await;
-                                        debug!(%registered_txid, "bump slot busy; CPFP entry registered without an eager bump");
-                                    } else {
-                                        register_cpfp_entry_and_bump(
-                                            ctx.as_ref(),
-                                            &cpfp_entries,
-                                            job_parent,
-                                            strategy,
-                                            bridge_protocol_floor,
-                                        )
-                                        .await;
-                                    }
+                                active_tx_subs.push(subscription);
+                                upsert_parent(&parents, job.tx, job.cpfp, abort, Some((job.condition, job.respond_on))).await;
+                                if let Some(ctx) = cpfp_ctx.as_ref() {
+                                    spawn_bump(ctx, &parents, txid, bridge_protocol_floor, BumpReason::NewJob, BumpFollowUp::None).await;
                                 }
                             }
 
                             continue;
                         }
 
-                        let options = broadcast_options(&rawtx_rpc_client);
-                        match rpc_client.send_raw_transaction(&rawtx_rpc_client, options).await {
+                        let options = broadcast_options(&rawtx);
+                        match rpc_client.send_raw_transaction(&rawtx, options).await {
                             Ok(txid) => {
                                 info!(%txid, "broadcasted transaction successfully");
-                                // only add subscriptions and jobs if the transaction was
-                                // broadcasted successfully
-                                // NOTE: (@Rajil1213) this code is duplicated here. An alternative
-                                // is to add the subscription at the top and then remove them if the submission errors
-                                // but removing a subscription from a `SelectAll` is not straightforward.
-                                active_tx_subs.push(tx_sub);
-                                let job_parent = job.tx.clone();
-                                let job_cpfp = job.cpfp.clone();
-                                active_jobs = active_jobs.merge(job.into());
-
-                                // Eager initial bump: if CPFP is configured and the fee
-                                // source's target is above the protocol floor, build and
-                                // submit a CPFP child as a package right now. Targets at or
-                                // below the floor mean the presigned parent's own rate is
-                                // sufficient; the helper's `perform_bump` skips internally.
-                                if let (Some(ctx), Some(strategy)) = (cpfp_ctx.as_ref(), job_cpfp) {
-                                    // The eager bump must not run next to an in-flight
-                                    // batch or eviction bump: two concurrent bumps of one
-                                    // entry snapshot the same handle, and the later
-                                    // write-back clobbers the earlier one's lease record.
-                                    // The entry registers either way; the next trigger
-                                    // bumps it. Failures are logged inside
-                                    // `bump_one_entry`.
-                                    if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
-                                        let (registered_txid, _) =
-                                            upsert_cpfp_entry(&cpfp_entries, job_parent, strategy)
-                                                .await;
-                                        debug!(%registered_txid, "bump slot busy; CPFP entry registered without an eager bump");
-                                    } else {
-                                        register_cpfp_entry_and_bump(
-                                            ctx.as_ref(),
-                                            &cpfp_entries,
-                                            job_parent,
-                                            strategy,
-                                            bridge_protocol_floor,
-                                        )
-                                        .await;
-                                    }
+                                active_tx_subs.push(subscription);
+                                upsert_parent(&parents, job.tx, job.cpfp, abort, Some((job.condition, job.respond_on))).await;
+                                if let Some(ctx) = cpfp_ctx.as_ref() {
+                                    spawn_bump(ctx, &parents, txid, bridge_protocol_floor, BumpReason::NewJob, BumpFollowUp::None).await;
                                 }
                             },
                             Err(err) => {
@@ -669,220 +835,154 @@ impl TxDriver {
                                 // rate is below the mempool's minimum and a CPFP child can
                                 // carry it in via `submitpackage` (package validation is
                                 // more lenient than single-tx acceptance). If CPFP is
-                                // configured, try that fallback before surfacing the error.
+                                // configured, try that fallback before failing the job.
+                                // `BumpFallback::FailJob` reports the broadcast error and
+                                // removes the record when the package does not land either.
                                 // TODO: <https://alpenlabs.atlassian.net/browse/STR-2689>
                                 // Distinguish invalid transactions and notify the job
                                 // submitter directly instead of attempting fee bumping.
-                                let job_parent = job.tx.clone();
-                                let job_cpfp = job.cpfp.clone();
-                                let pkg_submitted = if let (Some(ctx), Some(strategy)) =
-                                    (cpfp_ctx.as_ref(), job_cpfp)
-                                {
-                                    warn!(%txid, %err, "bare broadcast failed; attempting CPFP package fallback");
-                                    fallback_package_submit(
-                                        ctx.as_ref(),
-                                        &cpfp_entries,
-                                        job_parent,
-                                        strategy,
-                                        bridge_protocol_floor,
-                                    )
-                                    .await
-                                } else {
-                                    false
-                                };
-
-                                if pkg_submitted {
-                                    info!(%txid, "parent reached mempool via CPFP package fallback");
-                                    active_tx_subs.push(tx_sub);
-                                    active_jobs = active_jobs.merge(job.into());
-                                } else {
-                                    // `fallback_package_submit` has already removed any entry
-                                    // it registered — nothing here can observe this parent
-                                    // confirming once the job is failed.
-                                    error!(%txid, tx=?rawtx_rpc_client, %err, "could not submit transaction");
-                                    // send feedback to the job submitter
-                                    if job.respond_on.send(Err(DriveErr::PublishFailed(err))).is_err() {
-                                        error!("could not send error response to job submitter");
+                                match (cpfp_ctx.as_ref(), job.cpfp.is_some()) {
+                                    (Some(ctx), true) => {
+                                        warn!(%txid, %err, "bare broadcast failed; attempting CPFP package fallback");
+                                        active_tx_subs.push(subscription);
+                                        // `Defer` keeps this caller out of the record. The
+                                        // package attempt answers it directly, so a failure
+                                        // reaches this caller alone and leaves any earlier
+                                        // job on the same transaction untouched.
+                                        let listener = (job.condition, job.respond_on);
+                                        let created =
+                                            upsert_parent(&parents, job.tx, job.cpfp, abort, None).await;
+                                        spawn_bump(
+                                            ctx,
+                                            &parents,
+                                            txid,
+                                            bridge_protocol_floor,
+                                            BumpReason::NewJob,
+                                            BumpFollowUp::CarryJob { err, listener, created },
+                                        )
+                                        .await;
+                                    }
+                                    _ => {
+                                        error!(%txid, tx=?rawtx, %err, "could not submit transaction");
+                                        abort.abort();
+                                        if job.respond_on.send(Err(DriveErr::PublishFailed(err))).is_err() {
+                                            error!("could not send error response to job submitter");
+                                        }
                                     }
                                 }
                             }
                         }
                     }
                     Some(event) = active_tx_subs.next().fuse() => {
-                        let evicted_txid = event.rawtx.compute_txid();
+                        let txid = event.rawtx.compute_txid();
                         match event.status {
                             TxStatus::Unknown => {
-                                // Transaction has been evicted. If this parent has CPFP
-                                // enabled, rebuild the child at the current fee target and
-                                // re-submit as a package — that's the canonical bump path on
-                                // mempool eviction. Otherwise fall back to bare resubmission
-                                // (legacy behaviour preserved for non-CPFP callers).
-                                let has_cpfp_entry = cpfp_ctx.is_some() && {
-                                    let mut entries = cpfp_entries.lock().await;
-                                    match entries.get_mut(&evicted_txid) {
-                                        Some(entry) => {
-                                            // A dormant entry means the parent was mined. An
-                                            // eviction event for it means a reorg dropped
-                                            // the parent from its block and from the
-                                            // mempool. That is the situation the bumps
-                                            // exist for. Wake the entry.
-                                            if entry.dormant {
-                                                info!(%evicted_txid, "mined parent evicted after a reorg; resuming CPFP bumps");
-                                                entry.dormant = false;
+                                // Evicted from the mempool. A parent with CPFP rebuilds its
+                                // child at the current target and re-submits the package.
+                                // Everything else goes back bare.
+                                let has_cpfp = {
+                                    let mut guard = parents.lock().await;
+                                    match guard.get_mut(&txid) {
+                                        Some(record) => {
+                                            // An eviction of a mined parent means a reorg
+                                            // dropped it from its block and from the
+                                            // mempool. That is what the bumps exist for.
+                                            if record.stage == Stage::Mined {
+                                                info!(%txid, "mined parent evicted after a reorg; resuming CPFP bumps");
+                                                record.stage = Stage::Unconfirmed;
                                             }
-                                            true
+                                            record.cpfp.is_some()
                                         }
                                         None => false,
                                     }
                                 };
-                                if let (Some(ctx), true) = (cpfp_ctx.as_ref(), has_cpfp_entry) {
-                                    // The eviction bump shares the block/tick arms' single
-                                    // in-flight slot. Two concurrent bumps of one entry would
-                                    // snapshot the same handle and the later write-back would
-                                    // clobber the lease that the earlier one took,
-                                    // stranding the loser's wallet leases — the exact failure
-                                    // `perform_bump`'s eager lease recording exists to
-                                    // prevent. Spawning (rather than bumping inline) also
-                                    // keeps the driver select loop responsive through the
-                                    // build + sign + submitpackage round-trip.
-                                    if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
-                                        // The in-flight batch snapshotted its txid list at
-                                        // its start. It can miss this entry (registered
-                                        // after the snapshot) or it can have walked past
-                                        // this txid already. Neither case resubmits the
-                                        // evicted parent. Resubmit the bare parent now; the
-                                        // next block or tick rebuilds the child on top.
-                                        debug!(%evicted_txid, "bump slot busy; resubmitting evicted parent bare until the next trigger");
-                                        resubmit_bare(&rpc_client, &event.rawtx, evicted_txid).await;
-                                    } else {
-                                        let ctx = ctx.clone();
-                                        let entries = cpfp_entries.clone();
-                                        let floor = bridge_protocol_floor;
-                                        let rawtx = event.rawtx.clone();
-                                        let rpc_client = rpc_client.clone();
-                                        active_bump_task = Some(tokio::spawn(async move {
-                                            let submitted = bump_one_entry(
-                                                ctx.as_ref(),
-                                                &entries,
-                                                evicted_txid,
-                                                floor,
-                                                BumpReason::ParentEvicted,
-                                            )
-                                            .await;
-                                            if !submitted {
-                                                // Bump declined (target at floor) or failed;
-                                                // keep the legacy behaviour of at least
-                                                // putting the bare parent back.
-                                                resubmit_bare(&rpc_client, &rawtx, evicted_txid).await;
-                                            }
-                                        }));
+                                match (cpfp_ctx.as_ref(), has_cpfp) {
+                                    (Some(ctx), true) => {
+                                        spawn_bump(
+                                            ctx,
+                                            &parents,
+                                            txid,
+                                            bridge_protocol_floor,
+                                            BumpReason::ParentEvicted,
+                                            BumpFollowUp::ResubmitBare(rpc_client.clone(), event.rawtx.clone()),
+                                        )
+                                        .await;
                                     }
-                                } else {
-                                    resubmit_bare(&rpc_client, &event.rawtx, evicted_txid).await;
+                                    _ => resubmit_bare(&rpc_client, &event.rawtx, txid).await,
                                 }
                             }
-                            _ => {
-                                let txid = event.rawtx.compute_txid();
-                                let listeners = active_jobs.remove(&txid);
-                                let leftovers = monoid::concat(listeners
-                                    .into_iter()
-                                    .flat_map(Vec::into_iter)
-                                    .filter_map(|(condition, response)| {
-                                        if condition(&event.status) {
-                                            let _ = response.send(Ok(()));
-                                            None
-                                        } else {
-                                            Some(
-                                                TxJobHeap(
-                                                    BTreeMap::from([
-                                                        (txid, vec![(condition, response)])
-                                                    ])
-                                                )
-                                            )
-                                        }
-                                    }));
-                                active_jobs = active_jobs.merge(leftovers);
+                            status => {
                                 // CPFP lifecycle against confirmation depth:
                                 //
                                 // - Mined: stop the bumps (a confirmed parent needs no
-                                //   child), drop the lease of the child, and keep the
-                                //   entry dormant. Each production caller waits for
-                                //   burial. A reorg between mined and buried returns the
+                                //   child) and drop the lease of the last child. Almost
+                                //   every caller waits for burial, so the record stays. A
+                                //   reorg between mined and buried returns the
                                 //   parent to the mempool (`Mempool`) or evicts it
-                                //   (`Unknown`), and the bumps must resume then. A removal
-                                //   here makes the parent unbumpable for the rest of the
-                                //   wait: the eviction arm falls back to a bare resubmit
-                                //   of a floor-rate parent, no mempool accepts it under
-                                //   fee pressure, and the duty never completes.
-                                // - Mempool: the reorg case. Wake the entry.
-                                // - Buried: final. Remove the entry, which drops any lease
-                                //   that the Mined arm did not already drop.
+                                //   (`Unknown`), and the bumps resume then.
+                                // - Mempool: wake a record that the Mined arm stopped. A
+                                //   reorg is the only cause of that.
+                                // - Buried: final. Remove the record, which ends the
+                                //   subscription and drops any lease the Mined arm did not
+                                //   already drop.
                                 //
-                                // If the parent confirmed through a competitor's child,
-                                // the drop frees our dead child's funding. If our own
-                                // child confirmed, its funding is spent on chain — see the
-                                // release note in `perform_bump` step 4.5 for the bounded
-                                // side effect. A woken entry starts from an empty handle
-                                // and takes a fresh lease on its next bump.
-                                match event.status {
+                                // If the parent confirmed through a competitor's child, the
+                                // drop frees our dead child's funding. If our own child
+                                // confirmed, its funding is spent on chain — see the release
+                                // note in `perform_bump` step 4.5 for the bounded side
+                                // effect. A woken record starts from an empty handle and
+                                // takes a fresh lease on its next bump.
+                                let mut guard = parents.lock().await;
+                                let Some(record) = guard.get_mut(&txid) else {
+                                    continue;
+                                };
+                                record.notify(&status);
+                                match status {
                                     TxStatus::Mined { .. } => {
-                                        let mut entries = cpfp_entries.lock().await;
-                                        if let Some(entry) = entries.get_mut(&txid) {
-                                            entry.dormant = true;
-                                            entry.handle = CpfpHandle::default();
+                                        record.stage = Stage::Mined;
+                                        if let Some(cpfp) = record.cpfp.as_mut() {
+                                            cpfp.handle = CpfpHandle::default();
                                         }
                                     }
                                     TxStatus::Mempool => {
-                                        if let Some(entry) = cpfp_entries.lock().await.get_mut(&txid) {
-                                            if entry.dormant {
-                                                info!(%txid, "parent reorged back into the mempool; resuming CPFP bumps");
-                                                entry.dormant = false;
-                                            }
+                                        if record.stage == Stage::Mined {
+                                            info!(%txid, "parent reorged back into the mempool; resuming CPFP bumps");
+                                            record.stage = Stage::Unconfirmed;
                                         }
                                     }
                                     TxStatus::Buried { .. } => {
-                                        cpfp_entries.lock().await.remove(&txid);
+                                        if let Some(record) = guard.remove(&txid) {
+                                            record.subscription.abort();
+                                            // The driver stops tracking a buried
+                                            // transaction, so a condition that is still
+                                            // false can never become true. Say so, rather
+                                            // than drop the channel and leave the caller to
+                                            // read a dropped sender as an aborted driver.
+                                            for (_, respond_on) in record.listeners {
+                                                let _ = respond_on
+                                                    .send(Err(DriveErr::ConditionUnmet));
+                                            }
+                                        }
                                     }
                                     TxStatus::Unknown => {}
                                 }
                             }
                         }
-
                     }
                     _block = block_subscription.next().fuse() => {
-                        // On each new block, spawn a task that walks every CPFP parent and
-                        // runs a bump. Spawned (not inline) so the driver returns to its
-                        // select! immediately — new jobs and ZMQ events aren't blocked even
-                        // if there are many entries or the bumps stall on a slow RPC. See
-                        // `bump_all_entries` for the lock-discipline details, and
-                        // `active_bump_task` above for the fan-out guard rationale.
+                        // On each new block, walk every tracked parent and spawn a bump for
+                        // each one that can take it. Spawned (not inline) so the driver
+                        // returns to its select! immediately, and because a bump takes the
+                        // operator wallet's write lock — see `spawn_bump` for why an inline
+                        // bump deadlocks.
                         if let Some(ctx) = cpfp_ctx.as_ref() {
-                            if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
-                                debug!("skipping new-block bump: previous bump batch still running");
-                            } else {
-                                let ctx = ctx.clone();
-                                let entries = cpfp_entries.clone();
-                                let floor = bridge_protocol_floor;
-                                active_bump_task = Some(tokio::spawn(async move {
-                                    bump_all_entries(ctx, entries, floor, BumpReason::NewBlock).await;
-                                }));
-                            }
+                            spawn_batch_bump(ctx, &parents, bridge_protocol_floor, BumpReason::NewBlock).await;
                         }
                     }
                     _ = bump_tick.tick().fuse() => {
-                        // Periodic timer-driven bump — same shape as the new-block arm, with
-                        // the same in-flight guard.
+                        // Periodic timer-driven bump — same shape as the new-block arm.
                         if let Some(ctx) = cpfp_ctx.as_ref() {
-                            if active_bump_task.as_ref().is_some_and(|h| !h.is_finished()) {
-                                debug!("skipping tick bump: previous bump batch still running");
-                            } else {
-                                let ctx = ctx.clone();
-                                let entries = cpfp_entries.clone();
-                                let floor = bridge_protocol_floor;
-                                active_bump_task = Some(tokio::spawn(async move {
-                                    bump_all_entries(ctx, entries, floor, BumpReason::Tick).await;
-                                }));
-                            }
+                            spawn_batch_bump(ctx, &parents, bridge_protocol_floor, BumpReason::Tick).await;
                         }
                     }
                 }
@@ -952,17 +1052,16 @@ impl TxDriver {
 }
 
 impl Drop for TxDriver {
-    /// Aborts the main driver task. Note that any in-flight `bump_all_entries` task spawned
-    /// by the block / tick arms is **detached** — its `JoinHandle` was stored in the driver
-    /// task's local `active_bump_task` slot, which is dropped (not awaited) along with the
-    /// driver task itself. The detached bump task continues running on the runtime until it
-    /// finishes its current pass over `cpfp_entries`. At process shutdown the runtime tears
-    /// the task down regardless; for graceful in-process restart of `TxDriver`, a brief race
-    /// with the previous instance's bump task is possible (each call holds the wallet lock
-    /// per-bump, releases between, and the entries map is per-`TxDriver` so the old task
-    /// operates on its own snapshot). Acceptable for current call patterns; if mid-process
-    /// `TxDriver` lifecycle ever becomes load-bearing, expose a `shutdown(self)` that awaits
-    /// the active bump task before aborting the driver task.
+    /// Aborts the main driver task. Each in-flight bump task is detached, and a detached
+    /// bump runs to the end of its current attempt. The records map is behind an [`Arc`]: the
+    /// driver task drops its clone, and the map goes when the last bump task ends.
+    ///
+    /// At process shutdown the runtime tears those tasks down. A restart of `TxDriver` inside
+    /// one process can race the bump tasks of the previous instance for a short time. That
+    /// race is safe: each bump takes the wallet lock per attempt and releases it between
+    /// attempts, and the records map belongs to one `TxDriver`, so an old task reads only its
+    /// own map. If a mid-process `TxDriver` lifecycle becomes load-bearing, add a
+    /// `shutdown(self)` that awaits the in-flight bumps before it aborts the driver task.
     fn drop(&mut self) {
         self.driver.abort();
     }
@@ -1326,7 +1425,7 @@ mod e2e_tests {
 mod cpfp_lifecycle_tests {
     use std::collections::HashMap;
 
-    use bitcoin::{Amount, OutPoint};
+    use bitcoin::{Amount, OutPoint, XOnlyPublicKey};
 
     use super::*;
     use crate::cpfp::{
@@ -1354,11 +1453,33 @@ mod cpfp_lifecycle_tests {
         }
     }
 
-    /// A dormant entry (parent mined, burial pending) is not bumped. The wallet and the
-    /// mempool must not be called: a confirmed parent needs no child. The same entry with
-    /// `dormant = false` submits, so the skip is the only difference under test.
+    /// Builds a record whose CPFP state is fresh and whose subscription handle is inert.
+    fn test_record(parent: Transaction, key: XOnlyPublicKey, stage: Stage) -> ParentRecord {
+        ParentRecord {
+            tx: parent,
+            listeners: Vec::new(),
+            stage,
+            cpfp: Some(CpfpState::new(anchor_strategy(key))),
+            subscription: AbortHandle::new_pair().0,
+        }
+    }
+
+    /// Returns the records map and the bump mark of the single record it holds.
+    fn parents_with(txid: Txid, record: ParentRecord) -> (Parents, Arc<AtomicBool>) {
+        let mark = Arc::clone(&record.cpfp.as_ref().expect("cpfp state").bumping);
+        (Arc::new(Mutex::new(HashMap::from([(txid, record)]))), mark)
+    }
+
+    /// A listener that no status satisfies, paired with the receiver that hears its outcome.
+    fn never_listener() -> (Listener, oneshot::Receiver<Result<(), DriveErr>>) {
+        let (respond_on, receiver) = oneshot::channel();
+        ((Box::new(|_| false), respond_on), receiver)
+    }
+
+    /// A mined parent is not bumped: a confirmed parent needs no child. The same record at
+    /// `Unconfirmed` submits, so the stage is the only difference under test.
     #[tokio::test]
-    async fn bump_one_entry_skips_dormant_entries() {
+    async fn bump_parent_skips_mined_parents() {
         let (_, key) = test_keypair_and_xonly();
         let parent = synthetic_parent(key, Amount::from_sat(330));
         let parent_txid = parent.compute_txid();
@@ -1366,14 +1487,8 @@ mod cpfp_lifecycle_tests {
             txid: parent_txid,
             vout: 7,
         }];
-        let make_entry = |dormant: bool| CpfpEntry {
-            parent: parent.clone(),
-            strategy: anchor_strategy(key),
-            handle: CpfpHandle::default(),
-            dormant,
-        };
 
-        for (dormant, expect_submit) in [(true, false), (false, true)] {
+        for (stage, expect_submit) in [(Stage::Mined, false), (Stage::Unconfirmed, true)] {
             let submitter = Arc::new(FakeSubmitter::ok());
             let ctx = CpfpContext {
                 wallet: Arc::new(FakeWallet::returning(
@@ -1389,32 +1504,33 @@ mod cpfp_lifecycle_tests {
                 max_fee_rate: FeeRate::from_sat_per_vb(20).unwrap(),
                 mempool: submitter.clone(),
             };
-            let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::from([(
-                parent_txid,
-                make_entry(dormant),
-            )])));
-            let submitted = bump_one_entry(
+            let (parents, mark) =
+                parents_with(parent_txid, test_record(parent.clone(), key, stage));
+
+            let submitted = bump_parent(
                 &ctx,
-                &entries,
+                &parents,
                 parent_txid,
-                crate::cpfp::tests::PROTOCOL_FLOOR,
+                &mark,
+                PROTOCOL_FLOOR,
                 BumpReason::Tick,
             )
             .await;
-            assert_eq!(submitted, expect_submit, "dormant = {dormant}");
+
+            assert_eq!(submitted, expect_submit, "stage = {stage:?}");
             assert_eq!(
                 submitter.captured.lock().unwrap().len(),
                 usize::from(expect_submit),
-                "dormant = {dormant}"
+                "stage = {stage:?}"
             );
         }
     }
 
-    /// Even a failed bump must land its handle back in the entries map: `perform_bump` records
-    /// the freshly-leased funding inputs on the handle as soon as the wallet returns, and the
-    /// next bump can only release them if that update survives into the map.
+    /// Even a failed bump must land its handle back in the record. `perform_bump` takes the
+    /// lease on the new child's funding inputs before the steps that can fail, and the next
+    /// bump can only reuse those inputs if that update survives into the record.
     #[tokio::test]
-    async fn bump_one_entry_writes_handle_back_on_submit_failure() {
+    async fn bump_parent_writes_handle_back_on_submit_failure() {
         let (_, key) = test_keypair_and_xonly();
         let parent = synthetic_parent(key, Amount::from_sat(330));
         let parent_txid = parent.compute_txid();
@@ -1427,108 +1543,216 @@ mod cpfp_lifecycle_tests {
             FakeWallet::returning(psbt, funding.clone()),
             FakeSubmitter::failing("package-not-valid"),
         );
-        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::from([(
+        let (parents, mark) = parents_with(
             parent_txid,
-            CpfpEntry {
-                parent: parent.clone(),
-                strategy: anchor_strategy(key),
-                handle: CpfpHandle::default(),
-                dormant: false,
-            },
-        )])));
+            test_record(parent.clone(), key, Stage::Unconfirmed),
+        );
 
-        let submitted = bump_one_entry(
+        let submitted = bump_parent(
             &ctx,
-            &entries,
+            &parents,
             parent_txid,
+            &mark,
             PROTOCOL_FLOOR,
             BumpReason::Tick,
         )
         .await;
 
         assert!(!submitted, "rejected package must not report submission");
-        let map = entries.lock().await;
+        let map = parents.lock().await;
+        let cpfp = map[&parent_txid].cpfp.as_ref().expect("cpfp state");
         assert_eq!(
-            map[&parent_txid]
-                .handle
+            cpfp.handle
                 .last_child_lease
                 .as_deref()
-                .expect("the entry must hold a lease")
+                .expect("the record must hold a lease")
                 .outpoints(),
             funding,
-            "leased funding inputs must be written back even though submission failed"
+            "the lease must be written back even though submission failed"
         );
         assert!(
-            map[&parent_txid].handle.last_child_txid.is_none(),
+            cpfp.handle.last_child_txid.is_none(),
             "nothing reached the mempool, so the child txid must not advance"
         );
     }
 
-    /// A vanished entry (parent confirmed between look-up and bump) is a quiet no-op — in
+    /// A vanished record (parent buried between look-up and bump) is a quiet no-op — in
     /// particular the wallet must never be asked to fund a child for it.
     #[tokio::test]
-    async fn bump_one_entry_is_noop_when_entry_vanished() {
+    async fn bump_parent_is_noop_when_the_record_vanished() {
         let (_, key) = test_keypair_and_xonly();
         let parent = synthetic_parent(key, Amount::from_sat(330));
         let ctx = test_ctx(
-            FakeWallet::failing("wallet must not be called for a vanished entry"),
+            FakeWallet::failing("wallet must not be called for a vanished record"),
             FakeSubmitter::failing("submitter must not be called either"),
         );
-        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+        let parents: Parents = Arc::new(Mutex::new(HashMap::new()));
 
-        let submitted = bump_one_entry(
+        let submitted = bump_parent(
             &ctx,
-            &entries,
+            &parents,
             parent.compute_txid(),
+            &Arc::new(AtomicBool::new(true)),
             PROTOCOL_FLOOR,
             BumpReason::NewBlock,
         )
         .await;
 
         assert!(!submitted);
-        assert!(entries.lock().await.is_empty());
+        assert!(parents.lock().await.is_empty());
     }
 
-    /// The bare-broadcast fallback must not leave an orphaned entry behind when the package
-    /// submission fails too: the caller is about to fail the job and drop its subscription, so
-    /// nothing could ever remove the entry, and it would be re-bumped forever.
+    /// The package fallback is the last chance for a parent that bare broadcast rejected.
+    /// When it fails too, the record must go. Nothing else removes it, and every block and
+    /// tick bumps it. Its caller must hear the broadcast error rather than wait forever.
     #[tokio::test]
-    async fn failed_fallback_leaves_no_orphan_entry() {
+    async fn a_failed_package_fallback_removes_the_record_and_reports_the_error() {
         let (_, key) = test_keypair_and_xonly();
         let parent = synthetic_parent(key, Amount::from_sat(330));
-        let psbt = synthetic_child_psbt(&parent, 0, key);
-        let ctx = test_ctx(
+        let parent_txid = parent.compute_txid();
+        let ctx = Arc::new(test_ctx(
             FakeWallet::returning(
-                psbt,
+                synthetic_child_psbt(&parent, 0, key),
                 vec![OutPoint {
-                    txid: parent.compute_txid(),
+                    txid: parent_txid,
                     vout: 7,
                 }],
             ),
             FakeSubmitter::failing("package-not-valid"),
-        );
-        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+        ));
+        let (parents, _mark) =
+            parents_with(parent_txid, test_record(parent, key, Stage::Unconfirmed));
+        let (listener, receiver) = never_listener();
 
-        let submitted = fallback_package_submit(
+        let task = spawn_bump(
             &ctx,
-            &entries,
-            parent.clone(),
-            anchor_strategy(key),
+            &parents,
+            parent_txid,
             PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+            BumpFollowUp::CarryJob {
+                err: ClientError::Other("bare broadcast rejected".into()),
+                listener,
+                created: true,
+            },
         )
-        .await;
+        .await
+        .expect("a bumpable record must spawn a bump");
+        task.await.expect("the bump task must not panic");
 
-        assert!(!submitted);
         assert!(
-            entries.lock().await.is_empty(),
-            "failed fallback must remove the entry it registered"
+            parents.lock().await.is_empty(),
+            "a failed fallback must remove the record that it created"
+        );
+        assert!(
+            matches!(receiver.await, Ok(Err(DriveErr::PublishFailed(_)))),
+            "the caller must hear the broadcast error"
         );
     }
 
-    /// The successful fallback keeps its entry — the job survives, its subscription is pushed,
-    /// and the confirm-removal path owns the entry from here.
+    /// A record that an earlier job created is still driving that job's transaction. A later
+    /// job whose bare broadcast failed must not remove that record, and must not answer the
+    /// earlier caller with its own broadcast error.
     #[tokio::test]
-    async fn successful_fallback_keeps_entry_for_future_bumps() {
+    async fn a_failed_package_fallback_leaves_an_earlier_jobs_record_alone() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::returning(
+                synthetic_child_psbt(&parent, 0, key),
+                vec![OutPoint {
+                    txid: parent_txid,
+                    vout: 7,
+                }],
+            ),
+            FakeSubmitter::failing("package-not-valid"),
+        ));
+        let mut record = test_record(parent, key, Stage::Unconfirmed);
+        let (earlier, mut earlier_receiver) = never_listener();
+        record.listeners.push(earlier);
+        let (parents, _mark) = parents_with(parent_txid, record);
+        let (listener, receiver) = never_listener();
+
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+            BumpFollowUp::CarryJob {
+                err: ClientError::Other("bare broadcast rejected".into()),
+                listener,
+                // The registration of the later job found the record already there.
+                created: false,
+            },
+        )
+        .await
+        .expect("a bumpable record must spawn a bump");
+        task.await.expect("the bump task must not panic");
+
+        assert!(
+            parents.lock().await.contains_key(&parent_txid),
+            "the earlier job's record must survive a later job's broadcast failure"
+        );
+        assert!(
+            matches!(receiver.await, Ok(Err(DriveErr::PublishFailed(_)))),
+            "the later caller must hear its own broadcast error"
+        );
+        // `try_recv` and not `await`: the earlier caller is still waiting, so an await here
+        // never returns.
+        assert!(
+            matches!(earlier_receiver.try_recv(), Ok(None)),
+            "the earlier caller must still be waiting for its own outcome"
+        );
+    }
+
+    /// A bump that cannot start must still run its follow-up. The eviction path is the only
+    /// place that puts an evicted parent back in the mempool, so a declined bump that drops
+    /// its follow-up leaves that parent in no mempool at all.
+    #[tokio::test]
+    async fn a_declined_bump_still_reports_its_carried_job() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::failing("wallet must not be called while a bump runs"),
+            FakeSubmitter::failing("submitter must not be called either"),
+        ));
+        let (parents, mark) =
+            parents_with(parent_txid, test_record(parent, key, Stage::Unconfirmed));
+        // Stand in for a bump that another trigger already started.
+        mark.store(true, Ordering::Release);
+        let (listener, receiver) = never_listener();
+
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+            BumpFollowUp::CarryJob {
+                err: ClientError::Other("bare broadcast rejected".into()),
+                listener,
+                created: true,
+            },
+        )
+        .await;
+
+        assert!(
+            task.is_none(),
+            "a marked parent must not spawn a second bump"
+        );
+        assert!(
+            matches!(receiver.await, Ok(Err(DriveErr::PublishFailed(_)))),
+            "a declined bump must still answer the job that it carries"
+        );
+    }
+
+    /// The successful fallback keeps its record, so the confirmation path owns it from here,
+    /// the record carries the lease that the bump took, and the carried caller joins it.
+    #[tokio::test]
+    async fn a_successful_package_fallback_keeps_the_record_and_its_lease() {
         let (_, key) = test_keypair_and_xonly();
         let parent = synthetic_parent(key, Amount::from_sat(330));
         let parent_txid = parent.compute_txid();
@@ -1536,28 +1760,116 @@ mod cpfp_lifecycle_tests {
             txid: parent_txid,
             vout: 7,
         }];
-        let psbt = synthetic_child_psbt(&parent, 0, key);
-        let ctx = test_ctx(
-            FakeWallet::returning(psbt, funding.clone()),
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::returning(synthetic_child_psbt(&parent, 0, key), funding.clone()),
             FakeSubmitter::ok(),
-        );
-        let entries: CpfpEntries = Arc::new(Mutex::new(HashMap::new()));
+        ));
+        let (parents, _mark) =
+            parents_with(parent_txid, test_record(parent, key, Stage::Unconfirmed));
+        let (listener, _receiver) = never_listener();
 
-        let submitted =
-            fallback_package_submit(&ctx, &entries, parent, anchor_strategy(key), PROTOCOL_FLOOR)
-                .await;
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::NewJob,
+            BumpFollowUp::CarryJob {
+                err: ClientError::Other("must not be reported".into()),
+                listener,
+                created: true,
+            },
+        )
+        .await
+        .expect("a bumpable record must spawn a bump");
+        task.await.expect("the bump task must not panic");
 
-        assert!(submitted);
-        let map = entries.lock().await;
+        let map = parents.lock().await;
+        let record = &map[&parent_txid];
+        let cpfp = record.cpfp.as_ref().expect("cpfp state");
         assert_eq!(
-            map[&parent_txid]
-                .handle
+            cpfp.handle
                 .last_child_lease
                 .as_deref()
-                .expect("the entry must hold a lease")
+                .expect("the record must hold a lease")
                 .outpoints(),
             funding,
-            "the surviving entry must carry the bump's lease state"
+            "the surviving record must carry the lease that the bump took"
+        );
+        assert_eq!(
+            record.listeners.len(),
+            1,
+            "the carried caller joins the record once the package lands"
+        );
+    }
+
+    /// The per-parent mark stops a second trigger from bumping a parent whose bump is still
+    /// running. Two concurrent bumps snapshot one handle, and the later write-back drops the
+    /// lease that the earlier one took.
+    #[tokio::test]
+    async fn a_second_trigger_does_not_bump_a_parent_that_is_already_bumping() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let (parents, bumping) =
+            parents_with(parent_txid, test_record(parent, key, Stage::Unconfirmed));
+
+        // Stand in for a bump that is still running.
+        bumping.store(true, Ordering::Release);
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::failing("wallet must not be called while a bump runs"),
+            FakeSubmitter::failing("submitter must not be called either"),
+        ));
+
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+            BumpFollowUp::None,
+        )
+        .await;
+
+        assert!(task.is_none(), "the second trigger must not spawn a bump");
+    }
+
+    /// The mark clears when the bump task ends, so the next trigger can bump again.
+    #[tokio::test]
+    async fn the_bump_mark_clears_when_the_bump_ends() {
+        let (_, key) = test_keypair_and_xonly();
+        let parent = synthetic_parent(key, Amount::from_sat(330));
+        let parent_txid = parent.compute_txid();
+        let (parents, bumping) = parents_with(
+            parent_txid,
+            test_record(parent.clone(), key, Stage::Unconfirmed),
+        );
+        let ctx = Arc::new(test_ctx(
+            FakeWallet::returning(
+                synthetic_child_psbt(&parent, 0, key),
+                vec![OutPoint {
+                    txid: parent_txid,
+                    vout: 7,
+                }],
+            ),
+            FakeSubmitter::ok(),
+        ));
+
+        let task = spawn_bump(
+            &ctx,
+            &parents,
+            parent_txid,
+            PROTOCOL_FLOOR,
+            BumpReason::Tick,
+            BumpFollowUp::None,
+        )
+        .await
+        .expect("a bumpable record must spawn a bump");
+        assert!(bumping.load(Ordering::Acquire), "the mark is taken");
+        task.await.expect("the bump task must not panic");
+        assert!(
+            !bumping.load(Ordering::Acquire),
+            "the mark must clear when the bump ends"
         );
     }
 }

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -154,6 +154,25 @@ pub struct CovenantKeys {
     pub payout_descriptor: Descriptor,
 }
 
+/// Forces a compile-error if [`CovenantKeys`] grows or shrinks a field. The CPFP anchor
+/// inference path in `strata_bridge_exec::cpfp_adapters::infer_anchor_strategy` assumes
+/// `watchtower_pubkey == musig2_pubkey` for counterproof / counterproof_ack txs — an
+/// assumption made elsewhere too (see `bin/strata-bridge/src/mode/services/operator_wallet.rs`
+/// where `watchtower_keys` is sourced from `covenant[i].musig2`).
+///
+/// If anyone adds e.g. a `watchtower: XOnlyPublicKey` field to [`CovenantKeys`] in the future,
+/// this destructuring will fail to compile with "missing field `watchtower`" — that's the
+/// trigger to audit the CPFP path. The right fix at that point is to thread the per-anchor
+/// key through `CpfpKind::InferAnchor` and add a watchtower signer to `CpfpContext`.
+#[allow(dead_code)]
+fn _covenant_keys_field_audit(c: CovenantKeys) {
+    let CovenantKeys {
+        musig2: _,
+        p2p: _,
+        payout_descriptor: _,
+    } = c;
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct EncodedCovenantKeys {
     musig2: String,

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -155,7 +155,7 @@ pub struct CovenantKeys {
 }
 
 /// Forces a compile-error if [`CovenantKeys`] grows or shrinks a field. The CPFP anchor
-/// inference path in `strata_bridge_exec::cpfp_adapters::infer_anchor_strategy` assumes
+/// validation path in `strata_bridge_exec::chain::checked_anchor_strategy` assumes
 /// `watchtower_pubkey == musig2_pubkey` for counterproof / counterproof_ack txs — an
 /// assumption made elsewhere too (see `bin/strata-bridge/src/mode/services/operator_wallet.rs`
 /// where `watchtower_keys` is sourced from `covenant[i].musig2`).
@@ -163,7 +163,7 @@ pub struct CovenantKeys {
 /// If anyone adds e.g. a `watchtower: XOnlyPublicKey` field to [`CovenantKeys`] in the future,
 /// this destructuring will fail to compile with "missing field `watchtower`" — that's the
 /// trigger to audit the CPFP path. The right fix at that point is to thread the per-anchor
-/// key through `CpfpKind::InferAnchor` and add a watchtower signer to `CpfpContext`.
+/// key through `CpfpKind::AnchorAt` and add a watchtower signer to `CpfpContext`.
 #[allow(dead_code)]
 fn _covenant_keys_field_audit(c: CovenantKeys) {
     let CovenantKeys {

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -154,16 +154,17 @@ pub struct CovenantKeys {
     pub payout_descriptor: Descriptor,
 }
 
-/// Forces a compile-error if [`CovenantKeys`] grows or shrinks a field. The CPFP anchor
-/// validation path in `strata_bridge_exec::chain::checked_anchor_strategy` assumes
-/// `watchtower_pubkey == musig2_pubkey` for counterproof / counterproof_ack txs — an
-/// assumption made elsewhere too (see `bin/strata-bridge/src/mode/services/operator_wallet.rs`
-/// where `watchtower_keys` is sourced from `covenant[i].musig2`).
+/// Forces a compile error if [`CovenantKeys`] grows or shrinks a field.
 ///
-/// If anyone adds e.g. a `watchtower: XOnlyPublicKey` field to [`CovenantKeys`] in the future,
-/// this destructuring will fail to compile with "missing field `watchtower`" — that's the
-/// trigger to audit the CPFP path. The right fix at that point is to thread the per-anchor
-/// key through `CpfpKind::AnchorAt` and add a watchtower signer to `CpfpContext`.
+/// The operator table holds one BTC key for each operator, from `covenant[i].musig2` (see
+/// `bin/strata-bridge/src/mode/services/operator_table.rs`). `GraphSMCtx::watchtower_pubkeys`
+/// gives a graph its watchtower set from that table. For this reason,
+/// `watchtower_pubkey == musig2_pubkey` is a property of the whole graph, and not of one code
+/// path.
+///
+/// A new `watchtower: XOnlyPublicKey` field on [`CovenantKeys`] makes this destructuring fail
+/// to compile with "missing field `watchtower`". That is the point to audit each reader of
+/// the watchtower key set.
 #[allow(dead_code)]
 fn _covenant_keys_field_audit(c: CovenantKeys) {
     let CovenantKeys {

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -15,5 +15,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+bdk_wallet = { workspace = true, features = ["test-utils"] }
 corepc-node.workspace = true
 serial_test.workspace = true
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -111,6 +111,25 @@ const fn compact_size_len(n: usize) -> usize {
 /// item count + 65 bytes for the Schnorr signature push.
 pub(crate) const TAPROOT_KEY_PATH_SAT_WEIGHT: usize = 66;
 
+/// Whether the parent output that a CPFP child spends belongs to this wallet.
+///
+/// A child always spends one output of its parent. For most parents that output is a CPFP
+/// anchor keyed to a protocol key, and the wallet can never select it for another
+/// transaction. For a parent that pays this operator, the child spends the payout output
+/// instead, and the wallet can select that output once the parent confirms.
+///
+/// The composer reads this value to decide what the lease of the child covers. A foreign
+/// output stays out of the lease, because a lease on an outpoint that the wallet does not own
+/// records a claim it cannot act on. A wallet output enters the lease, because a concurrent
+/// duty must not select an output that a live child already spends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorOwnership {
+    /// The output belongs to a protocol key. It stays out of the lease.
+    Foreign,
+    /// The output pays this wallet. It enters the lease.
+    Wallet,
+}
+
 /// The prior CPFP child that a rebuild replaces via RBF.
 ///
 /// The backend has two obligations toward the replaced child:

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -111,6 +111,25 @@ const fn compact_size_len(n: usize) -> usize {
 /// item count + 65 bytes for the Schnorr signature push.
 pub(crate) const TAPROOT_KEY_PATH_SAT_WEIGHT: usize = 66;
 
+/// The prior CPFP child that a rebuild replaces via RBF.
+///
+/// The backend has two obligations toward the replaced child:
+///
+/// * Selection: `inputs` must stay selectable even when the backend's own view shows them as spent.
+///   After the backend observes the prior child, they read as spent. Without this override, each
+///   rebuild consumes a fresh funding set until no funding remains.
+/// * Fee: when `fee` is known, the new child must pay at least `fee + 1 sat/vB × the new child's
+///   vbytes` (BIP-125 rule 4). Below that floor, bitcoind rejects the replacement.
+///
+/// [`ReplacedChild::default`] means there is no prior child.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReplacedChild<'a> {
+    /// Funding outpoints of the prior child. Empty when there is no prior child.
+    pub inputs: &'a [OutPoint],
+    /// Absolute fee of the prior child, when known.
+    pub fee: Option<Amount>,
+}
+
 /// A backend that manages the operator's general-purpose Bitcoin funds.
 ///
 /// The trait is intentionally narrow: it covers UTXO discovery + signing + transaction
@@ -174,6 +193,8 @@ pub trait GeneralWallet: Send + Sync {
     /// * `target_pkg_fee_rate` — sat-per-vbyte target for the (parent, child) package as a whole.
     /// * `exclude` — fee-paying-input selection skips these outpoints. Used to avoid re-selecting
     ///   the funding input of a prior child being replaced via RBF.
+    /// * `replaced` — the prior child that this build supersedes ([`ReplacedChild`]). See the type
+    ///   documentation for the two obligations it carries.
     ///
     /// Per the trait-level signing contract, the anchor input is left unsigned with
     /// `witness_utxo` and `tap_internal_key` populated (the latter sourced from
@@ -185,6 +206,7 @@ pub trait GeneralWallet: Send + Sync {
         anchor: AnchorInfo,
         target_pkg_fee_rate: FeeRate,
         exclude: &[OutPoint],
+        replaced: ReplacedChild<'_>,
     ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;
 }
 

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -12,9 +12,104 @@ pub mod native;
 use std::error::Error as StdError;
 
 use bdk_wallet::{
-    bitcoin::{Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut},
+    bitcoin::{
+        taproot::ControlBlock, Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut,
+        XOnlyPublicKey,
+    },
     chain::ChainPosition,
 };
+
+/// Metadata about the Taproot anchor that the CPFP child will spend.
+///
+/// Carried into [`GeneralWallet::build_cpfp_child`] so the backend can populate the PSBT input
+/// without having to recover the spend data from the parent's anchor `script_pubkey` (which is
+/// impossible — Taproot output keys are tweaked and commit to the script tree).
+///
+/// The bridge has two anchor shapes and they are spent differently:
+///
+/// * Most transactions carry a `KeyedAnchor` — a bare key-path output with no script tree, spent
+///   with a single BIP-341 tap-tweaked signature.
+/// * `contest` and `bridge_proof_timeout` carry a `MultiAnchor` — a script tree with one
+///   `<watchtower_pubkey> OP_CHECKSIG` leaf per watchtower, so that any watchtower can bump them.
+///   Spending one requires a script-path witness (signature + leaf script + control block) and an
+///   *untweaked* signature.
+#[derive(Debug, Clone)]
+pub enum AnchorInfo {
+    /// Key-path spend of a keyed-Taproot anchor with no script tree.
+    KeyPath {
+        /// Index of the anchor output in `parent.output`.
+        vout: u32,
+        /// Internal x-only key the anchor was constructed from. The output key is this internal
+        /// key BIP-341-tweaked by an empty merkle root; the downstream signer needs the internal
+        /// key (not the output key) to construct a key-path signature.
+        internal_key: XOnlyPublicKey,
+    },
+    /// Script-path spend of a single leaf of a multi-leaf Taproot anchor.
+    ScriptPath {
+        /// Index of the anchor output in `parent.output`.
+        vout: u32,
+        /// The leaf script being satisfied.
+        leaf_script: ScriptBuf,
+        /// Control block proving `leaf_script`'s membership in the tree. Kept typed rather than
+        /// pre-serialized so a malformed block cannot reach the chain: the only bytes we ever
+        /// push are `ControlBlock::serialize`'s.
+        control_block: ControlBlock,
+    },
+}
+
+impl AnchorInfo {
+    /// Index of the anchor output in the parent's `output` vector.
+    pub const fn vout(&self) -> u32 {
+        match self {
+            Self::KeyPath { vout, .. } | Self::ScriptPath { vout, .. } => *vout,
+        }
+    }
+
+    /// Estimated witness weight, in weight units, of satisfying this anchor input.
+    ///
+    /// BDK needs this to account for the foreign anchor input in the child's fee math. The
+    /// key-path figure is the usual 1-byte item count plus a 65-byte signature push. The
+    /// script-path figure is computed exactly rather than estimated, because the caller already
+    /// holds the real leaf script and control block — a MultiAnchor's control block grows with
+    /// tree depth (33 + 32×depth bytes), so a fixed guess would drift with the watchtower count.
+    pub fn satisfaction_weight(&self) -> usize {
+        match self {
+            Self::KeyPath { .. } => TAPROOT_KEY_PATH_SAT_WEIGHT,
+            Self::ScriptPath {
+                leaf_script,
+                control_block,
+                ..
+            } => {
+                // Witness item count, then each element prefixed by its compact-size length.
+                // A deep tree pushes the control block past 252 bytes (33 + 32×depth), at which
+                // point the prefix is no longer a single byte — hence the varint helper rather
+                // than a hardcoded 1.
+                let elements = [64, leaf_script.len(), control_block.serialize().len()];
+                1 + elements
+                    .iter()
+                    .map(|len| compact_size_len(*len) + len)
+                    .sum::<usize>()
+            }
+        }
+    }
+}
+
+/// Byte length of a Bitcoin compact-size integer encoding `n`.
+const fn compact_size_len(n: usize) -> usize {
+    if n < 253 {
+        1
+    } else if n <= 0xFFFF {
+        3
+    } else if n <= 0xFFFF_FFFF {
+        5
+    } else {
+        9
+    }
+}
+
+/// Estimated witness weight (in weight units) for a Taproot key-path spend: 1 byte witness
+/// item count + 65 bytes for the Schnorr signature push.
+pub(crate) const TAPROOT_KEY_PATH_SAT_WEIGHT: usize = 66;
 
 /// A backend that manages the operator's general-purpose Bitcoin funds.
 ///
@@ -67,20 +162,27 @@ pub trait GeneralWallet: Send + Sync {
         exclude: &[OutPoint],
     ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;
 
-    /// Builds a v3 TRUC CPFP child for `parent`, spending the keyed-Taproot anchor at
-    /// `parent.output[anchor_vout]` plus one fee-paying input drawn from this wallet.
+    /// Builds a v3 TRUC CPFP child for `parent`, spending the keyed-Taproot output described
+    /// by `anchor` plus inputs drawn from this wallet to cover the child's share of the
+    /// package fee.
     ///
+    /// * `parent_fee` — caller-provided fee already paid by `parent`. Used together with parent
+    ///   vbytes and `target_pkg_fee_rate` to compute the implied child fee. The caller always knows
+    ///   this (it built or has access to the parent's prevouts), so the backend can stay I/O-free.
+    /// * `anchor` — [`AnchorInfo`] identifying the foreign-key output to spend and its internal
+    ///   key.
     /// * `target_pkg_fee_rate` — sat-per-vbyte target for the (parent, child) package as a whole.
     /// * `exclude` — fee-paying-input selection skips these outpoints. Used to avoid re-selecting
     ///   the funding input of a prior child being replaced via RBF.
     ///
     /// Per the trait-level signing contract, the anchor input is left unsigned with
-    /// `witness_utxo` and `tap_internal_key` populated; the fee-paying input is signed iff
-    /// the backend holds its key material.
+    /// `witness_utxo` and `tap_internal_key` populated (the latter sourced from
+    /// `anchor.internal_key`); inputs the backend holds key material for are signed.
     fn build_cpfp_child(
         &mut self,
         parent: &Transaction,
-        anchor_vout: u32,
+        parent_fee: Amount,
+        anchor: AnchorInfo,
         target_pkg_fee_rate: FeeRate,
         exclude: &[OutPoint],
     ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -167,7 +167,10 @@ pub struct ReplacedChild<'a> {
 /// sign them downstream by whatever means it sees fit.
 pub trait GeneralWallet: Send + Sync {
     /// Backend-specific error type.
-    type Error: StdError + Send + Sync + 'static;
+    ///
+    /// [`crate::ErrorPermanence`] is required because the composer boxes this type, and a
+    /// caller that retries on a timer needs the classification that the box hides.
+    type Error: StdError + crate::ErrorPermanence + Send + Sync + 'static;
 
     /// Refreshes internal state from the underlying source. Idempotent.
     ///

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -155,6 +155,11 @@ pub struct ReplacedChild<'a> {
 /// construction for the general wallet only. Lease bookkeeping, the reserved wallet, and
 /// anchor handling live on the composer.
 ///
+/// Every method except [`Self::sync`] takes `&self`, so a caller does not need an exclusive
+/// lock to build a transaction. A backend that must mutate to build one carries its own
+/// interior mutability. This keeps a read of the wallet, such as a health probe, off the
+/// queue behind a backend round trip that takes seconds.
+///
 /// # Signing contract
 ///
 /// A backend signs the inputs it has key material for. Inputs it leaves unsigned must
@@ -166,9 +171,8 @@ pub trait GeneralWallet: Send + Sync {
 
     /// Refreshes internal state from the underlying source. Idempotent.
     ///
-    /// Takes `&mut self` because the typical native impl needs to mutate its BDK wallet
-    /// state. Callers serialize via an outer lock; the trait doesn't impose interior
-    /// mutability.
+    /// This is the only method that takes `&mut self`. A backend replaces its whole view of
+    /// the chain here, and the composer's callers hold an exclusive outer lock for it.
     fn sync(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 
     /// Returns the receive script for this wallet. Stable across calls for native backends;
@@ -193,7 +197,7 @@ pub trait GeneralWallet: Send + Sync {
     /// carry `witness_utxo` and `tap_internal_key` (for Taproot) so the caller can sign
     /// downstream.
     fn fund_v3_transaction(
-        &mut self,
+        &self,
         outputs: Vec<TxOut>,
         explicit_inputs: Option<&[OutPoint]>,
         fee_rate: FeeRate,
@@ -219,7 +223,7 @@ pub trait GeneralWallet: Send + Sync {
     /// `witness_utxo` and `tap_internal_key` populated (the latter sourced from
     /// `anchor.internal_key`); inputs the backend holds key material for are signed.
     fn build_cpfp_child(
-        &mut self,
+        &self,
         parent: &Transaction,
         parent_fee: Amount,
         anchor: AnchorInfo,

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -8,7 +8,10 @@
 use std::collections::BTreeSet;
 
 use bdk_wallet::{
-    bitcoin::{FeeRate, Network, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    bitcoin::{
+        psbt::Input as PsbtInput, taproot::LeafVersion, Amount, FeeRate, Network, OutPoint, Psbt,
+        ScriptBuf, Transaction, TxOut, XOnlyPublicKey,
+    },
     descriptor,
     error::CreateTxError,
     KeychainKind, TxOrdering, Wallet,
@@ -17,7 +20,10 @@ use thiserror::Error;
 use tracing::info;
 
 use crate::{
-    general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    general::{
+        local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo,
+        TAPROOT_KEY_PATH_SAT_WEIGHT,
+    },
     sync::{Backend, SyncError},
 };
 
@@ -58,9 +64,39 @@ pub enum NativeGeneralError {
     /// Chain sync (block / mempool fetch) failed.
     #[error("wallet sync: {0:?}")]
     Sync(SyncError),
-    /// CPFP-child building is intentionally unimplemented until STR-3439 lands.
-    #[error("native build_cpfp_child not yet implemented (STR-3439)")]
-    CpfpChildNotImplemented,
+    /// `anchor.vout` indexes past the end of `parent.output`.
+    #[error("anchor vout {vout} out of range for parent with {parent_outputs} outputs")]
+    AnchorVoutOutOfRange {
+        /// The requested anchor vout.
+        vout: u32,
+        /// Number of outputs on `parent`.
+        parent_outputs: usize,
+    },
+    /// BDK rejected the foreign-utxo insertion of the parent's anchor (typically because it
+    /// could not parse the script_pubkey).
+    #[error("bdk add_foreign_utxo for anchor: {0}")]
+    AnchorForeignUtxo(String),
+    /// BDK rejected one of the funding outpoints this impl selected.
+    #[error("bdk add_utxos for CPFP funding: {0}")]
+    FundingUtxo(String),
+    /// The built child does not have the input count it was priced for, so its fee no longer
+    /// matches its size. Refuse it rather than broadcast a package at the wrong rate.
+    #[error("CPFP child has {actual} inputs, priced for {expected}")]
+    UnexpectedInputCount {
+        /// Anchor plus the funding inputs that `select_funding` chose.
+        expected: usize,
+        /// Inputs the builder actually produced.
+        actual: usize,
+    },
+    /// Every spendable wallet UTXO together with the anchor still cannot pay the child's fee
+    /// and leave a spendable drain output.
+    #[error("insufficient funds for CPFP child: {available} sat available, {needed} sat needed")]
+    InsufficientFunding {
+        /// Anchor value plus every candidate wallet UTXO.
+        available: u64,
+        /// Fee for that shape, plus the dust threshold for the drain output.
+        needed: u64,
+    },
 }
 
 impl GeneralWallet for NativeGeneralWallet {
@@ -104,15 +140,356 @@ impl GeneralWallet for NativeGeneralWallet {
 
     async fn build_cpfp_child(
         &mut self,
-        _parent: &Transaction,
-        _anchor_vout: u32,
-        _target_pkg_fee_rate: FeeRate,
-        _exclude: &[OutPoint],
+        parent: &Transaction,
+        parent_fee: Amount,
+        anchor: AnchorInfo,
+        target_pkg_fee_rate: FeeRate,
+        exclude: &[OutPoint],
     ) -> Result<FundedPsbt, Self::Error> {
-        // TODO: <https://alpenlabs.atlassian.net/browse/STR-3439>
-        // Wire up CPFP child construction during the tx-driver / RBF work.
-        Err(NativeGeneralError::CpfpChildNotImplemented)
+        build_cpfp_child_impl(
+            &mut self.wallet,
+            parent,
+            parent_fee,
+            anchor,
+            target_pkg_fee_rate,
+            exclude,
+        )
     }
+}
+
+/// Implementation of [`NativeGeneralWallet::build_cpfp_child`], factored into a free function
+/// so it doesn't borrow `self` through the trait method and can be unit-tested without an
+/// outer `NativeGeneralWallet`.
+///
+/// The child pays an absolute fee, and this function picks its own inputs.
+///
+/// BDK knows nothing about the parent, so it cannot price a package. This function computes the
+/// fee itself: `target × (parent.vbytes + child.vbytes) − parent_fee`. That formula needs
+/// `child.vbytes`, which depends on how many funding inputs the child has.
+///
+/// Therefore the inputs are chosen here, before the fee is computed, by
+/// [`select_funding`]. Once the input count is fixed the child's size is known exactly, so the
+/// fee is exact too, and the package lands on the target rate rather than near it.
+///
+/// Earlier revisions left the choice to BDK and tried to predict the result. That does not work.
+/// An absolute fee needs an upper bound on the child size, and no upper bound is knowable before
+/// selection runs. Predicting low makes the package underpay, and the prediction was wrong for
+/// any script-path anchor and for any child that drew more than one funding input.
+///
+/// The anchor enters through `add_foreign_utxo`, because the wallet does not hold the anchor key
+/// and cannot recognize the outpoint. The parent is usually not broadcast yet, so the wallet
+/// cannot see it at all. The PSBT input carries `witness_utxo` plus either `tap_internal_key`
+/// (key path) or `tap_scripts` (script path), and a witness-weight estimate. The caller signs
+/// that input downstream.
+fn build_cpfp_child_impl(
+    wallet: &mut Wallet,
+    parent: &Transaction,
+    parent_fee: Amount,
+    anchor: AnchorInfo,
+    target_pkg_fee_rate: FeeRate,
+    exclude: &[OutPoint],
+) -> Result<FundedPsbt, NativeGeneralError> {
+    let anchor_vout = anchor.vout();
+    let anchor_outpoint = OutPoint {
+        txid: parent.compute_txid(),
+        vout: anchor_vout,
+    };
+    let anchor_txout = parent
+        .output
+        .get(anchor_vout as usize)
+        .ok_or(NativeGeneralError::AnchorVoutOutOfRange {
+            vout: anchor_vout,
+            parent_outputs: parent.output.len(),
+        })?
+        .clone();
+
+    // ── Compute the child's absolute fee ────────────────────────────────────
+    //
+    // The package math:
+    //   package_vbytes = parent.vbytes + child_estimate
+    //   child_fee     = target_pkg_fee_rate × package_vbytes − parent_fee
+    //
+    // We don't know child.vbytes yet — it depends on how many funding inputs BDK picks, and
+    // with an absolute fee an UNDER-estimate means the package silently underpays (the fixed
+    // fee spread over more vbytes). So rather than trusting one guess, seed a derived
+    // estimate and then converge on what BDK actually produced — see the build loop below.
+    let parent_vbytes: u64 = parent
+        .vsize()
+        .try_into()
+        .expect("tx.vsize() fits in u64 on every supported target");
+    let fee_for = |child_vbytes: u64| -> u64 {
+        let pkg_vbytes = parent_vbytes.saturating_add(child_vbytes);
+        let target_pkg_fee_sat = target_pkg_fee_rate
+            .to_sat_per_kwu()
+            .saturating_mul(pkg_vbytes.saturating_mul(4))
+            / 1000;
+        target_pkg_fee_sat.saturating_sub(parent_fee.to_sat())
+    };
+
+    // ── Build the child ─────────────────────────────────────────────────────
+
+    // Note there is no `unspendable()` call here. It would do nothing: manual selection
+    // overrides it, and BDK skips the filter it feeds entirely. The anchor and the excluded
+    // outpoints are kept out by `select_funding` instead.
+    let exclude_set: BTreeSet<OutPoint> = exclude.iter().copied().collect();
+
+    // The child has no external recipient: it's a self-spend that consolidates the anchor
+    // value + selected funding back to the wallet (minus fee). Use `drain_to` to make this
+    // explicit, otherwise BDK rejects with `NoRecipients`.
+    let drain_script = wallet
+        .peek_address(KeychainKind::External, 0)
+        .address
+        .script_pubkey();
+
+    // Choose the funding inputs here rather than leaving the choice to BDK.
+    //
+    // The child's fee depends on its size, and its size depends on how many funding inputs it
+    // has. If BDK picks the inputs, we can only guess the size before the fact and check it
+    // after, which is what earlier revisions did. Choosing the inputs ourselves collapses that
+    // circularity: once the input count is fixed, the size is known exactly, so the fee is
+    // exact too.
+    let anchor_value_sat = anchor_txout.value.to_sat();
+    let selection = select_funding(
+        wallet,
+        &exclude_set,
+        anchor_outpoint,
+        anchor_value_sat,
+        &anchor,
+        &fee_for,
+    )?;
+
+    // Build the foreign UTXO PSBT input for the anchor. No signature — the caller signs
+    // downstream, and for the script-path case it also assembles the final witness, so all
+    // we owe it here is enough context to identify what is being spent.
+    let mut anchor_psbt_input = PsbtInput {
+        witness_utxo: Some(anchor_txout.clone()),
+        ..Default::default()
+    };
+    match &anchor {
+        AnchorInfo::KeyPath { internal_key, .. } => {
+            anchor_psbt_input.tap_internal_key = Some(*internal_key);
+        }
+        AnchorInfo::ScriptPath {
+            leaf_script,
+            control_block,
+            ..
+        } => {
+            // Record the leaf under its control block so the PSBT is self-describing. The
+            // downstream signer builds the witness from the same pair, but a populated
+            // `tap_scripts` keeps the intermediate PSBT meaningful to anything inspecting it.
+            anchor_psbt_input.tap_scripts.insert(
+                control_block.clone(),
+                (leaf_script.clone(), LeafVersion::TapScript),
+            );
+        }
+    }
+
+    let mut tx_builder = wallet.build_tx();
+    tx_builder.version(3);
+    tx_builder.fee_absolute(Amount::from_sat(selection.fee_sat));
+    // Pin the locktime. BDK otherwise sets it to the current chain tip as an anti-fee-sniping
+    // measure, and the funding inputs carry a sequence that enforces it. That makes the
+    // locktime a live consensus field which changes on every new block, and so changes the
+    // child's txid on every new block. A new block is also the most common reason to rebuild,
+    // so that default works directly against the determinism this builder needs.
+    tx_builder.nlocktime(bdk_wallet::bitcoin::absolute::LockTime::ZERO);
+    // Order inputs and outputs deterministically rather than leaving the order to BDK.
+    //
+    // `TxOrdering::Untouched` preserves BDK's own iteration order over the manually-selected
+    // set, and that order is not stable between calls. An unstable order gives the same child
+    // a different txid on every rebuild. RBF then treats a same-rate rebuild as a replacement
+    // and the incremental-fee rule rejects it, instead of the resubmission deduplicating
+    // against the child that is already in the mempool.
+    //
+    // The signer finds the anchor by outpoint rather than by index, so the input order is free
+    // to change. The child has one output today, but sort it on its own fields anyway: BDK
+    // sorts with `sort_unstable_by`, so a comparator that returns `Equal` for everything does
+    // not guarantee the original order if a second output is ever added.
+    tx_builder.ordering(TxOrdering::Custom {
+        input_sort: std::sync::Arc::new(|a, b| a.previous_output.cmp(&b.previous_output)),
+        output_sort: std::sync::Arc::new(|a, b| {
+            a.value
+                .cmp(&b.value)
+                .then_with(|| a.script_pubkey.cmp(&b.script_pubkey))
+        }),
+    });
+    // Funding inputs first, then the anchor. `add_foreign_utxo` rejects an outpoint that is
+    // already present as a local input, so this order turns a duplicate into a loud error.
+    // The reverse order silently overwrites the foreign entry, and the anchor would lose the
+    // spend data that the downstream signer needs.
+    tx_builder
+        .add_utxos(&selection.funding)
+        .map_err(|e| NativeGeneralError::FundingUtxo(format!("{e:?}")))?;
+    tx_builder
+        .add_foreign_utxo(
+            anchor_outpoint,
+            anchor_psbt_input,
+            bdk_wallet::bitcoin::Weight::from_wu(anchor.satisfaction_weight() as u64),
+        )
+        .map_err(|e| NativeGeneralError::AnchorForeignUtxo(format!("{e:?}")))?;
+    // Defence in depth. The selection invariant already leaves BDK nothing to add, because the
+    // chosen inputs cover the fee, and BDK stops as soon as that is true.
+    tx_builder.manually_selected_only();
+    tx_builder.drain_to(drain_script);
+
+    let psbt = tx_builder.finish()?;
+
+    // The input count decides the size, and the input count is fixed above. A mismatch means
+    // the fee no longer matches the shape it was computed for, which is a silent underpay or
+    // overpay rather than a visible failure. Check it on every build, not only in debug.
+    if psbt.unsigned_tx.input.len() != selection.funding.len() + 1 {
+        return Err(NativeGeneralError::UnexpectedInputCount {
+            expected: selection.funding.len() + 1,
+            actual: psbt.unsigned_tx.input.len(),
+        });
+    }
+
+    Ok(FundedPsbt { psbt })
+}
+
+/// The funding inputs chosen for a CPFP child, and the exact fee that this shape must pay.
+struct FundingSelection {
+    /// Wallet outpoints to spend, in addition to the anchor.
+    funding: Vec<OutPoint>,
+    /// Absolute fee, exact for the child that these inputs produce.
+    fee_sat: u64,
+}
+
+/// Chooses the funding inputs for a CPFP child and computes the exact fee for the resulting
+/// shape.
+///
+/// `fee_for` maps a child size in vbytes to the fee that lifts the package to the target rate.
+/// Both the size and the fee depend on the number of funding inputs, so this walks the input
+/// count upward and stops at the first count that works:
+///
+/// 1. Try no funding at all. When the anchor pays the fee and still leaves a spendable drain
+///    output, the child is just the anchor input and the drain output. This is the payout-combined
+///    shape.
+/// 2. Otherwise add wallet UTXOs, largest first, and re-check after each one. Largest first keeps
+///    the input count down, which keeps the child small and therefore the fee low.
+///
+/// Each candidate count gets its own fee, from its own exact size. Therefore the fee this
+/// returns is exact for the shape it returns.
+fn select_funding(
+    wallet: &Wallet,
+    exclude: &BTreeSet<OutPoint>,
+    anchor_outpoint: OutPoint,
+    anchor_value_sat: u64,
+    anchor: &AnchorInfo,
+    fee_for: &impl Fn(u64) -> u64,
+) -> Result<FundingSelection, NativeGeneralError> {
+    // The fee must also keep the child relayable on its own: at least 1 sat/vB over its own
+    // vbytes. That is Core's default `minrelaytxfee`, a generic policy floor rather than a
+    // BIP-431 rule. TRUC contributes topology limits and sibling eviction, not this floor.
+    let fee_at = |n_funding: u64| -> u64 {
+        let vbytes = child_vbytes_for(anchor, n_funding);
+        fee_for(vbytes).max(vbytes)
+    };
+
+    // Does the anchor alone cover its own fee and leave a spendable drain output?
+    let fee_no_funding = fee_at(0);
+    if anchor_value_sat >= fee_no_funding.saturating_add(DRAIN_DUST_SAT) {
+        return Ok(FundingSelection {
+            funding: Vec::new(),
+            fee_sat: fee_no_funding,
+        });
+    }
+
+    let tip = wallet.latest_checkpoint().height();
+    let mut candidates: Vec<(OutPoint, u64)> = wallet
+        .list_unspent()
+        .filter(|utxo| {
+            // Never the anchor. This filter is what keeps the anchor out of `add_utxos`, which
+            // would otherwise overwrite the foreign-UTXO entry that carries the anchor's spend
+            // data. It is load-bearing for `ParentTxCombined`: that payout output pays the
+            // wallet's own receive script, so once the parent confirms and the wallet syncs,
+            // the anchor really does appear in `list_unspent`.
+            if utxo.outpoint == anchor_outpoint || exclude.contains(&utxo.outpoint) {
+                return false;
+            }
+            is_spendable_funding(wallet, utxo, tip)
+        })
+        .map(|utxo| (utxo.outpoint, utxo.txout.value.to_sat()))
+        .collect();
+    // Largest first, then by outpoint so the choice is deterministic across calls. Determinism
+    // matters for RBF: an unchanged fee target must rebuild the same child, not a random one.
+    // Largest first also keeps the input count down, which matters for the size limit below.
+    candidates.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let mut funding = Vec::new();
+    let mut funded_sat = anchor_value_sat;
+    for (outpoint, value) in candidates {
+        // Stop before the child breaks the TRUC size limit. BIP-431 caps a v3 transaction that
+        // has an unconfirmed v3 ancestor at 1000 vB, and this child always has one: the parent.
+        // A child past that limit cannot enter any mempool, so building it is worse than
+        // reporting that the wallet cannot fund the bump.
+        if child_vbytes_for(anchor, funding.len() as u64 + 1) > TRUC_CHILD_MAX_VBYTES {
+            break;
+        }
+        funding.push(outpoint);
+        funded_sat = funded_sat.saturating_add(value);
+        let fee_sat = fee_at(funding.len() as u64);
+        if funded_sat >= fee_sat.saturating_add(DRAIN_DUST_SAT) {
+            return Ok(FundingSelection { funding, fee_sat });
+        }
+    }
+
+    Err(NativeGeneralError::InsufficientFunding {
+        available: funded_sat,
+        needed: fee_at(funding.len() as u64).saturating_add(DRAIN_DUST_SAT),
+    })
+}
+
+/// Whether `utxo` can fund a CPFP child at chain height `tip`.
+///
+/// Two conditions, both of which BDK used to apply on our behalf when it did the selecting:
+///
+/// * The output must be confirmed. The child already has one unconfirmed parent, the CPFP parent
+///   itself. A second unconfirmed parent breaks the TRUC topology rule and the package is rejected.
+/// * A coinbase output must be mature. Spending one before 100 confirmations is a consensus error,
+///   and the bump would repeat it on every tick.
+fn is_spendable_funding(wallet: &Wallet, utxo: &bdk_wallet::LocalOutput, tip: u32) -> bool {
+    let Some(confirmation_height) = utxo.chain_position.confirmation_height_upper_bound() else {
+        return false;
+    };
+    let is_coinbase = wallet
+        .get_tx(utxo.outpoint.txid)
+        .is_some_and(|tx| tx.tx_node.tx.is_coinbase());
+    if is_coinbase && tip.saturating_sub(confirmation_height) + 1 < COINBASE_MATURITY {
+        return false;
+    }
+    true
+}
+
+/// Dust threshold for the child's P2TR drain output. Below this the output is unspendable and
+/// the transaction is nonstandard.
+const DRAIN_DUST_SAT: u64 = 330;
+
+/// BIP-431 caps a v3 transaction that has an unconfirmed v3 ancestor at this size. The CPFP
+/// child always has such an ancestor, because the parent is what it exists to pay for.
+const TRUC_CHILD_MAX_VBYTES: u64 = 1000;
+
+/// Confirmations a coinbase output needs before it can be spent.
+const COINBASE_MATURITY: u32 = 100;
+
+/// Predicted signed vbytes of a CPFP child spending `anchor` plus `n_funding` key-path
+/// wallet inputs, draining to a single P2TR output.
+///
+/// Derived rather than guessed, and exact for the layouts we build: non-witness bytes are
+/// version (4) + input/output counts (1 + 1) + locktime (4) + 41 per input (36 outpoint +
+/// 1 script-len + 4 sequence) + 43 for the P2TR output (8 value + 1 len + 34 script);
+/// witness is the anchor's own satisfaction weight, [`TAPROOT_KEY_PATH_SAT_WEIGHT`] per
+/// funding input, and 2 wu for the segwit marker/flag.
+///
+/// Being anchor-aware matters: a `MultiAnchor` script-path spend carries a leaf script and a
+/// control block that grows with tree depth, so a fixed figure would under-estimate it and —
+/// because the child pays an *absolute* fee — silently underpay the package on every bump.
+/// `n_funding = 0` gives the canonical 111 vB for a 1-in/1-out key-path Taproot spend.
+fn child_vbytes_for(anchor: &AnchorInfo, n_funding: u64) -> u64 {
+    let non_witness_bytes = 4 + 1 + 1 + 4 + (1 + n_funding) * 41 + 43;
+    let witness_wu =
+        anchor.satisfaction_weight() as u64 + n_funding * TAPROOT_KEY_PATH_SAT_WEIGHT as u64 + 2;
+    (non_witness_bytes * 4 + witness_wu).div_ceil(4)
 }
 
 /// Builds a v3 (TRUC) PSBT using BDK's transaction builder, with `outputs` as recipients,
@@ -151,4 +528,730 @@ fn build_v3_psbt(
     }
 
     tx_builder.finish()
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use bdk_wallet::{
+        bitcoin::{
+            absolute, hashes::Hash, opcodes, script, secp256k1::Secp256k1, taproot::TaprootBuilder,
+            transaction::Version, Address, Amount, OutPoint, Transaction, TxIn, TxOut, Txid,
+            Witness, XOnlyPublicKey,
+        },
+        test_utils::{get_funded_wallet_single, get_test_tr_single_sig},
+    };
+
+    use super::*;
+    use crate::general::AnchorInfo;
+
+    /// Builds a `MultiAnchor`-shaped Taproot output: one `<pubkey> OP_CHECKSIG` leaf per
+    /// watchtower over a balanced tree. Returns the [`AnchorInfo::ScriptPath`] for the first
+    /// leaf plus the resulting `script_pubkey`, so a parent can actually carry the output.
+    fn script_path_anchor(n_watchtowers: usize) -> (AnchorInfo, ScriptBuf) {
+        let secp = Secp256k1::new();
+        let leaves: Vec<ScriptBuf> = (0..n_watchtowers)
+            .map(|i| {
+                let key = xonly_from_scalar(i as u8 + 2);
+                script::Builder::new()
+                    .push_slice(key.serialize())
+                    .push_opcode(opcodes::all::OP_CHECKSIG)
+                    .into_script()
+            })
+            .collect();
+        let builder =
+            TaprootBuilder::with_huffman_tree(leaves.iter().map(|s| (1u32, s.clone()))).unwrap();
+        let internal_key = xonly_from_scalar(99);
+        let spend_info = builder.finalize(&secp, internal_key).unwrap();
+        let control_block = spend_info
+            .control_block(&(leaves[0].clone(), LeafVersion::TapScript))
+            .unwrap();
+        let spk = ScriptBuf::new_p2tr(&secp, internal_key, spend_info.merkle_root());
+        (
+            AnchorInfo::ScriptPath {
+                vout: 0,
+                leaf_script: leaves[0].clone(),
+                control_block,
+            },
+            spk,
+        )
+    }
+
+    /// A v3 parent whose single output pays `script_pubkey`.
+    fn parent_with_script_pubkey(script_pubkey: ScriptBuf, value: Amount) -> Transaction {
+        Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([9u8; 32]),
+                    vout: 0,
+                },
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value,
+                script_pubkey,
+            }],
+        }
+    }
+
+    /// Measures what `tx` will actually weigh once signed, by attaching witnesses of the real
+    /// shape and letting rust-bitcoin serialize it. The anchor input is found by outpoint,
+    /// because the builder sorts its inputs and the anchor is not necessarily first. A
+    /// script-path anchor gets `[sig, leaf, control_block]`; every other input, and a key-path
+    /// anchor, gets a bare signature.
+    ///
+    /// This is the independent oracle for the size predictor — it shares no arithmetic with
+    /// `child_vbytes_for`, so a bug in the predictor cannot hide behind it.
+    fn signed_vsize_of(tx: &Transaction, anchor: &AnchorInfo, anchor_outpoint: OutPoint) -> usize {
+        let mut signed = tx.clone();
+        for input in &mut signed.input {
+            let mut witness = Witness::new();
+            match anchor {
+                AnchorInfo::ScriptPath {
+                    leaf_script,
+                    control_block,
+                    ..
+                } if input.previous_output == anchor_outpoint => {
+                    witness.push([0u8; 64]);
+                    witness.push(leaf_script.as_bytes());
+                    witness.push(control_block.serialize());
+                }
+                // Key-path anchor and every wallet funding input: a bare 64-byte Schnorr
+                // signature (TapSighashType::Default omits the trailing sighash byte).
+                _ => witness.push([0u8; 64]),
+            }
+            input.witness = witness;
+        }
+        signed.vsize()
+    }
+
+    fn xonly_from_scalar(seed: u8) -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let sk = bdk_wallet::bitcoin::secp256k1::SecretKey::from_slice(&[seed; 32])
+            .expect("valid scalar");
+        sk.x_only_public_key(&secp).0
+    }
+
+    /// Constructs an XOnlyPublicKey from a deterministic non-zero scalar, for tests that need
+    /// "some valid key, doesn't matter which".
+    pub(super) fn fake_anchor_key() -> XOnlyPublicKey {
+        let bytes = [3u8; 32];
+        let sk = bdk_wallet::bitcoin::secp256k1::SecretKey::from_slice(&bytes).unwrap();
+        let secp = Secp256k1::new();
+        let (xonly, _) = bdk_wallet::bitcoin::secp256k1::PublicKey::from_secret_key(&secp, &sk)
+            .x_only_public_key();
+        xonly
+    }
+
+    /// Builds a synthetic "parent" tx whose `vout = anchor_vout` is a keyed-Taproot anchor
+    /// at `anchor_value`. The rest of the outputs are dummies, so the parent looks like a
+    /// real bridge tx that has an anchor at a known position.
+    pub(super) fn parent_with_anchor(
+        anchor_internal_key: XOnlyPublicKey,
+        anchor_vout: u32,
+        anchor_value: Amount,
+    ) -> Transaction {
+        let secp = Secp256k1::new();
+        let anchor_addr = Address::p2tr(&secp, anchor_internal_key, None, Network::Regtest);
+        let anchor_txout = TxOut {
+            value: anchor_value,
+            script_pubkey: anchor_addr.script_pubkey(),
+        };
+        let mut outputs = Vec::new();
+        let dummy_addr = Address::p2tr(&secp, fake_anchor_key(), None, Network::Regtest);
+        for _ in 0..anchor_vout {
+            outputs.push(TxOut {
+                value: Amount::from_sat(10_000),
+                script_pubkey: dummy_addr.script_pubkey(),
+            });
+        }
+        outputs.push(anchor_txout);
+
+        Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                ..Default::default()
+            }],
+            output: outputs,
+        }
+    }
+
+    /// The payout-combined shape: the foreign "anchor" is a full-value payout output that
+    /// can pay for the child on its own. Pins the two properties the e2e caught a
+    /// regression in: (a) the no-funding arm is selected (single input — the payout), and
+    /// (b) the child pays the exact absolute package make-up fee, independent of the size
+    /// BDK realizes (a per-vB-rate regression pays less on the smaller-than-estimate child
+    /// and undershoots the package target).
+    #[tokio::test]
+    async fn payout_combined_child_pays_absolute_package_fee_without_funding_input() {
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let anchor_key = fake_anchor_key();
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(1_000_000));
+        let parent_fee = Amount::from_sat(500);
+        let target = FeeRate::from_sat_per_vb(20).unwrap();
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        // Pinned literal, NOT `child_vbytes_for(..)` — calling the implementation here would
+        // re-derive any error in the size predictor and the assertion below would hold for a
+        // wrong constant. 111 vB is the canonical 1-in/1-out Taproot key-path spend.
+        let expected_child_vb = 111;
+        assert_eq!(
+            child_vbytes_for(&anchor, 0),
+            expected_child_vb,
+            "size predictor drifted from the canonical 1-in/1-out key-path Taproot vsize"
+        );
+
+        let funded = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            parent_fee,
+            anchor.clone(),
+            target,
+            &[],
+        )
+        .expect("payout-combined child must build");
+
+        assert_eq!(
+            funded.psbt.unsigned_tx.input.len(),
+            1,
+            "payout value covers the fee: the child must spend only the payout output"
+        );
+        // Cross-check the pinned 111 against a real serialization of the built child.
+        assert_eq!(
+            signed_vsize_of(
+                &funded.psbt.unsigned_tx,
+                &anchor,
+                OutPoint {
+                    txid: parent.compute_txid(),
+                    vout: 0
+                },
+            ) as u64,
+            expected_child_vb,
+            "realized signed child vsize disagrees with the pinned constant"
+        );
+        let parent_vb = parent.vsize() as u64;
+        // Independent oracle: 20 sat/vB × package vbytes − parent fee, in plain integer
+        // math (exact for whole sat/vB targets).
+        let expected_fee = 20 * (parent_vb + expected_child_vb) - parent_fee.to_sat();
+        assert_eq!(
+            funded
+                .psbt
+                .fee()
+                .expect("witness_utxo on every input")
+                .to_sat(),
+            expected_fee,
+            "child must pay the exact absolute package make-up fee"
+        );
+    }
+
+    /// BDK's coin selection returns early — without ever consulting wallet UTXOs — once the
+    /// already-selected value exceeds the target fee. An anchor worth slightly more than the
+    /// fee therefore yields a below-dust drain output and the whole build fails with
+    /// `InsufficientFunds`, despite a well-funded wallet. `InferGeneralPayout` makes this
+    /// reachable in production: it uses BDK's own change output as the CPFP anchor, and change
+    /// values are arbitrary.
+    ///
+    /// Sweeps anchor values across the whole region where the shape flips, at several targets.
+    /// Low targets matter most: the gap between the no-funding and funded fees is
+    /// `(169 − 111) × target` sat, so below roughly 6 sat/vB it is narrower than the dust
+    /// threshold and the shape threshold alone cannot keep selection off the failing path.
+    #[tokio::test]
+    async fn anchor_value_near_the_fee_boundary_still_builds() {
+        let anchor_key = fake_anchor_key();
+        let parent_fee = Amount::from_sat(100);
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        let probe = parent_with_anchor(anchor_key, 0, Amount::from_sat(1));
+        let parent_vb = probe.vsize() as u64;
+
+        let cases: Vec<(u64, u64)> = [2u64, 3, 5, 10, 20]
+            .into_iter()
+            .flat_map(|target_sat_vb| {
+                let fee_at = |vb: u64| target_sat_vb * (parent_vb + vb) - parent_fee.to_sat();
+                let lo = fee_at(111).saturating_sub(400);
+                let hi = fee_at(169) + 700;
+                // Step 29 (coprime with the 330-sat dust threshold) so the sweep can't alias
+                // past a narrow failing band.
+                (lo..=hi)
+                    .step_by(29)
+                    .map(move |av| (target_sat_vb, av))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        for (target_sat_vb, anchor_value) in cases {
+            let target = FeeRate::from_sat_per_vb(target_sat_vb).unwrap();
+            let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+            let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(anchor_value));
+            let funded = build_cpfp_child_impl(
+                &mut wallet,
+                &parent,
+                parent_fee,
+                anchor.clone(),
+                target,
+                &[],
+            )
+            .unwrap_or_else(|e| {
+                panic!("target {target_sat_vb} sat/vB, anchor {anchor_value} sat: must build, got {e:?}")
+            });
+
+            // Whatever shape it picked, the drain output must be spendable.
+            let drain = funded
+                .psbt
+                .unsigned_tx
+                .output
+                .first()
+                .expect("child always has a drain output");
+            assert!(
+                drain.value.to_sat() >= DRAIN_DUST_SAT,
+                "anchor {anchor_value} sat: drain {} below dust",
+                drain.value
+            );
+        }
+    }
+
+    /// With an absolute fee, an under-estimated child size means the fixed fee is spread over
+    /// more vbytes and the package pays BELOW target. A script-path (`MultiAnchor`) child is
+    /// materially heavier than a key-path one — leaf script plus a control block that grows
+    /// with tree depth — so a size predictor blind to anchor shape underpays every contest and
+    /// bridge-proof-timeout bump. Assert the realized package rate holds at target for a range
+    /// of watchtower counts.
+    #[tokio::test]
+    async fn script_path_anchor_package_meets_target_at_every_tree_depth() {
+        let parent_fee = Amount::from_sat(500);
+        let target_sat_vb = 20;
+        let target = FeeRate::from_sat_per_vb(target_sat_vb).unwrap();
+
+        for n_watchtowers in [2usize, 3, 5, 9, 16] {
+            let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+            let (anchor, anchor_spk) = script_path_anchor(n_watchtowers);
+            let parent = parent_with_script_pubkey(anchor_spk, Amount::from_sat(330));
+
+            let funded = build_cpfp_child_impl(
+                &mut wallet,
+                &parent,
+                parent_fee,
+                anchor.clone(),
+                target,
+                &[],
+            )
+            .unwrap_or_else(|e| panic!("{n_watchtowers} watchtowers must build, got {e:?}"));
+
+            let child_fee = funded
+                .psbt
+                .fee()
+                .expect("witness_utxo on every input")
+                .to_sat();
+            // Independent oracle: attach witnesses of the real shape and let rust-bitcoin's
+            // own serializer measure the result. Deliberately NOT `child_vbytes_for` — using
+            // the predictor here would make the assertion hold for any predictor, including a
+            // wrong one.
+            let child_vb = signed_vsize_of(
+                &funded.psbt.unsigned_tx,
+                &anchor,
+                OutPoint {
+                    txid: parent.compute_txid(),
+                    vout: 0,
+                },
+            ) as u64;
+            let pkg_fee = child_fee + parent_fee.to_sat();
+            let pkg_vb = parent.vsize() as u64 + child_vb;
+
+            // Exact, not merely sufficient. The funding inputs are chosen before the fee is
+            // computed, so the shape that was priced is the shape that got built. The only
+            // slack allowed is integer truncation, worth well under one sat per package.
+            let required = target_sat_vb * pkg_vb;
+            assert!(
+                pkg_fee >= required,
+                "{n_watchtowers} watchtowers: package pays {pkg_fee} sat over {pkg_vb} vB \
+                 = {:.2} sat/vB, below the {target_sat_vb} sat/vB target",
+                pkg_fee as f64 / pkg_vb as f64
+            );
+            assert!(
+                pkg_fee <= required + 1,
+                "{n_watchtowers} watchtowers: package pays {pkg_fee} sat against {required} \
+                 required — more than rounding, so the priced shape is not the built shape"
+            );
+        }
+    }
+
+    /// A wallet of many tiny UTXOs must not produce an oversized child.
+    ///
+    /// BIP-431 caps a v3 transaction that has an unconfirmed v3 ancestor at 1000 vB, and this
+    /// child always has one. Without a bound the selection keeps adding inputs, because each
+    /// tiny UTXO contributes less than the fee that its own input costs. The result is a child
+    /// that no mempool accepts, rebuilt on every tick.
+    ///
+    /// Reporting that the wallet cannot fund the bump is the honest outcome here.
+    #[tokio::test]
+    async fn tiny_utxos_do_not_produce_an_oversized_child() {
+        use bdk_wallet::test_utils::receive_output_in_latest_block;
+
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let big = wallet
+            .list_unspent()
+            .next()
+            .expect("seeded wallet has one utxo")
+            .outpoint;
+        // Each of these is worth barely more than the 575 sat that one extra input costs at
+        // 10 sat/vB. Therefore the selection does reach the fee eventually, but only after
+        // about 24 inputs, by which point the child is roughly 1 491 vB.
+        for i in 0..40u64 {
+            receive_output_in_latest_block(&mut wallet, 650 + i);
+        }
+
+        let anchor_key = fake_anchor_key();
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+
+        let result = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(308),
+            anchor.clone(),
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            &[big],
+        );
+
+        match result {
+            Err(NativeGeneralError::InsufficientFunding { .. }) => {}
+            Err(other) => panic!("expected InsufficientFunding, got {other:?}"),
+            Ok(funded) => {
+                let vb = signed_vsize_of(
+                    &funded.psbt.unsigned_tx,
+                    &anchor,
+                    OutPoint {
+                        txid: parent.compute_txid(),
+                        vout: 0,
+                    },
+                );
+                panic!(
+                    "built a {vb} vB child from {} inputs; TRUC rejects anything over \
+                     {TRUC_CHILD_MAX_VBYTES} vB with an unconfirmed parent",
+                    funded.psbt.unsigned_tx.input.len()
+                );
+            }
+        }
+    }
+
+    /// The review that prompted deterministic selection noted that every existing test used a
+    /// single-UTXO wallet, so no child ever had more than one funding input, and the
+    /// multi-input fee math was never exercised. Build a wallet of small UTXOs so the child
+    /// must draw several, and assert the package still lands exactly on target.
+    #[tokio::test]
+    async fn multi_input_funding_pays_the_exact_package_fee() {
+        use bdk_wallet::test_utils::receive_output_in_latest_block;
+
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let big = wallet
+            .list_unspent()
+            .next()
+            .expect("seeded wallet has one utxo")
+            .outpoint;
+        // Distinct values, because two outputs of the same value to the same address produce
+        // the same txid and therefore collapse into a single UTXO.
+        for i in 0..8u64 {
+            receive_output_in_latest_block(&mut wallet, 5_000 + i * 137);
+        }
+
+        let anchor_key = fake_anchor_key();
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+        let parent_fee = Amount::from_sat(308);
+        let target_sat_vb = 50;
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+
+        // Exclude the single large seeded UTXO, forcing the builder onto the small ones.
+        let funded = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            parent_fee,
+            anchor.clone(),
+            FeeRate::from_sat_per_vb(target_sat_vb).unwrap(),
+            &[big],
+        )
+        .expect("multi-input child must build");
+
+        let n_funding = funded.psbt.unsigned_tx.input.len() - 1;
+        assert!(
+            n_funding >= 2,
+            "test is pointless unless several funding inputs are drawn; got {n_funding}"
+        );
+
+        let child_fee = funded
+            .psbt
+            .fee()
+            .expect("witness_utxo on every input")
+            .to_sat();
+        let child_vb = signed_vsize_of(
+            &funded.psbt.unsigned_tx,
+            &anchor,
+            OutPoint {
+                txid: parent.compute_txid(),
+                vout: 0,
+            },
+        ) as u64;
+        let pkg_fee = child_fee + parent_fee.to_sat();
+        let pkg_vb = parent.vsize() as u64 + child_vb;
+        let required = target_sat_vb * pkg_vb;
+
+        assert!(
+            pkg_fee >= required && pkg_fee <= required + 1,
+            "{n_funding} funding inputs: package pays {pkg_fee} sat over {pkg_vb} vB, \
+             required {required} sat at {target_sat_vb} sat/vB"
+        );
+    }
+
+    #[tokio::test]
+    async fn happy_path_emits_psbt_with_anchor_and_funding() {
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let anchor_key = fake_anchor_key();
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+
+        let funded = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            &[],
+        )
+        .expect("happy-path build_cpfp_child must succeed");
+
+        let anchor_outpoint = OutPoint {
+            txid: parent.compute_txid(),
+            vout: 0,
+        };
+        let psbt = &funded.psbt;
+
+        // Anchor must be present as an input with witness_utxo + tap_internal_key, unsigned.
+        let anchor_input_idx = psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .position(|i| i.previous_output == anchor_outpoint)
+            .expect("anchor outpoint must appear as an input");
+        let anchor_psbt_input = &psbt.inputs[anchor_input_idx];
+        assert!(anchor_psbt_input.witness_utxo.is_some());
+        assert_eq!(anchor_psbt_input.tap_internal_key, Some(anchor_key));
+        assert!(
+            anchor_psbt_input.tap_key_sig.is_none(),
+            "anchor must not be signed by the backend"
+        );
+
+        // At least one funding input must exist (the wallet's contribution).
+        assert!(psbt.unsigned_tx.input.len() >= 2);
+
+        // `spent()` (derived from psbt.unsigned_tx) includes EVERY input — including the
+        // anchor. The caller is responsible for filtering anchor outpoints out of the lease
+        // set when bookkeeping is anchor-aware (the OperatorWallet composer does that via
+        // its release/lease cycle around build_cpfp_child).
+        let spent = funded.spent();
+        assert!(
+            spent.contains(&anchor_outpoint),
+            "spent() reports every input including the foreign anchor"
+        );
+        assert!(
+            spent.iter().any(|op| *op != anchor_outpoint),
+            "must report at least one wallet input as spent"
+        );
+
+        // The child must be v3.
+        assert_eq!(psbt.unsigned_tx.version, Version(3));
+    }
+
+    #[tokio::test]
+    async fn anchor_vout_out_of_range_errors() {
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let anchor_key = fake_anchor_key();
+        // Parent has 1 output (vout 0). Asking for anchor at vout 5 is out of range.
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+        let anchor = AnchorInfo::KeyPath {
+            vout: 5,
+            internal_key: anchor_key,
+        };
+
+        let err = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor,
+            FeeRate::from_sat_per_vb(10).unwrap(),
+            &[],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            NativeGeneralError::AnchorVoutOutOfRange { vout: 5, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn anchor_at_non_zero_vout_resolves_correctly() {
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let anchor_key = fake_anchor_key();
+        let parent = parent_with_anchor(anchor_key, 2, Amount::from_sat(330));
+        let anchor = AnchorInfo::KeyPath {
+            vout: 2,
+            internal_key: anchor_key,
+        };
+
+        let funded = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor,
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            &[],
+        )
+        .expect("non-zero-vout anchor must work");
+
+        let anchor_outpoint = OutPoint {
+            txid: parent.compute_txid(),
+            vout: 2,
+        };
+        assert!(funded
+            .psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .any(|i| i.previous_output == anchor_outpoint));
+    }
+}
+
+#[cfg(test)]
+mod determinism {
+    use bdk_wallet::{
+        bitcoin::{Amount, FeeRate},
+        test_utils::{
+            get_funded_wallet_single, get_test_tr_single_sig, receive_output_in_latest_block,
+        },
+    };
+
+    use super::{build_cpfp_child_impl, tests::*};
+    use crate::general::AnchorInfo;
+
+    /// The same request must always produce the same child.
+    ///
+    /// This is not cosmetic. A reactive bump rebuilds the child at an unchanged fee target, and
+    /// relies on that rebuild being byte-identical: the resubmission then deduplicates against
+    /// the child already in the mempool. A child whose txid moves between rebuilds is instead
+    /// treated as an RBF replacement and rejected by the incremental-fee rule.
+    ///
+    /// Two sources of instability were found here and both are now closed. Coin selection ran
+    /// under a fresh `thread_rng` per build, which an earlier revision inherited from letting
+    /// BDK select. Input order also came from BDK's iteration over its selected set, which is
+    /// unstable between calls even when the set is identical.
+    #[tokio::test]
+    async fn repeated_builds_produce_an_identical_child() {
+        let anchor_key = fake_anchor_key();
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+
+        let mut seen = std::collections::BTreeSet::new();
+        for _ in 0..40 {
+            let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+            for i in 0..6u64 {
+                receive_output_in_latest_block(&mut wallet, 5_030 + i * 91);
+            }
+            let funded = build_cpfp_child_impl(
+                &mut wallet,
+                &parent,
+                Amount::from_sat(308),
+                anchor.clone(),
+                FeeRate::from_sat_per_vb(20).unwrap(),
+                &[],
+            )
+            .expect("every build must succeed, not a random subset of them");
+            seen.insert(funded.psbt.unsigned_tx.compute_txid());
+        }
+
+        assert_eq!(
+            seen.len(),
+            1,
+            "40 identical requests produced {} different children",
+            seen.len()
+        );
+    }
+
+    /// A new block must not change the child.
+    ///
+    /// BDK sets nLockTime to the chain tip by default, as an anti-fee-sniping measure, and the
+    /// funding inputs carry a sequence that enforces it. That makes the locktime a live
+    /// consensus field which moves with every block, so the txid moves too.
+    ///
+    /// A new block is the most common reason to rebuild the child. If the txid moved on every
+    /// block, then the most common reactive path would always produce a conflicting
+    /// replacement at an unchanged fee rate, which the incremental-fee rule rejects.
+    #[tokio::test]
+    async fn a_new_block_does_not_change_the_child() {
+        use bdk_wallet::{
+            bitcoin::{hashes::Hash, BlockHash},
+            chain::BlockId,
+            test_utils::insert_checkpoint,
+        };
+
+        let anchor_key = fake_anchor_key();
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+
+        let build = |wallet: &mut bdk_wallet::Wallet| {
+            build_cpfp_child_impl(
+                wallet,
+                &parent,
+                Amount::from_sat(308),
+                anchor.clone(),
+                FeeRate::from_sat_per_vb(20).unwrap(),
+                &[],
+            )
+            .expect("child must build")
+            .psbt
+            .unsigned_tx
+            .compute_txid()
+        };
+
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let before = build(&mut wallet);
+
+        let tip = wallet.latest_checkpoint().height();
+        insert_checkpoint(
+            &mut wallet,
+            BlockId {
+                height: tip + 1,
+                hash: BlockHash::all_zeros(),
+            },
+        );
+        let after = build(&mut wallet);
+
+        assert_eq!(
+            before, after,
+            "the child's txid changed when a block arrived, so a same-rate rebuild will \
+             conflict with the child already in the mempool instead of deduplicating"
+        );
+    }
 }

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -21,7 +21,7 @@ use tracing::info;
 
 use crate::{
     general::{
-        local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo,
+        local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, ReplacedChild, UtxoInfo,
         TAPROOT_KEY_PATH_SAT_WEIGHT,
     },
     sync::{Backend, SyncError},
@@ -145,6 +145,7 @@ impl GeneralWallet for NativeGeneralWallet {
         anchor: AnchorInfo,
         target_pkg_fee_rate: FeeRate,
         exclude: &[OutPoint],
+        replaced: ReplacedChild<'_>,
     ) -> Result<FundedPsbt, Self::Error> {
         build_cpfp_child_impl(
             &mut self.wallet,
@@ -153,6 +154,7 @@ impl GeneralWallet for NativeGeneralWallet {
             anchor,
             target_pkg_fee_rate,
             exclude,
+            replaced,
         )
     }
 }
@@ -188,6 +190,7 @@ fn build_cpfp_child_impl(
     anchor: AnchorInfo,
     target_pkg_fee_rate: FeeRate,
     exclude: &[OutPoint],
+    replaced: ReplacedChild<'_>,
 ) -> Result<FundedPsbt, NativeGeneralError> {
     let anchor_vout = anchor.vout();
     let anchor_outpoint = OutPoint {
@@ -219,10 +222,13 @@ fn build_cpfp_child_impl(
         .expect("tx.vsize() fits in u64 on every supported target");
     let fee_for = |child_vbytes: u64| -> u64 {
         let pkg_vbytes = parent_vbytes.saturating_add(child_vbytes);
+        // Round up. Truncating pays up to 1 sat under the target whenever the rate has
+        // sat/kwu granularity (fractional sat/vB — the common case from `estimatesmartfee`),
+        // and an underpaid package sits exactly at the node's acceptance boundary.
         let target_pkg_fee_sat = target_pkg_fee_rate
             .to_sat_per_kwu()
             .saturating_mul(pkg_vbytes.saturating_mul(4))
-            / 1000;
+            .div_ceil(1000);
         target_pkg_fee_sat.saturating_sub(parent_fee.to_sat())
     };
 
@@ -256,7 +262,23 @@ fn build_cpfp_child_impl(
         anchor_value_sat,
         &anchor,
         &fee_for,
+        replaced,
     )?;
+
+    // Resolve the witness data of any replaced funding inputs up front, before the builder
+    // takes its mutable borrow of the wallet. Once the wallet has observed the prior child
+    // (any sync between two bumps applies the mempool), these outpoints read as spent, so
+    // `add_utxo` refuses them and they must enter as foreign inputs instead — with a
+    // `witness_utxo`, which is all the downstream signer needs.
+    let replaced_txouts: Vec<(OutPoint, TxOut)> = replaced
+        .inputs
+        .iter()
+        .filter_map(|&outpoint| {
+            let wtx = wallet.get_tx(outpoint.txid)?;
+            let txout = wtx.tx_node.tx.output.get(outpoint.vout as usize)?.clone();
+            Some((outpoint, txout))
+        })
+        .collect();
 
     // Build the foreign UTXO PSBT input for the anchor. No signature — the caller signs
     // downstream, and for the script-path case it also assembles the final witness, so all
@@ -315,11 +337,33 @@ fn build_cpfp_child_impl(
     });
     // Funding inputs first, then the anchor. `add_foreign_utxo` rejects an outpoint that is
     // already present as a local input, so this order turns a duplicate into a loud error.
-    // The reverse order silently overwrites the foreign entry, and the anchor would lose the
-    // spend data that the downstream signer needs.
-    tx_builder
-        .add_utxos(&selection.funding)
-        .map_err(|e| NativeGeneralError::FundingUtxo(format!("{e:?}")))?;
+    // The reverse order overwrites the foreign entry without an error, and the anchor then
+    // loses the spend data that the downstream signer needs.
+    //
+    // A funding input that the wallet counts as spent enters as a foreign input. Only a
+    // `replacing` outpoint can be in that state: the prior child spends it in the wallet's
+    // view. The replacement child conflicts with the prior child by construction (both
+    // spend the anchor), so the re-spend is the intended RBF.
+    for outpoint in &selection.funding {
+        match tx_builder.add_utxo(*outpoint) {
+            Ok(_) => {}
+            Err(e) => {
+                let Some((_, txout)) = replaced_txouts.iter().find(|(op, _)| op == outpoint) else {
+                    return Err(NativeGeneralError::FundingUtxo(format!("{e:?}")));
+                };
+                tx_builder
+                    .add_foreign_utxo(
+                        *outpoint,
+                        PsbtInput {
+                            witness_utxo: Some(txout.clone()),
+                            ..Default::default()
+                        },
+                        bdk_wallet::bitcoin::Weight::from_wu(TAPROOT_KEY_PATH_SAT_WEIGHT as u64),
+                    )
+                    .map_err(|e| NativeGeneralError::FundingUtxo(format!("{e:?}")))?;
+            }
+        }
+    }
     tx_builder
         .add_foreign_utxo(
             anchor_outpoint,
@@ -377,13 +421,22 @@ fn select_funding(
     anchor_value_sat: u64,
     anchor: &AnchorInfo,
     fee_for: &impl Fn(u64) -> u64,
+    replaced: ReplacedChild<'_>,
 ) -> Result<FundingSelection, NativeGeneralError> {
     // The fee must also keep the child relayable on its own: at least 1 sat/vB over its own
     // vbytes. That is Core's default `minrelaytxfee`, a generic policy floor rather than a
     // BIP-431 rule. TRUC contributes topology limits and sibling eviction, not this floor.
     let fee_at = |n_funding: u64| -> u64 {
         let vbytes = child_vbytes_for(anchor, n_funding);
-        fee_for(vbytes).max(vbytes)
+        // Three floors apply to the child fee. The target-rate fee prices the package. The
+        // vbytes floor keeps the child relayable on its own (1 sat/vB, Core's default
+        // `minrelaytxfee`). The replacement floor is BIP-125 rule 4: the new child must pay
+        // the replaced child's fee plus the incremental relay fee over its own size, or
+        // bitcoind rejects the replacement.
+        let rbf_floor = replaced
+            .fee
+            .map_or(0, |prior| prior.to_sat().saturating_add(vbytes));
+        fee_for(vbytes).max(vbytes).max(rbf_floor)
     };
 
     // Does the anchor alone cover its own fee and leave a spendable drain output?
@@ -411,6 +464,48 @@ fn select_funding(
         })
         .map(|utxo| (utxo.outpoint, utxo.txout.value.to_sat()))
         .collect();
+    // Add the prior child's funding inputs to the candidates explicitly. They do not come
+    // through `list_unspent`: a sync between two bumps applies the mempool, and BDK then
+    // counts them as spent by the prior child. They are still correct funding for the
+    // replacement, because the new child conflicts with the prior one by construction
+    // (both spend the anchor). Without this step, each rebuild after a sync consumes a
+    // fresh funding set. A wallet with one suitable UTXO then deadlocks: the UTXO frees
+    // only when a conflicting child replaces the prior one, and no such child can be
+    // built without the UTXO.
+    //
+    // Each outpoint still has to satisfy what `is_spendable_funding` demands of ordinary
+    // candidates: known to the wallet, confirmed, and not an immature coinbase. Its own
+    // confirmation status comes from the funding transaction, not from the (unconfirmed)
+    // prior child spending it.
+    //
+    // Known gap, accepted: this checks the funding tx's confirmation, not whether some
+    // *other confirmed* tx already spent the outpoint. Such an outpoint produces a child
+    // that Core rejects with missing-inputs, retried on the next trigger. Reaching that
+    // state requires the lease bookkeeping to have failed first — normally a confirmed
+    // spend of our funding means our child confirmed, which means the parent confirmed
+    // and the driver dropped the entry.
+    for &outpoint in replaced.inputs {
+        if outpoint == anchor_outpoint
+            || exclude.contains(&outpoint)
+            || candidates.iter().any(|(op, _)| *op == outpoint)
+        {
+            continue;
+        }
+        let Some(wtx) = wallet.get_tx(outpoint.txid) else {
+            continue;
+        };
+        let Some(confirmation_height) = wtx.chain_position.confirmation_height_upper_bound() else {
+            continue;
+        };
+        let tx = &wtx.tx_node.tx;
+        if tx.is_coinbase() && tip.saturating_sub(confirmation_height) + 1 < COINBASE_MATURITY {
+            continue;
+        }
+        let Some(txout) = tx.output.get(outpoint.vout as usize) else {
+            continue;
+        };
+        candidates.push((outpoint, txout.value.to_sat()));
+    }
     // Largest first, then by outpoint so the choice is deterministic across calls. Determinism
     // matters for RBF: an unchanged fee target must rebuild the same child, not a random one.
     // Largest first also keeps the input count down, which matters for the size limit below.
@@ -682,6 +777,157 @@ pub(super) mod tests {
         }
     }
 
+    /// A replacement child must pay at least the replaced child's fee plus 1 sat/vB over
+    /// its own size (BIP-125 rule 4). At an unchanged target the rate-based fee equals the
+    /// prior fee, which rule 4 rejects. With `prior_child_fee` set, the builder lifts the
+    /// fee to the floor, and the increment equals the child's vbytes.
+    #[tokio::test]
+    async fn a_replacement_child_pays_the_rbf_floor() {
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let anchor_key = fake_anchor_key();
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        let target = FeeRate::from_sat_per_vb(5).unwrap();
+
+        let first = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor.clone(),
+            target,
+            &[],
+            ReplacedChild::default(),
+        )
+        .expect("first child must build");
+        let first_fee = first.psbt.fee().expect("witness_utxo on every input");
+        let child_vbytes = child_vbytes_for(&anchor, first.psbt.unsigned_tx.input.len() as u64 - 1);
+
+        let replacement = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor,
+            target,
+            &[],
+            ReplacedChild {
+                inputs: &[],
+                fee: Some(first_fee),
+            },
+        )
+        .expect("replacement must build");
+        let replacement_fee = replacement.psbt.fee().expect("witness_utxo on every input");
+        assert_eq!(
+            replacement_fee,
+            first_fee + Amount::from_sat(child_vbytes),
+            "replacement fee must sit exactly on the BIP-125 floor"
+        );
+    }
+
+    /// A rebuild after the wallet has observed the prior child must be able to re-spend
+    /// that child's own funding inputs.
+    ///
+    /// Production syncs apply the mempool (`apply_unconfirmed_txs`), after which BDK counts
+    /// the prior child's funding as spent: `list_unspent` stops offering it and `add_utxo`
+    /// refuses it. The replacement child conflicts with the prior one by construction (both
+    /// spend the anchor), so re-spending that funding is plain RBF — without the `replacing`
+    /// override, every rebuild-after-sync burns a fresh UTXO, and a wallet whose only
+    /// suitable UTXO is tied up in the prior child deadlocks entirely. This test pins both
+    /// halves: the deadlock exists without `replacing`, and `replacing` resolves it onto
+    /// the exact same funding set.
+    #[tokio::test]
+    async fn a_rebuild_after_sync_reuses_the_prior_childs_funding() {
+        let (mut wallet, _) = get_funded_wallet_single(get_test_tr_single_sig());
+        let anchor_key = fake_anchor_key();
+        let parent = parent_with_anchor(anchor_key, 0, Amount::from_sat(330));
+        let anchor = AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: anchor_key,
+        };
+        let anchor_outpoint = OutPoint {
+            txid: parent.compute_txid(),
+            vout: 0,
+        };
+
+        let first = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor.clone(),
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            &[],
+            ReplacedChild::default(),
+        )
+        .expect("first child must build");
+        let prior_funding: Vec<OutPoint> = first
+            .psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|i| i.previous_output)
+            .filter(|op| *op != anchor_outpoint)
+            .collect();
+        assert!(
+            !prior_funding.is_empty(),
+            "test needs a child that draws wallet funding"
+        );
+
+        // The sync between two bumps: the wallet observes its own unconfirmed child.
+        wallet.apply_unconfirmed_txs(vec![(first.psbt.unsigned_tx.clone(), 100u64)]);
+
+        // Without the override the funded wallet's only UTXO is gone and the rebuild
+        // deadlocks. This is the bug, pinned.
+        let starved = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor.clone(),
+            FeeRate::from_sat_per_vb(8).unwrap(),
+            &[],
+            ReplacedChild::default(),
+        );
+        assert!(
+            matches!(starved, Err(NativeGeneralError::InsufficientFunding { .. })),
+            "without `replacing` the synced wallet must starve, got {starved:?}"
+        );
+
+        // With the override the rebuild re-spends exactly the prior funding set.
+        let rebuilt = build_cpfp_child_impl(
+            &mut wallet,
+            &parent,
+            Amount::from_sat(220),
+            anchor,
+            FeeRate::from_sat_per_vb(8).unwrap(),
+            &[],
+            ReplacedChild {
+                inputs: &prior_funding,
+                fee: None,
+            },
+        )
+        .expect("rebuild with `replacing` must succeed");
+        let rebuilt_funding: Vec<OutPoint> = rebuilt
+            .psbt
+            .unsigned_tx
+            .input
+            .iter()
+            .map(|i| i.previous_output)
+            .filter(|op| *op != anchor_outpoint)
+            .collect();
+        assert_eq!(
+            rebuilt_funding, prior_funding,
+            "the replacement must fund from the prior child's own inputs"
+        );
+        // The foreign-input route must still carry what the downstream signer needs.
+        for (i, input) in rebuilt.psbt.inputs.iter().enumerate() {
+            assert!(
+                input.witness_utxo.is_some(),
+                "psbt input {i} lacks witness_utxo"
+            );
+        }
+    }
+
     /// The payout-combined shape: the foreign "anchor" is a full-value payout output that
     /// can pay for the child on its own. Pins the two properties the e2e caught a
     /// regression in: (a) the no-funding arm is selected (single input — the payout), and
@@ -716,6 +962,7 @@ pub(super) mod tests {
             anchor.clone(),
             target,
             &[],
+            ReplacedChild::default(),
         )
         .expect("payout-combined child must build");
 
@@ -800,6 +1047,7 @@ pub(super) mod tests {
                 anchor.clone(),
                 target,
                 &[],
+                ReplacedChild::default(),
             )
             .unwrap_or_else(|e| {
                 panic!("target {target_sat_vb} sat/vB, anchor {anchor_value} sat: must build, got {e:?}")
@@ -844,6 +1092,7 @@ pub(super) mod tests {
                 anchor.clone(),
                 target,
                 &[],
+                ReplacedChild::default(),
             )
             .unwrap_or_else(|e| panic!("{n_watchtowers} watchtowers must build, got {e:?}"));
 
@@ -924,6 +1173,7 @@ pub(super) mod tests {
             anchor.clone(),
             FeeRate::from_sat_per_vb(10).unwrap(),
             &[big],
+            ReplacedChild::default(),
         );
 
         match result {
@@ -984,6 +1234,7 @@ pub(super) mod tests {
             anchor.clone(),
             FeeRate::from_sat_per_vb(target_sat_vb).unwrap(),
             &[big],
+            ReplacedChild::default(),
         )
         .expect("multi-input child must build");
 
@@ -1034,6 +1285,7 @@ pub(super) mod tests {
             anchor,
             FeeRate::from_sat_per_vb(10).unwrap(),
             &[],
+            ReplacedChild::default(),
         )
         .expect("happy-path build_cpfp_child must succeed");
 
@@ -1097,6 +1349,7 @@ pub(super) mod tests {
             anchor,
             FeeRate::from_sat_per_vb(10).unwrap(),
             &[],
+            ReplacedChild::default(),
         )
         .unwrap_err();
         assert!(matches!(
@@ -1122,6 +1375,7 @@ pub(super) mod tests {
             anchor,
             FeeRate::from_sat_per_vb(5).unwrap(),
             &[],
+            ReplacedChild::default(),
         )
         .expect("non-zero-vout anchor must work");
 
@@ -1148,7 +1402,7 @@ mod determinism {
     };
 
     use super::{build_cpfp_child_impl, tests::*};
-    use crate::general::AnchorInfo;
+    use crate::general::{AnchorInfo, ReplacedChild};
 
     /// The same request must always produce the same child.
     ///
@@ -1183,6 +1437,7 @@ mod determinism {
                 anchor.clone(),
                 FeeRate::from_sat_per_vb(20).unwrap(),
                 &[],
+                ReplacedChild::default(),
             )
             .expect("every build must succeed, not a random subset of them");
             seen.insert(funded.psbt.unsigned_tx.compute_txid());
@@ -1228,6 +1483,7 @@ mod determinism {
                 anchor.clone(),
                 FeeRate::from_sat_per_vb(20).unwrap(),
                 &[],
+                ReplacedChild::default(),
             )
             .expect("child must build")
             .psbt

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -5,7 +5,10 @@
 //! returns carries `witness_utxo` and `tap_internal_key` on its inputs but no signatures —
 //! the caller signs downstream.
 
-use std::collections::BTreeSet;
+use std::{
+    collections::BTreeSet,
+    sync::{Mutex, MutexGuard},
+};
 
 use bdk_wallet::{
     bitcoin::{
@@ -32,8 +35,24 @@ use crate::{
 pub struct NativeGeneralWallet {
     /// Cached at construction; the BDK descriptor doesn't change at runtime.
     script_pubkey: ScriptBuf,
-    wallet: Wallet,
+    /// The BDK wallet.
+    ///
+    /// BDK builds a transaction through `&mut Wallet`, and [`GeneralWallet`] builds through
+    /// `&self`. The lock closes that gap. Every critical section here is synchronous, so the
+    /// lock is never held across an await point.
+    wallet: Mutex<Wallet>,
     sync_backend: Backend,
+}
+
+/// Locks the BDK wallet and recovers from a poisoned lock.
+///
+/// A poisoned lock means a panic happened inside one of the critical sections of this file.
+/// Each one is a single BDK call, so the wallet state stays consistent, and one panic must
+/// not stop every later transaction that the operator builds.
+fn lock_wallet(wallet: &Mutex<Wallet>) -> MutexGuard<'_, Wallet> {
+    wallet
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 impl NativeGeneralWallet {
@@ -49,7 +68,7 @@ impl NativeGeneralWallet {
         let script_pubkey = address.script_pubkey();
         Self {
             script_pubkey,
-            wallet,
+            wallet: Mutex::new(wallet),
             sync_backend,
         }
     }
@@ -103,8 +122,14 @@ impl GeneralWallet for NativeGeneralWallet {
     type Error = NativeGeneralError;
 
     async fn sync(&mut self) -> Result<(), Self::Error> {
+        // `get_mut` and not a lock: `&mut self` already proves that nothing else holds the
+        // wallet, so the sync can await without a guard alive across it.
         self.sync_backend
-            .sync_wallet(&mut self.wallet)
+            .sync_wallet(
+                self.wallet
+                    .get_mut()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+            )
             .await
             .map_err(NativeGeneralError::Sync)
     }
@@ -114,22 +139,23 @@ impl GeneralWallet for NativeGeneralWallet {
     }
 
     fn list_utxos(&self) -> Vec<UtxoInfo> {
-        let tip = self.wallet.latest_checkpoint().height();
-        self.wallet
+        let wallet = lock_wallet(&self.wallet);
+        let tip = wallet.latest_checkpoint().height();
+        wallet
             .list_unspent()
             .map(|lo| local_output_to_utxo_info(&lo, tip))
             .collect()
     }
 
     async fn fund_v3_transaction(
-        &mut self,
+        &self,
         outputs: Vec<TxOut>,
         explicit_inputs: Option<&[OutPoint]>,
         fee_rate: FeeRate,
         exclude: &[OutPoint],
     ) -> Result<FundedPsbt, Self::Error> {
         let psbt = build_v3_psbt(
-            &mut self.wallet,
+            &mut lock_wallet(&self.wallet),
             &outputs,
             explicit_inputs,
             fee_rate,
@@ -139,7 +165,7 @@ impl GeneralWallet for NativeGeneralWallet {
     }
 
     async fn build_cpfp_child(
-        &mut self,
+        &self,
         parent: &Transaction,
         parent_fee: Amount,
         anchor: AnchorInfo,
@@ -148,7 +174,7 @@ impl GeneralWallet for NativeGeneralWallet {
         replaced: ReplacedChild<'_>,
     ) -> Result<FundedPsbt, Self::Error> {
         build_cpfp_child_impl(
-            &mut self.wallet,
+            &mut lock_wallet(&self.wallet),
             parent,
             parent_fee,
             anchor,

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -594,10 +594,7 @@ fn is_spendable_funding(wallet: &Wallet, utxo: &bdk_wallet::LocalOutput, tip: u3
     let is_coinbase = wallet
         .get_tx(utxo.outpoint.txid)
         .is_some_and(|tx| tx.tx_node.tx.is_coinbase());
-    if is_coinbase && tip.saturating_sub(confirmation_height) + 1 < COINBASE_MATURITY {
-        return false;
-    }
-    true
+    !(is_coinbase && tip.saturating_sub(confirmation_height) + 1 < COINBASE_MATURITY)
 }
 
 /// Dust threshold for the child's P2TR drain output. Below this the output is unspendable and

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -118,6 +118,24 @@ pub enum NativeGeneralError {
     },
 }
 
+impl crate::ErrorPermanence for NativeGeneralError {
+    fn is_permanent(&self) -> bool {
+        match self {
+            // The output count of a signed parent never changes, and a script that BDK cannot
+            // read as a foreign UTXO stays unreadable. Every later attempt for this parent
+            // fails at the same step.
+            Self::AnchorVoutOutOfRange { .. } | Self::AnchorForeignUtxo(_) => true,
+            // Funds arrive, the chain moves, and selection picks a different set. Each of
+            // these passes on a later attempt.
+            Self::CreateTx(_)
+            | Self::Sync(_)
+            | Self::FundingUtxo(_)
+            | Self::UnexpectedInputCount { .. }
+            | Self::InsufficientFunding { .. } => false,
+        }
+    }
+}
+
 impl GeneralWallet for NativeGeneralWallet {
     type Error = NativeGeneralError;
 

--- a/crates/operator-wallet/src/leases.rs
+++ b/crates/operator-wallet/src/leases.rs
@@ -1,0 +1,545 @@
+//! Lease bookkeeping for wallet outpoints.
+//!
+//! A lease holds outpoints and keeps them out of input selection. Two duties that run at the
+//! same time therefore cannot spend one UTXO twice.
+//!
+//! [`Lease`] releases its outpoints when it drops. A duty keeps the value for as long as the
+//! outpoints must stay held. A duty that fails at any step drops the lease on the error path,
+//! so no error path needs an explicit release call, and a new early return cannot strand a
+//! UTXO.
+//!
+//! A duty that writes its outpoints to durable storage, or that broadcasts the spend, calls
+//! [`Lease::commit`] instead. The outpoints then stay held after the value drops.
+//! [`LeaseSet::release_committed`] is the only way to free them again, and the wallet also
+//! frees them when a sync shows the UTXO is gone.
+//!
+//! # Overlapping leases
+//!
+//! [`LeaseSet`] records the leases that hold each outpoint, not one flat set of outpoints.
+//! Two leases can hold the same outpoint at the same time. This state occurs while the driver
+//! builds a replacement CPFP child: the new lease takes an input before the driver drops the
+//! lease of the child that the new child replaces. The outpoint stays held until both leases
+//! are gone. A flat set frees the outpoint when the first of the two leases drops, and a
+//! concurrent duty can then spend an input of a live child.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
+};
+
+use bdk_wallet::bitcoin::{OutPoint, Txid};
+use tracing::{debug, warn};
+
+/// Identifies one lease inside a [`LeaseSet`].
+///
+/// Private to this module. Callers hold a [`Lease`] value, which is the only handle they
+/// need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct LeaseId(u64);
+
+/// The duty that holds a lease.
+///
+/// The wallet records this value against each live lease. A lease that outlives its duty then
+/// names its holder in the log line that reports the release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeaseOwner {
+    /// Inputs of a transaction that refills the pool of claim-funding UTXOs.
+    ClaimFundingRefill,
+    /// One reserved-wallet UTXO that funds the claim of one graph.
+    ClaimFunding,
+    /// Inputs of the stake funding reservation.
+    StakeFunding,
+    /// Inputs of the withdrawal fulfillment transaction of one deposit.
+    WithdrawalFulfillment,
+    /// The general-wallet UTXO that pays for an unstaking burn transaction.
+    UnstakingBurn,
+    /// Funding inputs of the CPFP child of one parent transaction.
+    CpfpChild {
+        /// Txid of the parent that the child pays for.
+        parent: Txid,
+    },
+    /// Read from durable storage at startup. The duty that took the original lease is not
+    /// recorded, because durable storage keeps outpoints and not owners.
+    Rehydrated,
+}
+
+/// State of one live lease.
+#[derive(Debug)]
+struct LeaseRecord {
+    owner: LeaseOwner,
+    outpoints: BTreeSet<OutPoint>,
+    /// True after [`Lease::commit`]. A committed record has no live [`Lease`] value behind
+    /// it, so only [`LeaseSet::release_committed`] and the sync prune can remove it.
+    committed: bool,
+}
+
+/// The live leases and the outpoints that they hold.
+#[derive(Debug, Default)]
+struct Holdings {
+    /// Owner and outpoints of each live lease.
+    leases: BTreeMap<LeaseId, LeaseRecord>,
+    /// The leases that hold each outpoint. An outpoint is unavailable for selection while
+    /// its entry exists.
+    holders: BTreeMap<OutPoint, BTreeSet<LeaseId>>,
+}
+
+impl Holdings {
+    /// Removes `outpoints` from every lease that holds them and that `predicate` accepts.
+    /// Drops a lease record that keeps no outpoints after the removal.
+    fn remove_outpoints(
+        &mut self,
+        outpoints: impl IntoIterator<Item = OutPoint>,
+        predicate: impl Fn(&LeaseRecord) -> bool,
+    ) {
+        for outpoint in outpoints {
+            let Some(holders) = self.holders.get(&outpoint) else {
+                continue;
+            };
+            let affected: Vec<LeaseId> = holders
+                .iter()
+                .copied()
+                .filter(|id| self.leases.get(id).is_some_and(&predicate))
+                .collect();
+            for id in affected {
+                self.detach(id, outpoint);
+            }
+        }
+    }
+
+    /// Removes one outpoint from one lease, and drops either side that becomes empty.
+    fn detach(&mut self, id: LeaseId, outpoint: OutPoint) {
+        if let Some(record) = self.leases.get_mut(&id) {
+            record.outpoints.remove(&outpoint);
+            if record.outpoints.is_empty() {
+                self.leases.remove(&id);
+            }
+        }
+        if let Some(holders) = self.holders.get_mut(&outpoint) {
+            holders.remove(&id);
+            if holders.is_empty() {
+                self.holders.remove(&outpoint);
+            }
+        }
+    }
+
+    /// Removes one lease and every outpoint that only it holds.
+    fn remove_lease(&mut self, id: LeaseId) {
+        let Some(record) = self.leases.remove(&id) else {
+            return;
+        };
+        for outpoint in record.outpoints {
+            let Some(holders) = self.holders.get_mut(&outpoint) else {
+                continue;
+            };
+            holders.remove(&id);
+            if holders.is_empty() {
+                self.holders.remove(&outpoint);
+            }
+        }
+    }
+
+    /// The owners of every lease that holds `outpoint`.
+    fn owners_of(&self, outpoint: OutPoint) -> Vec<LeaseOwner> {
+        self.holders
+            .get(&outpoint)
+            .into_iter()
+            .flatten()
+            .filter_map(|id| self.leases.get(id).map(|record| record.owner))
+            .collect()
+    }
+
+    /// Whether a committed lease holds `outpoint`.
+    fn committed_holds(&self, outpoint: OutPoint) -> bool {
+        self.holders.get(&outpoint).is_some_and(|holders| {
+            holders
+                .iter()
+                .any(|id| self.leases.get(id).is_some_and(|record| record.committed))
+        })
+    }
+}
+
+/// Shared record of the outpoints that duties hold.
+///
+/// The wallet keeps one of these behind an [`Arc`] and hands out [`Lease`] values against it.
+/// The lock inside is a [`std::sync::Mutex`] and not a `tokio` mutex, because [`Lease`]
+/// releases its outpoints in [`Drop`], which cannot await. No code path holds the lock across
+/// an await point.
+#[derive(Debug, Default)]
+pub struct LeaseSet {
+    holdings: Mutex<Holdings>,
+    next_id: AtomicU64,
+}
+
+impl LeaseSet {
+    /// Constructs a lease set that already holds `outpoints` under
+    /// [`LeaseOwner::Rehydrated`], as one committed lease.
+    ///
+    /// Startup reads these outpoints from durable storage. They have no live [`Lease`] value,
+    /// because the duty that took the original lease ran in an earlier process.
+    pub fn with_committed(outpoints: impl IntoIterator<Item = OutPoint>) -> Self {
+        let set = Self::default();
+        let outpoints: Vec<OutPoint> = outpoints.into_iter().collect();
+        if !outpoints.is_empty() {
+            let id = set.insert(outpoints, LeaseOwner::Rehydrated);
+            set.commit(id);
+        }
+        set
+    }
+
+    /// Takes a lease on `outpoints` for `owner`.
+    ///
+    /// The returned value releases the outpoints when it drops.
+    pub fn take(self: &Arc<Self>, outpoints: Vec<OutPoint>, owner: LeaseOwner) -> Lease {
+        let id = self.insert(outpoints.clone(), owner);
+        Lease {
+            set: Arc::clone(self),
+            id,
+            outpoints,
+            owner,
+            committed: false,
+        }
+    }
+
+    /// Returns every outpoint that a lease holds.
+    pub fn held(&self) -> BTreeSet<OutPoint> {
+        self.lock().holders.keys().copied().collect()
+    }
+
+    /// Returns every held outpoint that `exempt` does not contain.
+    ///
+    /// The CPFP rebuild path passes the inputs of the child that the new child replaces. They
+    /// must stay selectable, because a replacement that drops them leaves the parent with two
+    /// children and breaks the TRUC one-parent-one-child shape.
+    ///
+    /// The result is exact when only one lease holds each outpoint in `exempt`. The CPFP
+    /// rebuild path meets that condition: the inputs of the child came from a selection that
+    /// skipped every held outpoint, so no other lease held them at the time, and automatic
+    /// selection cannot take a held outpoint later.
+    ///
+    /// The condition is a requirement on the caller and not a property of the whole set.
+    /// [`OperatorWallet::fund_v3_transaction_with_inputs`](crate::OperatorWallet::fund_v3_transaction_with_inputs)
+    /// names its inputs and skips selection, so it can take a second lease on a held
+    /// outpoint. No caller passes those outpoints here.
+    pub fn held_excluding(&self, exempt: &[OutPoint]) -> BTreeSet<OutPoint> {
+        self.lock()
+            .holders
+            .keys()
+            .filter(|outpoint| !exempt.contains(outpoint))
+            .copied()
+            .collect()
+    }
+
+    /// Releases `outpoints` that a committed lease holds.
+    ///
+    /// A live [`Lease`] value keeps its outpoints through this call. Only [`Drop`] frees
+    /// those. This method exists for the outpoints that startup read from durable storage,
+    /// and for a duty that discards a stored reservation that it can no longer use.
+    pub fn release_committed(&self, outpoints: &[OutPoint]) {
+        let mut holdings = self.lock();
+        for outpoint in outpoints {
+            if !holdings.committed_holds(*outpoint) {
+                warn!(
+                    ?outpoint,
+                    "released an outpoint that no committed lease holds"
+                );
+            }
+        }
+        holdings.remove_outpoints(outpoints.iter().copied(), |record| record.committed);
+    }
+
+    /// Drops every held outpoint that `live` does not contain.
+    ///
+    /// A wallet sync calls this method. An outpoint that leaves the spendable set was spent
+    /// on chain, and the on-chain spend supersedes the local bookkeeping. The method reports
+    /// the owner of each lease that loses an outpoint, because a lease that loses inputs it
+    /// still expects to spend explains a later funding error.
+    pub fn retain_live(&self, live: &BTreeSet<OutPoint>) {
+        let mut holdings = self.lock();
+        let stale: Vec<OutPoint> = holdings
+            .holders
+            .keys()
+            .filter(|outpoint| !live.contains(outpoint))
+            .copied()
+            .collect();
+        for outpoint in &stale {
+            let owners = holdings.owners_of(*outpoint);
+            debug!(
+                ?outpoint,
+                ?owners,
+                "sync pruned a lease on a spent outpoint"
+            );
+        }
+        holdings.remove_outpoints(stale, |_| true);
+    }
+
+    /// Records a new lease and returns its identifier.
+    fn insert(&self, outpoints: Vec<OutPoint>, owner: LeaseOwner) -> LeaseId {
+        let id = LeaseId(self.next_id.fetch_add(1, Ordering::Relaxed));
+        let mut holdings = self.lock();
+        for outpoint in &outpoints {
+            holdings.holders.entry(*outpoint).or_default().insert(id);
+        }
+        holdings.leases.insert(
+            id,
+            LeaseRecord {
+                owner,
+                outpoints: outpoints.into_iter().collect(),
+                committed: false,
+            },
+        );
+        id
+    }
+
+    /// Marks the lease as committed, so its outpoints outlive the [`Lease`] value.
+    ///
+    /// Drops the lease instead when a committed lease already holds every one of its
+    /// outpoints. The set of held outpoints is the same either way, and the record count
+    /// stays bounded. Without this check, each retry of a duty that reuses a stored
+    /// reservation adds one more permanent record for the same outpoints, and nothing in
+    /// production removes it before the spend confirms.
+    fn commit(&self, id: LeaseId) {
+        let mut holdings = self.lock();
+        let Some(record) = holdings.leases.get(&id) else {
+            return;
+        };
+        let redundant = record
+            .outpoints
+            .iter()
+            .all(|outpoint| holdings.committed_holds(*outpoint));
+        if redundant {
+            holdings.remove_lease(id);
+            return;
+        }
+        if let Some(record) = holdings.leases.get_mut(&id) {
+            record.committed = true;
+        }
+    }
+
+    /// Frees every outpoint that only the lease `id` holds. Called from [`Lease::drop`].
+    fn release(&self, id: LeaseId) {
+        self.lock().remove_lease(id);
+    }
+
+    /// The number of live lease records. Test-only: the record count is not observable
+    /// through [`Self::held`], because a repeated commit and a single commit hold the same
+    /// outpoints.
+    #[cfg(test)]
+    fn lease_count(&self) -> usize {
+        self.lock().leases.len()
+    }
+
+    /// Locks the holdings and recovers from a poisoned lock.
+    ///
+    /// A poisoned lock means a panic happened inside one of the short critical sections of
+    /// this module. The data stays consistent, because no step between the two map writes of
+    /// a critical section can panic: the closures are comparisons, and the log statements run
+    /// before any mutation. A panic in [`Lease::drop`] must not cascade into every later
+    /// wallet operation.
+    fn lock(&self) -> MutexGuard<'_, Holdings> {
+        self.holdings
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+/// Holds outpoints against input selection until it drops.
+///
+/// A duty keeps this value alive for as long as it needs the outpoints. The error paths of
+/// the duty need no release call, because the value drops with the stack frame.
+///
+/// [`Self::commit`] hands the outpoints to durable storage or to a broadcast transaction.
+/// The outpoints then stay held after this value drops.
+#[must_use = "the lease releases its outpoints as soon as the value drops"]
+#[derive(Debug)]
+pub struct Lease {
+    set: Arc<LeaseSet>,
+    id: LeaseId,
+    outpoints: Vec<OutPoint>,
+    owner: LeaseOwner,
+    committed: bool,
+}
+
+impl Lease {
+    /// The outpoints that this lease holds.
+    pub fn outpoints(&self) -> &[OutPoint] {
+        &self.outpoints
+    }
+
+    /// Keeps the outpoints held after this value drops.
+    ///
+    /// A duty calls this method once the outpoints are safe to hold without a live value:
+    /// durable storage records them, or a broadcast transaction spends them. A later sync
+    /// frees them when the spend confirms. [`LeaseSet::release_committed`] frees them if the
+    /// duty must discard the record instead.
+    pub fn commit(mut self) {
+        self.set.commit(self.id);
+        self.committed = true;
+    }
+}
+
+impl Drop for Lease {
+    fn drop(&mut self) {
+        if self.committed {
+            return;
+        }
+        debug!(
+            owner = ?self.owner,
+            outpoints = ?self.outpoints,
+            "released a lease"
+        );
+        self.set.release(self.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::bitcoin::hashes::Hash;
+
+    use super::*;
+
+    fn outpoint(n: u8) -> OutPoint {
+        OutPoint {
+            txid: Txid::from_byte_array([n; 32]),
+            vout: 0,
+        }
+    }
+
+    #[test]
+    fn a_dropped_lease_frees_its_outpoints() {
+        let set = Arc::new(LeaseSet::default());
+        let lease = set.take(vec![outpoint(1), outpoint(2)], LeaseOwner::StakeFunding);
+        assert_eq!(set.held().len(), 2);
+        drop(lease);
+        assert!(set.held().is_empty());
+    }
+
+    #[test]
+    fn a_committed_lease_outlives_its_value() {
+        let set = Arc::new(LeaseSet::default());
+        let lease = set.take(vec![outpoint(1)], LeaseOwner::ClaimFunding);
+        lease.commit();
+        assert_eq!(set.held(), BTreeSet::from([outpoint(1)]));
+
+        set.release_committed(&[outpoint(1)]);
+        assert!(set.held().is_empty());
+    }
+
+    #[test]
+    fn release_committed_leaves_a_live_lease_alone() {
+        let set = Arc::new(LeaseSet::default());
+        let lease = set.take(vec![outpoint(1)], LeaseOwner::ClaimFunding);
+        set.release_committed(&[outpoint(1)]);
+        assert_eq!(
+            set.held(),
+            BTreeSet::from([outpoint(1)]),
+            "a live lease must survive a committed-release of the same outpoint"
+        );
+        drop(lease);
+        assert!(set.held().is_empty());
+    }
+
+    #[test]
+    fn an_outpoint_two_leases_hold_survives_the_first_drop() {
+        let set = Arc::new(LeaseSet::default());
+        let shared = outpoint(1);
+        let old = set.take(
+            vec![shared, outpoint(2)],
+            LeaseOwner::CpfpChild {
+                parent: Txid::from_byte_array([9; 32]),
+            },
+        );
+        let new = set.take(
+            vec![shared, outpoint(3)],
+            LeaseOwner::CpfpChild {
+                parent: Txid::from_byte_array([9; 32]),
+            },
+        );
+
+        drop(old);
+        assert_eq!(
+            set.held(),
+            BTreeSet::from([shared, outpoint(3)]),
+            "the replacement child's inputs must stay held; only outpoint 2 is freed"
+        );
+        drop(new);
+        assert!(set.held().is_empty());
+    }
+
+    #[test]
+    fn held_excluding_keeps_every_other_lease_excluded() {
+        let set = Arc::new(LeaseSet::default());
+        let prior = set.take(vec![outpoint(1), outpoint(2)], LeaseOwner::ClaimFunding);
+        let other = set.take(vec![outpoint(3)], LeaseOwner::StakeFunding);
+
+        assert_eq!(
+            set.held_excluding(prior.outpoints()),
+            BTreeSet::from([outpoint(3)]),
+            "the prior lease's inputs are selectable again; another lease's are not"
+        );
+        assert_eq!(
+            set.held_excluding(&[]),
+            BTreeSet::from([outpoint(1), outpoint(2), outpoint(3)]),
+            "an empty exemption excludes everything held"
+        );
+        drop((prior, other));
+    }
+
+    #[test]
+    fn retain_live_drops_leases_on_spent_outpoints() {
+        let set = Arc::new(LeaseSet::default());
+        let lease = set.take(vec![outpoint(1), outpoint(2)], LeaseOwner::ClaimFunding);
+        set.retain_live(&BTreeSet::from([outpoint(2)]));
+        assert_eq!(set.held(), BTreeSet::from([outpoint(2)]));
+        assert_eq!(
+            lease.outpoints(),
+            [outpoint(1), outpoint(2)],
+            "the value keeps its own record of what it asked for"
+        );
+        drop(lease);
+        assert!(set.held().is_empty());
+    }
+
+    /// A duty that reuses a stored reservation commits a fresh lease on every retry. Each of
+    /// those commits must collapse into the record that already holds the outpoints, or the
+    /// record count grows with the retry count and nothing removes the surplus.
+    #[test]
+    fn a_repeated_commit_of_held_outpoints_adds_no_record() {
+        let set = Arc::new(LeaseSet::default());
+        for _ in 0..5 {
+            set.take(vec![outpoint(1)], LeaseOwner::StakeFunding)
+                .commit();
+        }
+        assert_eq!(set.held(), BTreeSet::from([outpoint(1)]));
+        assert_eq!(
+            set.lease_count(),
+            1,
+            "repeat commits must not stack records"
+        );
+    }
+
+    #[test]
+    fn a_commit_that_adds_an_outpoint_keeps_its_record() {
+        let set = Arc::new(LeaseSet::default());
+        set.take(vec![outpoint(1)], LeaseOwner::StakeFunding)
+            .commit();
+        set.take(vec![outpoint(1), outpoint(2)], LeaseOwner::StakeFunding)
+            .commit();
+        assert_eq!(set.held(), BTreeSet::from([outpoint(1), outpoint(2)]));
+        assert_eq!(
+            set.lease_count(),
+            2,
+            "a commit that holds a new outpoint keeps its own record"
+        );
+    }
+
+    #[test]
+    fn with_committed_seeds_rehydrated_outpoints() {
+        let set = LeaseSet::with_committed([outpoint(1), outpoint(2)]);
+        assert_eq!(set.held(), BTreeSet::from([outpoint(1), outpoint(2)]));
+        set.release_committed(&[outpoint(1)]);
+        assert_eq!(set.held(), BTreeSet::from([outpoint(2)]));
+    }
+}

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod config;
 pub mod general;
+pub mod leases;
 pub mod sync;
 pub mod wallet;
 
@@ -29,10 +30,12 @@ use thiserror::Error;
 pub use crate::{
     config::OperatorWalletConfig,
     general::{
-        native::NativeGeneralWallet, AnchorInfo, FundedPsbt, GeneralWallet, ReplacedChild, UtxoInfo,
+        native::NativeGeneralWallet, AnchorInfo, AnchorOwnership, FundedPsbt, GeneralWallet,
+        ReplacedChild, UtxoInfo,
     },
+    leases::{Lease, LeaseOwner, LeaseSet},
     sync::SyncError,
-    wallet::{GeneralUtxoPolicy, OperatorWallet},
+    wallet::{GeneralUtxoPolicy, LeasedPsbt, OperatorWallet},
 };
 
 /// Errors returned by [`OperatorWallet`] methods. Backend errors are boxed so call sites don't

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -28,7 +28,9 @@ use thiserror::Error;
 
 pub use crate::{
     config::OperatorWalletConfig,
-    general::{native::NativeGeneralWallet, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo},
+    general::{
+        native::NativeGeneralWallet, AnchorInfo, FundedPsbt, GeneralWallet, ReplacedChild, UtxoInfo,
+    },
     sync::SyncError,
     wallet::{GeneralUtxoPolicy, OperatorWallet},
 };

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -38,13 +38,28 @@ pub use crate::{
     wallet::{GeneralUtxoPolicy, LeasedPsbt, OperatorWallet},
 };
 
+/// Whether an error describes a condition that a later attempt can pass.
+///
+/// A caller that retries on a timer needs this. An error about the shape of a transaction
+/// that is already signed repeats on every attempt, and a caller that cannot tell the two
+/// apart retries that one for as long as the process runs.
+pub trait ErrorPermanence {
+    /// True when every later attempt against the same inputs fails the same way.
+    fn is_permanent(&self) -> bool;
+}
+
 /// Errors returned by [`OperatorWallet`] methods. Backend errors are boxed so call sites don't
 /// have to be generic over `G::Error`.
 #[derive(Debug, Error)]
 pub enum Error {
     /// The general wallet backend reported an error.
-    #[error("general wallet: {0}")]
-    General(Box<dyn std::error::Error + Send + Sync>),
+    #[error("general wallet: {source}")]
+    General {
+        /// The backend error.
+        source: Box<dyn std::error::Error + Send + Sync>,
+        /// Read from the backend error before the box hid its type.
+        permanent: bool,
+    },
     /// Confirmed-only reserved-wallet funding can see only unconfirmed general-wallet funds.
     #[error(
         "no confirmed general-wallet UTXOs available for reserved-wallet funding \
@@ -71,7 +86,30 @@ pub enum Error {
 }
 
 impl Error {
-    pub(crate) fn from_general<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
-        Self::General(Box::new(e))
+    pub(crate) fn from_general<E>(e: E) -> Self
+    where
+        E: std::error::Error + ErrorPermanence + Send + Sync + 'static,
+    {
+        // Read the classification here. The box that follows hides the concrete type, and no
+        // later caller can recover it.
+        let permanent = e.is_permanent();
+        Self::General {
+            source: Box::new(e),
+            permanent,
+        }
+    }
+}
+
+impl ErrorPermanence for Error {
+    fn is_permanent(&self) -> bool {
+        match self {
+            Self::General { permanent, .. } => *permanent,
+            // A missing confirmed UTXO, a failed sync, and a rejected build all pass once the
+            // wallet or the chain moves on.
+            Self::NoConfirmedGeneralUtxos { .. } | Self::Reserved(_) | Self::Sync(_) => false,
+            // A script that is not addressable, and an address that is not a descriptor, are
+            // properties of the configured wallet.
+            Self::Address(_) | Self::Descriptor(_) => true,
+        }
     }
 }

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 
 pub use crate::{
     config::OperatorWalletConfig,
-    general::{native::NativeGeneralWallet, FundedPsbt, GeneralWallet, UtxoInfo},
+    general::{native::NativeGeneralWallet, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo},
     sync::SyncError,
     wallet::{GeneralUtxoPolicy, OperatorWallet},
 };

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -24,7 +24,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     config::OperatorWalletConfig,
-    general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    general::{local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo},
     sync::Backend,
     Error,
 };
@@ -245,7 +245,12 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         Ok(funded)
     }
 
-    /// Builds a CPFP child for `parent` spending the anchor at `anchor_vout`.
+    /// Builds a CPFP child for `parent` spending the foreign-key output described by
+    /// `anchor` plus inputs from this wallet to cover the child's share of the package fee.
+    ///
+    /// `parent_fee` is the caller-known fee already paid by `parent`; the backend uses it
+    /// together with parent vbytes and `target_pkg_fee_rate` to compute the implied child
+    /// fee.
     ///
     /// `replacing`, when `Some`, identifies the funding outpoints of a prior child being
     /// replaced via RBF. Those outpoints are released from the lease set before
@@ -253,7 +258,8 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     pub async fn build_cpfp_child(
         &mut self,
         parent: &Transaction,
-        anchor_vout: u32,
+        parent_fee: Amount,
+        anchor: AnchorInfo,
         target_pkg_fee_rate: FeeRate,
         replacing: Option<&[OutPoint]>,
     ) -> Result<FundedPsbt, Error> {
@@ -263,7 +269,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         let exclude = self.exclude_anchors_and_leases();
         match self
             .general
-            .build_cpfp_child(parent, anchor_vout, target_pkg_fee_rate, &exclude)
+            .build_cpfp_child(parent, parent_fee, anchor, target_pkg_fee_rate, &exclude)
             .await
         {
             Ok(funded) => {

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -1,7 +1,7 @@
 //! The [`OperatorWallet`] composer.
 //!
 //! Composes a swappable [`crate::GeneralWallet`] backend with an always-native reserved wallet
-//! and shared in-memory lease bookkeeping. The composer owns:
+//! and shared lease bookkeeping. The composer owns:
 //!
 //! - the BDK descriptor-only reserved wallet (signed downstream by the caller),
 //! - the lease set shared across both wallets,
@@ -9,13 +9,22 @@
 //! - cross-wallet construction helpers that produce PSBTs paying from the general wallet into
 //!   reserved-wallet outputs of a caller-specified denomination.
 //!
-//! Methods on [`OperatorWallet`] take `&mut self`; callers serialize via an outer lock when
-//! they need a multi-step critical section (e.g. DB-lookup-then-fund-then-persist).
+//! Every method that consumes UTXOs returns a [`Lease`] over the outpoints that it consumed.
+//! The caller keeps that value for as long as the outpoints must stay held. An error path
+//! that drops the value releases the outpoints, so no error path needs an explicit release
+//! call. A caller that records the outpoints in durable storage, or that broadcasts the
+//! spend, calls [`Lease::commit`] instead.
+//!
+//! Methods on [`OperatorWallet`] take `&mut self`. Callers serialize via an outer lock when
+//! they need a multi-step critical section, such as a database lookup, then funding, then a
+//! write.
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, sync::Arc};
 
 use bdk_wallet::{
-    bitcoin::{Address, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    bitcoin::{
+        Address, Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey,
+    },
     descriptor, KeychainKind, Wallet,
 };
 use bitcoin_bosd::Descriptor;
@@ -25,11 +34,48 @@ use tracing::{error, info, warn};
 use crate::{
     config::OperatorWalletConfig,
     general::{
-        local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, ReplacedChild, UtxoInfo,
+        local_output_to_utxo_info, AnchorInfo, AnchorOwnership, FundedPsbt, GeneralWallet,
+        ReplacedChild, UtxoInfo,
     },
+    leases::{Lease, LeaseOwner, LeaseSet},
     sync::Backend,
     Error,
 };
+
+/// A funded PSBT and the lease on the inputs that it spends.
+///
+/// Both fields are private, and [`Self::into_parts`] is the only way to take the PSBT out.
+/// Public fields let a caller write `funded.psbt`, which moves the PSBT and drops the lease in
+/// the same expression. The funding inputs of a transaction that the caller is about to sign
+/// and broadcast then become selectable again, and a concurrent duty can spend them. The
+/// caller must name the lease to reach the PSBT, and so must state what happens to it.
+#[derive(Debug)]
+#[must_use = "the lease releases the funding inputs as soon as this value drops"]
+pub struct LeasedPsbt {
+    psbt: Psbt,
+    lease: Lease,
+}
+
+impl LeasedPsbt {
+    /// Splits the value into the funded PSBT and the lease on its inputs.
+    ///
+    /// The caller keeps the lease for as long as the inputs must stay held, and calls
+    /// [`Lease::commit`] once durable storage or a broadcast transaction records them.
+    pub fn into_parts(self) -> (Psbt, Lease) {
+        (self.psbt, self.lease)
+    }
+
+    /// The lease on the inputs of this PSBT, for callers that only read it.
+    pub const fn lease(&self) -> &Lease {
+        &self.lease
+    }
+
+    /// The funded PSBT. See the [`GeneralWallet`] signing contract for which inputs the
+    /// backend signs, and which inputs the caller must sign downstream.
+    pub const fn psbt(&self) -> &Psbt {
+        &self.psbt
+    }
+}
 
 /// Whether general-wallet funding may spend unconfirmed UTXOs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,13 +95,15 @@ pub struct OperatorWallet<G: GeneralWallet> {
     reserved_sync_backend: Backend,
     reserved_script_pubkey: ScriptBuf,
     config: OperatorWalletConfig,
-    leased_outpoints: BTreeSet<OutPoint>,
+    leases: Arc<LeaseSet>,
 }
 
 impl<G: GeneralWallet> OperatorWallet<G> {
     /// Constructs an [`OperatorWallet`] from a [`GeneralWallet`] backend and a reserved-wallet
-    /// pubkey. `initial_leases` is the set of outpoints to seed the lease state with
-    /// (typically rehydrated from durable storage at startup).
+    /// pubkey. `initial_leases` is the set of outpoints to seed the lease state with,
+    /// normally read from durable storage at startup. They enter as one committed lease
+    /// under [`LeaseOwner::Rehydrated`], because the duty that took the original lease ran in
+    /// an earlier process.
     pub fn new(
         general: G,
         reserved_pubkey: XOnlyPublicKey,
@@ -80,7 +128,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             reserved_sync_backend,
             reserved_script_pubkey,
             config,
-            leased_outpoints: initial_leases,
+            leases: Arc::new(LeaseSet::with_committed(initial_leases)),
         }
     }
 
@@ -110,30 +158,27 @@ impl<G: GeneralWallet> OperatorWallet<G> {
 
     // ── Lease bookkeeping ───────────────────────────────────────────────────
 
-    /// Returns the currently-leased outpoints.
-    pub const fn leased_outpoints(&self) -> &BTreeSet<OutPoint> {
-        &self.leased_outpoints
+    /// Returns a snapshot of the outpoints that a lease holds.
+    pub fn leased_outpoints(&self) -> BTreeSet<OutPoint> {
+        self.leases.held()
     }
 
-    /// Marks each of `outpoints` as leased. Safe to call with already-leased outpoints
-    /// (the set is idempotent).
-    pub fn lease(&mut self, outpoints: &[OutPoint]) {
-        for outpoint in outpoints {
-            self.leased_outpoints.insert(*outpoint);
-        }
+    /// Holds `outpoints` under `owner` with no live [`Lease`] value behind them.
+    ///
+    /// This is for outpoints that durable storage already records, such as the inputs of a
+    /// stake funding reservation that a duty reads back and reuses. A caller that still
+    /// controls the lifetime of the outpoints takes a normal lease and keeps the value
+    /// instead. [`Self::release_committed`] frees them again.
+    pub fn lease_committed(&self, outpoints: Vec<OutPoint>, owner: LeaseOwner) {
+        self.leases.take(outpoints, owner).commit();
     }
 
-    /// Removes each of `outpoints` from the lease set. Safe to call repeatedly or with
-    /// outpoints that were never leased.
-    pub fn release(&mut self, outpoints: &[OutPoint]) {
-        for outpoint in outpoints {
-            if !self.leased_outpoints.remove(outpoint) {
-                warn!(
-                    ?outpoint,
-                    "attempted to release outpoint that was not leased"
-                );
-            }
-        }
+    /// Releases `outpoints` that a committed lease holds.
+    ///
+    /// A live [`Lease`] value keeps its outpoints through this call. Only dropping the value
+    /// frees those.
+    pub fn release_committed(&self, outpoints: &[OutPoint]) {
+        self.leases.release_committed(outpoints);
     }
 
     // ── Sync status ─────────────────────────────────────────────────────────
@@ -165,56 +210,61 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             .collect()
     }
 
-    /// Selects and leases one unleased reserved-wallet UTXO of value `value` that the
-    /// `ignore` predicate doesn't reject. Returns the selected outpoint (if any) and the
-    /// number of *additional* matching UTXOs left after the selection.
+    /// Takes a lease on one free reserved-wallet UTXO of value `value` that the `ignore`
+    /// predicate does not reject.
+    ///
+    /// Returns the selected UTXO with its lease, and the number of other matching free UTXOs
+    /// left after the selection.
     pub fn reserve_utxo_with_value(
-        &mut self,
+        &self,
         value: Amount,
+        owner: LeaseOwner,
         ignore: impl Fn(&UtxoInfo) -> bool,
-    ) -> (Option<OutPoint>, u64) {
+    ) -> (Option<(OutPoint, Lease)>, u64) {
         let available = self.reserved_utxos_with_value(value);
-        let leased = &self.leased_outpoints;
+        let leased = self.leases.held();
         let mut considered = available
             .into_iter()
             .filter(|u| !leased.contains(&u.outpoint) && !ignore(u));
         let selected = considered.next();
         let remaining = considered.count() as u64;
-        if let Some(ref utxo) = selected {
-            self.leased_outpoints.insert(utxo.outpoint);
-        }
-        (selected.map(|u| u.outpoint), remaining)
+        let selected = selected.map(|utxo| {
+            let lease = self.leases.take(vec![utxo.outpoint], owner);
+            (utxo.outpoint, lease)
+        });
+        (selected, remaining)
     }
 
     // ── General-wallet pass-throughs with lease bookkeeping ────────────────
 
-    /// Selects the first general-wallet UTXO that satisfies `predicate`, excluding CPFP
-    /// anchors and currently-leased outpoints, leases it so concurrent duties don't
-    /// re-select the same outpoint, and returns it. Returns `None` if nothing matches.
+    /// Takes a lease on the first general-wallet UTXO that satisfies `predicate`, skipping
+    /// CPFP anchors and held outpoints. Returns `None` when nothing matches.
     ///
-    /// Unlike [`Self::fund_v3_transaction`], this hands back a single chosen UTXO for callers
-    /// that build a bespoke transaction around it — e.g. the unstaking-burn executor, whose tx
-    /// has a fixed non-wallet first input that the generic outputs-only funding path can't
-    /// express.
-    pub fn select_and_lease_general_utxo(
-        &mut self,
+    /// Unlike [`Self::fund_v3_transaction`], this hands back one chosen UTXO for callers that
+    /// build a transaction around it. The unstaking-burn executor needs this, because its
+    /// transaction has a fixed non-wallet first input that the outputs-only funding path
+    /// cannot express.
+    pub fn select_general_utxo(
+        &self,
+        owner: LeaseOwner,
         predicate: impl Fn(&UtxoInfo) -> bool,
-    ) -> Option<UtxoInfo> {
-        let exclude: BTreeSet<OutPoint> = self.exclude_anchors_and_leases().into_iter().collect();
+    ) -> Option<(UtxoInfo, Lease)> {
+        let exclude: BTreeSet<OutPoint> =
+            self.exclude_anchors_and_leases(&[]).into_iter().collect();
         let selected = self
             .general
             .list_utxos()
             .into_iter()
             .find(|u| !exclude.contains(&u.outpoint) && predicate(u))?;
-        self.lease(&[selected.outpoint]);
-        Some(selected)
+        let lease = self.leases.take(vec![selected.outpoint], owner);
+        Some((selected, lease))
     }
 
     /// Funds an unsigned v3 transaction from the general wallet.
     ///
-    /// Selects inputs from spendable general-wallet UTXOs (excluding anchors and currently-
-    /// leased outpoints), signs them where the backend has key material, and returns a
-    /// [`FundedPsbt`]. The consumed inputs are leased before return.
+    /// Selects inputs from spendable general-wallet UTXOs, skipping anchors and held
+    /// outpoints, signs them where the backend has key material, and returns the PSBT with a
+    /// lease on the inputs.
     ///
     /// Callers of v3 paths must pass [`GeneralUtxoPolicy::ConfirmedOnly`]. TRUC (BIP-431)
     /// rejects a v3 transaction with an unconfirmed non-v3 ancestor, and it caps a v3
@@ -226,33 +276,33 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         unsigned_tx: Transaction,
         fee_rate: FeeRate,
         general_utxo_policy: GeneralUtxoPolicy,
-    ) -> Result<FundedPsbt, Error> {
-        let mut exclude = self.exclude_anchors_and_leases();
+        owner: LeaseOwner,
+    ) -> Result<LeasedPsbt, Error> {
+        let mut exclude = self.exclude_anchors_and_leases(&[]);
         self.apply_general_utxo_policy(general_utxo_policy, &mut exclude)?;
         let funded = self
             .general
             .fund_v3_transaction(unsigned_tx.output, None, fee_rate, &exclude)
             .await
             .map_err(Error::from_general)?;
-        self.lease(&funded.spent());
-        Ok(funded)
+        Ok(self.attach_lease(funded, owner))
     }
 
-    /// Funds an unsigned v3 transaction using `inputs` as the explicit input set (typically
-    /// a previously-persisted funding plan being replayed on retry).
+    /// Funds an unsigned v3 transaction using `inputs` as the explicit input set, normally a
+    /// stored funding plan that a retry replays.
     pub async fn fund_v3_transaction_with_inputs(
         &mut self,
         unsigned_tx: Transaction,
         inputs: &[OutPoint],
         fee_rate: FeeRate,
-    ) -> Result<FundedPsbt, Error> {
+        owner: LeaseOwner,
+    ) -> Result<LeasedPsbt, Error> {
         let funded = self
             .general
             .fund_v3_transaction(unsigned_tx.output, Some(inputs), fee_rate, &[])
             .await
             .map_err(Error::from_general)?;
-        self.lease(&funded.spent());
-        Ok(funded)
+        Ok(self.attach_lease(funded, owner))
     }
 
     /// Builds a CPFP child for `parent` spending the foreign-key output described by
@@ -262,23 +312,29 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// together with parent vbytes and `target_pkg_fee_rate` to compute the implied child
     /// fee.
     ///
-    /// `replacing`, when `Some`, identifies the funding outpoints of a prior child being
-    /// replaced via RBF. Those outpoints are released from the lease set before
-    /// fee-paying-input selection so they can be re-selected.
+    /// `replaced` describes the prior child that this build supersedes via RBF. Input
+    /// selection exempts its inputs, so the new child can spend them again. The lease of the
+    /// prior child is untouched: a failed build leaves it as it was, and the caller drops it
+    /// once the new child supersedes the old one.
+    ///
+    /// `anchor_ownership` states whether the parent output at `anchor` belongs to this
+    /// wallet. The returned lease covers the funding inputs, and covers the parent output
+    /// only for [`AnchorOwnership::Wallet`].
     pub async fn build_cpfp_child(
         &mut self,
         parent: &Transaction,
         parent_fee: Amount,
         anchor: AnchorInfo,
+        anchor_ownership: AnchorOwnership,
         target_pkg_fee_rate: FeeRate,
-        replacing: Option<&[OutPoint]>,
-        prior_child_fee: Option<Amount>,
-    ) -> Result<FundedPsbt, Error> {
-        if let Some(prior) = replacing {
-            self.release(prior);
-        }
-        let exclude = self.exclude_anchors_and_leases();
-        match self
+        replaced: ReplacedChild<'_>,
+    ) -> Result<LeasedPsbt, Error> {
+        let anchor_outpoint = OutPoint {
+            txid: parent.compute_txid(),
+            vout: anchor.vout(),
+        };
+        let exclude = self.exclude_anchors_and_leases(replaced.inputs);
+        let funded = self
             .general
             .build_cpfp_child(
                 parent,
@@ -286,27 +342,25 @@ impl<G: GeneralWallet> OperatorWallet<G> {
                 anchor,
                 target_pkg_fee_rate,
                 &exclude,
-                ReplacedChild {
-                    inputs: replacing.unwrap_or(&[]),
-                    fee: prior_child_fee,
-                },
+                replaced,
             )
             .await
-        {
-            Ok(funded) => {
-                self.lease(&funded.spent());
-                Ok(funded)
-            }
-            Err(e) => {
-                // Restore the lease state torn down before selection so a retry observes the
-                // same world. Without this, a backend failure silently un-leases the prior
-                // child's funding inputs.
-                if let Some(prior) = replacing {
-                    self.lease(prior);
-                }
-                Err(Error::from_general(e))
-            }
+            .map_err(Error::from_general)?;
+
+        let mut held = funded.spent();
+        if anchor_ownership == AnchorOwnership::Foreign {
+            held.retain(|outpoint| *outpoint != anchor_outpoint);
         }
+        let lease = self.leases.take(
+            held,
+            LeaseOwner::CpfpChild {
+                parent: anchor_outpoint.txid,
+            },
+        );
+        Ok(LeasedPsbt {
+            psbt: funded.psbt,
+            lease,
+        })
     }
 
     // ── Cross-wallet (general → reserved) ──────────────────────────────────
@@ -328,7 +382,8 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         utxo_value: Amount,
         quantity: usize,
         general_utxo_policy: GeneralUtxoPolicy,
-    ) -> Result<FundedPsbt, Error> {
+        owner: LeaseOwner,
+    ) -> Result<LeasedPsbt, Error> {
         // Exclude already-existing reserved UTXOs of the same value from selection so the
         // composer doesn't accidentally spend pool members back to itself.
         let existing: BTreeSet<OutPoint> = self
@@ -344,7 +399,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             })
             .collect();
 
-        let mut exclude = self.exclude_anchors_and_leases();
+        let mut exclude = self.exclude_anchors_and_leases(&[]);
         exclude.extend(existing);
 
         self.apply_general_utxo_policy(general_utxo_policy, &mut exclude)?;
@@ -354,8 +409,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             .fund_v3_transaction(outputs, None, fee_rate, &exclude)
             .await
             .map_err(Error::from_general)?;
-        self.lease(&funded.spent());
-        Ok(funded)
+        Ok(self.attach_lease(funded, owner))
     }
 
     // ── Sync ───────────────────────────────────────────────────────────────
@@ -391,9 +445,9 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             }
         }
 
-        // Prune stale leases. After a successful sync, drop any leased outpoint whose
-        // underlying UTXO is no longer in either wallet's spendable set — it was observed
-        // spent on-chain (the on-chain spend supersedes our local lease bookkeeping).
+        // Prune stale leases. After a successful sync, drop each held outpoint that left the
+        // spendable set of both wallets. That outpoint was spent on chain, and the on-chain
+        // spend supersedes the local bookkeeping.
         let live: BTreeSet<OutPoint> = self
             .general
             .list_utxos()
@@ -401,11 +455,20 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             .map(|u| u.outpoint)
             .chain(self.reserved.list_unspent().map(|lo| lo.outpoint))
             .collect();
-        self.leased_outpoints.retain(|o| live.contains(o));
+        self.leases.retain_live(&live);
         Ok(())
     }
 
     // ── Internal helpers ───────────────────────────────────────────────────
+
+    /// Takes a lease on the inputs of `funded` and pairs the two.
+    fn attach_lease(&self, funded: FundedPsbt, owner: LeaseOwner) -> LeasedPsbt {
+        let lease = self.leases.take(funded.spent(), owner);
+        LeasedPsbt {
+            psbt: funded.psbt,
+            lease,
+        }
+    }
 
     /// Applies `policy` to a funding exclusion set.
     ///
@@ -447,17 +510,18 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         Ok(())
     }
 
-    /// Returns the set of general-wallet outpoints that should be excluded from input
-    /// selection: CPFP anchors (zero-confirmation outputs at the configured anchor value)
-    /// plus currently-leased outpoints.
-    fn exclude_anchors_and_leases(&self) -> Vec<OutPoint> {
+    /// Returns the general-wallet outpoints that input selection must skip: CPFP anchors,
+    /// which are zero-confirmation outputs at the configured anchor value, and the outpoints
+    /// that a lease holds.
+    ///
+    /// `exempt` names outpoints that stay selectable. The CPFP rebuild path passes the
+    /// funding inputs of the child that the new child replaces.
+    fn exclude_anchors_and_leases(&self, exempt: &[OutPoint]) -> Vec<OutPoint> {
         let utxos = self.general.list_utxos();
         let anchors = utxos
             .iter()
             .filter(|u| u.amount == self.config.cpfp_value && u.confirmations == 0)
             .map(|u| u.outpoint);
-        anchors
-            .chain(self.leased_outpoints.iter().copied())
-            .collect()
+        anchors.chain(self.leases.held_excluding(exempt)).collect()
     }
 }

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -24,7 +24,9 @@ use tracing::{error, info, warn};
 
 use crate::{
     config::OperatorWalletConfig,
-    general::{local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo},
+    general::{
+        local_output_to_utxo_info, AnchorInfo, FundedPsbt, GeneralWallet, ReplacedChild, UtxoInfo,
+    },
     sync::Backend,
     Error,
 };
@@ -213,12 +215,20 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// Selects inputs from spendable general-wallet UTXOs (excluding anchors and currently-
     /// leased outpoints), signs them where the backend has key material, and returns a
     /// [`FundedPsbt`]. The consumed inputs are leased before return.
+    ///
+    /// Callers of v3 paths must pass [`GeneralUtxoPolicy::ConfirmedOnly`]. TRUC (BIP-431)
+    /// rejects a v3 transaction with an unconfirmed non-v3 ancestor, and it caps a v3
+    /// transaction with an unconfirmed v3 ancestor to one parent and one child. A funding
+    /// input from an unconfirmed UTXO therefore makes the transaction unrelayable in most
+    /// mempool states.
     pub async fn fund_v3_transaction(
         &mut self,
         unsigned_tx: Transaction,
         fee_rate: FeeRate,
+        general_utxo_policy: GeneralUtxoPolicy,
     ) -> Result<FundedPsbt, Error> {
-        let exclude = self.exclude_anchors_and_leases();
+        let mut exclude = self.exclude_anchors_and_leases();
+        self.apply_general_utxo_policy(general_utxo_policy, &mut exclude)?;
         let funded = self
             .general
             .fund_v3_transaction(unsigned_tx.output, None, fee_rate, &exclude)
@@ -262,6 +272,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         anchor: AnchorInfo,
         target_pkg_fee_rate: FeeRate,
         replacing: Option<&[OutPoint]>,
+        prior_child_fee: Option<Amount>,
     ) -> Result<FundedPsbt, Error> {
         if let Some(prior) = replacing {
             self.release(prior);
@@ -269,7 +280,17 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         let exclude = self.exclude_anchors_and_leases();
         match self
             .general
-            .build_cpfp_child(parent, parent_fee, anchor, target_pkg_fee_rate, &exclude)
+            .build_cpfp_child(
+                parent,
+                parent_fee,
+                anchor,
+                target_pkg_fee_rate,
+                &exclude,
+                ReplacedChild {
+                    inputs: replacing.unwrap_or(&[]),
+                    fee: prior_child_fee,
+                },
+            )
             .await
         {
             Ok(funded) => {
@@ -326,31 +347,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         let mut exclude = self.exclude_anchors_and_leases();
         exclude.extend(existing);
 
-        if general_utxo_policy == GeneralUtxoPolicy::ConfirmedOnly {
-            let excluded: BTreeSet<OutPoint> = exclude.iter().copied().collect();
-            let (confirmed, unconfirmed): (Vec<UtxoInfo>, Vec<UtxoInfo>) = self
-                .general
-                .list_utxos()
-                .into_iter()
-                .filter(|u| !excluded.contains(&u.outpoint))
-                .partition(|u| u.confirmations > 0);
-            if confirmed.is_empty() && !unconfirmed.is_empty() {
-                let unconfirmed_count = unconfirmed.len();
-                let unconfirmed_amount = unconfirmed
-                    .iter()
-                    .fold(Amount::ZERO, |total, u| total + u.amount);
-                warn!(
-                    unconfirmed_count,
-                    %unconfirmed_amount,
-                    "reserved-wallet funding has no confirmed general-wallet UTXOs available"
-                );
-                return Err(Error::NoConfirmedGeneralUtxos {
-                    unconfirmed_count,
-                    unconfirmed_amount,
-                });
-            }
-            exclude.extend(unconfirmed.into_iter().map(|u| u.outpoint));
-        }
+        self.apply_general_utxo_policy(general_utxo_policy, &mut exclude)?;
 
         let funded = self
             .general
@@ -409,6 +406,46 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     }
 
     // ── Internal helpers ───────────────────────────────────────────────────
+
+    /// Applies `policy` to a funding exclusion set.
+    ///
+    /// For [`GeneralUtxoPolicy::ConfirmedOnly`], this adds every unconfirmed general-wallet
+    /// UTXO to `exclude`. When that leaves no confirmed candidate at all, it returns
+    /// [`Error::NoConfirmedGeneralUtxos`] so the caller reports a clear cause instead of a
+    /// generic selection failure. [`GeneralUtxoPolicy::IncludeUnconfirmed`] changes nothing.
+    fn apply_general_utxo_policy(
+        &self,
+        policy: GeneralUtxoPolicy,
+        exclude: &mut Vec<OutPoint>,
+    ) -> Result<(), Error> {
+        if policy != GeneralUtxoPolicy::ConfirmedOnly {
+            return Ok(());
+        }
+        let excluded: BTreeSet<OutPoint> = exclude.iter().copied().collect();
+        let (confirmed, unconfirmed): (Vec<UtxoInfo>, Vec<UtxoInfo>) = self
+            .general
+            .list_utxos()
+            .into_iter()
+            .filter(|u| !excluded.contains(&u.outpoint))
+            .partition(|u| u.confirmations > 0);
+        if confirmed.is_empty() && !unconfirmed.is_empty() {
+            let unconfirmed_count = unconfirmed.len();
+            let unconfirmed_amount = unconfirmed
+                .iter()
+                .fold(Amount::ZERO, |total, u| total + u.amount);
+            warn!(
+                unconfirmed_count,
+                %unconfirmed_amount,
+                "no confirmed general-wallet UTXOs are available for funding"
+            );
+            return Err(Error::NoConfirmedGeneralUtxos {
+                unconfirmed_count,
+                unconfirmed_amount,
+            });
+        }
+        exclude.extend(unconfirmed.into_iter().map(|u| u.outpoint));
+        Ok(())
+    }
 
     /// Returns the set of general-wallet outpoints that should be excluded from input
     /// selection: CPFP anchors (zero-confirmation outputs at the configured anchor value)

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -15,9 +15,13 @@
 //! call. A caller that records the outpoints in durable storage, or that broadcasts the
 //! spend, calls [`Lease::commit`] instead.
 //!
-//! Methods on [`OperatorWallet`] take `&mut self`. Callers serialize via an outer lock when
-//! they need a multi-step critical section, such as a database lookup, then funding, then a
-//! write.
+//! Only [`OperatorWallet::sync`] takes `&mut self`. Every other method takes `&self`, so a
+//! caller holds a shared outer lock to fund a transaction, and a read of the wallet does not
+//! queue behind a backend round trip that takes seconds. An internal lock serializes the
+//! paths that select UTXOs, so two of them cannot pick one outpoint twice.
+//!
+//! Callers still take the exclusive outer lock for a multi-step critical section, such as a
+//! database lookup, then funding, then a write.
 
 use std::{collections::BTreeSet, sync::Arc};
 
@@ -28,7 +32,7 @@ use bdk_wallet::{
     descriptor, KeychainKind, Wallet,
 };
 use bitcoin_bosd::Descriptor;
-use tokio::time::sleep;
+use tokio::{sync::Mutex as TokioMutex, time::sleep};
 use tracing::{error, info, warn};
 
 use crate::{
@@ -96,6 +100,21 @@ pub struct OperatorWallet<G: GeneralWallet> {
     reserved_script_pubkey: ScriptBuf,
     config: OperatorWalletConfig,
     leases: Arc<LeaseSet>,
+    /// Serializes every path that selects UTXOs and then takes a lease on them.
+    ///
+    /// A selection reads the set of held outpoints, awaits the backend, and takes the lease
+    /// when the backend returns. Two selections that overlap read the same set, so they pick
+    /// one outpoint twice and build two transactions that conflict. This lock makes the read,
+    /// the selection, and the lease one step.
+    ///
+    /// It is a `tokio` mutex because the backend selection is a future. It replaces the
+    /// exclusive outer lock that callers held for the same reason, so a read of the wallet no
+    /// longer queues behind a backend round trip that takes seconds.
+    ///
+    /// A path with no await between the read and the lease is atomic without this lock. Those
+    /// paths take it as well, so that an await added to one of them later cannot open the gap
+    /// without notice.
+    funding: TokioMutex<()>,
 }
 
 impl<G: GeneralWallet> OperatorWallet<G> {
@@ -129,6 +148,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             reserved_script_pubkey,
             config,
             leases: Arc::new(LeaseSet::with_committed(initial_leases)),
+            funding: TokioMutex::new(()),
         }
     }
 
@@ -169,7 +189,11 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// stake funding reservation that a duty reads back and reuses. A caller that still
     /// controls the lifetime of the outpoints takes a normal lease and keeps the value
     /// instead. [`Self::release_committed`] frees them again.
-    pub fn lease_committed(&self, outpoints: Vec<OutPoint>, owner: LeaseOwner) {
+    pub async fn lease_committed(&self, outpoints: Vec<OutPoint>, owner: LeaseOwner) {
+        // Under the funding lock: a selection that is awaiting its backend computed its
+        // exclusion set already, and a commit that lands between that read and the backend's
+        // return hands the same outpoints to two spenders.
+        let _funding = self.funding.lock().await;
         self.leases.take(outpoints, owner).commit();
     }
 
@@ -215,12 +239,13 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     ///
     /// Returns the selected UTXO with its lease, and the number of other matching free UTXOs
     /// left after the selection.
-    pub fn reserve_utxo_with_value(
+    pub async fn reserve_utxo_with_value(
         &self,
         value: Amount,
         owner: LeaseOwner,
         ignore: impl Fn(&UtxoInfo) -> bool,
     ) -> (Option<(OutPoint, Lease)>, u64) {
+        let _funding = self.funding.lock().await;
         let available = self.reserved_utxos_with_value(value);
         let leased = self.leases.held();
         let mut considered = available
@@ -244,11 +269,12 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// build a transaction around it. The unstaking-burn executor needs this, because its
     /// transaction has a fixed non-wallet first input that the outputs-only funding path
     /// cannot express.
-    pub fn select_general_utxo(
+    pub async fn select_general_utxo(
         &self,
         owner: LeaseOwner,
         predicate: impl Fn(&UtxoInfo) -> bool,
     ) -> Option<(UtxoInfo, Lease)> {
+        let _funding = self.funding.lock().await;
         let exclude: BTreeSet<OutPoint> =
             self.exclude_anchors_and_leases(&[]).into_iter().collect();
         let selected = self
@@ -272,12 +298,13 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// input from an unconfirmed UTXO therefore makes the transaction unrelayable in most
     /// mempool states.
     pub async fn fund_v3_transaction(
-        &mut self,
+        &self,
         unsigned_tx: Transaction,
         fee_rate: FeeRate,
         general_utxo_policy: GeneralUtxoPolicy,
         owner: LeaseOwner,
     ) -> Result<LeasedPsbt, Error> {
+        let _funding = self.funding.lock().await;
         let mut exclude = self.exclude_anchors_and_leases(&[]);
         self.apply_general_utxo_policy(general_utxo_policy, &mut exclude)?;
         let funded = self
@@ -291,12 +318,13 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// Funds an unsigned v3 transaction using `inputs` as the explicit input set, normally a
     /// stored funding plan that a retry replays.
     pub async fn fund_v3_transaction_with_inputs(
-        &mut self,
+        &self,
         unsigned_tx: Transaction,
         inputs: &[OutPoint],
         fee_rate: FeeRate,
         owner: LeaseOwner,
     ) -> Result<LeasedPsbt, Error> {
+        let _funding = self.funding.lock().await;
         let funded = self
             .general
             .fund_v3_transaction(unsigned_tx.output, Some(inputs), fee_rate, &[])
@@ -321,7 +349,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// wallet. The returned lease covers the funding inputs, and covers the parent output
     /// only for [`AnchorOwnership::Wallet`].
     pub async fn build_cpfp_child(
-        &mut self,
+        &self,
         parent: &Transaction,
         parent_fee: Amount,
         anchor: AnchorInfo,
@@ -329,6 +357,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         target_pkg_fee_rate: FeeRate,
         replaced: ReplacedChild<'_>,
     ) -> Result<LeasedPsbt, Error> {
+        let _funding = self.funding.lock().await;
         let anchor_outpoint = OutPoint {
             txid: parent.compute_txid(),
             vout: anchor.vout(),
@@ -377,7 +406,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// members back to themselves. `general_utxo_policy` controls whether unconfirmed
     /// general-wallet UTXOs may be selected.
     pub async fn create_reserved_utxos(
-        &mut self,
+        &self,
         fee_rate: FeeRate,
         utxo_value: Amount,
         quantity: usize,
@@ -386,6 +415,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     ) -> Result<LeasedPsbt, Error> {
         // Exclude already-existing reserved UTXOs of the same value from selection so the
         // composer doesn't accidentally spend pool members back to itself.
+        let _funding = self.funding.lock().await;
         let existing: BTreeSet<OutPoint> = self
             .reserved_utxos_with_value(utxo_value)
             .into_iter()

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -7,7 +7,7 @@
 //!
 //! These tests cover the load-bearing surface of [`OperatorWallet`]:
 //!
-//! - **Lease bookkeeping** is idempotent and additive (lease + release semantics).
+//! - **Lease bookkeeping**: a committed lease holds its outpoints until an explicit release.
 //! - **Reserved-UTXO creation** funds the reserved wallet with the requested denomination +
 //!   quantity, and the resulting UTXOs are discoverable via `reserved_utxos_with_value`.
 //! - **Pool refill** semantics: caller computes batch size from current count, requests only the
@@ -36,7 +36,7 @@ use bdk_wallet::bitcoin::{
 };
 use corepc_node::{Conf, Node};
 use operator_wallet::{
-    sync::Backend, Error as OperatorWalletError, GeneralUtxoPolicy, GeneralWallet,
+    sync::Backend, Error as OperatorWalletError, GeneralUtxoPolicy, GeneralWallet, LeaseOwner,
     NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
 };
 use serial_test::serial;
@@ -159,9 +159,9 @@ fn sign_and_finalize(mut psbt: Psbt, keypair: Keypair) -> Transaction {
 
 #[tokio::test]
 #[serial]
-async fn lease_release_are_idempotent_and_additive() {
+async fn committed_leases_survive_until_an_explicit_release() {
     let bitcoind = setup_bitcoind();
-    let (mut wallet, _kp, _pk) =
+    let (wallet, _kp, _pk) =
         build_operator_wallet(&bitcoind, 1, 2, 1, Amount::from_btc(0.5).unwrap()).await;
 
     let op_a = OutPoint {
@@ -174,22 +174,22 @@ async fn lease_release_are_idempotent_and_additive() {
     };
 
     assert!(wallet.leased_outpoints().is_empty(), "starts empty");
-    wallet.lease(&[op_a, op_b]);
-    assert_eq!(wallet.leased_outpoints().len(), 2, "two leased");
-    // Idempotent: re-leasing the same outpoints doesn't grow the set.
-    wallet.lease(&[op_a]);
+    wallet.lease_committed(vec![op_a, op_b], LeaseOwner::StakeFunding);
+    assert_eq!(wallet.leased_outpoints().len(), 2, "two held");
+    // A second committed lease on one of them does not change what is held.
+    wallet.lease_committed(vec![op_a], LeaseOwner::StakeFunding);
     assert_eq!(
         wallet.leased_outpoints().len(),
         2,
-        "still two after re-lease"
+        "still two after a repeat"
     );
 
-    wallet.release(&[op_a]);
-    assert_eq!(wallet.leased_outpoints().len(), 1, "one left after release");
-    // Release-of-unleased is safe (no panic; logs a warning we don't capture here).
-    wallet.release(&[op_a]);
+    wallet.release_committed(&[op_a]);
+    assert_eq!(wallet.leased_outpoints().len(), 1, "one left");
+    // A release of an outpoint that nothing holds logs a warning and changes nothing.
+    wallet.release_committed(&[op_a]);
     assert_eq!(wallet.leased_outpoints().len(), 1, "still one");
-    wallet.release(&[op_b]);
+    wallet.release_committed(&[op_b]);
     assert!(wallet.leased_outpoints().is_empty(), "empty again");
 }
 
@@ -211,28 +211,26 @@ async fn create_reserved_utxos_funds_pool_and_leases_inputs() {
             utxo_value,
             quantity,
             GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect("funding must succeed");
 
-    // The wallet should have leased the funding inputs (so concurrent duties don't double-
-    // pick them). The actual leased outpoints come from the funded PSBT's inputs.
+    // The returned lease must hold every funding input, so that a concurrent duty cannot
+    // select one of them.
     let leased = wallet.leased_outpoints();
-    assert!(
-        !leased.is_empty(),
-        "wallet must have leased the funding inputs"
-    );
-    for spent in funded.spent() {
+    assert!(!leased.is_empty(), "the lease must hold the funding inputs");
+    for spent in funded.lease().outpoints() {
         assert!(
-            leased.contains(&spent),
-            "every spent outpoint must be leased; missing {spent}"
+            leased.contains(spent),
+            "every spent outpoint must be held; missing {spent}"
         );
     }
 
     // The PSBT must carry the requested quantity of reserved-wallet outputs.
     let reserved_script = wallet.reserved_script_pubkey();
     let reserved_output_count = funded
-        .psbt
+        .psbt()
         .unsigned_tx
         .output
         .iter()
@@ -243,8 +241,9 @@ async fn create_reserved_utxos_funds_pool_and_leases_inputs() {
         "PSBT must contain {quantity} reserved-wallet outputs of {utxo_value}"
     );
 
-    // Sign + broadcast + confirm; resync; the reserved pool now contains the new UTXOs.
-    let signed = sign_and_finalize(funded.psbt, general_kp);
+    // Sign, broadcast, confirm, and resync. The reserved pool then holds the new UTXOs.
+    let (psbt, _funding_lease) = funded.into_parts();
+    let signed = sign_and_finalize(psbt, general_kp);
     bitcoind
         .client
         .send_raw_transaction(&signed)
@@ -296,6 +295,7 @@ async fn create_reserved_utxos_reports_only_unconfirmed_general_utxos() {
             Amount::from_btc(0.01).unwrap(),
             1,
             GeneralUtxoPolicy::ConfirmedOnly,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect_err("unconfirmed general-wallet funds must not be selected");
@@ -338,12 +338,13 @@ async fn create_reserved_utxos_can_include_unconfirmed_general_utxos_when_allowe
             Amount::from_btc(0.01).unwrap(),
             1,
             GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect("unconfirmed general-wallet funds may be selected when allowed");
 
     assert!(
-        funded.spent().contains(&unconfirmed_outpoint),
+        funded.lease().outpoints().contains(&unconfirmed_outpoint),
         "funding transaction should spend the unconfirmed general-wallet UTXO"
     );
     assert!(
@@ -380,16 +381,17 @@ async fn create_reserved_utxos_excludes_unconfirmed_when_confirmed_funds_are_ava
             Amount::from_btc(0.01).unwrap(),
             1,
             GeneralUtxoPolicy::ConfirmedOnly,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect("confirmed funds should fund reserved UTXOs");
 
     assert!(
-        funded.spent().contains(&confirmed_outpoint),
+        funded.lease().outpoints().contains(&confirmed_outpoint),
         "funding transaction should spend the confirmed UTXO"
     );
     assert!(
-        !funded.spent().contains(&unconfirmed_outpoint),
+        !funded.lease().outpoints().contains(&unconfirmed_outpoint),
         "funding transaction must exclude the unconfirmed UTXO"
     );
 }
@@ -409,10 +411,12 @@ async fn reserve_utxo_with_value_picks_and_leases_one() {
             utxo_value,
             3,
             GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect("seed funding");
-    let signed = sign_and_finalize(funded.psbt, general_kp);
+    let (seed_psbt, seed_lease) = funded.into_parts();
+    let signed = sign_and_finalize(seed_psbt, general_kp);
     bitcoind
         .client
         .send_raw_transaction(&signed)
@@ -424,25 +428,34 @@ async fn reserve_utxo_with_value_picks_and_leases_one() {
         .expect("mine");
     wallet.sync().await.expect("sync");
 
-    // Reset wallet's lease state — the funding-tx inputs were leased; the new reserved
-    // UTXOs themselves haven't been. We're testing reserve_utxo_with_value on the pool.
-    let funding_inputs: Vec<OutPoint> = wallet.leased_outpoints().iter().copied().collect();
-    wallet.release(&funding_inputs);
+    // Clear the lease state. The seed transaction's inputs are held by its lease, and the
+    // sync above already pruned them because the spend confirmed. The new reserved UTXOs are
+    // free. This test covers `reserve_utxo_with_value` against that pool.
+    drop(seed_lease);
     assert!(wallet.leased_outpoints().is_empty(), "lease state cleared");
 
-    let (picked, remaining) = wallet.reserve_utxo_with_value(utxo_value, |_| false);
-    let picked = picked.expect("must return one outpoint");
+    let (picked, remaining) =
+        wallet.reserve_utxo_with_value(utxo_value, LeaseOwner::ClaimFunding, |_| false);
+    let (picked, picked_lease) = picked.expect("must return one outpoint");
     assert_eq!(remaining, 2, "two more left in the pool");
     assert!(
         wallet.leased_outpoints().contains(&picked),
-        "picked outpoint must be leased"
+        "picked outpoint must be held"
     );
 
-    // Picking again skips the leased one; we get a different outpoint.
-    let (picked_again, remaining_again) = wallet.reserve_utxo_with_value(utxo_value, |_| false);
-    let picked_again = picked_again.expect("must return another outpoint");
-    assert_ne!(picked_again, picked, "must pick a different unleased UTXO");
+    // A second pick skips the held outpoint and returns a different one.
+    let (picked_again, remaining_again) =
+        wallet.reserve_utxo_with_value(utxo_value, LeaseOwner::ClaimFunding, |_| false);
+    let (picked_again, _picked_again_lease) = picked_again.expect("must return another outpoint");
+    assert_ne!(picked_again, picked, "must pick a different free UTXO");
     assert_eq!(remaining_again, 1, "one more left after second pick");
+
+    // Dropping the first lease returns its outpoint to the pool.
+    drop(picked_lease);
+    assert!(
+        !wallet.leased_outpoints().contains(&picked),
+        "a dropped lease must return its outpoint to the pool"
+    );
 }
 
 #[tokio::test]
@@ -462,10 +475,12 @@ async fn reserve_utxo_with_value_filters_by_value() {
                 value,
                 2,
                 GeneralUtxoPolicy::IncludeUnconfirmed,
+                LeaseOwner::ClaimFundingRefill,
             )
             .await
             .unwrap_or_else(|e| panic!("seed funding for {value} failed: {e}"));
-        let signed = sign_and_finalize(funded.psbt, general_kp);
+        let (psbt, _lease) = funded.into_parts();
+        let signed = sign_and_finalize(psbt, general_kp);
         bitcoind
             .client
             .send_raw_transaction(&signed)
@@ -512,7 +527,7 @@ async fn sync_prunes_leases_whose_outpoints_have_been_spent() {
         .map(|u| u.outpoint)
         .collect();
     let target_outpoint = general_utxos[0];
-    wallet.lease(&[target_outpoint]);
+    wallet.lease_committed(vec![target_outpoint], LeaseOwner::StakeFunding);
     assert!(wallet.leased_outpoints().contains(&target_outpoint));
 
     // Spend `target_outpoint` directly via a manually-built tx, broadcast it, mine, sync.
@@ -582,10 +597,12 @@ async fn refill_workflow_skips_existing_pool_members() {
             utxo_value,
             2,
             GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect("first seed");
-    let signed = sign_and_finalize(first.psbt, general_kp);
+    let (first_psbt, _first_lease) = first.into_parts();
+    let signed = sign_and_finalize(first_psbt, general_kp);
     bitcoind
         .client
         .send_raw_transaction(&signed)
@@ -609,16 +626,17 @@ async fn refill_workflow_skips_existing_pool_members() {
             utxo_value,
             2,
             GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
         )
         .await
         .expect("refill");
-    for spent in refill.spent() {
+    for spent in refill.lease().outpoints() {
         assert!(
-            !pool_outpoints_first.contains(&spent),
+            !pool_outpoints_first.contains(spent),
             "refill must not spend an existing pool UTXO ({spent})"
         );
     }
-    let signed_refill = sign_and_finalize(refill.psbt, general_kp);
+    let signed_refill = sign_and_finalize(refill.psbt().clone(), general_kp);
     bitcoind
         .client
         .send_raw_transaction(&signed_refill)

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -174,10 +174,14 @@ async fn committed_leases_survive_until_an_explicit_release() {
     };
 
     assert!(wallet.leased_outpoints().is_empty(), "starts empty");
-    wallet.lease_committed(vec![op_a, op_b], LeaseOwner::StakeFunding);
+    wallet
+        .lease_committed(vec![op_a, op_b], LeaseOwner::StakeFunding)
+        .await;
     assert_eq!(wallet.leased_outpoints().len(), 2, "two held");
     // A second committed lease on one of them does not change what is held.
-    wallet.lease_committed(vec![op_a], LeaseOwner::StakeFunding);
+    wallet
+        .lease_committed(vec![op_a], LeaseOwner::StakeFunding)
+        .await;
     assert_eq!(
         wallet.leased_outpoints().len(),
         2,
@@ -434,8 +438,9 @@ async fn reserve_utxo_with_value_picks_and_leases_one() {
     drop(seed_lease);
     assert!(wallet.leased_outpoints().is_empty(), "lease state cleared");
 
-    let (picked, remaining) =
-        wallet.reserve_utxo_with_value(utxo_value, LeaseOwner::ClaimFunding, |_| false);
+    let (picked, remaining) = wallet
+        .reserve_utxo_with_value(utxo_value, LeaseOwner::ClaimFunding, |_| false)
+        .await;
     let (picked, picked_lease) = picked.expect("must return one outpoint");
     assert_eq!(remaining, 2, "two more left in the pool");
     assert!(
@@ -444,8 +449,9 @@ async fn reserve_utxo_with_value_picks_and_leases_one() {
     );
 
     // A second pick skips the held outpoint and returns a different one.
-    let (picked_again, remaining_again) =
-        wallet.reserve_utxo_with_value(utxo_value, LeaseOwner::ClaimFunding, |_| false);
+    let (picked_again, remaining_again) = wallet
+        .reserve_utxo_with_value(utxo_value, LeaseOwner::ClaimFunding, |_| false)
+        .await;
     let (picked_again, _picked_again_lease) = picked_again.expect("must return another outpoint");
     assert_ne!(picked_again, picked, "must pick a different free UTXO");
     assert_eq!(remaining_again, 1, "one more left after second pick");
@@ -455,6 +461,133 @@ async fn reserve_utxo_with_value_picks_and_leases_one() {
     assert!(
         !wallet.leased_outpoints().contains(&picked),
         "a dropped lease must return its outpoint to the pool"
+    );
+}
+
+/// A general-wallet backend that yields before it selects.
+///
+/// The native backend builds a transaction without an await, so two funding calls on it never
+/// interleave whatever the composer does. A backend that reaches a remote custodian does
+/// await, and that is the shape which exposes the gap between reading the held outpoints and
+/// taking the lease. This mock reproduces that shape with `yield_now`.
+#[derive(Debug)]
+struct YieldingGeneralWallet {
+    utxos: Vec<operator_wallet::UtxoInfo>,
+}
+
+impl GeneralWallet for YieldingGeneralWallet {
+    type Error = std::io::Error;
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn script_pubkey(&self) -> bdk_wallet::bitcoin::ScriptBuf {
+        bdk_wallet::bitcoin::ScriptBuf::new()
+    }
+
+    fn list_utxos(&self) -> Vec<operator_wallet::UtxoInfo> {
+        self.utxos.clone()
+    }
+
+    async fn fund_v3_transaction(
+        &self,
+        _outputs: Vec<bdk_wallet::bitcoin::TxOut>,
+        _explicit_inputs: Option<&[OutPoint]>,
+        _fee_rate: FeeRate,
+        exclude: &[OutPoint],
+    ) -> Result<operator_wallet::FundedPsbt, Self::Error> {
+        // The await that a remote custodian performs.
+        tokio::task::yield_now().await;
+        let picked = self
+            .utxos
+            .iter()
+            .find(|u| !exclude.contains(&u.outpoint))
+            .ok_or_else(|| std::io::Error::other("no candidate"))?;
+        let tx = Transaction {
+            version: bdk_wallet::bitcoin::transaction::Version::TWO,
+            lock_time: bdk_wallet::bitcoin::absolute::LockTime::ZERO,
+            input: vec![bdk_wallet::bitcoin::TxIn {
+                previous_output: picked.outpoint,
+                ..Default::default()
+            }],
+            output: Vec::new(),
+        };
+        Ok(operator_wallet::FundedPsbt {
+            psbt: Psbt::from_unsigned_tx(tx).expect("unsigned tx"),
+        })
+    }
+
+    async fn build_cpfp_child(
+        &self,
+        _parent: &Transaction,
+        _parent_fee: Amount,
+        _anchor: operator_wallet::AnchorInfo,
+        _target_pkg_fee_rate: FeeRate,
+        _exclude: &[OutPoint],
+        _replaced: operator_wallet::ReplacedChild<'_>,
+    ) -> Result<operator_wallet::FundedPsbt, Self::Error> {
+        unreachable!("this test does not build CPFP children")
+    }
+}
+
+/// Two funding calls that run at the same time must not select one general-wallet UTXO twice.
+///
+/// A funding call reads the set of held outpoints, awaits the backend selection, and takes its
+/// lease when the backend returns. The read and the lease sit on either side of an await, so
+/// without a lock across both, two calls read the same set and pick the same outpoint. The two
+/// transactions that follow then conflict, and the chain accepts only one.
+#[tokio::test]
+#[serial]
+async fn concurrent_funding_never_selects_one_utxo_twice() {
+    let bitcoind = setup_bitcoind();
+    let (_reserved_kp, reserved_pubkey) = keypair_from_seed(16);
+    let utxos = (1u8..=4)
+        .map(|n| operator_wallet::UtxoInfo {
+            outpoint: OutPoint {
+                txid: bdk_wallet::bitcoin::Txid::from_slice(&[n; 32]).unwrap(),
+                vout: 0,
+            },
+            amount: Amount::from_btc(0.2).unwrap(),
+            confirmations: 3,
+            script_pubkey: bdk_wallet::bitcoin::ScriptBuf::new(),
+        })
+        .collect();
+    let wallet = Arc::new(OperatorWallet::new(
+        YieldingGeneralWallet { utxos },
+        reserved_pubkey,
+        OperatorWalletConfig::new(SENTINEL_ANCHOR_VALUE, Network::Regtest),
+        Backend::BitcoinCore(Arc::new(sync_rpc_client(&bitcoind))),
+        BTreeSet::new(),
+    ));
+
+    let utxo_value = Amount::from_btc(0.01).unwrap();
+    let fee_rate = FeeRate::from_sat_per_vb(5).unwrap();
+    let (first, second) = tokio::join!(
+        wallet.create_reserved_utxos(
+            fee_rate,
+            utxo_value,
+            1,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
+        ),
+        wallet.create_reserved_utxos(
+            fee_rate,
+            utxo_value,
+            1,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+            LeaseOwner::ClaimFundingRefill,
+        ),
+    );
+    let first = first.expect("the first funding must succeed");
+    let second = second.expect("the second funding must succeed");
+
+    let first_inputs: BTreeSet<OutPoint> = first.lease().outpoints().iter().copied().collect();
+    let second_inputs: BTreeSet<OutPoint> = second.lease().outpoints().iter().copied().collect();
+    let shared: Vec<_> = first_inputs.intersection(&second_inputs).collect();
+    assert!(
+        shared.is_empty(),
+        "two funding calls that run at the same time selected the same input: {shared:?}"
     );
 }
 
@@ -527,7 +660,9 @@ async fn sync_prunes_leases_whose_outpoints_have_been_spent() {
         .map(|u| u.outpoint)
         .collect();
     let target_outpoint = general_utxos[0];
-    wallet.lease_committed(vec![target_outpoint], LeaseOwner::StakeFunding);
+    wallet
+        .lease_committed(vec![target_outpoint], LeaseOwner::StakeFunding)
+        .await;
     assert!(wallet.leased_outpoints().contains(&target_outpoint));
 
     // Spend `target_outpoint` directly via a manually-built tx, broadcast it, mine, sync.

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -475,8 +475,19 @@ struct YieldingGeneralWallet {
     utxos: Vec<operator_wallet::UtxoInfo>,
 }
 
+/// Error of the mock backend. Nothing in this test depends on the classification.
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct MockError(String);
+
+impl operator_wallet::ErrorPermanence for MockError {
+    fn is_permanent(&self) -> bool {
+        false
+    }
+}
+
 impl GeneralWallet for YieldingGeneralWallet {
-    type Error = std::io::Error;
+    type Error = MockError;
 
     async fn sync(&mut self) -> Result<(), Self::Error> {
         Ok(())
@@ -503,7 +514,7 @@ impl GeneralWallet for YieldingGeneralWallet {
             .utxos
             .iter()
             .find(|u| !exclude.contains(&u.outpoint))
-            .ok_or_else(|| std::io::Error::other("no candidate"))?;
+            .ok_or_else(|| MockError("no candidate".into()))?;
         let tx = Transaction {
             version: bdk_wallet::bitcoin::transaction::Version::TWO,
             lock_time: bdk_wallet::bitcoin::absolute::LockTime::ZERO,

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -70,7 +70,7 @@ static PLACEHOLDER_P2TR_SCRIPT_PUBKEY: LazyLock<ScriptBuf> = LazyLock::new(|| {
 /// When [`FEE_RATE_SAT_PER_VB`] is non-zero, returns rust-bitcoin's `Script::minimal_non_dust`
 /// for a P2TR script_pubkey, the smallest amount bitcoin core's relay policy accepts on a tx
 /// that pays a fee.
-pub(crate) fn anchor_dust_value() -> Amount {
+pub fn anchor_dust_value() -> Amount {
     if FEE_RATE_SAT_PER_VB == 0 {
         Amount::ZERO
     } else {


### PR DESCRIPTION
## Description

Wires CPFP fee-bumping for **15 of 17** bridge tx kinds via v3 1P1C packages submitted with `submitpackage`. Aggressive RBF on every new block, mempool eviction, and a configurable timer tick (default 30 s).

Both `CpfpStrategy` variants are wired:
- **AnchorBearing** for keyed-anchor parents: claim, stake, unstaking_intent, counterproof, counterproof_ack, contest, bridge_proof_timeout.
- **ParentTxCombined** for payout-output parents: coop_payout, uncontested_payout, contested_payout, unstaking, counterproof_nack (statically-known vout) + WFT, stake funding, slash (script-discovery via `InferGeneralPayout`).

Only **deposit** and **bridge_proof** remain unbumpable — both genuinely lack any operator-owned output and would need tx-graph changes to gain a CPFP hook.

### Type of Change

- [x] New feature/Enhancement

## Notes to Reviewers

**Architecture seam.** `btc-tracker` defines three abstract traits (`CpfpWallet`, `CpfpFeeSource`, `CpfpPackageSubmitter`); `bridge-exec` wires concrete adapters over `OperatorWallet` + bitcoind. `CpfpContext` + `perform_bump` are the single source of truth for one bump attempt. The trait split keeps `btc-tracker` at the bottom of the dependency graph and makes the upcoming Fireblocks backend a pure trait-impl exercise.

**Backend-agnostic signing contract.** `CpfpWallet::build_cpfp_child` may return a fully-unsigned, partially-signed, or fully-signed PSBT. `perform_bump` inspects each input's `final_script_witness` and only signs the unsigned ones (anchor via `anchor_input_signer` keyed to the operator's musig2 key; everything else via `wallet_input_signer` keyed to the general key). This means:
- `NativeGeneralWallet` (descriptor-only) returns unsigned PSBT → bump loop signs everything.
- Upcoming Fireblocks backend (create-and-sign) will return partial PSBT → bump loop only signs the foreign anchor input.

**Notable design choices**, full rationale in commit body:
- `CpfpKind` enum lets each `publish_signed_transaction` call site declare CPFP intent explicitly.
- `parent_fee` is caller-supplied (presigned txs use `FEE_RATE × vsize`; wallet-funded txs use `Psbt::fee()` or `exact_fee_from_prevouts`).
- `CachedFeeSource` wraps `estimatesmartfee` with an atomic background refresh so the bump loop reads constant-time.
- `BumpReason` enum: eager bumps skip on `target ≤ last`; reactive bumps always rebuild to handle silent child eviction.
- Block/tick arms spawn `bump_all_entries` with a `JoinHandle` guard to prevent fan-out pile-up; entries-mutex held briefly for snapshot/writeback only.
- `_covenant_keys_field_audit` in `crates/common/src/params.rs` — compile-time guard so splitting watchtower keys from musig2 keys breaks the build until the CPFP anchor-inference path is taught to dispatch per-anchor.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-3439