### PR TITLE
feat(dev-cli): add bridge-proof subcommand

### DIFF
--- a/bin/dev-cli/src/cli.rs
+++ b/bin/dev-cli/src/cli.rs
@@ -29,6 +29,9 @@ pub(crate) enum Commands {
     /// Post a claim transaction.
     Claim(ClaimArgs),
 
+    /// Post an empty bridge proof receipt transaction.
+    BridgeProof(BridgeProofArgs),
+
     /// Post an unstaking intent transaction.
     UnstakingIntent(UnstakingIntentArgs),
 }
@@ -136,6 +139,28 @@ pub(crate) struct ClaimArgs {
     pub(crate) bridge_node_url: String,
 
     #[arg(long, help = "hex-encoded seed of the claiming operator")]
+    pub(crate) seed: String,
+
+    #[arg(long, help = "the path to the params file")]
+    pub(crate) params: PathBuf,
+
+    #[clap(flatten)]
+    pub(crate) btc_args: BtcArgs,
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(about = "Post an empty bridge proof receipt transaction", version)]
+pub(crate) struct BridgeProofArgs {
+    #[arg(long, help = "deposit index of the graph")]
+    pub(crate) deposit_idx: u32,
+
+    #[arg(long, help = "operator index of the graph")]
+    pub(crate) operator_idx: u32,
+
+    #[arg(long, help = "url of the bridge node RPC")]
+    pub(crate) bridge_node_url: String,
+
+    #[arg(long, help = "hex-encoded seed of the graph-owning operator")]
     pub(crate) seed: String,
 
     #[arg(long, help = "the path to the params file")]

--- a/bin/dev-cli/src/handlers/bridge_proof.rs
+++ b/bin/dev-cli/src/handlers/bridge_proof.rs
@@ -1,0 +1,93 @@
+use anyhow::bail;
+use bitcoincore_rpc::RpcApi;
+use secp256k1::{Keypair, SECP256K1};
+use strata_bridge_common::params::Params;
+use strata_bridge_key_deriv::Musig2Keys;
+use strata_bridge_primitives::types::GraphIdx;
+use strata_bridge_rpc::traits::{StrataBridgeControlApiClient, StrataBridgeDaApiClient};
+use strata_bridge_tx_graph::transactions::bridge_proof::{BridgeProofData, BridgeProofTx};
+use tracing::info;
+
+use crate::{
+    cli,
+    handlers::{derive_keys, graph, rpc},
+};
+
+/// Post an empty bridge proof receipt transaction for the given graph idx.
+pub(crate) async fn handle_bridge_proof(args: cli::BridgeProofArgs) -> anyhow::Result<()> {
+    let params = Params::from_path(&args.params)?;
+    let operator_keys = derive_keys::derive_operator_keys(&args.seed, params.network)?;
+    let musig2_keys = Musig2Keys::derive(operator_keys.base_xpriv())
+        .map_err(|e| anyhow::anyhow!("failed to derive musig2 keys: {}", e))?;
+    let operator_keypair: Keypair = *musig2_keys.keypair;
+
+    let btc_client =
+        rpc::get_btc_client(&args.btc_args.url, args.btc_args.user, args.btc_args.pass)?;
+    let bridge_rpc_client = rpc::get_bridge_client(&args.bridge_node_url)?;
+
+    if let Err(e) = btc_client.get_blockchain_info() {
+        bail!(
+            "unable to reach bitcoin node at {}: {}",
+            args.btc_args.url,
+            e
+        );
+    }
+
+    if let Err(e) = bridge_rpc_client.get_uptime().await {
+        bail!(
+            "unable to reach bridge node at {}: {}",
+            args.bridge_node_url,
+            e
+        );
+    }
+
+    let graph_idx = GraphIdx {
+        deposit: args.deposit_idx,
+        operator: args.operator_idx,
+    };
+    info!(
+        deposit_idx = args.deposit_idx,
+        operator_idx = args.operator_idx,
+        "posting empty bridge proof receipt"
+    );
+
+    let graph_data = bridge_rpc_client
+        .get_graph_data(graph_idx)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fetch graph data: {}", e))?;
+    let graph_data = match graph_data {
+        Some(data) => data,
+        None => bail!("no graph data found for graph {:?}", graph_idx),
+    };
+    info!(?graph_idx, "fetched graph data");
+
+    let game_index = graph_data.deposit.game_index;
+
+    let (game_graph, connectors) = graph::build_game_graph(&params, graph_data)?;
+    info!(?graph_idx, "reconstructed game graph");
+
+    let contest_txid = game_graph.contest.as_ref().compute_txid();
+
+    let data = BridgeProofData {
+        contest_txid,
+        proof_bytes: vec![0u8; 128],
+        game_index,
+    };
+    let bridge_proof_tx = BridgeProofTx::new(data, connectors.contest_proof);
+
+    let tweaked_operator_keypair = operator_keypair
+        .add_xonly_tweak(SECP256K1, &bridge_proof_tx.operator_key_tweak())
+        .map_err(|e| anyhow::anyhow!("failed to tweak operator keypair: {}", e))?;
+
+    let operator_signature = bridge_proof_tx
+        .signing_info_partial()
+        .sign(&tweaked_operator_keypair);
+    let signed_tx = bridge_proof_tx.finalize_partial(operator_signature);
+
+    let txid = btc_client
+        .send_raw_transaction(&signed_tx)
+        .map_err(|e| anyhow::anyhow!("failed to broadcast bridge proof transaction: {}", e))?;
+    info!(?graph_idx, ?txid, "broadcast bridge proof transaction");
+
+    Ok(())
+}

--- a/bin/dev-cli/src/handlers/mod.rs
+++ b/bin/dev-cli/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod bridge_in;
+pub(crate) mod bridge_proof;
 pub(crate) mod checkpoint;
 pub(crate) mod claim;
 pub(crate) mod contest;

--- a/bin/dev-cli/src/main.rs
+++ b/bin/dev-cli/src/main.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use handlers::derive_keys;
 use strata_bridge_common::logging;
 
-use crate::handlers::{bridge_in, checkpoint, claim, contest, unstaking_intent};
+use crate::handlers::{bridge_in, bridge_proof, checkpoint, claim, contest, unstaking_intent};
 
 mod cli;
 
@@ -24,6 +24,7 @@ async fn main() -> Result<(), Error> {
         }
         cli::Commands::Contest(args) => contest::handle_contest(args).await,
         cli::Commands::Claim(args) => claim::handle_claim(args).await,
+        cli::Commands::BridgeProof(args) => bridge_proof::handle_bridge_proof(args).await,
         cli::Commands::UnstakingIntent(args) => {
             unstaking_intent::handle_unstaking_intent(args).await
         }

--- a/functional-tests/tests/contest/fn_publish_counterproof.py
+++ b/functional-tests/tests/contest/fn_publish_counterproof.py
@@ -4,7 +4,7 @@ from constants import CONTEST_WATCHTOWER_0_VOUT
 from envs import BridgeNetworkEnv
 from envs.base_test import StrataTestBase
 from factory.bridge_operator.config_cfg import BridgeConfigParams
-from factory.bridge_operator.params_cfg import BridgeProtocolParams, ProofPredicate
+from factory.bridge_operator.params_cfg import BridgeProtocolParams
 from rpc.types import RpcDepositStatusComplete
 from utils.bridge import get_bridge_nodes_and_rpcs
 from utils.deposit import (
@@ -14,36 +14,33 @@ from utils.deposit import (
 )
 from utils.dev_cli import DevCli
 from utils.utils import (
+    find_utxo_spender_txid,
     read_operator_key,
     wait_for_tx_confirmation,
-    wait_until,
 )
-from utils.withdrawal import wait_until_active_valid_claim, wait_until_bridge_proof_posted
 
 
 @flexitest.register
 class CounterproofPublishedOnBridgeProofVerificationFailureTest(StrataTestBase):
     """
-    Test that every watchtower publishes a counterproof when the bridge proof is invalid.
+    Test that every watchtower publishes a counterproof when a dishonest operator
+    posts a faulty bridge proof.
 
-    NEVER_ACCEPT forces every watchtower to reject the bridge proof regardless of its
-    content, so the counterproof step is what's under test.
+    The dev-cli publish-bridge-proof handler embeds an empty ProofReceipt, which the
+    watchtower rejects.
 
     1. Complete a deposit.
-    2. Post a mock checkpoint so ASM produces an assignment; the assigned operator
-       fulfills and posts a real claim.
-    3. A different operator dev-cli-contests the claim.
-    4. Assigned operator generates a bridge proof.
-    5. Every watchtower auto-publishes a counterproof because the predicate is
-       NEVER_ACCEPT. Verified by asserting every watchtower's counterproof output
-       on the contest tx is spent.
+    2. Post a faulty claim via dev-cli from operator-0 (no assignment, no fulfillment).
+    3. Wait for an honest watchtower to auto-contest.
+    4. Post a faulty bridge proof via dev-cli from operator-0.
+    5. Every watchtower auto-publishes a counterproof because verification of the
+       empty proof fails. Verified by asserting every watchtower's counterproof
+       output on the contest tx is spent.
     """
 
     def __init__(self, ctx: flexitest.InitContext):
         self.bridge_protocol_params = BridgeProtocolParams(
             contest_timelock=5,
-            proof_timelock=100,
-            bridge_proof_predicate=ProofPredicate.NEVER_ACCEPT,
         )
         ctx.set_env(
             BridgeNetworkEnv(
@@ -60,9 +57,6 @@ class CounterproofPublishedOnBridgeProofVerificationFailureTest(StrataTestBase):
 
         bitcoind_service = ctx.get_service("bitcoin")
         bitcoin_rpc = bitcoind_service.create_rpc()
-
-        asm_service = ctx.get_service("asm_rpc")
-        asm_rpc = asm_service.create_rpc()
 
         num_operators = len(bridge_nodes)
         operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
@@ -84,58 +78,50 @@ class CounterproofPublishedOnBridgeProofVerificationFailureTest(StrataTestBase):
         assert deposit_info is not None, "Deposit did not complete"
         self.logger.info("Deposit completed")
 
-        # 2. Trigger assignment via mock checkpoint; orchestrator fulfills + claims.
-        recent_block_hash = bitcoin_rpc.proxy.getblockhash(bitcoin_rpc.proxy.getblockcount())
-        ckp_l1_txn = dev_cli.send_mock_checkpoint_from_tip(
-            asm_rpc,
-            recent_block_hash,
-            num_ol_slots=1,
-        )
-        ckp_block_hash = wait_for_tx_confirmation(bitcoin_rpc, ckp_l1_txn)
-        self.logger.info(f"Checkpoint tx {ckp_l1_txn} included in block {ckp_block_hash}")
+        # 2. Post a faulty claim via dev-cli from operator-0 (no assignment).
+        dishonest_idx = 0
+        dishonest_node = bridge_nodes[dishonest_idx]
+        dishonest_rpc_url = f"http://127.0.0.1:{dishonest_node.props['rpc_port']}"
+        dishonest_seed = read_operator_key(dishonest_idx).SEED
 
-        wait_until(
-            lambda: len(asm_rpc.strata_asm_getAssignments(ckp_block_hash)) > 0,
-            timeout=300,
-            error_msg="ASM did not produce assignment",
+        claim_txid = dev_cli.send_claim(
+            deposit_idx=0,
+            operator_idx=dishonest_idx,
+            bridge_node_url=dishonest_rpc_url,
+            seed=dishonest_seed,
         )
+        self.logger.info(f"Broadcasted faulty claim tx from op-{dishonest_idx}: {claim_txid}")
 
-        active_claim = wait_until_active_valid_claim(bridge_rpc)
-        self.logger.info(
-            "Active claim %s for deposit %s assigned to operator %s",
-            active_claim.claim_txid,
-            active_claim.deposit_idx,
-            active_claim.assigned_operator,
-        )
-        claim_block_hash = wait_for_tx_confirmation(
-            bitcoin_rpc,
-            active_claim.claim_txid,
-            timeout=300,
-        )
-        self.logger.info(
-            f"Claim tx {active_claim.claim_txid} confirmed in block {claim_block_hash}"
-        )
+        claim_block_hash = wait_for_tx_confirmation(bitcoin_rpc, claim_txid, timeout=300)
+        self.logger.info(f"Faulty claim tx {claim_txid} confirmed in block {claim_block_hash}")
 
-        # 3. Contest from a different operator (a watchtower).
-        contester_idx = (active_claim.assigned_operator + 1) % num_operators
-        contester_node = bridge_nodes[contester_idx]
-        contester_rpc_url = f"http://127.0.0.1:{contester_node.props['rpc_port']}"
-        contester_seed = read_operator_key(contester_idx).SEED
-
-        self.logger.info(f"Contesting with operator {contester_idx} via {contester_rpc_url}")
-        contest_txid = dev_cli.send_contest(
-            deposit_idx=active_claim.deposit_idx,
-            operator_idx=active_claim.assigned_operator,
-            bridge_node_url=contester_rpc_url,
-            contester_node_idx=contester_idx,
-            seed=contester_seed,
-        )
+        # 3. Wait for a watchtower to contest the claim (claim:vout=0 spent).
+        wait_until_utxo_spent(bitcoin_rpc, claim_txid, vout=0, timeout=300)
+        contest_txid = find_utxo_spender_txid(bitcoin_rpc, claim_txid, 0)
         contest_block_hash = wait_for_tx_confirmation(bitcoin_rpc, contest_txid, timeout=300)
-        self.logger.info(f"Contest tx {contest_txid} confirmed in block {contest_block_hash}")
+        self.logger.info(
+            f"Watchtower contested op-{dishonest_idx} claim: contest tx {contest_txid} "
+            f"confirmed in block {contest_block_hash}"
+        )
 
-        # 4. Assigned operator posts a real bridge proof defending the contest.
-        wait_until_bridge_proof_posted(bridge_rpc, active_claim.deposit_idx)
-        self.logger.info("Bridge proof posted")
+        # 4. Post a faulty bridge proof via dev-cli from operator-0.
+        bridge_proof_txid = dev_cli.send_bridge_proof(
+            deposit_idx=0,
+            operator_idx=dishonest_idx,
+            bridge_node_url=dishonest_rpc_url,
+            seed=dishonest_seed,
+        )
+        self.logger.info(
+            f"Broadcasted faulty bridge proof tx from op-{dishonest_idx}: {bridge_proof_txid}"
+        )
+
+        bridge_proof_block_hash = wait_for_tx_confirmation(
+            bitcoin_rpc, bridge_proof_txid, timeout=300
+        )
+        self.logger.info(
+            f"Faulty bridge proof tx {bridge_proof_txid} confirmed in block "
+            f"{bridge_proof_block_hash}"
+        )
 
         # 5. Every watchtower must publish its counterproof. The contest tx has one
         # counterproof output per watchtower starting at WATCHTOWER_0_VOUT.

--- a/functional-tests/utils/dev_cli.py
+++ b/functional-tests/utils/dev_cli.py
@@ -237,6 +237,41 @@ class DevCli:
         txid = res.splitlines()[-1].split("=")[-1].strip()
         return txid
 
+    def send_bridge_proof(
+        self,
+        deposit_idx: int,
+        operator_idx: int,
+        bridge_node_url: str,
+        seed: str,
+    ):
+        rpc_port = self.bitcoind_props["rpc_port"]  # fail fast if missing
+        wallet = self.bitcoind_props.get("walletname", "testwallet")
+
+        args = [
+            "bridge-proof",
+            "--btc-url",
+            f"http://127.0.0.1:{rpc_port}/wallet/{wallet}",
+            "--btc-user",
+            self.bitcoind_props.get("rpc_user", "user"),
+            "--btc-pass",
+            self.bitcoind_props.get("rpc_password", "password"),
+            "--params",
+            self.params_path,
+            "--deposit-idx",
+            str(deposit_idx),
+            "--operator-idx",
+            str(operator_idx),
+            "--bridge-node-url",
+            bridge_node_url,
+            "--seed",
+            seed,
+        ]
+
+        res = self._run_command(args)
+        # HACK: (@Rajil1213) parse raw stdout to extract txid
+        txid = res.splitlines()[-1].split("=")[-1].strip()
+        return txid
+
     def send_unstaking_intent(
         self,
         operator_idx: int,


### PR DESCRIPTION
## Description
- Adds a `bridge-proof` subcommand to dev-cli that broadcasts a bridge proof tx with an empty `ProofReceipt`
- Rewrite `tests/contest/fn_publish_counterproof.py` to drive the counterproof path via dev-cli droping the `NEVER_ACCEPT` predicate override

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->