### PR TITLE
add sighash to Musig2Params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9154,7 +9154,6 @@ dependencies = [
  "colored",
  "hkdf",
  "libp2p-identity",
- "make_buf",
  "memory_pprof",
  "musig2",
  "rand 0.8.5",

--- a/bin/secret-service/Cargo.toml
+++ b/bin/secret-service/Cargo.toml
@@ -12,8 +12,6 @@ secret-service-server.workspace = true
 strata-bridge-key-deriv.workspace = true
 strata-bridge-primitives.workspace = true
 
-make_buf = { git = "https://github.com/alpenlabs/make_buf", version = "1.0.0" }
-
 bitcoin.workspace = true
 cache-advisor = "1.0.16"
 colored = "3.1.1"

--- a/bin/secret-service/src/seeded_impl/musig2.rs
+++ b/bin/secret-service/src/seeded_impl/musig2.rs
@@ -192,7 +192,6 @@ impl Musig2Signer<Server> for Ms2Signer {
         &self,
         params: Musig2Params,
         aggnonce: AggNonce,
-        message: [u8; 32],
     ) -> Result<PartialSignature, OneOf<(OurPubKeyIsNotInParams, SelfVerifyFailed)>> {
         let key_agg_ctx = Self::key_agg_ctx(&params);
         let secnonce = self
@@ -205,7 +204,7 @@ impl Musig2Signer<Server> for Ms2Signer {
             secnonce,
             &aggnonce,
             MaybePoint::Infinity,
-            message,
+            params.sighash,
         ) {
             Ok(ps) => ps,
             Err(SigningError::UnknownKey) => {

--- a/bin/secret-service/src/seeded_impl/musig2.rs
+++ b/bin/secret-service/src/seeded_impl/musig2.rs
@@ -257,7 +257,7 @@ impl SchnorrSigner<Server> for Ms2Signer {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::{bip32::Xpriv, hashes::Hash, Network, OutPoint, Txid};
+    use bitcoin::{bip32::Xpriv, Network};
     use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer};
     use strata_bridge_primitives::scripts::taproot::TaprootTweak;
 
@@ -273,7 +273,6 @@ mod tests {
         Musig2Params {
             ordered_pubkeys: vec![signer.kp.x_only_public_key().0],
             tweak,
-            input: OutPoint::new(Txid::all_zeros(), 0),
             sighash,
         }
     }

--- a/bin/secret-service/src/seeded_impl/musig2.rs
+++ b/bin/secret-service/src/seeded_impl/musig2.rs
@@ -8,13 +8,11 @@ use std::{
 
 use bitcoin::{
     bip32::Xpriv,
-    hashes::Hash as _,
     key::{Parity, TapTweak},
     TapNodeHash, XOnlyPublicKey,
 };
 use cache_advisor::CacheAdvisor;
 use hkdf::Hkdf;
-use make_buf::make_buf;
 use musig2::{
     errors::SigningError,
     secp::{MaybePoint, Point},
@@ -141,11 +139,20 @@ impl Ms2Signer {
         key_agg_ctx: &KeyAggContext,
     ) -> Result<SecNonce, OurPubKeyIsNotInParams> {
         SECNONCE_CACHE.lock().await.get(params, |params| {
+            // HKDF `info` = domain-separation tag || sighash.
+            //
+            // - The sighash is the load-bearing binding: distinct messages must produce distinct
+            //   SecNonces, otherwise reusing the same nonce across different messages leaks the
+            //   operator's secret key.
+            // - The domain tag guarantees that, if `self.ikm` is ever reused as input keying
+            //   material for a different HKDF purpose, the resulting derivations are
+            //   cryptographically independent
+            const DOMAIN_TAG: &[u8] = b"strata-bridge-musig2-secnonce";
+            let mut info = Vec::with_capacity(DOMAIN_TAG.len() + params.sighash.len());
+            info.extend_from_slice(DOMAIN_TAG);
+            info.extend_from_slice(&params.sighash);
+
             let nonce_seed = {
-                let info = make_buf! {
-                    (&params.input.txid.as_raw_hash().to_byte_array(), 32),
-                    (&params.input.vout.to_le_bytes(), 4)
-                };
                 let hk = Hkdf::<Sha256>::new(None, &*self.ikm);
                 let mut output = [0u8; 32];
                 hk.expand(&info, &mut output)
@@ -246,5 +253,99 @@ impl SchnorrSigner<Server> for Ms2Signer {
 
     async fn pubkey(&self) -> <Server as Origin>::Container<XOnlyPublicKey> {
         self.kp.x_only_public_key().0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{bip32::Xpriv, hashes::Hash, Network, OutPoint, Txid};
+    use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer};
+    use strata_bridge_primitives::scripts::taproot::TaprootTweak;
+
+    use super::*;
+
+    fn test_signer() -> Ms2Signer {
+        let seed = [0x42u8; 32];
+        let xpriv = Xpriv::new_master(Network::Signet, &seed).expect("valid xpriv");
+        Ms2Signer::new(&xpriv)
+    }
+
+    fn params_with(signer: &Ms2Signer, sighash: [u8; 32], tweak: TaprootTweak) -> Musig2Params {
+        Musig2Params {
+            ordered_pubkeys: vec![signer.kp.x_only_public_key().0],
+            tweak,
+            input: OutPoint::new(Txid::all_zeros(), 0),
+            sighash,
+        }
+    }
+
+    /// Regression test for the MuSig2 nonce-reuse vulnerability: distinct sighashes
+    /// must produce distinct pubnonces, even when the rest of the Musig2Params is
+    /// identical. The original bug derived the secret nonce from `(txid, vout)`
+    /// only, so two contest-tx tapscript leaves on the same input shared a nonce.
+    #[tokio::test]
+    async fn distinct_sighash_yields_distinct_pubnonce() {
+        let signer = test_signer();
+        let tweak = TaprootTweak::Key { tweak: None };
+        let n1 = signer
+            .get_pub_nonce(params_with(&signer, [0x11; 32], tweak))
+            .await
+            .expect("our pubkey is in params");
+        let n2 = signer
+            .get_pub_nonce(params_with(&signer, [0x22; 32], tweak))
+            .await
+            .expect("our pubkey is in params");
+        assert_ne!(
+            n1.serialize(),
+            n2.serialize(),
+            "different sighashes must produce different pubnonces"
+        );
+    }
+
+    /// Determinism: identical params return the same pubnonce. Exercises the
+    /// cache hit path on the second call.
+    #[tokio::test]
+    async fn identical_params_yield_identical_pubnonce() {
+        let signer = test_signer();
+        let tweak = TaprootTweak::Key { tweak: None };
+        let n1 = signer
+            .get_pub_nonce(params_with(&signer, [0x33; 32], tweak))
+            .await
+            .expect("our pubkey is in params");
+        let n2 = signer
+            .get_pub_nonce(params_with(&signer, [0x33; 32], tweak))
+            .await
+            .expect("our pubkey is in params");
+        assert_eq!(
+            n1.serialize(),
+            n2.serialize(),
+            "identical params must produce identical pubnonces"
+        );
+    }
+
+    /// Distinct tweaks must produce distinct pubnonces. The tweak shifts the
+    /// aggregated key (key-path tweak) or skips the tweak entirely (script path),
+    /// which is bound into the SecNonce via `with_aggregated_pubkey`.
+    #[tokio::test]
+    async fn distinct_tweak_yields_distinct_pubnonce() {
+        let signer = test_signer();
+        let sighash = [0x44; 32];
+        let n1 = signer
+            .get_pub_nonce(params_with(
+                &signer,
+                sighash,
+                TaprootTweak::Key { tweak: None },
+            ))
+            .await
+            .expect("our pubkey is in params");
+        let n2 = signer
+            .get_pub_nonce(params_with(&signer, sighash, TaprootTweak::Script))
+            .await
+            .expect("our pubkey is in params");
+        assert_ne!(
+            n1.serialize(),
+            n2.serialize(),
+            "different tweaks must produce different pubnonces"
+        );
     }
 }

--- a/bin/secret-service/src/tests.rs
+++ b/bin/secret-service/src/tests.rs
@@ -293,6 +293,7 @@ async fn musig2() {
     let tweak = TaprootTweak::Key { tweak: None };
 
     let remote_public_key = ms2_signer.pubkey().await.expect("good response");
+    let digest_to_sign: [u8; 32] = thread_rng().gen();
     let params = Musig2Params {
         ordered_pubkeys: {
             let mut pubkeys = local_signers
@@ -305,6 +306,7 @@ async fn musig2() {
         },
         tweak,
         input: OutPoint::new(Txid::all_zeros(), 0),
+        sighash: digest_to_sign,
     };
 
     println!("remote pubkey: {remote_public_key:?}");
@@ -377,8 +379,6 @@ async fn musig2() {
         .unwrap()] = remote_pub_nonce.clone();
 
     let aggnonce = AggNonce::sum(&pubnonces);
-
-    let digest_to_sign = thread_rng().gen();
 
     // send this signer's public nonce to secret service
     let remote_partial_sig = ms2_signer

--- a/bin/secret-service/src/tests.rs
+++ b/bin/secret-service/src/tests.rs
@@ -382,7 +382,7 @@ async fn musig2() {
 
     // send this signer's public nonce to secret service
     let remote_partial_sig = ms2_signer
-        .get_our_partial_sig(params.clone(), aggnonce.clone(), digest_to_sign)
+        .get_our_partial_sig(params.clone(), aggnonce.clone())
         .await
         .expect("good response")
         .expect("partial sig");

--- a/bin/secret-service/src/tests.rs
+++ b/bin/secret-service/src/tests.rs
@@ -10,7 +10,7 @@ use std::{
 use bitcoin::{
     hashes::Hash,
     key::{Parity, Secp256k1, TapTweak},
-    Network, OutPoint, TapNodeHash, Txid, XOnlyPublicKey,
+    Network, TapNodeHash, Txid, XOnlyPublicKey,
 };
 use musig2::{
     secp256k1::{Message, Scalar, SecretKey, SECP256K1},
@@ -305,7 +305,6 @@ async fn musig2() {
             pubkeys
         },
         tweak,
-        input: OutPoint::new(Txid::all_zeros(), 0),
         sighash: digest_to_sign,
     };
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -270,7 +270,6 @@ async fn publish_deposit_nonce(
     let params = Musig2Params {
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: drt_tweak,
-        input: drt_outpoint,
         sighash: *sighash.as_ref(),
     };
 
@@ -330,7 +329,6 @@ async fn publish_deposit_partial(
     let params = Musig2Params {
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: signing_info.tweak,
-        input: drt_outpoint,
         sighash: *signing_info.sighash.as_ref(),
     };
 
@@ -658,7 +656,6 @@ async fn publish_payout_nonce(
     let params = Musig2Params {
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak,
-        input: deposit_outpoint,
         sighash: *payout_sighash.as_ref(),
     };
 
@@ -703,7 +700,6 @@ async fn publish_payout_partial(
     let params = Musig2Params {
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: TaprootTweak::Key { tweak: None },
-        input: deposit_outpoint,
         sighash: *payout_sighash.as_ref(),
     };
 
@@ -752,7 +748,7 @@ async fn publish_payout(
     pov_operator_idx: OperatorIdx,
 ) -> Result<(), ExecutorError> {
     let txid = (*payout_coop_tx).as_ref().compute_txid();
-    info!(%txid, "signing cooperative payout");
+    info!(%deposit_outpoint, %txid, "signing cooperative payout");
 
     // Derive the sighash from the cooperative payout transaction
     let payout_sighash = payout_coop_tx
@@ -766,7 +762,6 @@ async fn publish_payout(
     let params = Musig2Params {
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: TaprootTweak::Key { tweak: None },
-        input: deposit_outpoint,
         sighash: *payout_sighash.as_ref(),
     };
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -271,6 +271,7 @@ async fn publish_deposit_nonce(
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: drt_tweak,
         input: drt_outpoint,
+        sighash: *sighash.as_ref(),
     };
 
     // Generate nonce via secret service
@@ -330,6 +331,7 @@ async fn publish_deposit_partial(
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: signing_info.tweak,
         input: drt_outpoint,
+        sighash: *signing_info.sighash.as_ref(),
     };
 
     // Generate partial signature via secret service
@@ -657,6 +659,7 @@ async fn publish_payout_nonce(
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak,
         input: deposit_outpoint,
+        sighash: *payout_sighash.as_ref(),
     };
 
     // Generate nonce via secret service
@@ -701,6 +704,7 @@ async fn publish_payout_partial(
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: TaprootTweak::Key { tweak: None },
         input: deposit_outpoint,
+        sighash: *payout_sighash.as_ref(),
     };
 
     // Generate partial signature via secret service
@@ -763,6 +767,7 @@ async fn publish_payout(
         ordered_pubkeys: ordered_pubkeys.to_vec(),
         tweak: TaprootTweak::Key { tweak: None },
         input: deposit_outpoint,
+        sighash: *payout_sighash.as_ref(),
     };
 
     // Generate assignee's partial signature

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -52,6 +52,7 @@ pub async fn execute_deposit_duty(
             claim_txids,
             ordered_pubkeys,
             drt_tweak,
+            sighash,
         } => {
             publish_deposit_nonce(
                 &output_handles,
@@ -60,6 +61,7 @@ pub async fn execute_deposit_duty(
                 claim_txids,
                 ordered_pubkeys,
                 *drt_tweak,
+                *sighash,
             )
             .await
         }
@@ -110,6 +112,7 @@ pub async fn execute_deposit_duty(
             deposit_outpoint,
             ordered_pubkeys,
             tweak,
+            payout_sighash,
         } => {
             publish_payout_nonce(
                 &output_handles,
@@ -117,6 +120,7 @@ pub async fn execute_deposit_duty(
                 *deposit_outpoint,
                 ordered_pubkeys,
                 *tweak,
+                *payout_sighash,
             )
             .await
         }
@@ -239,6 +243,7 @@ async fn publish_deposit_nonce(
     claim_txids: &[Txid],
     ordered_pubkeys: &[XOnlyPublicKey],
     drt_tweak: TaprootTweak,
+    sighash: Message,
 ) -> Result<(), ExecutorError> {
     info!(%drt_outpoint, "checking pre-conditions before generating deposit nonce");
     info!(
@@ -643,6 +648,7 @@ async fn publish_payout_nonce(
     deposit_outpoint: OutPoint,
     ordered_pubkeys: &[XOnlyPublicKey],
     tweak: TaprootTweak,
+    payout_sighash: Message,
 ) -> Result<(), ExecutorError> {
     info!(%deposit_outpoint, "generating payout nonce");
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -338,7 +338,7 @@ async fn publish_deposit_partial(
     let partial_sig: PartialSignature = output_handles
         .s2_client
         .musig2_signer()
-        .get_our_partial_sig(params, deposit_agg_nonce, *signing_info.sighash.as_ref())
+        .get_our_partial_sig(params, deposit_agg_nonce)
         .await?
         .map_err(|e| match e.to_enum() {
             terrors::E2::A(_) => ExecutorError::OurPubKeyNotInParams,
@@ -711,7 +711,7 @@ async fn publish_payout_partial(
     let partial_sig: PartialSignature = output_handles
         .s2_client
         .musig2_signer()
-        .get_our_partial_sig(params, payout_agg_nonce, *payout_sighash.as_ref())
+        .get_our_partial_sig(params, payout_agg_nonce)
         .await?
         .map_err(|e| match e.to_enum() {
             terrors::E2::A(_) => ExecutorError::OurPubKeyNotInParams,
@@ -774,7 +774,7 @@ async fn publish_payout(
     let assignee_partial: PartialSignature = output_handles
         .s2_client
         .musig2_signer()
-        .get_our_partial_sig(params, payout_agg_nonce.clone(), *payout_sighash.as_ref())
+        .get_our_partial_sig(params, payout_agg_nonce.clone())
         .await?
         .map_err(|e| match e.to_enum() {
             terrors::E2::A(_) => ExecutorError::OurPubKeyNotInParams,

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -394,7 +394,6 @@ pub(super) async fn publish_graph_nonces(
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak: *tweak,
-                input: *inpoint,
                 sighash: *sighash.as_ref(),
             };
             musig_signer.get_pub_nonce(params).map(move |res| match res {
@@ -488,7 +487,6 @@ pub(super) async fn publish_graph_partials(
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak: *tweak,
-                input: *inpoint,
                 sighash: *sighash.as_ref(),
             };
             musig_signer

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -492,7 +492,7 @@ pub(super) async fn publish_graph_partials(
                 sighash: *sighash.as_ref(),
             };
             musig_signer
-                .get_our_partial_sig(params, agg_nonce.clone(), *sighash.as_ref())
+                .get_our_partial_sig(params, agg_nonce.clone())
                 .map(move |res| match res {
                 Ok(inner) => inner.map_err(|e| match e.to_enum() {
                     terrors::E2::A(_) => {

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -377,6 +377,7 @@ pub(super) async fn publish_graph_nonces(
     graph_idx: GraphIdx,
     graph_inpoints: &[OutPoint],
     graph_tweaks: &[TaprootTweak],
+    sighashes: &[Message],
     ordered_pubkeys: &[XOnlyPublicKey],
 ) -> Result<(), ExecutorError> {
     info!(?graph_idx, "publishing graph nonces");

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -389,11 +389,13 @@ pub(super) async fn publish_graph_nonces(
     let nonce_futures = graph_inpoints
         .iter()
         .zip(graph_tweaks.iter())
-        .map(|(inpoint, tweak)| {
+        .zip(sighashes.iter())
+        .map(|((inpoint, tweak), sighash)| {
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak: *tweak,
                 input: *inpoint,
+                sighash: *sighash.as_ref(),
             };
             musig_signer.get_pub_nonce(params).map(move |res| match res {
                 Ok(inner) => inner.map_err(|_| {
@@ -487,6 +489,7 @@ pub(super) async fn publish_graph_partials(
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak: *tweak,
                 input: *inpoint,
+                sighash: *sighash.as_ref(),
             };
             musig_signer
                 .get_our_partial_sig(params, agg_nonce.clone(), *sighash.as_ref())

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -78,6 +78,7 @@ pub async fn execute_graph_duty(
             graph_idx,
             graph_inpoints,
             graph_tweaks,
+            sighashes,
             ordered_pubkeys,
         } => {
             publish_graph_nonces(
@@ -85,6 +86,7 @@ pub async fn execute_graph_duty(
                 *graph_idx,
                 graph_inpoints,
                 graph_tweaks,
+                sighashes,
                 ordered_pubkeys,
             )
             .await

--- a/crates/bridge-exec/src/stake/mod.rs
+++ b/crates/bridge-exec/src/stake/mod.rs
@@ -29,6 +29,7 @@ pub async fn execute_stake_duty(
             operator_idx,
             graph_inpoints,
             graph_tweaks,
+            sighashes,
             ordered_pubkeys,
         } => {
             info!(%operator_idx, "executing StakeDuty::PublishUnstakingNonces");
@@ -37,6 +38,7 @@ pub async fn execute_stake_duty(
                 *operator_idx,
                 **graph_inpoints,
                 **graph_tweaks,
+                **sighashes,
                 ordered_pubkeys.clone(),
             )
             .await

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -296,7 +296,6 @@ pub(crate) async fn publish_unstaking_nonces(
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak,
-                input: inpoint,
                 sighash: *sighash.as_ref(),
             };
 
@@ -343,7 +342,6 @@ pub(crate) async fn publish_unstaking_partials(
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak,
-                input: inpoint,
                 sighash: *sighash.as_ref(),
             };
 

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -290,12 +290,14 @@ pub(crate) async fn publish_unstaking_nonces(
 
     let musig_signer = output_handles.s2_client.musig2_signer();
 
-    let nonce_futures = graph_inpoints.zip(graph_tweaks).into_iter()
-        .map(|(inpoint, tweak)| {
+    let nonce_futures = StakeFunctor::zip3(graph_inpoints, graph_tweaks, sighashes)
+        .into_iter()
+        .map(|(inpoint, tweak, sighash)| {
             let params = Musig2Params {
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak,
                 input: inpoint,
+                sighash: *sighash.as_ref(),
             };
 
             musig_signer.get_pub_nonce(params).map(move |res| match res {
@@ -342,6 +344,7 @@ pub(crate) async fn publish_unstaking_partials(
                 ordered_pubkeys: ordered_pubkeys.clone(),
                 tweak,
                 input: inpoint,
+                sighash: *sighash.as_ref(),
             };
 
             musig_signer

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -348,7 +348,7 @@ pub(crate) async fn publish_unstaking_partials(
             };
 
             musig_signer
-                .get_our_partial_sig(params, agg_nonce, *sighash.as_ref())
+                .get_our_partial_sig(params, agg_nonce)
                 .map(move |res| match res {
                     Ok(inner) => inner.map_err(|e| match e.to_enum() {
                         terrors::E2::A(_) => {

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -283,6 +283,7 @@ pub(crate) async fn publish_unstaking_nonces(
     operator_idx: OperatorIdx,
     graph_inpoints: StakeFunctor<OutPoint>,
     graph_tweaks: StakeFunctor<TaprootTweak>,
+    sighashes: StakeFunctor<Message>,
     ordered_pubkeys: Vec<XOnlyPublicKey>,
 ) -> Result<(), ExecutorError> {
     info!(%operator_idx, "generating and publishing unstaking nonces for the stake graph");

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -112,6 +112,8 @@ pub enum DepositDuty {
         ordered_pubkeys: Vec<XOnlyPublicKey>,
         /// The taproot tweak for the DRT output (merkle root of take-back script)
         drt_tweak: TaprootTweak,
+        /// Sighash for the DRT input. Used to bind the MuSig2 nonce to the message.
+        sighash: Message,
     },
     /// Publish this operator's partial signature for spending the DRT
     PublishDepositPartial {
@@ -161,6 +163,9 @@ pub enum DepositDuty {
         ordered_pubkeys: Vec<XOnlyPublicKey>,
         /// The taproot tweak for the deposit output.
         tweak: TaprootTweak,
+        /// Sighash for the cooperative payout input. Used to bind the MuSig2 nonce to the
+        /// message.
+        payout_sighash: Message,
     },
     /// Publish the partial signature for spending the deposit UTXO cooperatively.
     PublishPayoutPartial {

--- a/crates/bridge-sm/src/deposit/handlers/nag.rs
+++ b/crates/bridge-sm/src/deposit/handlers/nag.rs
@@ -172,11 +172,10 @@ impl DepositSM {
                 claim_txids,
                 ..
             } => {
-                let drt_tweak = deposit_transaction
+                let drt_signing_info = *deposit_transaction
                     .signing_info()
                     .first()
-                    .expect("deposit transaction must have signing info")
-                    .tweak;
+                    .expect("deposit transaction must have signing info");
                 let ordered_pubkeys = self
                     .context()
                     .operator_table()
@@ -189,7 +188,8 @@ impl DepositSM {
                     drt_outpoint: self.context().deposit_outpoint(),
                     claim_txids: claim_txids.values().copied().collect(),
                     ordered_pubkeys,
-                    drt_tweak,
+                    drt_tweak: drt_signing_info.tweak,
+                    sighash: drt_signing_info.sighash,
                 }])
             }
             _ => {
@@ -251,8 +251,19 @@ impl DepositSM {
     fn process_payout_nonce_nag(&self, event: &NagReceivedEvent) -> DSMResult<Vec<DepositDuty>> {
         let deposit_idx = self.context().deposit_idx();
         match self.state() {
-            DepositState::PayoutDescriptorReceived { .. }
-            | DepositState::PayoutNoncesCollected { .. } => {
+            DepositState::PayoutDescriptorReceived {
+                cooperative_payout_tx,
+                ..
+            }
+            | DepositState::PayoutNoncesCollected {
+                cooperative_payout_tx,
+                ..
+            } => {
+                let payout_sighash = cooperative_payout_tx
+                    .signing_info()
+                    .first()
+                    .expect("cooperative payout transaction must have signing info")
+                    .sighash;
                 let ordered_pubkeys = self
                     .context()
                     .operator_table()
@@ -266,6 +277,7 @@ impl DepositSM {
                     ordered_pubkeys,
                     // NOfNConnector uses key-path spend with no script tree
                     tweak: TaprootTweak::Key { tweak: None },
+                    payout_sighash,
                 }])
             }
             _ => {

--- a/crates/bridge-sm/src/deposit/tests/handlers/process_nag_received.rs
+++ b/crates/bridge-sm/src/deposit/tests/handlers/process_nag_received.rs
@@ -46,17 +46,17 @@ mod tests {
             .collect();
 
         let signing_info = deposit_tx.signing_info();
-        let drt_tweak = signing_info
+        let drt_signing_info = *signing_info
             .first()
-            .expect("deposit tx must have signing info")
-            .tweak;
+            .expect("deposit tx must have signing info");
 
         let expected_duty = DepositDuty::PublishDepositNonce {
             deposit_idx: TEST_DEPOSIT_IDX,
             drt_outpoint: test_deposit_outpoint(),
             claim_txids: expected_claim_txids,
             ordered_pubkeys,
-            drt_tweak,
+            drt_tweak: drt_signing_info.tweak,
+            sighash: drt_signing_info.sighash,
         };
 
         let nag_event = create_nag_event(NagRequestPayload::DepositNonce {
@@ -90,10 +90,9 @@ mod tests {
             .collect();
 
         let signing_info = deposit_tx.signing_info();
-        let drt_tweak = signing_info
+        let drt_signing_info = *signing_info
             .first()
-            .expect("deposit tx must have signing info")
-            .tweak;
+            .expect("deposit tx must have signing info");
         let agg_nonce = AggNonce::sum((0..N_TEST_OPERATORS).map(|_| generate_pubnonce()));
 
         let expected_duty = DepositDuty::PublishDepositNonce {
@@ -101,7 +100,8 @@ mod tests {
             drt_outpoint: test_deposit_outpoint(),
             claim_txids: expected_claim_txids,
             ordered_pubkeys,
-            drt_tweak,
+            drt_tweak: drt_signing_info.tweak,
+            sighash: drt_signing_info.sighash,
         };
 
         let nag_event = create_nag_event(NagRequestPayload::DepositNonce {
@@ -183,11 +183,18 @@ mod tests {
             .map(|pk| pk.x_only_public_key().0)
             .collect();
 
+        let payout_sighash = cooperative_payout_tx
+            .signing_info()
+            .first()
+            .expect("cooperative payout tx must have signing info")
+            .sighash;
+
         let expected_duty = DepositDuty::PublishPayoutNonce {
             deposit_idx: TEST_DEPOSIT_IDX,
             deposit_outpoint: test_deposit_outpoint(),
             ordered_pubkeys,
             tweak: TaprootTweak::Key { tweak: None },
+            payout_sighash,
         };
 
         let nag_event = create_nag_event(NagRequestPayload::PayoutNonce {
@@ -222,11 +229,18 @@ mod tests {
         let payout_aggregated_nonce =
             AggNonce::sum((0..N_TEST_OPERATORS).map(|_| generate_pubnonce()));
 
+        let payout_sighash = cooperative_payout_tx
+            .signing_info()
+            .first()
+            .expect("cooperative payout tx must have signing info")
+            .sighash;
+
         let expected_duty = DepositDuty::PublishPayoutNonce {
             deposit_idx: TEST_DEPOSIT_IDX,
             deposit_outpoint: test_deposit_outpoint(),
             ordered_pubkeys,
             tweak: TaprootTweak::Key { tweak: None },
+            payout_sighash,
         };
 
         let nag_event = create_nag_event(NagRequestPayload::PayoutNonce {

--- a/crates/bridge-sm/src/deposit/tests/payout/process_payout_descriptor_received.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_payout_descriptor_received.rs
@@ -41,7 +41,7 @@ mod tests {
                 fulfillment_txid,
                 cooperative_payment_deadline: LATER_BLOCK_HEIGHT
                     + test_deposit_sm_cfg().cooperative_payout_timeout_blocks(),
-                cooperative_payout_tx: test_cooperative_payout_txn(operator_desc),
+                cooperative_payout_tx: test_cooperative_payout_txn(operator_desc.clone()),
                 payout_nonces: BTreeMap::new(),
             },
             expected_duties: vec![DepositDuty::PublishPayoutNonce {
@@ -53,6 +53,11 @@ mod tests {
                     .map(|pk| pk.x_only_public_key().0)
                     .collect(),
                 tweak: TaprootTweak::Key { tweak: None },
+                payout_sighash: test_cooperative_payout_txn(operator_desc)
+                    .signing_info()
+                    .first()
+                    .expect("cooperative payout tx must have signing info")
+                    .sighash,
             }],
             expected_signals: vec![],
         });

--- a/crates/bridge-sm/src/deposit/transitions/deposit.rs
+++ b/crates/bridge-sm/src/deposit/transitions/deposit.rs
@@ -123,12 +123,11 @@ impl DepositSM {
                             let claim_txids = claim_txids.clone();
                             let claim_txids_list = claim_txids.values().copied().collect();
 
-                            // Get the tweak from signing_info
-                            let drt_tweak = deposit_transaction
+                            // Get the signing info (tweak + sighash) from the deposit tx
+                            let drt_signing_info = *deposit_transaction
                                 .signing_info()
                                 .first()
-                                .expect("deposit transaction must have signing info")
-                                .tweak;
+                                .expect("deposit transaction must have signing info");
 
                             // All operators have linked their graphs, transition to GraphGenerated
                             // state
@@ -155,7 +154,8 @@ impl DepositSM {
                                 drt_outpoint: deposit_outpoint,
                                 claim_txids: claim_txids_list,
                                 ordered_pubkeys,
-                                drt_tweak,
+                                drt_tweak: drt_signing_info.tweak,
+                                sighash: drt_signing_info.sighash,
                             };
 
                             return Ok(DSMOutput::with_duties(vec![duty]));

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -194,6 +194,12 @@ impl DepositSM {
                     descriptor.operator_desc,
                 );
 
+                let payout_sighash = cooperative_payout_tx
+                    .signing_info()
+                    .first()
+                    .expect("cooperative payout transaction must have signing info")
+                    .sighash;
+
                 // Transition to the PayoutDescriptorReceived state
                 self.state = DepositState::PayoutDescriptorReceived {
                     last_block_height: *last_block_height,
@@ -220,6 +226,7 @@ impl DepositSM {
                         ordered_pubkeys,
                         // NOfNConnector uses key-path spend with no script tree
                         tweak: TaprootTweak::Key { tweak: None },
+                        payout_sighash,
                     },
                 ]))
             }

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -140,6 +140,10 @@ pub enum GraphDuty {
         /// The tweak required for taproot spend per input being signed.
         graph_tweaks: Vec<TaprootTweak>,
 
+        /// Sighashes to sign. Used to bind the per-input MuSig2 nonce to the message,
+        /// preventing nonce reuse across distinct spend paths sharing an outpoint.
+        sighashes: Vec<Message>,
+
         /// The ordered public keys of all operators for MuSig2 aggregation.
         ordered_pubkeys: Vec<XOnlyPublicKey>,
     },

--- a/crates/bridge-sm/src/graph/handlers/nag.rs
+++ b/crates/bridge-sm/src/graph/handlers/nag.rs
@@ -217,12 +217,12 @@ impl GraphSM {
     ) -> GraphDuty {
         let game_graph = generate_game_graph(cfg, self.context(), graph_data);
         let graph_inpoints = game_graph.musig_inpoints().pack();
-        let graph_tweaks = game_graph
+        let (graph_tweaks, sighashes): (Vec<TaprootTweak>, Vec<Message>) = game_graph
             .musig_signing_info()
             .pack()
             .iter()
-            .map(|m| m.tweak)
-            .collect::<Vec<TaprootTweak>>();
+            .map(|m| (m.tweak, m.sighash))
+            .unzip();
         let ordered_pubkeys = self
             .context()
             .operator_table()
@@ -235,6 +235,7 @@ impl GraphSM {
             graph_idx: self.context().graph_idx(),
             graph_inpoints,
             graph_tweaks,
+            sighashes,
             ordered_pubkeys,
         }
     }

--- a/crates/bridge-sm/src/graph/tests/handlers/process_nag_received.rs
+++ b/crates/bridge-sm/src/graph/tests/handlers/process_nag_received.rs
@@ -3,7 +3,7 @@
 mod tests {
     use std::collections::BTreeMap;
 
-    use musig2::AggNonce;
+    use musig2::{AggNonce, secp256k1::Message};
     use strata_bridge_p2p_types::NagRequestPayload;
     use strata_bridge_primitives::scripts::taproot::TaprootTweak;
 
@@ -38,12 +38,12 @@ mod tests {
         let ctx = test_graph_sm_ctx();
         let game_graph = generate_game_graph(cfg, &ctx, &test_deposit_params());
         let graph_inpoints = game_graph.musig_inpoints().pack();
-        let graph_tweaks = game_graph
+        let (graph_tweaks, sighashes): (Vec<TaprootTweak>, Vec<Message>) = game_graph
             .musig_signing_info()
             .pack()
             .iter()
-            .map(|m| m.tweak)
-            .collect::<Vec<TaprootTweak>>();
+            .map(|m| (m.tweak, m.sighash))
+            .unzip();
         let ordered_pubkeys = ctx
             .operator_table()
             .btc_keys()
@@ -55,6 +55,7 @@ mod tests {
             graph_idx: ctx.graph_idx(),
             graph_inpoints,
             graph_tweaks,
+            sighashes,
             ordered_pubkeys,
         }
     }

--- a/crates/bridge-sm/src/graph/transitions/uncontested.rs
+++ b/crates/bridge-sm/src/graph/transitions/uncontested.rs
@@ -86,12 +86,12 @@ impl GraphSM {
                 // signatures. Transition directly to `AdaptorsVerified` state
                 if is_my_graph {
                     let graph_inpoints = game_graph.musig_inpoints().pack();
-                    let graph_tweaks = game_graph
+                    let (graph_tweaks, sighashes): (Vec<TaprootTweak>, Vec<Message>) = game_graph
                         .musig_signing_info()
                         .pack()
                         .iter()
-                        .map(|m| m.tweak)
-                        .collect::<Vec<TaprootTweak>>();
+                        .map(|m| (m.tweak, m.sighash))
+                        .unzip();
 
                     self.state = GraphState::AdaptorsVerified {
                         last_block_height: *last_block_height,
@@ -112,6 +112,7 @@ impl GraphSM {
                         graph_idx: self.context.graph_idx(),
                         graph_inpoints,
                         graph_tweaks,
+                        sighashes,
                         ordered_pubkeys,
                     }];
 
@@ -211,12 +212,12 @@ impl GraphSM {
             } => {
                 let game_graph = generate_game_graph(&cfg, self.context(), graph_data);
                 let graph_inpoints = game_graph.musig_inpoints().pack();
-                let graph_tweaks = game_graph
+                let (graph_tweaks, sighashes): (Vec<TaprootTweak>, Vec<Message>) = game_graph
                     .musig_signing_info()
                     .pack()
                     .iter()
-                    .map(|m| m.tweak)
-                    .collect::<Vec<TaprootTweak>>();
+                    .map(|m| (m.tweak, m.sighash))
+                    .unzip();
 
                 self.state = GraphState::AdaptorsVerified {
                     last_block_height: *last_block_height,
@@ -238,6 +239,7 @@ impl GraphSM {
                         graph_idx: self.context.graph_idx(),
                         graph_inpoints,
                         graph_tweaks,
+                        sighashes,
                         ordered_pubkeys,
                     },
                 ]))

--- a/crates/bridge-sm/src/stake/duties.rs
+++ b/crates/bridge-sm/src/stake/duties.rs
@@ -40,6 +40,10 @@ pub enum StakeDuty {
         /// The tweak required for taproot spend per input being signed.
         graph_tweaks: Box<StakeFunctor<TaprootTweak>>,
 
+        /// Sighashes per input being signed. Used to bind the MuSig2 nonce to the message,
+        /// preventing nonce reuse across distinct spend paths sharing an outpoint.
+        sighashes: Box<StakeFunctor<Message>>,
+
         /// The ordered public keys of all operators for MuSig2 aggregation.
         ordered_pubkeys: Vec<XOnlyPublicKey>,
     },

--- a/crates/bridge-sm/src/stake/handlers/nag_received.rs
+++ b/crates/bridge-sm/src/stake/handlers/nag_received.rs
@@ -146,10 +146,10 @@ impl StakeSM {
     ) -> StakeDuty {
         let stake_graph = StakeGraph::new(stake_data.expand(*cfg, self.context()));
         let graph_inpoints = stake_graph.musig_inpoints().boxed();
-        let graph_tweaks = stake_graph
+        let (graph_tweaks, sighashes) = stake_graph
             .musig_signing_info()
-            .map(|info| info.tweak)
-            .boxed();
+            .map(|info| (info.tweak, info.sighash))
+            .unzip();
         let ordered_pubkeys = self
             .context()
             .operator_table()
@@ -161,7 +161,8 @@ impl StakeSM {
         StakeDuty::PublishUnstakingNonces {
             operator_idx: self.context().operator_idx(),
             graph_inpoints,
-            graph_tweaks,
+            graph_tweaks: graph_tweaks.boxed(),
+            sighashes: sighashes.boxed(),
             ordered_pubkeys,
         }
     }

--- a/crates/bridge-sm/src/stake/tests/nag_received.rs
+++ b/crates/bridge-sm/src/stake/tests/nag_received.rs
@@ -20,10 +20,10 @@ fn create_nag_event(payload: NagRequestPayload) -> NagReceivedEvent {
 
 fn expected_publish_unstaking_nonces_duty() -> StakeDuty {
     let graph_inpoints = TEST_GRAPH.musig_inpoints().boxed();
-    let graph_tweaks = TEST_GRAPH
+    let (graph_tweaks, sighashes) = TEST_GRAPH
         .musig_signing_info()
-        .map(|info| info.tweak)
-        .boxed();
+        .map(|info| (info.tweak, info.sighash))
+        .unzip();
     let ordered_pubkeys = TEST_CTX
         .operator_table()
         .btc_keys()
@@ -34,7 +34,8 @@ fn expected_publish_unstaking_nonces_duty() -> StakeDuty {
     StakeDuty::PublishUnstakingNonces {
         operator_idx: TEST_CTX.operator_idx(),
         graph_inpoints,
-        graph_tweaks,
+        graph_tweaks: graph_tweaks.boxed(),
+        sighashes: sighashes.boxed(),
         ordered_pubkeys,
     }
 }

--- a/crates/bridge-sm/src/stake/transitions/stake_data_received.rs
+++ b/crates/bridge-sm/src/stake/transitions/stake_data_received.rs
@@ -50,10 +50,10 @@ impl StakeSM {
                 };
 
                 let graph_inpoints = stake_graph.musig_inpoints().boxed();
-                let graph_tweaks = stake_graph
+                let (graph_tweaks, sighashes) = stake_graph
                     .musig_signing_info()
-                    .map(|info| info.tweak)
-                    .boxed();
+                    .map(|info| (info.tweak, info.sighash))
+                    .unzip();
 
                 let ordered_pubkeys = self
                     .context()
@@ -67,7 +67,8 @@ impl StakeSM {
                     StakeDuty::PublishUnstakingNonces {
                         operator_idx: self.context().operator_idx(),
                         graph_inpoints,
-                        graph_tweaks,
+                        graph_tweaks: graph_tweaks.boxed(),
+                        sighashes: sighashes.boxed(),
                         ordered_pubkeys,
                     },
                 ]))

--- a/crates/secret-service-client/src/musig2.rs
+++ b/crates/secret-service-client/src/musig2.rs
@@ -49,14 +49,12 @@ impl Musig2Signer<Client> for Musig2Client {
         &self,
         params: Musig2Params,
         aggnonce: AggNonce,
-        message: [u8; 32],
     ) -> <Client as Origin>::Container<
         Result<PartialSignature, terrors::OneOf<(OurPubKeyIsNotInParams, SelfVerifyFailed)>>,
     > {
         let msg = ClientMessage::Musig2GetOurPartialSig {
             params: params.into(),
             aggnonce: aggnonce.serialize(),
-            message,
         };
         let res = self.conn.make_v2_req(msg).await?;
         if let ServerMessage::Musig2GetOurPartialSig(res) = res {

--- a/crates/secret-service-proto/src/v2/traits.rs
+++ b/crates/secret-service-proto/src/v2/traits.rs
@@ -245,6 +245,10 @@ pub struct Musig2Params {
     /// This is composed of the [`Txid`] of the transaction being signed and its input index
     /// (`vout`).
     pub input: OutPoint,
+    /// The sighash of the transaction input being signed.
+    ///
+    /// Included in the cache key so that nonce derivation is bound to the exact message.
+    pub sighash: [u8; 32],
 }
 
 /// The preimages are used to generate deterministic preimages

--- a/crates/secret-service-proto/src/v2/traits.rs
+++ b/crates/secret-service-proto/src/v2/traits.rs
@@ -217,10 +217,15 @@ pub trait Musig2Signer<O: Origin>: SchnorrSigner<O> + Send + Sync {
         params: Musig2Params,
     ) -> impl Future<Output = O::Container<Result<PubNonce, OurPubKeyIsNotInParams>>> + Send;
 
-    /// Given the params of a musig2 session, an aggregated nonce created from
-    /// the signers' session pubnonces and the message to sign, return a partial
-    /// signature. These can be validated and aggregated into the final
-    /// signature valid for the musig2 group public key by the caller.
+    /// Given the params of a musig2 session and an aggregated nonce created from
+    /// the signers' session pubnonces, return a partial signature over
+    /// [`Musig2Params::sighash`]. These can be validated and aggregated into the
+    /// final signature valid for the musig2 group public key by the caller.
+    ///
+    /// The message being signed is taken from `params.sighash` — the same value
+    /// that bound the secret nonce derivation — so the caller cannot accidentally
+    /// (or maliciously) request a partial signature over a different message than
+    /// the one the nonce was bound to.
     ///
     /// Fails if our pubkey wasn't present in [`Musig2Params::ordered_pubkeys`],
     /// or if the signature we produced fails to verify.
@@ -228,7 +233,6 @@ pub trait Musig2Signer<O: Origin>: SchnorrSigner<O> + Send + Sync {
         &self,
         params: Musig2Params,
         aggnonce: AggNonce,
-        message: [u8; 32],
     ) -> impl Future<
         Output = O::Container<
             Result<PartialSignature, OneOf<(OurPubKeyIsNotInParams, SelfVerifyFailed)>>,
@@ -247,7 +251,8 @@ pub struct Musig2Params {
     pub input: OutPoint,
     /// The sighash of the transaction input being signed.
     ///
-    /// Included in the cache key so that nonce derivation is bound to the exact message.
+    /// Used as the partial-signature message and as part of deterministic
+    /// secret nonce derivation.
     pub sighash: [u8; 32],
 }
 

--- a/crates/secret-service-proto/src/v2/traits.rs
+++ b/crates/secret-service-proto/src/v2/traits.rs
@@ -2,7 +2,7 @@
 
 use std::future::Future;
 
-use bitcoin::{OutPoint, TapNodeHash, Txid, XOnlyPublicKey};
+use bitcoin::{TapNodeHash, Txid, XOnlyPublicKey};
 use libp2p_identity::ed25519::SecretKey;
 use musig2::{secp256k1::schnorr::Signature, AggNonce, PartialSignature, PubNonce};
 use quinn::{ConnectionError, ReadExactError, WriteError};
@@ -244,11 +244,6 @@ pub trait Musig2Signer<O: Origin>: SchnorrSigner<O> + Send + Sync {
 pub struct Musig2Params {
     pub ordered_pubkeys: Vec<XOnlyPublicKey>,
     pub tweak: TaprootTweak,
-    /// The inpoint of a transaction being signed.
-    ///
-    /// This is composed of the [`Txid`] of the transaction being signed and its input index
-    /// (`vout`).
-    pub input: OutPoint,
     /// The sighash of the transaction input being signed.
     ///
     /// Used as the partial-signature message and as part of deterministic

--- a/crates/secret-service-proto/src/v2/wire.rs
+++ b/crates/secret-service-proto/src/v2/wire.rs
@@ -121,12 +121,11 @@ pub enum ClientMessage {
     /// Request for
     /// [`Musig2Signer::get_our_partial_sig`](super::traits::Musig2Signer::get_our_partial_sig).
     Musig2GetOurPartialSig {
-        /// Params for the musig2 session
+        /// Params for the musig2 session. The message being signed is
+        /// `params.sighash` — see the trait method docs.
         params: SerializableMusig2Params,
         /// Aggregated nonce from round 1
         aggnonce: [u8; 66],
-        /// Message to be signed
-        message: [u8; 32],
     },
 
     /// Request for

--- a/crates/secret-service-proto/src/v2/wire.rs
+++ b/crates/secret-service-proto/src/v2/wire.rs
@@ -187,6 +187,7 @@ pub struct SerializableMusig2Params {
     pub tweak: SerializableTaprootTweak,
     #[rkyv(with = super::rkyv_wrappers::OutPoint)]
     pub input: OutPoint,
+    pub sighash: [u8; 32],
 }
 
 impl From<Musig2Params> for SerializableMusig2Params {
@@ -199,6 +200,7 @@ impl From<Musig2Params> for SerializableMusig2Params {
                 .collect(),
             tweak: From::from(value.tweak),
             input: value.input,
+            sighash: value.sighash,
         }
     }
 }
@@ -221,6 +223,7 @@ impl TryFrom<SerializableMusig2Params> for Musig2Params {
             ordered_pubkeys,
             tweak: value.tweak.into(),
             input: value.input,
+            sighash: value.sighash,
         })
     }
 }

--- a/crates/secret-service-proto/src/v2/wire.rs
+++ b/crates/secret-service-proto/src/v2/wire.rs
@@ -2,7 +2,7 @@
 // TODO: <https://alpenlabs.atlassian.net/browse/STR-2706>
 // Calculate these hardcoded lengths at compile time once the compiler upgrade lands.
 
-use bitcoin::{taproot::TaprootError, OutPoint, XOnlyPublicKey};
+use bitcoin::{taproot::TaprootError, XOnlyPublicKey};
 use rkyv::{Archive, Deserialize, Serialize};
 use strata_bridge_primitives::scripts::taproot::TaprootTweak;
 use terrors::OneOf;
@@ -184,8 +184,6 @@ pub enum SignerTarget {
 pub struct SerializableMusig2Params {
     pub ordered_pubkeys: Vec<[u8; 32]>,
     pub tweak: SerializableTaprootTweak,
-    #[rkyv(with = super::rkyv_wrappers::OutPoint)]
-    pub input: OutPoint,
     pub sighash: [u8; 32],
 }
 
@@ -198,7 +196,6 @@ impl From<Musig2Params> for SerializableMusig2Params {
                 .map(|pk| pk.serialize())
                 .collect(),
             tweak: From::from(value.tweak),
-            input: value.input,
             sighash: value.sighash,
         }
     }
@@ -221,7 +218,6 @@ impl TryFrom<SerializableMusig2Params> for Musig2Params {
         Ok(Self {
             ordered_pubkeys,
             tweak: value.tweak.into(),
-            input: value.input,
             sighash: value.sighash,
         })
     }

--- a/crates/secret-service-server/src/lib.rs
+++ b/crates/secret-service-server/src/lib.rs
@@ -188,11 +188,7 @@ where
                 ServerMessage::Musig2GetPubNonce(res)
             }
 
-            ClientMessage::Musig2GetOurPartialSig {
-                params,
-                aggnonce,
-                message,
-            } => {
+            ClientMessage::Musig2GetOurPartialSig { params, aggnonce } => {
                 let params = match params.try_into() {
                     Ok(params) => params,
                     Err(e) => {
@@ -211,7 +207,7 @@ where
                 };
                 let res = service
                     .musig2_signer()
-                    .get_our_partial_sig(params, aggnonce, message)
+                    .get_our_partial_sig(params, aggnonce)
                     .await
                     .map(|ps| ps.serialize());
                 ServerMessage::Musig2GetOurPartialSig(res)


### PR DESCRIPTION
## Description

Fixes a MuSig2 nonce-reuse vulnerability in the secret service. The contest transaction's N watchtower tapscript leaves share an outpoint but commit to different sighashes; the previous cache and HKDF binding keyed only on the outpoint, so all N reused the same secret nonce.

The fix makes `sighash` the sole source of truth for the message across cache keying, HKDF info, and partial-signature signing
 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## AI DIsclosure

Claude was used to plan and implement the PR.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

closes #437.
