### PR TITLE
feat(operator-wallet): Fireblocks GeneralWallet backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,7 +2451,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3113,7 +3113,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4076,6 +4076,7 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -4194,7 +4195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5854,6 +5855,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek 2.2.0",
+ "getrandom 0.2.16",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "jwalk"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5939,7 +5964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7221,6 +7246,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,7 +7572,13 @@ dependencies = [
  "bdk_wallet",
  "bitcoin-bosd",
  "corepc-node",
+ "hex",
+ "jsonwebtoken",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
  "serial_test",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7830,6 +7877,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7979,6 +8038,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -8300,7 +8370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -8320,7 +8390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8333,7 +8403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8476,7 +8546,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8968,6 +9038,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9075,7 +9165,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9143,7 +9233,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9164,7 +9254,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9824,6 +9914,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -12553,7 +12655,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13691,7 +13793,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -4076,7 +4077,6 @@ dependencies = [
  "ff",
  "generic-array 0.14.7",
  "group",
- "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -5860,19 +5860,13 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
- "ed25519-dalek 2.2.0",
  "getrandom 0.2.16",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.5",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
  "zeroize",
@@ -7246,22 +7240,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7877,18 +7855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8038,17 +8004,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
 
 [[package]]
 name = "pkcs8"
@@ -8976,7 +8931,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -9035,26 +8990,6 @@ dependencies = [
  "downcast-rs",
  "num_enum 0.5.11",
  "paste",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature 2.2.0",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -9272,7 +9207,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -13457,6 +13392,12 @@ name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 hkdf = "0.12.4"
 indexmap = "2.13.0"
 jsonrpsee = "0.26.0"
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 libp2p = { version = "0.56.0", features = [
   "noise",
   "gossipsub",
@@ -232,6 +233,10 @@ proptest = "1.11.0"
 proptest-derive = "0.5.1"
 quinn = "0.11.9"
 rand = "0.8.5"
+reqwest = { version = "0.12.9", default-features = false, features = [
+  "json",
+  "rustls-tls",
+] }
 rkyv = "0.8.17"
 rustls-pemfile = "2.2.0"
 secp256k1 = "0.29.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 hkdf = "0.12.4"
 indexmap = "2.13.0"
 jsonrpsee = "0.26.0"
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 libp2p = { version = "0.56.0", features = [
   "noise",
   "gossipsub",

--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -11,7 +11,7 @@ algebra.workspace = true
 btc-tracker.workspace = true
 mosaic-rpc-api.workspace = true
 mosaic-rpc-types.workspace = true
-operator-wallet.workspace = true
+operator-wallet = { workspace = true, features = ["fireblocks"] }
 secret-service-client.workspace = true
 secret-service-proto.workspace = true
 strata-bridge-asm-events.workspace = true

--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -288,11 +288,80 @@ pub(crate) struct RpcConfig {
 }
 
 /// Configuration for the operator wallet.
+///
+/// `deny_unknown_fields` so a mistyped key — e.g. `[operator_wallet.firebloks]` — is a hard
+/// error rather than silently deserializing `fireblocks` as `None` and downgrading a
+/// Fireblocks-custodied operator to the native backend.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct OperatorWalletConfig {
     /// The size of the claim funding pool, i.e., the number of UTXOs to generate for funding claim
     /// transactions when they run out.
     pub claim_funding_pool_size: usize,
+
+    /// When present, the operator's general wallet is custodied in Fireblocks instead of a local
+    /// BDK wallet. When absent (the default), the native backend is used. The reserved wallet is
+    /// always native regardless.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fireblocks: Option<FireblocksWalletConfig>,
+}
+
+/// Connection + identity configuration for a Fireblocks-backed general wallet.
+///
+/// `Debug` is hand-written to redact `api_key`: the whole [`Config`] is logged at startup
+/// (`mode/operator.rs`), so a derived `Debug` would leak the API key into the logs.
+///
+/// `deny_unknown_fields` so a mistyped credential key surfaces as a config error instead of
+/// being silently dropped.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct FireblocksWalletConfig {
+    /// API host root, **without** the `/v1` path segment, e.g. `https://api.fireblocks.io`.
+    pub base_url: String,
+
+    /// Fireblocks API key (sent as the `X-API-Key` header).
+    pub api_key: String,
+
+    /// Vault account id holding the BTC asset.
+    pub vault_account_id: String,
+
+    /// Asset id for the network — `BTC` on mainnet, `BTC_TEST` on test networks.
+    pub asset_id: String,
+
+    /// The vault account's BTC deposit address (P2WPKH). Where the general wallet receives
+    /// funding and earnings.
+    pub deposit_address: String,
+
+    /// Path to the Fireblocks API secret — an RSA private key in PEM form, used to sign the
+    /// per-request JWTs. Kept out of the config body (like the secret-service TLS material) so
+    /// the key never lives in the config file itself.
+    pub api_secret_path: PathBuf,
+
+    /// BIP44 address index (`bip44AddressIndex`) telling Fireblocks which derived key under the
+    /// vault to RAW-sign with. Must correspond to `deposit_address`. Defaults to `0` (the
+    /// vault's default address).
+    #[serde(default)]
+    pub bip44_address_index: u32,
+
+    /// BIP44 change index (`bip44change`). `0` for receive, `1` for internal. Defaults to `0`.
+    #[serde(default)]
+    pub bip44_change: u32,
+}
+
+impl fmt::Debug for FireblocksWalletConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redact the API key; everything else is non-secret operational config.
+        f.debug_struct("FireblocksWalletConfig")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"<redacted>")
+            .field("vault_account_id", &self.vault_account_id)
+            .field("asset_id", &self.asset_id)
+            .field("deposit_address", &self.deposit_address)
+            .field("api_secret_path", &self.api_secret_path)
+            .field("bip44_address_index", &self.bip44_address_index)
+            .field("bip44_change", &self.bip44_change)
+            .finish()
+    }
 }
 
 /// Configuration for the mosaic client.
@@ -332,9 +401,9 @@ pub(crate) struct MetricsConfig {
 /// The Bitcoin RPC credentials are sentinels so `debug_redacts_btc_rpc_credentials` can search
 /// rendered output for them without matching field names or other values.
 #[cfg(test)]
-pub(crate) fn test_config() -> Config {
-    toml::from_str(
-        r#"
+/// Everything except the `[operator_wallet]` table, so individual tests can append
+/// different operator-wallet configurations (native vs Fireblocks).
+pub(crate) const BASE_TOML: &str = r#"
             num_threads = 4
             thread_stack_size = 8_388_608 # 8 * 1024 * 1024
             is_faulty = false
@@ -393,9 +462,6 @@ pub(crate) fn test_config() -> Config {
             rawtx_connection_string = "tcp://127.0.0.1:28335"
             sequence_connection_string = "tcp://127.0.0.1:28336"
 
-            [operator_wallet]
-            claim_funding_pool_size = 32
-
             [mosaic]
             rpc_url = "http://localhost:7500"
             retry_delay = { secs = 2, nanos = 0 }
@@ -416,8 +482,15 @@ pub(crate) fn test_config() -> Config {
 
             [metrics]
             prometheus_listener_addr = "127.0.0.1:9615"
-        "#,
-    )
+        "#;
+
+/// A full parsed test config with the native operator-wallet backend. Startup-check tests
+/// and config tests share this constructor.
+#[cfg(test)]
+pub(crate) fn test_config() -> Config {
+    toml::from_str(&format!(
+        "{BASE_TOML}\n[operator_wallet]\nclaim_funding_pool_size = 32\n"
+    ))
     .expect("valid test config")
 }
 
@@ -425,9 +498,11 @@ pub(crate) fn test_config() -> Config {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_config_serde_toml() {
-        let config = test_config();
+    /// Parses `toml_str` and asserts a serde round-trip preserves every field, returning the
+    /// parsed config.
+    fn assert_roundtrips(toml_str: &str) -> Config {
+        let config = toml::from_str::<Config>(toml_str)
+            .unwrap_or_else(|e| panic!("must deserialize config from toml: {e}"));
         let serialized = toml::to_string(&config).unwrap();
         let reparsed = toml::from_str::<Config>(&serialized).unwrap();
         let reserialized = toml::to_string(&reparsed).unwrap();
@@ -435,6 +510,41 @@ mod tests {
             reserialized, serialized,
             "serde round-trip must preserve every field"
         );
+        config
+    }
+
+    #[test]
+    fn test_config_serde_toml() {
+        let toml_str = format!("{BASE_TOML}\n[operator_wallet]\nclaim_funding_pool_size = 32\n");
+        let config = assert_roundtrips(&toml_str);
+        assert!(
+            config.operator_wallet.fireblocks.is_none(),
+            "no fireblocks table => native backend"
+        );
+    }
+
+    #[test]
+    fn test_config_serde_toml_with_fireblocks() {
+        let toml_str = format!(
+            "{BASE_TOML}\n\
+             [operator_wallet]\n\
+             claim_funding_pool_size = 32\n\n\
+             [operator_wallet.fireblocks]\n\
+             base_url = \"https://api.fireblocks.io\"\n\
+             api_key = \"api-key-id\"\n\
+             vault_account_id = \"0\"\n\
+             asset_id = \"BTC\"\n\
+             deposit_address = \"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq\"\n\
+             api_secret_path = \"fireblocks_secret.pem\"\n"
+        );
+        let config = assert_roundtrips(&toml_str);
+        let fb = config
+            .operator_wallet
+            .fireblocks
+            .expect("fireblocks table => Fireblocks backend");
+        assert_eq!(fb.asset_id, "BTC");
+        assert_eq!(fb.vault_account_id, "0");
+        assert_eq!(fb.api_secret_path, PathBuf::from("fireblocks_secret.pem"));
     }
 
     // Operator startup logs the whole config, so no debug rendering of it may carry the Bitcoin

--- a/bin/strata-bridge/src/constants.rs
+++ b/bin/strata-bridge/src/constants.rs
@@ -18,6 +18,18 @@ pub(crate) const DEFAULT_HEALTH_PROBE_INTERVAL: Duration = Duration::from_secs(6
 /// Maximum time a single health probe waits on an external system before it is marked unhealthy.
 pub(crate) const DEFAULT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Maximum time the wallet health probe waits for the wallet's shared read guard.
+///
+/// This is a liveness cutoff, not a worst-case hold bound. A healthy wallet can hold the
+/// exclusive guard for minutes: `OperatorWallet::sync` is a retry loop (six attempts, each up
+/// to a 15 s Fireblocks round trip, plus a reserved-wallet sync with no timeout of its own),
+/// and the Fireblocks signing path holds the same guard for up to `SIGN_MAX_DURATION` (180 s)
+/// while it waits on workspace approval. A `probe_timed_out` report during those windows is
+/// expected and self-clears on the next probe tick; sizing the cutoff to the true ceiling
+/// would delay detection of a genuinely wedged lock by several ticks, which is the one thing
+/// the probe exists to catch quickly.
+pub(crate) const WALLET_PROBE_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
 const _: () = assert!(
     DEFAULT_HEALTH_PROBE_TIMEOUT.as_secs() < DEFAULT_HEALTH_PROBE_INTERVAL.as_secs(),
     "health probe timeout must be shorter than the probe interval"

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -5,11 +5,11 @@ use std::{fmt::Display, future::Future, sync::Arc, time::Duration};
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::tx_driver::TxDriverHealthHandle;
 use jsonrpsee::http_client::HttpClient;
+use operator_wallet::AnyOperatorWallet;
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_asm_rpc::traits::AsmControlApiClient;
 use strata_bridge_db::fdb::client::FdbClient;
-use strata_bridge_exec::output_handles::NativeWallet;
 use strata_mosaic_client::MosaicClient;
 use strata_p2p::swarm::handle::CommandHandle;
 use tokio::{
@@ -195,7 +195,7 @@ pub(in crate::mode) fn spawn_s2_probe(
 /// duties. The read-lock acquisition is bounded so a stuck writer cannot leave the component
 /// reporting a stale `ok` state.
 pub(in crate::mode) fn spawn_wallet_probe(
-    wallet: Arc<RwLock<NativeWallet>>,
+    wallet: Arc<RwLock<AnyOperatorWallet>>,
     probe_interval: Duration,
     health_registry: HealthRegistry,
 ) {

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -19,7 +19,7 @@ use tokio::{
 use tracing::{error, warn};
 
 use crate::{
-    constants::DEFAULT_HEALTH_PROBE_TIMEOUT,
+    constants::{DEFAULT_HEALTH_PROBE_TIMEOUT, WALLET_PROBE_LOCK_TIMEOUT},
     health::{
         COMPONENT_ASM_RPC, COMPONENT_BITCOIN_RPC, COMPONENT_FDB, COMPONENT_MOSAIC,
         COMPONENT_ORCHESTRATOR, COMPONENT_P2P, COMPONENT_S2, COMPONENT_TX_DRIVER, COMPONENT_WALLET,
@@ -211,7 +211,11 @@ pub(in crate::mode) fn spawn_wallet_probe(
 
         loop {
             ticker.tick().await;
-            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, wallet.read()).await {
+            // This wait is its own bound, not the general probe timeout — and it is a
+            // liveness cutoff, not a worst-case hold: a healthy wallet can hold the
+            // exclusive guard for minutes (retrying sync, Fireblocks signing wait), so a
+            // timeout here is expected during those windows and self-clears next tick.
+            match timeout(WALLET_PROBE_LOCK_TIMEOUT, wallet.read()).await {
                 Ok(guard) => {
                     let height = guard.local_chain_tip_height();
                     let general_sync = guard.last_general_sync();

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -187,6 +187,13 @@ pub(in crate::mode) fn spawn_s2_probe(
     });
 }
 
+/// Age past which a successful general-backend sync stops counting as `ok` and reports
+/// `degraded` instead. Thirty minutes covers the normal duty cadence with margin: under
+/// regular operation duties sync far more often than this, so a verdict this old means the
+/// bridge is idle or the duty pipeline is stuck — either way, "the backend is healthy now"
+/// is no longer a claim the probe can make.
+const GENERAL_SYNC_STALENESS_BOUND: Duration = Duration::from_secs(30 * 60);
+
 /// Starts a periodic operator-wallet liveness probe.
 ///
 /// Reads the wallet's local chain tip through a shared read lock — a non-mutating, in-memory
@@ -207,8 +214,46 @@ pub(in crate::mode) fn spawn_wallet_probe(
             match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, wallet.read()).await {
                 Ok(guard) => {
                     let height = guard.local_chain_tip_height();
+                    let general_sync = guard.last_general_sync();
                     drop(guard);
-                    health_registry.mark_ok(COMPONENT_WALLET, format!("synced_to_height_{height}"));
+                    // The tip comes from the reserved wallet and keeps advancing while the
+                    // general backend fails its syncs (the two sync independently), so the
+                    // general backend gets its own verdict:
+                    //
+                    // - A failed last attempt is unhealthy until a sync succeeds.
+                    // - A success older than the staleness bound is degraded, not ok. Syncs are
+                    //   duty-driven, so an idle bridge holds an old verdict — the degraded state
+                    //   says "the backend was healthy when last used", which is the true claim.
+                    // - `None` means no sync has run yet: expected briefly at startup while the
+                    //   initial sync task retries, not a fault by itself.
+                    match general_sync {
+                        Some((false, _)) => {
+                            health_registry.mark_unhealthy(
+                                COMPONENT_WALLET,
+                                format!("general_backend_sync_failed_at_height_{height}"),
+                            );
+                            error!("operator wallet general backend failed its last sync");
+                        }
+                        Some((true, at)) if at.elapsed() > GENERAL_SYNC_STALENESS_BOUND => {
+                            health_registry.mark_degraded(
+                                COMPONENT_WALLET,
+                                format!(
+                                    "last_general_sync_ok_{}s_ago_at_height_{height}",
+                                    at.elapsed().as_secs()
+                                ),
+                            );
+                        }
+                        Some((true, _)) => {
+                            health_registry
+                                .mark_ok(COMPONENT_WALLET, format!("synced_to_height_{height}"));
+                        }
+                        None => {
+                            health_registry.mark_ok(
+                                COMPONENT_WALLET,
+                                format!("awaiting_first_sync_at_height_{height}"),
+                            );
+                        }
+                    }
                 }
                 Err(_) => {
                     health_registry.mark_unhealthy(COMPONENT_WALLET, "probe_timed_out");

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -147,7 +147,7 @@ const INITIAL_SYNC_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 /// are duty-driven after startup: without it, a bitcoind or backend outage at boot leaves
 /// the wallet empty, and every CPFP bump fails with `InsufficientFunding` until the first
 /// duty happens to call `sync()`. A failed attempt does not crash the node — it is logged
-/// and retried, and the health probe reads the outcome through `last_general_sync_ok`.
+/// and retried, and the health probe reads the outcome through `last_general_sync`.
 pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(
     wallet: Arc<RwLock<AnyOperatorWallet>>,
 ) {

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -13,13 +13,16 @@ use bitcoin::{
     hashes::{Hash, sha256},
     relative,
 };
-use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
+use operator_wallet::{
+    AnyOperatorWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
+    general::fireblocks::{FireblocksConfig, FireblocksGeneralWallet},
+    sync::Backend,
+};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_common::params::Params;
 use strata_bridge_connectors::prelude::{ClaimContestConnector, ClaimPayoutConnector};
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb};
-use strata_bridge_exec::output_handles::NativeWallet;
 use strata_bridge_primitives::constants::SEGWIT_MIN_AMOUNT;
 use strata_bridge_tx_graph::{fee, transactions::prelude::ClaimTx};
 use tokio::sync::RwLock;
@@ -33,8 +36,9 @@ use crate::config::Config;
 /// orchestrator forwards it into `strata_bridge_exec::config::ExecutionConfig` so duty
 /// executors can reference the pool by value.
 pub(in crate::mode) struct InitializedOperatorWallet {
-    /// The composed operator wallet, ready to lease + sign against.
-    pub wallet: NativeWallet,
+    /// The composed operator wallet, ready to lease + sign against. Backend (native vs
+    /// Fireblocks) is selected from config; erased so the orchestrator stays backend-agnostic.
+    pub wallet: AnyOperatorWallet,
     /// Per-UTXO denomination of the claim-funding pool. The composer is denomination-
     /// agnostic; this value is propagated into `strata_bridge_exec::config::ExecutionConfig`
     /// so duty executors can reference the pool by value.
@@ -66,8 +70,6 @@ pub(in crate::mode) async fn init_operator_wallet(
     );
     debug!(?bitcoin_rpc_client, "bitcoin rpc client");
 
-    let general_key = s2_client.general_wallet_signer().pubkey().await?;
-    info!(%general_key, "operator wallet general key");
     let reserved_key = s2_client.reserved_wallet_signer().pubkey().await?;
     info!(%reserved_key, "operator wallet reserved key");
     let own_musig2_key = s2_client.musig2_signer().pubkey().await?;
@@ -75,18 +77,59 @@ pub(in crate::mode) async fn init_operator_wallet(
     let operator_wallet_config = OperatorWalletConfig::new(SEGWIT_MIN_AMOUNT, params.network);
     debug!(?operator_wallet_config, %claim_funding_utxo_value, "operator wallet config");
 
-    let general_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
+    // The reserved wallet is always native (BDK), regardless of the general-wallet backend.
     let reserved_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
-    debug!(?general_sync_backend, "operator wallet sync backend");
-    let general_wallet =
-        NativeGeneralWallet::new(general_key, params.network, general_sync_backend);
-    let wallet = OperatorWallet::new(
-        general_wallet,
-        reserved_key,
-        operator_wallet_config,
-        reserved_sync_backend,
-        leased_outpoints,
-    );
+
+    let wallet: AnyOperatorWallet = match &config.operator_wallet.fireblocks {
+        None => {
+            let general_key = s2_client.general_wallet_signer().pubkey().await?;
+            info!(%general_key, "operator wallet general key (native backend)");
+            let general_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
+            let general_wallet =
+                NativeGeneralWallet::new(general_key, params.network, general_sync_backend);
+            OperatorWallet::new(
+                general_wallet,
+                reserved_key,
+                operator_wallet_config,
+                reserved_sync_backend,
+                leased_outpoints,
+            )
+            .into()
+        }
+        Some(fb) => {
+            info!(
+                vault = %fb.vault_account_id,
+                asset = %fb.asset_id,
+                "operator wallet general backend: fireblocks"
+            );
+            let api_secret = std::fs::read(&fb.api_secret_path).map_err(|e| {
+                anyhow!(
+                    "failed to read Fireblocks API secret at {:?}: {e}",
+                    fb.api_secret_path
+                )
+            })?;
+            let fb_config = FireblocksConfig {
+                base_url: fb.base_url.clone(),
+                api_key: fb.api_key.clone(),
+                vault_account_id: fb.vault_account_id.clone(),
+                asset_id: fb.asset_id.clone(),
+                network: params.network,
+                deposit_address: fb.deposit_address.clone(),
+                bip44_address_index: fb.bip44_address_index,
+                bip44_change: fb.bip44_change,
+            };
+            let general_wallet = FireblocksGeneralWallet::new(fb_config, &api_secret)
+                .map_err(|e| anyhow!("failed to initialize Fireblocks general wallet: {e}"))?;
+            OperatorWallet::new(
+                general_wallet,
+                reserved_key,
+                operator_wallet_config,
+                reserved_sync_backend,
+                leased_outpoints,
+            )
+            .into()
+        }
+    };
     debug!("operator wallet initialized");
 
     Ok(InitializedOperatorWallet {
@@ -104,8 +147,10 @@ const INITIAL_SYNC_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 /// are duty-driven after startup: without it, a bitcoind or backend outage at boot leaves
 /// the wallet empty, and every CPFP bump fails with `InsufficientFunding` until the first
 /// duty happens to call `sync()`. A failed attempt does not crash the node — it is logged
-/// and retried.
-pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(wallet: Arc<RwLock<NativeWallet>>) {
+/// and retried, and the health probe reads the outcome through `last_general_sync_ok`.
+pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(
+    wallet: Arc<RwLock<AnyOperatorWallet>>,
+) {
     info!("starting initial operator wallet sync");
     let mut attempt: u32 = 0;
     loop {

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -244,16 +244,55 @@ where
     // output this wallet neither tracks nor can sign — unspendable by this operator, and
     // their CPFP bumps fail forever. Warn rather than abort: graphs presigned under older
     // params can differ legitimately, and an operator mid-rotation must still start.
+    //
+    // The comparison is type-aware. Params validation pins every covenant payout descriptor
+    // to P2TR, and the Fireblocks backend derives its descriptor from a P2WPKH vault
+    // address, so on that backend the scripts can never match — a same-script check fires
+    // on every startup and reads as rotation drift, which it is not. The two cases carry
+    // different messages: a cross-type mismatch is structural (the backend class cannot
+    // receive presigned-graph payouts; the general key held by secret-service still can,
+    // out of band), while a same-type mismatch is the rotation-drift signal the check was
+    // built for.
     {
-        let wallet_payout_script = wallet.read().await.payout_descriptor().to_script();
+        let wallet_payout_descriptor = wallet.read().await.payout_descriptor();
+        let wallet_payout_script = wallet_payout_descriptor.to_script();
         let covenant_payout_script = own_covenant.payout_descriptor.to_script();
         if covenant_payout_script != wallet_payout_script {
-            warn!(
-                covenant_descriptor = %own_covenant.payout_descriptor,
-                %wallet_payout_script,
-                "params covenant payout_descriptor does not match the wallet's payout script; \
-                 presigned-graph payouts will be unspendable and unbumpable by this operator"
-            );
+            if own_covenant.payout_descriptor.type_tag() == wallet_payout_descriptor.type_tag() {
+                warn!(
+                    covenant_descriptor = %own_covenant.payout_descriptor,
+                    %wallet_payout_script,
+                    "params covenant payout_descriptor does not match the wallet's payout \
+                     script; presigned-graph payouts will be unspendable and unbumpable by \
+                     this operator"
+                );
+            } else {
+                // Only claim "recoverable via the secret-service general key" after
+                // checking it: the claim holds exactly when the covenant descriptor is the
+                // tap-tweaked P2TR of the s2 general key. On a mainnet-first deployment
+                // this line informs an operator's judgment about whether presigned-graph
+                // payouts are safe to leave unclaimed — it must not overstate.
+                let s2_general_script = bitcoin::Address::p2tr(
+                    bitcoin::secp256k1::SECP256K1,
+                    operator_general_pubkey,
+                    None,
+                    params.network,
+                )
+                .script_pubkey();
+                let recovery = if covenant_payout_script == s2_general_script {
+                    "those outputs stay recoverable through the secret-service general key"
+                } else {
+                    "those outputs are recoverable only by whoever controls the key behind \
+                     the params descriptor"
+                };
+                warn!(
+                    covenant_descriptor = %own_covenant.payout_descriptor,
+                    wallet_descriptor = %wallet_payout_descriptor,
+                    "the general-wallet backend cannot receive presigned-graph payouts \
+                     (descriptor types differ); {recovery}, and this wallet will not track \
+                     or bump them"
+                );
+            }
         }
     }
 

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -12,6 +12,7 @@ use btc_tracker::{
 };
 use jsonrpsee::http_client::HttpClient;
 use libp2p_identity::ed25519::Keypair;
+use operator_wallet::AnyOperatorWallet;
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_asm_events::client::{AsmEventFeed, AsmFeedHealthEvent};
@@ -24,7 +25,7 @@ use strata_bridge_exec::{
         BitcoindCpfpFeeSource, BitcoindCpfpMempool, OperatorWalletCpfpAdapter,
         build_anchor_input_signer, build_multi_anchor_signer, build_wallet_input_signer,
     },
-    output_handles::{NativeWallet, OutputHandles},
+    output_handles::OutputHandles,
 };
 use strata_bridge_orchestrator::{
     duty_dispatcher::DutyDispatcher, events_mux::EventsMux, persister::Persister,
@@ -48,7 +49,7 @@ use tokio::{
     select,
     sync::{RwLock, mpsc, oneshot},
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     config::Config,
@@ -73,7 +74,7 @@ pub(crate) async fn init_orchestrator<M>(
     gossip_handle: GossipHandle,
     req_resp_handle: ReqRespHandle,
     p2p_keypair: Keypair,
-    wallet: Arc<RwLock<NativeWallet>>,
+    wallet: Arc<RwLock<AnyOperatorWallet>>,
     claim_funding_utxo_value: bitcoin::Amount,
     btc_rpc_client: BitcoinClient,
     asm_rpc_client: HttpClient,
@@ -224,7 +225,7 @@ where
     // The related invariant is `watchtower_pubkey == musig2_pubkey`. The operator table makes
     // it, from `covenant[i].musig2`. A field change on `CovenantKeys` breaks the compilation
     // of `_covenant_keys_field_audit` (see `crates/common/src/params.rs`).
-    params
+    let own_covenant = params
         .keys
         .covenant
         .iter()
@@ -235,6 +236,26 @@ where
                 operator_musig2_pubkey,
             )
         })?;
+
+    // The presigned graph pays this operator's covenant `payout_descriptor` (a params-file
+    // value the peers signed against), while gossip-built payouts and every spend go through
+    // the wallet's own `payout_descriptor()`. These must resolve to the same script: on a
+    // mismatch, graph payouts (uncontested/contested payout, counterproof nack) land on an
+    // output this wallet neither tracks nor can sign — unspendable by this operator, and
+    // their CPFP bumps fail forever. Warn rather than abort: graphs presigned under older
+    // params can differ legitimately, and an operator mid-rotation must still start.
+    {
+        let wallet_payout_script = wallet.read().await.payout_descriptor().to_script();
+        let covenant_payout_script = own_covenant.payout_descriptor.to_script();
+        if covenant_payout_script != wallet_payout_script {
+            warn!(
+                covenant_descriptor = %own_covenant.payout_descriptor,
+                %wallet_payout_script,
+                "params covenant payout_descriptor does not match the wallet's payout script; \
+                 presigned-graph payouts will be unspendable and unbumpable by this operator"
+            );
+        }
+    }
 
     let cpfp_wallet = Arc::new(OperatorWalletCpfpAdapter::new(
         wallet.clone(),

--- a/crates/bridge-exec/src/chain.rs
+++ b/crates/bridge-exec/src/chain.rs
@@ -1,7 +1,7 @@
 //! Shared Bitcoin chain helpers for executors.
 
 use bitcoin::{
-    Address, Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid, secp256k1::SECP256K1,
+    Address, Amount, OutPoint, Script, ScriptBuf, Transaction, TxOut, Txid, secp256k1::SECP256K1,
     taproot::ControlBlock,
 };
 use bitcoind_async_client::{Client as BitcoinClient, error::ClientError, traits::Reader};
@@ -59,36 +59,42 @@ fn parent_fee_for_floor_tx(tx: &Transaction) -> Amount {
         .expect("protocol-floor × tx vsize cannot overflow Amount")
 }
 
-/// Scans `tx.output` for the first output paying the operator's general-wallet P2TR script
-/// (the script of `tr(operator_general_pubkey)` on `output_handles.network`). Returns the
-/// outpoint, or `None` if no matching output exists.
+/// Scans `tx.output` for the first output paying the operator's general-wallet receive script
+/// and returns its outpoint, or `None` if no matching output exists.
+///
+/// The receive script is the backend's `general_script_pubkey`: the BIP86-tweaked
+/// `tr(general_pubkey)` P2TR for the native BDK backend, or the vault P2WPKH
+/// for the Fireblocks backend. Both backends draw their funding change to this script, so this
+/// is what `InferGeneralPayout` must match — using a hardcoded P2TR derivation would silently
+/// miss the Fireblocks change output and disable CPFP for that backend.
 ///
 /// Used by [`CpfpKind::InferGeneralPayout`] to opportunistically classify a tx as
 /// `PayoutCombined` when an operator-owned output happens to be present. Three call sites
 /// rely on this:
 ///
-/// - **Withdrawal fulfillment**: BDK adds a change output back to the general wallet at
+/// - **Withdrawal fulfillment**: the wallet adds a change output back to the general wallet at
 ///   `WithdrawalFulfillmentTx::OPTIONAL_CHANGE_VOUT` (vout 2) when selected inputs exceed
 ///   user_amount + fee. When change exists, CPFP via that output.
-/// - **Stake funding**: BDK adds a change output back to the general wallet (vout depends on BDK
+/// - **Stake funding**: the wallet adds a change output back to the general wallet (vout depends on
 ///   ordering, typically vout 1 after the reserved-wallet output at vout 0).
-/// - **Slash**: The calling watchtower's payout is at `vout = 1 + their_index_in_watchtowers` keyed
-///   to their payout descriptor (= the general-wallet P2TR, by the bridge's `payout_descriptor`
-///   convention). Scan finds it without threading the index through.
+/// - **Slash**: the calling watchtower's payout sits at `vout = 1 + their_index_in_watchtowers`,
+///   keyed to its params-file covenant `payout_descriptor`. This is found only when that
+///   descriptor's script equals the general-wallet receive script — which is exactly what the
+///   native `payout_descriptor()` returns, so the scan matches whenever the params descriptor
+///   agrees with the wallet (the orchestrator warns at startup when it doesn't). On a mismatch (or
+///   a Fireblocks vault script, which is not the general P2TR) the scan returns `None` and slash
+///   CPFP falls back to no-bump (see `publish_slash`).
 ///
 /// Brittle assumption: matches by exact `script_pubkey` equality. If two different
-/// operators happened to share the same payout descriptor, the first match wins — but each
-/// operator has a unique general-wallet key in practice (one per s2 instance), so this
-/// can't collide in production.
-pub(crate) fn first_general_payout_outpoint(
+/// operators happened to share the same receive script, the first match wins — but each
+/// operator has a unique general-wallet key/vault in practice, so this can't collide in
+/// production.
+pub(crate) async fn first_general_payout_outpoint(
     tx: &Transaction,
     output_handles: &OutputHandles,
 ) -> Option<OutPoint> {
-    first_payout_outpoint_keyed_to(
-        tx,
-        output_handles.operator_general_pubkey,
-        output_handles.network,
-    )
+    let expected_script = output_handles.wallet.read().await.general_script_pubkey();
+    first_output_paying_script(tx, &expected_script)
 }
 
 /// Validates the caller-named anchor and returns the CPFP strategy for it.
@@ -159,17 +165,12 @@ fn checked_anchor_strategy(
     })
 }
 
-/// Inner helper for [`first_general_payout_outpoint`]; takes the pubkey/network explicitly so
+/// Inner helper for [`first_general_payout_outpoint`]; takes the receive script explicitly so
 /// it can be unit-tested without constructing a full [`OutputHandles`].
-fn first_payout_outpoint_keyed_to(
-    tx: &Transaction,
-    pubkey: bitcoin::XOnlyPublicKey,
-    network: bitcoin::Network,
-) -> Option<OutPoint> {
-    let expected_script = Address::p2tr(SECP256K1, pubkey, None, network).script_pubkey();
+fn first_output_paying_script(tx: &Transaction, expected_script: &Script) -> Option<OutPoint> {
     let txid = tx.compute_txid();
     tx.output.iter().enumerate().find_map(|(vout, o)| {
-        if o.script_pubkey != expected_script {
+        if o.script_pubkey != *expected_script {
             return None;
         }
         u32::try_from(vout).ok().map(|vout| OutPoint { txid, vout })
@@ -336,6 +337,7 @@ pub(crate) async fn publish_signed_transaction(
             parent_fee,
         }),
         CpfpKind::InferGeneralPayout => first_general_payout_outpoint(signed_tx, output_handles)
+            .await
             .map(|payout_outpoint| CpfpStrategy::ParentTxCombined {
                 payout_outpoint,
                 parent_fee,
@@ -418,8 +420,7 @@ mod tests {
     use strata_bridge_tx_graph::fee;
 
     use super::{
-        checked_anchor_strategy, first_payout_outpoint_keyed_to, is_outpoint_unspent,
-        is_txid_onchain,
+        checked_anchor_strategy, first_output_paying_script, is_outpoint_unspent, is_txid_onchain,
     };
 
     /// Per-coinbase reward on regtest before any halving.
@@ -530,11 +531,10 @@ mod tests {
             }, // vout 1: other key
             TxOut {
                 value: Amount::from_sat(50_000),
-                script_pubkey: our_script,
+                script_pubkey: our_script.clone(),
             }, // vout 2: our key
         ]);
-        let found = first_payout_outpoint_keyed_to(&tx, our_key, Network::Regtest)
-            .expect("should find our output");
+        let found = first_output_paying_script(&tx, &our_script).expect("should find our output");
         assert_eq!(found.vout, 2);
     }
 
@@ -544,6 +544,7 @@ mod tests {
         // output exists on this tx.
         let our_key = xonly_from_seed(1);
         let other_key = xonly_from_seed(2);
+        let our_script = Address::p2tr(SECP256K1, our_key, None, Network::Regtest).script_pubkey();
         let other_script =
             Address::p2tr(SECP256K1, other_key, None, Network::Regtest).script_pubkey();
         let tx = dummy_v3_tx(vec![
@@ -556,7 +557,7 @@ mod tests {
                 script_pubkey: other_script,
             },
         ]);
-        assert!(first_payout_outpoint_keyed_to(&tx, our_key, Network::Regtest).is_none());
+        assert!(first_output_paying_script(&tx, &our_script).is_none());
     }
 
     #[test]
@@ -573,11 +574,10 @@ mod tests {
             }, // vout 0
             TxOut {
                 value: Amount::from_sat(50_000),
-                script_pubkey: our_script,
+                script_pubkey: our_script.clone(),
             }, // vout 1
         ]);
-        let found = first_payout_outpoint_keyed_to(&tx, our_key, Network::Regtest)
-            .expect("should find first match");
+        let found = first_output_paying_script(&tx, &our_script).expect("should find first match");
         assert_eq!(found.vout, 0);
     }
 

--- a/crates/bridge-exec/src/chain.rs
+++ b/crates/bridge-exec/src/chain.rs
@@ -241,6 +241,53 @@ pub(crate) async fn is_outpoint_unspent(
     }
 }
 
+/// Returns whether chain state shows the persisted withdrawal-funding `outpoints` were
+/// written under a previous general-wallet backend: every outpoint is unspent (mempool
+/// included) AND none of them pays `current_general_spk`.
+///
+/// Every ambiguous outcome resolves to "not a previous-backend row" because the caller's
+/// discard-and-reselect on a false positive funds, signs, and broadcasts a second payout,
+/// while a false negative is a stuck row an operator can edit with the funds intact:
+///
+/// - Any outpoint spent or unknown (`gettxout` null): most likely this deposit's own fulfillment
+///   transaction is in the mempool or confirmed while its confirmation event has not reached the
+///   state machine yet → `Ok(false)`, the caller keeps the row and the funding path no-ops and
+///   retries.
+/// - All unspent, but any pays the current backend's own script: the wallet view and the chain
+///   disagree (backend cache lag, mempool eviction, reorg), not a backend switch → `Ok(false)`.
+/// - All unspent at scripts other than the current backend's: the cross-backend recovery case →
+///   `Ok(true)`, the caller may discard the row and reselect.
+/// - Any RPC failure propagates as `Err`; the caller keeps the row.
+pub(crate) async fn outpoints_belong_to_previous_backend(
+    bitcoind_rpc_client: &BitcoinClient,
+    outpoints: &[OutPoint],
+    current_general_spk: &ScriptBuf,
+) -> Result<bool, ClientError> {
+    for outpoint in outpoints {
+        debug!(%outpoint, "classifying persisted funding outpoint against chain state");
+        match bitcoind_rpc_client
+            .get_tx_out(&outpoint.txid, outpoint.vout, true)
+            .await
+        {
+            Ok(res) => {
+                if res.tx_out.script_pubkey == *current_general_spk {
+                    return Ok(false);
+                }
+            }
+            // Same mapping as `is_outpoint_unspent`: bitcoind returns `null` for a spent or
+            // non-existent UTXO, surfaced by the client as this `Other` variant.
+            Err(ClientError::Other(ref msg)) if msg == "Empty data received" => {
+                return Ok(false);
+            }
+            Err(e) => {
+                warn!(%outpoint, ?e, "could not classify persisted funding outpoint");
+                return Err(e);
+            }
+        }
+    }
+    Ok(true)
+}
+
 /// Hint that lets the caller of [`publish_signed_transaction`] override how the CPFP
 /// strategy is selected for a parent transaction.
 ///
@@ -421,6 +468,7 @@ mod tests {
 
     use super::{
         checked_anchor_strategy, first_output_paying_script, is_outpoint_unspent, is_txid_onchain,
+        outpoints_belong_to_previous_backend,
     };
 
     /// Per-coinbase reward on regtest before any halving.
@@ -787,6 +835,135 @@ mod tests {
             mined_status.confirmations.is_some_and(|c| c >= 1),
             "stage 3 (mined): spending tx should have ≥1 confirmation, got {:?}",
             mined_status.confirmations
+        );
+    }
+
+    /// Drives the previous-backend gate through the outcomes that decide whether a persisted
+    /// withdrawal-funding row may be discarded. Only unspent-at-a-foreign-script says
+    /// "previous backend" (discard); unspent at the current backend's own script, spent in
+    /// the mempool, spent on chain, and a mixed set all say "keep".
+    #[tokio::test]
+    async fn previous_backend_gate_discards_only_unspent_foreign_outpoints() {
+        let mut conf = Conf::default();
+        conf.args.push("-txindex=1");
+
+        let bitcoind = Node::with_conf("bitcoind", &conf).expect("bitcoind should start");
+        let mining_address = bitcoind
+            .client
+            .new_address()
+            .expect("wallet address should be generated");
+        bitcoind
+            .client
+            .generate_to_address(102, &mining_address)
+            .expect("coinbase outputs should mature");
+
+        let rpc_client = setup_btc_client(&bitcoind);
+
+        // Two matured coinbase outputs stand in for a persisted funding row. Their script
+        // belongs to the node wallet — a "previous backend" relative to any other script.
+        let mut outpoints = Vec::new();
+        let mut spks = Vec::new();
+        for height in [1, 2] {
+            let block = rpc_client
+                .get_block_at(height)
+                .await
+                .expect("mined block should be retrievable");
+            let coinbase_tx = block
+                .coinbase()
+                .expect("mined block should contain a coinbase transaction");
+            outpoints.push(OutPoint {
+                txid: coinbase_tx.compute_txid(),
+                vout: 0,
+            });
+            spks.push(coinbase_tx.output[0].script_pubkey.clone());
+        }
+        let own_spk = spks[0].clone();
+        let foreign_spk = Address::p2tr(
+            SECP256K1,
+            xonly_from_seed(3),
+            None,
+            bitcoin::Network::Regtest,
+        )
+        .script_pubkey();
+
+        // All unspent at a script that is not the current backend's: the backend-switch
+        // signature — the one outcome that may discard.
+        assert!(
+            outpoints_belong_to_previous_backend(&rpc_client, &outpoints, &foreign_spk)
+                .await
+                .expect("rpc should succeed"),
+            "unspent outpoints at a foreign script should classify as previous-backend"
+        );
+
+        // Same outpoints, but the current backend claims that script: anomaly, keep.
+        assert!(
+            !outpoints_belong_to_previous_backend(&rpc_client, &outpoints, &own_spk)
+                .await
+                .expect("rpc should succeed"),
+            "unspent outpoints at the current backend's script must not discard"
+        );
+
+        // Spend the first outpoint into the mempool (not mined): the gate must see the
+        // mempool spend and keep the row — this is the own-WFT-pending window.
+        let recipient = bitcoind
+            .client
+            .new_address()
+            .expect("recipient address should be generated");
+        let inputs = [Input {
+            txid: outpoints[0].txid,
+            vout: u64::from(outpoints[0].vout),
+            sequence: None,
+        }];
+        let outputs = [Output::new(
+            recipient,
+            Amount::from_sat(REGTEST_COINBASE_AMOUNT.to_sat() - 2_000),
+        )];
+        let unsigned_tx = bitcoind
+            .client
+            .create_raw_transaction(&inputs, &outputs)
+            .expect("create raw tx")
+            .transaction()
+            .expect("decode unsigned tx");
+        let signed = bitcoind
+            .client
+            .sign_raw_transaction_with_wallet(&unsigned_tx)
+            .expect("wallet should sign the spending tx");
+        assert!(
+            signed.complete,
+            "wallet should produce a complete signature"
+        );
+        let signed_tx: Transaction =
+            deserialize_hex(&signed.hex).expect("signed tx hex should deserialize");
+        bitcoind
+            .client
+            .send_raw_transaction(&signed_tx)
+            .expect("broadcast spending tx");
+
+        // Spent-in-mempool alone → keep.
+        assert!(
+            !outpoints_belong_to_previous_backend(&rpc_client, &outpoints[..1], &foreign_spk)
+                .await
+                .expect("rpc should succeed"),
+            "a mempool-spent outpoint must not classify as previous-backend"
+        );
+        // Mixed set (one spent, one unspent-foreign) → keep.
+        assert!(
+            !outpoints_belong_to_previous_backend(&rpc_client, &outpoints, &foreign_spk)
+                .await
+                .expect("rpc should succeed"),
+            "a partially spent set must not classify as previous-backend"
+        );
+
+        // Mined spend → still keep.
+        bitcoind
+            .client
+            .generate_to_address(1, &mining_address)
+            .expect("mine the spending tx");
+        assert!(
+            !outpoints_belong_to_previous_backend(&rpc_client, &outpoints, &foreign_spk)
+                .await
+                .expect("rpc should succeed"),
+            "a chain-spent outpoint must not classify as previous-backend"
         );
     }
 }

--- a/crates/bridge-exec/src/cpfp_adapters.rs
+++ b/crates/bridge-exec/src/cpfp_adapters.rs
@@ -22,8 +22,7 @@ use btc_tracker::{
     submitpackage::{self, SubmitPackageError, SubmitPackageSummary},
 };
 use operator_wallet::{
-    AnchorInfo, AnchorOwnership, ErrorPermanence, GeneralWallet, Lease, OperatorWallet,
-    ReplacedChild,
+    AnchorInfo, AnchorOwnership, AnyOperatorWallet, ErrorPermanence, Lease, ReplacedChild,
 };
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
@@ -31,7 +30,7 @@ use strata_bridge_connectors::{Connector, prelude::MultiAnchor};
 use tokio::sync::RwLock;
 use tracing::warn;
 
-/// Wraps the bridge's `Arc<RwLock<OperatorWallet<G>>>` and implements [`CpfpWallet`] over it.
+/// Wraps the bridge's `Arc<RwLock<AnyOperatorWallet>>` and implements [`CpfpWallet`] over it.
 ///
 /// Both [`CpfpStrategy`] variants funnel through
 /// [`OperatorWallet::build_cpfp_child`](operator_wallet::OperatorWallet::build_cpfp_child) with the
@@ -40,30 +39,37 @@ use tracing::warn;
 /// - [`CpfpStrategy::AnchorBearing`]: a 330-sat keyed-Taproot anchor at `anchor_vout`, internal key
 ///   = the operator's musig2 pubkey (the "btc key" from the operator table).
 /// - [`CpfpStrategy::ParentTxCombined`]: the operator's payout output at `payout_outpoint.vout`,
-///   internal key = the operator's general-wallet pubkey (the bridge assumes the operator's
-///   covenant `payout_descriptor` resolves to the general-wallet P2TR — if not, signing fails
-///   downstream and the bump is skipped + retried).
+///   internal key = the operator's general-wallet pubkey. This holds when the payout output pays
+///   the wallet's own `payout_descriptor()` (the BIP-341-tweaked general key) — guaranteed by
+///   construction for the descriptor-gossip parents (cooperative payout, unstaking), but the
+///   presigned-graph parents (uncontested/contested payout, counterproof nack) pay the params-file
+///   covenant descriptor, which the orchestrator only WARNS about at startup when it differs from
+///   the wallet. On a mismatch, signing fails downstream and the bump is skipped + retried. The
+///   Fireblocks backend ignores the hint — it recognises its own vault script on the prevout and
+///   signs that input itself.
 ///
 /// Treating the payout as a foreign UTXO (rather than asking BDK to track it in the wallet's
 /// UTXO set) is essential: the parent has NOT been broadcast at the time we build the child
 /// (we submit `[parent, child]` as a v3 1P1C package), so BDK has no knowledge of the
 /// payout outpoint. `add_foreign_utxo` accepts it with a caller-provided `witness_utxo`.
 #[derive(Debug)]
-pub struct OperatorWalletCpfpAdapter<G: GeneralWallet + std::fmt::Debug + 'static> {
-    wallet: Arc<RwLock<OperatorWallet<G>>>,
+pub struct OperatorWalletCpfpAdapter {
+    wallet: Arc<RwLock<AnyOperatorWallet>>,
     /// Operator's general-wallet pubkey. Used as the foreign-UTXO `tap_internal_key` when
     /// CPFPing a [`CpfpStrategy::ParentTxCombined`] parent — every payout output across
     /// cooperative_payout / uncontested_payout / contested_payout / unstaking goes to the
-    /// operator's payout descriptor, which the bridge expects to be the general-wallet P2TR.
+    /// operator's payout descriptor. The descriptor is backend-dependent (the native
+    /// wallet's P2TR receive script, the Fireblocks vault's P2WPKH script); the
+    /// classification of a prevout as the payout is backend-agnostic.
     operator_general_pubkey: XOnlyPublicKey,
 }
 
-impl<G: GeneralWallet + std::fmt::Debug + 'static> OperatorWalletCpfpAdapter<G> {
+impl OperatorWalletCpfpAdapter {
     /// Constructs a new adapter wrapping the shared wallet handle. `operator_general_pubkey`
     /// is the operator's general-wallet x-only pubkey (typically fetched once at
     /// orchestrator startup via `s2_client.general_wallet_signer().pubkey()`).
     pub const fn new(
-        wallet: Arc<RwLock<OperatorWallet<G>>>,
+        wallet: Arc<RwLock<AnyOperatorWallet>>,
         operator_general_pubkey: XOnlyPublicKey,
     ) -> Self {
         Self {
@@ -89,7 +95,7 @@ impl FundingLease for WalletFundingLease {
     }
 }
 
-impl<G: GeneralWallet + std::fmt::Debug + 'static> CpfpWallet for OperatorWalletCpfpAdapter<G> {
+impl CpfpWallet for OperatorWalletCpfpAdapter {
     fn build_cpfp_child(
         &self,
         parent: &Transaction,

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -671,15 +671,30 @@ async fn fulfill_withdrawal(
     let sign_result: Result<Transaction, ExecutorError> = async {
         let mut sighash_cache = SighashCache::new(&wft_psbt.unsigned_tx);
 
+        // Collect one prevout per input, preserving index alignment for `Prevouts::All` (a
+        // `filter_map` that dropped an input would silently misalign every subsequent sighash).
+        // Every WFT input is wallet-funded, so `witness_utxo` is always populated.
         let prevouts: Vec<_> = wft_psbt
             .inputs
             .iter()
-            .filter_map(|input| input.witness_utxo.clone())
+            .map(|input| {
+                input
+                    .witness_utxo
+                    .clone()
+                    .expect("WFT PSBT input is wallet-funded and always carries witness_utxo")
+            })
             .collect();
         let prevouts = Prevouts::All(&prevouts);
 
         let mut signed_tx = wft_psbt.unsigned_tx.clone();
-        for (input_index, _) in wft_psbt.inputs.iter().enumerate() {
+        for (input_index, input) in wft_psbt.inputs.iter().enumerate() {
+            // A create-and-sign backend (Fireblocks) already populated this input's witness;
+            // use it verbatim. Otherwise it's a native descriptor-only input we sign via
+            // secret-service. (`GeneralWallet` signing contract — skip what the backend signed.)
+            if let Some(witness) = &input.final_script_witness {
+                signed_tx.input[input_index].witness = witness.clone();
+                continue;
+            }
             let msg = create_message_hash(
                 &mut sighash_cache,
                 prevouts.clone(),
@@ -756,15 +771,11 @@ async fn request_payout_nonces(
         None => {
             info!(%deposit_idx, "creating descriptor to request payout nonces");
 
-            output_handles
-                .wallet
-                .read()
-                .await
-                .descriptor()
-                .map(PayoutDescriptor::from)
-                .map_err(|e| {
-                    ExecutorError::WalletErr(format!("failed to create descriptor: {e}"))
-                })?
+            // The payout destination is backend-supplied: the operator wallet knows where it
+            // can receive *and spend* funds (native general-key P2TR vs. Fireblocks vault
+            // P2WPKH). Peers honour whatever descriptor we broadcast, building the payout
+            // output via `Descriptor::to_script`.
+            PayoutDescriptor::from(output_handles.wallet.read().await.payout_descriptor())
         }
     };
 

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -765,6 +765,22 @@ async fn request_payout_nonces(
 ) -> Result<(), ExecutorError> {
     let payout_descriptor = match payout_descriptor {
         Some(descriptor) => {
+            // Reuse is load-bearing: peers have nonced against this exact descriptor, and a
+            // substitution here invalidates the collected nonces. When the wallet backend
+            // (or its vault address) changed after the session started, the payout lands on
+            // a script the current backend does not track — warn so the operator sees which
+            // deposits a backend switch stranded. The remedy is operational (drain in-flight
+            // payouts before a switch), not a substitution on retry.
+            let current = output_handles.wallet.read().await.payout_descriptor();
+            if current.to_script() != descriptor.to_script() {
+                warn!(
+                    %deposit_idx,
+                    session_descriptor = %descriptor,
+                    wallet_descriptor = %current,
+                    "reused payout descriptor differs from the current wallet backend; \
+                     this payout will land on a script the active backend does not track"
+                );
+            }
             info!(%deposit_idx, "reusing descriptor to request payout nonces");
             PayoutDescriptor::from(descriptor)
         }

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bitcoin::{
-    Amount, OutPoint, TapSighashType, Transaction, Txid,
+    Amount, OutPoint, ScriptBuf, TapSighashType, Transaction, Txid,
     secp256k1::{Message, PublicKey, XOnlyPublicKey, schnorr},
     sighash::{Prevouts, SighashCache},
 };
@@ -14,7 +14,7 @@ use bitcoin_bosd::Descriptor;
 use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use musig2::{AggNonce, PartialSignature, PubNonce, aggregate_partial_signatures};
-use operator_wallet::LeaseOwner;
+use operator_wallet::{LeaseOwner, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_connectors::SigningInfo;
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
@@ -22,7 +22,7 @@ use strata_bridge_p2p_types::{NagRequest, NagRequestPayload, PayoutDescriptor};
 use strata_bridge_primitives::{
     key_agg::create_agg_ctx,
     scripts::taproot::{TaprootTweak, TaprootWitness, create_message_hash},
-    types::{BitcoinBlockHeight, DepositIdx, OperatorIdx},
+    types::{BitcoinBlockHeight, DepositIdx, GraphIdx, OperatorIdx},
 };
 use strata_bridge_sm::deposit::duties::{DepositDuty, NagDuty};
 use strata_bridge_tx_graph::{
@@ -559,14 +559,100 @@ async fn fulfill_withdrawal(
         let mut wallet = output_handles.wallet.write().await;
 
         info!(%deposit_idx, "syncing wallet before funding withdrawal fulfillment tx");
-        if let Err(e) = wallet.sync().await {
-            warn!(%deposit_idx, ?e, "could not sync wallet, continuing anyway");
-        }
+        let sync_ok = match wallet.sync().await {
+            Ok(()) => true,
+            Err(e) => {
+                warn!(%deposit_idx, ?e, "could not sync wallet, continuing anyway");
+                false
+            }
+        };
 
         let persisted_funding_outpoints = output_handles
             .db
             .get_withdrawal_funding_outpoints(deposit_idx)
             .await?;
+
+        // Outpoints persisted under a previous general backend (a native to Fireblocks
+        // switch) are not spendable by the current one: every retry would fail inside
+        // the backend and the withdrawal would be stuck until the row is edited by
+        // hand. Verify the persisted set against the freshly synced UTXO set — the
+        // same discard-and-reselect recovery the stake-reservation path uses. Only
+        // verify after a successful sync: a stale cache would report live outpoints
+        // as missing.
+        //
+        // A view mismatch alone must NOT discard the row. The same mismatch appears
+        // when this deposit's own fulfillment transaction is in the mempool or
+        // confirmed while the state machine still says `Assigned` (a retry tick or a
+        // restart re-runs this duty in exactly that window), and discarding there
+        // funds, signs, and broadcasts a second payout. Only chain state showing the
+        // outpoints unspent at a script other than the current backend's — the
+        // backend-switch signature — may discard; every other outcome keeps the row,
+        // and the funding path no-ops and retries as it did before this recovery
+        // existed.
+        let persisted_funding_outpoints = if sync_ok {
+            match persisted_funding_outpoints {
+                Some(outpoints)
+                    if persisted_outpoints_are_current(
+                        &wallet.list_general_utxos(),
+                        &wallet.general_script_pubkey(),
+                        &outpoints,
+                    ) =>
+                {
+                    Some(outpoints)
+                }
+                Some(outpoints) => {
+                    match chain::outpoints_belong_to_previous_backend(
+                        &output_handles.bitcoind_rpc_client,
+                        &outpoints,
+                        &wallet.general_script_pubkey(),
+                    )
+                    .await
+                    {
+                        Ok(true) => {
+                            warn!(
+                                %deposit_idx,
+                                ?outpoints,
+                                "persisted withdrawal funding outpoints belong to a \
+                                 previous wallet backend; discarding the row and \
+                                 selecting fresh"
+                            );
+                            output_handles
+                                .db
+                                .delete_withdrawal_funding_outpoints(GraphIdx {
+                                    deposit: deposit_idx,
+                                    // The delete reads only the deposit index.
+                                    operator: 0,
+                                })
+                                .await?;
+                            None
+                        }
+                        Ok(false) => {
+                            warn!(
+                                %deposit_idx,
+                                ?outpoints,
+                                "persisted withdrawal funding outpoints are spent or \
+                                 pending in the current backend; keeping the row for \
+                                 retry"
+                            );
+                            Some(outpoints)
+                        }
+                        Err(e) => {
+                            warn!(
+                                %deposit_idx,
+                                ?outpoints,
+                                ?e,
+                                "chain lookup for persisted withdrawal funding \
+                                 outpoints failed; keeping the row"
+                            );
+                            Some(outpoints)
+                        }
+                    }
+                }
+                None => None,
+            }
+        } else {
+            persisted_funding_outpoints
+        };
 
         // Every path that ends with a funded PSBT commits its lease. The database row keeps
         // the funding outpoints of a deposit across duties and across restarts, and the
@@ -751,6 +837,25 @@ async fn fulfill_withdrawal(
     info!(%deposit_idx, %txid, "withdrawal fulfillment confirmed");
 
     Ok(())
+}
+
+/// The persisted withdrawal-funding outpoints are spendable by the current general
+/// backend: every outpoint is in `current_utxos` (the freshly synced UTXO set) and pays
+/// `general_spk` (the general wallet's script). Catches a row written under a previous
+/// backend so it can be discarded and reselected instead of failing in the backend forever.
+///
+/// Takes plain data rather than the wallet handle so the mock-backend unit suites can
+/// exercise both verdicts (same shape as `stake::staking::validate_reservation`).
+fn persisted_outpoints_are_current(
+    current_utxos: &[UtxoInfo],
+    general_spk: &ScriptBuf,
+    outpoints: &[OutPoint],
+) -> bool {
+    outpoints.iter().all(|outpoint| {
+        current_utxos
+            .iter()
+            .any(|utxo| utxo.outpoint == *outpoint && utxo.script_pubkey == *general_spk)
+    })
 }
 
 /// Initiates the cooperative payout flow by publishing the assignee's payout descriptor.
@@ -1141,4 +1246,56 @@ async fn publish_sweep(
 
     info!(%txid, "sweep transaction confirmed");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{Amount, hashes::Hash};
+
+    use super::*;
+
+    fn spk(byte: u8) -> ScriptBuf {
+        ScriptBuf::from_bytes(vec![0x00, 0x14, byte])
+    }
+
+    fn utxo(outpoint: OutPoint, script_pubkey: &ScriptBuf) -> UtxoInfo {
+        UtxoInfo {
+            outpoint,
+            amount: Amount::from_sat(50_000),
+            confirmations: 1,
+            script_pubkey: script_pubkey.clone(),
+        }
+    }
+
+    fn outpoint(seed: u8) -> OutPoint {
+        OutPoint {
+            txid: Txid::from_byte_array([seed; 32]),
+            vout: 0,
+        }
+    }
+
+    /// The destructive-delete gate's fast path: a row whose every outpoint is in the
+    /// current backend's synced view at the backend's own script passes; a row written
+    /// under another backend (present at a different script, or absent entirely) fails.
+    #[test]
+    fn persisted_outpoints_are_current_distinguishes_backends() {
+        let general = spk(0xaa);
+        let foreign = spk(0xbb);
+        let (a, b) = (outpoint(1), outpoint(2));
+        let current = vec![utxo(a, &general), utxo(b, &general)];
+
+        // Every persisted outpoint in the current view at the general script: current.
+        assert!(persisted_outpoints_are_current(&current, &general, &[a, b]));
+
+        // An outpoint missing from the view is not current.
+        assert!(!persisted_outpoints_are_current(
+            &current,
+            &general,
+            &[a, outpoint(3)]
+        ));
+
+        // An outpoint present but at another backend's script is not current.
+        let mixed = vec![utxo(a, &general), utxo(b, &foreign)];
+        assert!(!persisted_outpoints_are_current(&mixed, &general, &[a, b]));
+    }
 }

--- a/crates/bridge-exec/src/errors.rs
+++ b/crates/bridge-exec/src/errors.rs
@@ -55,6 +55,12 @@ pub enum ExecutorError {
     #[error("stake outpoint {0} already spent on chain")]
     StakeOutPointAlreadySpent(OutPoint),
 
+    /// A stake funding reservation is being discarded while its funding transaction is still in
+    /// the mempool. Re-funding would select the same inputs and the replacement would fail
+    /// BIP125, so the discard is deferred until the old transaction resolves.
+    #[error("stake funding tx {0} is still in the mempool; discarding its reservation is deferred")]
+    StakeFundingTxInMempool(Txid),
+
     /// Error interacting with the database.
     #[error("database error: {0:?}")]
     DatabaseErr(OneOf<(FdbBindingError, LayerError)>),

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -9,7 +9,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
-use operator_wallet::{GeneralUtxoPolicy, LeaseOwner, UtxoInfo};
+use operator_wallet::{AnyOperatorWallet, GeneralUtxoPolicy, LeaseOwner, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_connectors::{Connector, ParentTx};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
@@ -755,6 +755,19 @@ mod tests {
 
     impl GeneralWallet for ReconciliationGeneralWallet {
         type Error = MockError;
+
+        fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
+            unreachable!("reconciliation tests do not resolve payout descriptors")
+        }
+
+        async fn sign_owned_inputs(
+            &self,
+            _tx: &Transaction,
+            _input_indices: &[usize],
+            _prevouts: &[TxOut],
+        ) -> Result<Vec<Option<bitcoin::Witness>>, Self::Error> {
+            unreachable!("reconciliation tests do not sign inputs")
+        }
 
         async fn sync(&mut self) -> Result<(), Self::Error> {
             if self.sync_fails {

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -9,7 +9,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
-use operator_wallet::{AnyOperatorWallet, GeneralUtxoPolicy, LeaseOwner, UtxoInfo};
+use operator_wallet::{GeneralUtxoPolicy, LeaseOwner, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_connectors::{Connector, ParentTx};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -8,7 +8,7 @@ use bitcoin::{
 };
 use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
-use operator_wallet::{Lease, LeaseOwner};
+use operator_wallet::{AnyOperatorWallet, Lease, LeaseOwner};
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_primitives::types::GraphIdx;
 use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnTx;
@@ -18,7 +18,7 @@ use crate::{
     chain::{CpfpKind, ParentFee, publish_signed_transaction},
     config::ExecutionConfig,
     errors::ExecutorError,
-    output_handles::{NativeWallet, OutputHandles},
+    output_handles::OutputHandles,
 };
 
 /// Index of the payout connector input in the unfunded burn template.
@@ -202,7 +202,7 @@ async fn burn_fee_rate(output_handles: &OutputHandles) -> Result<FeeRate, Execut
 ///   - general_wallet_output_value
 /// ```
 async fn select_funding(
-    wallet: &mut NativeWallet,
+    wallet: &mut AnyOperatorWallet,
     graph_idx: GraphIdx,
     unstaking_burn_tx: &UnstakingBurnTx,
     unstaking_preimage: [u8; 32],
@@ -369,10 +369,30 @@ async fn build_and_sign_tx(
 
     let prevouts = funded_burn.prevouts().to_vec();
     let mut signed_tx = funded_burn.finalize_partial(unstaking_preimage);
-    let wallet_signature = sign_wallet_input(output_handles, &signed_tx, &prevouts).await?;
-    signed_tx.input[WALLET_INPUT_INDEX]
-        .witness
-        .push(wallet_signature.to_vec());
+
+    // Sign the general-wallet funding input. A create-and-sign backend (Fireblocks) signs its
+    // P2WPKH input and returns the witness; the native descriptor-only backend returns `None`,
+    // and we sign the Taproot key-path via secret-service. (Sighashes don't depend on other
+    // inputs' witnesses, so computing over `signed_tx` after the connector is finalized is fine.)
+    let backend_witness = output_handles
+        .wallet
+        .read()
+        .await
+        .sign_owned_inputs(&signed_tx, &[WALLET_INPUT_INDEX], &prevouts)
+        .await
+        .map_err(|e| ExecutorError::WalletErr(format!("backend signing failed: {e}")))?
+        .into_iter()
+        .next()
+        .flatten();
+    match backend_witness {
+        Some(witness) => signed_tx.input[WALLET_INPUT_INDEX].witness = witness,
+        None => {
+            let wallet_signature = sign_wallet_input(output_handles, &signed_tx, &prevouts).await?;
+            signed_tx.input[WALLET_INPUT_INDEX]
+                .witness
+                .push(wallet_signature.to_vec());
+        }
+    }
 
     let final_vsize = signed_tx.vsize() as u64;
     let final_fee = plan
@@ -424,7 +444,9 @@ struct FeeEstimate {
 ///
 /// The estimate is derived from the actual transaction template: one payout connector input, one
 /// general-wallet input, and one output back to the general wallet. The connector witness is
-/// populated by `finalize_partial`; the wallet witness is modeled with a 64-byte Schnorr signature.
+/// populated by `finalize_partial`; the wallet witness is modeled to match the backend's receive
+/// script — a 73-byte DER signature + 33-byte pubkey for a P2WPKH (Fireblocks) input, or a 64-byte
+/// Schnorr signature for a P2TR (native) input.
 fn estimate_unstaking_burn_fee(
     unstaking_burn_tx: &UnstakingBurnTx,
     unstaking_preimage: [u8; 32],
@@ -446,12 +468,24 @@ fn estimate_unstaking_burn_fee(
         },
     );
 
-    // The connector witness is exact after `finalize_partial`; the general wallet witness is a
-    // fixed-size Schnorr signature, so a 64-byte dummy witness gives an exact vsize.
+    // The connector witness is exact after `finalize_partial`. The general-wallet input's
+    // witness shape depends on the backend: the native general wallet is P2TR (64-byte
+    // key-path Schnorr signature), Fireblocks is P2WPKH (DER signature + compressed pubkey).
+    // Model whichever the wallet uses (its receive `payout_script`) so the vsize estimate
+    // matches the signed transaction.
     let mut estimated_tx = unstaking_burn_tx.finalize_partial(unstaking_preimage);
-    estimated_tx.input[WALLET_INPUT_INDEX]
-        .witness
-        .push([0u8; 64]);
+    if payout_script.is_p2wpkh() {
+        estimated_tx.input[WALLET_INPUT_INDEX]
+            .witness
+            .push([0u8; 73]); // max DER signature + sighash-type byte
+        estimated_tx.input[WALLET_INPUT_INDEX]
+            .witness
+            .push([0u8; 33]); // compressed public key
+    } else {
+        estimated_tx.input[WALLET_INPUT_INDEX]
+            .witness
+            .push([0u8; 64]); // P2TR key-path Schnorr signature
+    }
 
     let vsize = estimated_tx.vsize() as u64;
     let fee = fee_rate
@@ -532,6 +566,7 @@ mod tests {
     use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnData;
 
     use super::*;
+    use crate::output_handles::NativeWallet;
 
     const TEST_GRAPH_IDX: GraphIdx = GraphIdx {
         deposit: 0,
@@ -564,7 +599,7 @@ mod tests {
         keypair.x_only_public_key().0
     }
 
-    fn wallet(bitcoind: &Node) -> NativeWallet {
+    fn wallet(bitcoind: &Node) -> AnyOperatorWallet {
         let general = NativeGeneralWallet::new(
             xonly_pubkey(1),
             Network::Regtest,
@@ -577,9 +612,10 @@ mod tests {
             Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
             BTreeSet::new(),
         )
+        .into()
     }
 
-    fn fund_general_wallet(bitcoind: &Node, wallet: &NativeWallet, amount: Amount) {
+    fn fund_general_wallet(bitcoind: &Node, wallet: &AnyOperatorWallet, amount: Amount) {
         let mining_address = bitcoind
             .client
             .new_address()

--- a/crates/bridge-exec/src/graph/utils.rs
+++ b/crates/bridge-exec/src/graph/utils.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for graph executors.
 
 use bitcoin::{
-    Psbt, TapSighashType, Transaction,
+    Psbt, TapSighashType, Transaction, Witness,
     hashes::Hash,
     sighash::{Prevouts, SighashCache},
     taproot,
@@ -32,12 +32,25 @@ pub(super) async fn sign_claim_funding_tx(
                 .expect("PSBT input from claim-funding refill always has witness_utxo")
         })
         .collect::<Vec<_>>();
+    // A "create-and-sign" backend (Fireblocks) returns the funding inputs already signed via
+    // `final_script_witness`; capture those before moving the unsigned tx. Inputs without one are
+    // the native descriptor-only backend's and get secret-service-signed below. Honouring this is
+    // the `GeneralWallet` signing contract — skip what the backend already signed.
+    let final_witnesses: Vec<Option<Witness>> = psbt
+        .inputs
+        .iter()
+        .map(|input| input.final_script_witness.clone())
+        .collect();
     let mut tx = psbt.unsigned_tx;
 
     let mut sighasher = SighashCache::new(&mut tx);
     let sighash_type = TapSighashType::Default;
     let prevouts = Prevouts::All(&txins_as_outs);
-    for input_index in 0..txins_as_outs.len() {
+    for (input_index, final_witness) in final_witnesses.iter().enumerate() {
+        if let Some(witness) = final_witness {
+            *sighasher.witness_mut(input_index).expect("an input here") = witness.clone();
+            continue;
+        }
         let sighash = sighasher
             .taproot_key_spend_signature_hash(input_index, &prevouts, sighash_type)
             .expect("failed to construct sighash");

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -26,10 +26,14 @@ pub type NativeWallet = OperatorWallet<NativeGeneralWallet>;
 pub struct OutputHandles {
     /// Handle for accessing operator funds.
     ///
-    /// Methods on [`OperatorWallet`] take `&mut self`. The outer `RwLock` also lets executors
-    /// span multi-step critical sections (e.g. DB-lookup-then-fund-then-persist) without
-    /// races between concurrent duties. Erased over the backend so the binary can pick native
-    /// vs Fireblocks at startup without threading `<G>` through every executor.
+    /// Only `sync` takes the wallet's exclusive guard; fund, build, and selection run under
+    /// the shared read guard plus the wallet's internal funding lock. That funding lock
+    /// serializes funding across duties for the length of a backend round trip — what
+    /// concurrent duties gain from the shared guard is that read-only observations do not
+    /// queue behind a round trip. The outer write guard is for duties that span a multi-step
+    /// critical section (e.g. DB-lookup-then-fund-then-persist) without races between concurrent
+    /// duties. Erased over the backend so the binary can pick native vs Fireblocks at
+    /// startup without threading `<G>` through every executor.
     pub wallet: Arc<RwLock<AnyOperatorWallet>>,
 
     /// Handle for accessing the database.

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -6,7 +6,7 @@ use bitcoin::{Network, XOnlyPublicKey};
 use bitcoind_async_client::Client as BitcoinClient;
 use btc_tracker::tx_driver::TxDriver;
 use jsonrpsee::http_client::HttpClient;
-use operator_wallet::{NativeGeneralWallet, OperatorWallet};
+use operator_wallet::{AnyOperatorWallet, NativeGeneralWallet, OperatorWallet};
 use secret_service_client::SecretServiceClient;
 use strata_bridge_counterproof::BridgeCounterproofHost;
 use strata_bridge_db::fdb::client::FdbClient;
@@ -15,9 +15,8 @@ use strata_bridge_proof::BridgeProofHost;
 use strata_mosaic_client_api::MosaicClientApi;
 use tokio::sync::RwLock;
 
-/// Concrete operator-wallet type used by bridge-exec. Today the only general-wallet backend in
-/// use is [`NativeGeneralWallet`]; Fireblocks support (STR-3437) will add a sibling impl and
-/// the binary will pick between them at startup.
+/// The native operator-wallet type. The binary constructs one of these (or a Fireblocks-backed
+/// wallet) at startup and erases the choice into [`AnyOperatorWallet`] for [`OutputHandles`].
 pub type NativeWallet = OperatorWallet<NativeGeneralWallet>;
 
 /// The handles for external services that need to be accessed by the executors.
@@ -29,8 +28,9 @@ pub struct OutputHandles {
     ///
     /// Methods on [`OperatorWallet`] take `&mut self`. The outer `RwLock` also lets executors
     /// span multi-step critical sections (e.g. DB-lookup-then-fund-then-persist) without
-    /// races between concurrent duties.
-    pub wallet: Arc<RwLock<NativeWallet>>,
+    /// races between concurrent duties. Erased over the backend so the binary can pick native
+    /// vs Fireblocks at startup without threading `<G>` through every executor.
+    pub wallet: Arc<RwLock<AnyOperatorWallet>>,
 
     /// Handle for accessing the database.
     // TODO: <https://alpenlabs.atlassian.net/browse/STR-2670>

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -26,7 +26,7 @@ use strata_bridge_primitives::{
     types::OperatorIdx,
 };
 use strata_bridge_tx_graph::{fee, musig_functor::StakeFunctor, transactions::prelude::StakeTx};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     chain::{self, CpfpKind, publish_signed_transaction},
@@ -157,6 +157,37 @@ async fn read_or_create_stake_funding(
                     "persisted stake funding reservation is invalid for the current wallet; \
                      discarding it and creating a new funding tx"
                 );
+                // While the reservation's funding tx is still in the mempool (an operator
+                // changed the stake params while it was pending), re-funding selects the
+                // same live inputs and the replacement fails BIP125: the new tx is funded
+                // at the same live rate and does not pay the original fee plus the
+                // replacement premium. Defer this cycle; once the old tx confirms its
+                // inputs leave the wallet and the discard proceeds cleanly.
+                let old_txid = reservation.unsigned_tx.compute_txid();
+                match output_handles
+                    .bitcoind_rpc_client
+                    .call_raw::<serde_json::Value>(
+                        "getmempoolentry",
+                        &[serde_json::json!(old_txid)],
+                    )
+                    .await
+                {
+                    Ok(_) => {
+                        warn!(
+                            %operator_idx,
+                            %old_txid,
+                            "old stake funding tx is still in the mempool; deferring the \
+                             reservation discard until it resolves"
+                        );
+                        return Err(ExecutorError::StakeFundingTxInMempool(old_txid));
+                    }
+                    Err(e) => {
+                        // A failed lookup is not evidence the tx is live: the RPC is down,
+                        // or the tx already left the mempool. Proceed with the discard; a
+                        // live conflict then surfaces as a publish failure, as before.
+                        debug!(?e, "getmempoolentry failed; proceeding with the discard");
+                    }
+                }
                 // Startup rehydration (`get_all_funds`) leased this reservation's inputs.
                 // Deleting the row alone leaves those leases in place, and the sync prune
                 // only drops leases whose UTXO is gone — in the same-backend case (a params

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -81,15 +81,10 @@ pub(crate) async fn publish_stake_data(
     info!(%unstaking_image, "fetched unstaking intent preimage and computed the unstaking image");
 
     info!("constructing the unstaking output descriptor");
-    let output_desc = output_handles
-        .wallet
-        .read()
-        .await
-        .descriptor()
-        .map_err(|e| {
-            ExecutorError::WalletErr(format!("failed to create unstaking descriptor: {e}"))
-        })?;
-    info!(%output_desc, "constructed the unstaking output descriptor");
+    // Backend-aware receive destination: where this operator gets its unstaking funds, so the
+    // funds land somewhere it can actually spend — the wallet's own receive script for the
+    // native backend, the vault P2WPKH for Fireblocks.
+    let output_desc = output_handles.wallet.read().await.payout_descriptor();
 
     let unstaking_input = UnstakingInput {
         stake_funds,
@@ -296,34 +291,52 @@ async fn sign_reservation(
     output_handles: &OutputHandles,
     reservation: &StakeFundingReservation,
 ) -> Result<Transaction, ExecutorError> {
-    let prevouts = Prevouts::All(&reservation.prevouts);
-
     const DEFAULT_SIGHASH_TYPE: TapSighashType = TapSighashType::Default;
 
+    let input_count = reservation.unsigned_tx.input.len();
+    let all_indices: Vec<usize> = (0..input_count).collect();
+
+    // The stake-funding tx is funded entirely from the general wallet, but the reservation is
+    // persisted as an unsigned tx + prevouts (the funded PSBT's witnesses, if any, aren't
+    // stored), so sign on demand here. A create-and-sign backend (Fireblocks) signs its P2WPKH
+    // inputs and returns their witnesses; the native descriptor-only backend returns all `None`
+    // and those inputs are signed via secret-service below.
+    let backend_witnesses = output_handles
+        .wallet
+        .read()
+        .await
+        .sign_owned_inputs(
+            &reservation.unsigned_tx,
+            &all_indices,
+            &reservation.prevouts,
+        )
+        .await
+        .map_err(|e| ExecutorError::WalletErr(format!("backend signing failed: {e}")))?;
+
+    let prevouts = Prevouts::All(&reservation.prevouts);
     let mut sighash_cache = SighashCache::new(&reservation.unsigned_tx);
-    let sighashes = (0..reservation.unsigned_tx.input.len()).map(|input_index| {
-        create_key_spend_hash(
+    let s2_signer = output_handles.s2_client.general_wallet_signer();
+
+    let mut signed_tx = reservation.unsigned_tx.clone();
+    for (input_index, backend_witness) in backend_witnesses.iter().enumerate() {
+        if let Some(witness) = backend_witness {
+            signed_tx.input[input_index].witness = witness.clone();
+            continue;
+        }
+        let sighash = create_key_spend_hash(
             &mut sighash_cache,
             prevouts.clone(),
             DEFAULT_SIGHASH_TYPE,
             input_index,
         )
-        .expect("must be able to create key spend hash")
-    });
-
-    let s2_signer = output_handles.s2_client.general_wallet_signer();
-    let mut signatures = Vec::with_capacity(reservation.unsigned_tx.input.len());
-    for sighash in sighashes {
+        .map_err(|e| ExecutorError::WalletErr(format!("key spend hash: {e}")))?;
         let signature = s2_signer
             .sign(sighash.as_ref(), None)
             .await
             .map_err(ExecutorError::SecretServiceErr)?;
-        signatures.push(signature);
-    }
-
-    let mut signed_tx = reservation.unsigned_tx.clone();
-    for (input, signature) in signed_tx.input.iter_mut().zip(signatures) {
-        input.witness.push(signature.serialize());
+        signed_tx.input[input_index]
+            .witness
+            .push(signature.serialize());
     }
 
     Ok(signed_tx)

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -123,25 +123,60 @@ async fn read_or_create_stake_funding(
         .get_stake_funding_reservation(operator_idx)
         .await?
     {
-        info!(%operator_idx, "reusing persisted stake funding reservation");
-        validate_reservation(
+        match validate_reservation(
             &reservation,
             &wallet.reserved_script_pubkey(),
+            &wallet.general_script_pubkey(),
             funding_amount,
-        )?;
-        let inputs: Vec<OutPoint> = reservation
-            .unsigned_tx
-            .input
-            .iter()
-            .map(|txin| txin.previous_output)
-            .collect();
-        // The database row keeps this reservation across restarts, so the lease has no owning
-        // value to drop. Startup rehydration holds the same outpoints. This call covers the
-        // case where the row was written after startup read the funds.
-        wallet
-            .lease_committed(inputs, LeaseOwner::StakeFunding)
-            .await;
-        return Ok(reservation);
+        ) {
+            Ok(()) => {
+                info!(%operator_idx, "reusing persisted stake funding reservation");
+                let inputs: Vec<OutPoint> = reservation
+                    .unsigned_tx
+                    .input
+                    .iter()
+                    .map(|txin| txin.previous_output)
+                    .collect();
+                // The database row keeps this reservation across restarts, so the lease has
+                // no owning value to drop. Startup rehydration holds the same outpoints.
+                // This call covers the case where the row was written after startup read
+                // the funds.
+                wallet
+                    .lease_committed(inputs, LeaseOwner::StakeFunding)
+                    .await;
+                return Ok(reservation);
+            }
+            Err(e) => {
+                // A reservation that fails validation fails it forever (it is durable and
+                // the wallet it was built against is gone or changed). Erroring out here
+                // blocked stake publication permanently with no operator-facing recovery.
+                // Discard it and fund afresh instead.
+                warn!(
+                    %operator_idx,
+                    error = %e,
+                    "persisted stake funding reservation is invalid for the current wallet; \
+                     discarding it and creating a new funding tx"
+                );
+                // Startup rehydration (`get_all_funds`) leased this reservation's inputs.
+                // Deleting the row alone leaves those leases in place, and the sync prune
+                // only drops leases whose UTXO is gone — in the same-backend case (a params
+                // change, not a backend switch) the inputs are live wallet UTXOs, and the
+                // stale leases would silently shrink the spendable balance until restart.
+                // The wallet write lock is held across this whole function, so the release
+                // and the delete are atomic against other duties.
+                let stale_inputs: Vec<OutPoint> = reservation
+                    .unsigned_tx
+                    .input
+                    .iter()
+                    .map(|txin| txin.previous_output)
+                    .collect();
+                wallet.release_committed(&stale_inputs);
+                output_handles
+                    .db
+                    .delete_stake_funding_reservation(operator_idx)
+                    .await?;
+            }
+        }
     }
 
     info!(%operator_idx, "no persisted stake funding reservation; creating a new funding tx");
@@ -180,9 +215,13 @@ async fn read_or_create_stake_funding(
         Ok(FundingAssignment::Existing(reservation)) => {
             info!(%operator_idx, "using existing stake funding reservation saved by another duty");
             drop(candidate_lease);
+            // No discard-and-rebuild here, unlike the read path: this reservation was just
+            // written by a concurrently-running duty of this same process, so its backend
+            // is the current backend and a validation failure means real corruption.
             validate_reservation(
                 &reservation,
                 &wallet.reserved_script_pubkey(),
+                &wallet.general_script_pubkey(),
                 funding_amount,
             )?;
             let assigned_inputs: Vec<OutPoint> = reservation
@@ -232,6 +271,7 @@ async fn estimate_funding_fee_rate(
 fn validate_reservation(
     reservation: &StakeFundingReservation,
     expected_stake_script: &bitcoin::ScriptBuf,
+    expected_funding_script: &bitcoin::ScriptBuf,
     expected_funding_amount: Amount,
 ) -> Result<(), ExecutorError> {
     if reservation.prevouts.len() != reservation.unsigned_tx.input.len() {
@@ -240,6 +280,19 @@ fn validate_reservation(
             reservation.prevouts.len(),
             reservation.unsigned_tx.input.len(),
         )));
+    }
+    // The funding inputs must belong to the CURRENT general backend. A reservation persisted
+    // under one backend and signed by another produces either a hard signing error
+    // (P2TR prevouts through the Fireblocks P2WPKH sighash) or an invalid transaction
+    // (a Schnorr key-spend witness on a P2WPKH input) — permanently, because the reservation
+    // is durable. Reject it here so the caller discards it and funds afresh.
+    for (i, prevout) in reservation.prevouts.iter().enumerate() {
+        if prevout.script_pubkey != *expected_funding_script {
+            return Err(ExecutorError::InvalidTxStructure(format!(
+                "stake funding reservation prevout {i} pays a script the current general \
+                 wallet does not control (backend changed since the reservation was made?)",
+            )));
+        }
     }
     let stake_output = reservation
         .unsigned_tx
@@ -523,4 +576,65 @@ fn stake_funding_amount(network: Network, stake_amount: Amount) -> Amount {
         fee::unstaking_intent_surcharge(),
     );
     StakeTx::stake_funds_required(stake_amount, &unstaking_intent_output)
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        Amount, Transaction, TxIn, TxOut, absolute::LockTime, hashes::Hash, transaction::Version,
+    };
+    use strata_bridge_db::types::StakeFundingReservation;
+
+    use super::validate_reservation;
+
+    fn script(byte: u8) -> bitcoin::ScriptBuf {
+        // The shape is irrelevant to `validate_reservation`; only script identity matters.
+        bitcoin::ScriptBuf::from_bytes(vec![0x51, 0x20, byte])
+    }
+
+    fn reservation(
+        funding_script: &bitcoin::ScriptBuf,
+        stake_script: &bitcoin::ScriptBuf,
+    ) -> StakeFundingReservation {
+        let prevout = TxOut {
+            value: Amount::from_sat(60_000),
+            script_pubkey: funding_script.clone(),
+        };
+        StakeFundingReservation {
+            unsigned_tx: Transaction {
+                version: Version(3),
+                lock_time: LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: bitcoin::OutPoint {
+                        txid: bitcoin::Txid::all_zeros(),
+                        vout: 0,
+                    },
+                    ..Default::default()
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(50_000),
+                    script_pubkey: stake_script.clone(),
+                }],
+            },
+            prevouts: vec![prevout],
+            stake_output_vout: 0,
+        }
+    }
+
+    /// A reservation funded by a previous general backend must be rejected, not signed.
+    /// Signing it produces either a hard error or an invalid transaction — forever,
+    /// because the reservation is durable. Rejection is what lets the caller discard the
+    /// row and fund afresh.
+    #[test]
+    fn a_reservation_from_another_backend_is_rejected() {
+        let old_backend = script(1);
+        let current_backend = script(2);
+        let stake = script(3);
+        let r = reservation(&old_backend, &stake);
+        let err = validate_reservation(&r, &stake, &current_backend, Amount::from_sat(50_000));
+        assert!(err.is_err(), "foreign-backend prevout must fail validation");
+
+        let ok = validate_reservation(&r, &stake, &old_backend, Amount::from_sat(50_000));
+        assert!(ok.is_ok(), "same-backend prevout must pass");
+    }
 }

--- a/crates/bridge-exec/tests/cpfp_e2e.rs
+++ b/crates/bridge-exec/tests/cpfp_e2e.rs
@@ -42,7 +42,9 @@ use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::cpfp::{
     self, BumpOutcome, BumpReason, CpfpContext, CpfpHandle, CpfpStrategy, InputSigner,
 };
-use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
+use operator_wallet::{
+    AnyOperatorWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend,
+};
 use serial_test::serial;
 use strata_bridge_connectors::{Connector, multi_anchor::MultiAnchor};
 use strata_bridge_exec::cpfp_adapters::{BitcoindCpfpMempool, OperatorWalletCpfpAdapter};
@@ -145,7 +147,7 @@ async fn build_operator_wallet(
     pubkey: XOnlyPublicKey,
     funding_utxos: usize,
     funding_per_utxo: Amount,
-) -> Arc<RwLock<OperatorWallet<NativeGeneralWallet>>> {
+) -> Arc<RwLock<AnyOperatorWallet>> {
     let backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
     let backend_clone = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
     let general_wallet = NativeGeneralWallet::new(pubkey, Network::Regtest, backend);
@@ -177,14 +179,14 @@ async fn build_operator_wallet(
         .expect("mine confirmation");
 
     wallet.sync().await.expect("wallet sync after funding");
-    Arc::new(RwLock::new(wallet))
+    Arc::new(RwLock::new(wallet.into()))
 }
 
 /// Builds a fully-signed v3 parent transaction with a 330-sat keyed-Taproot anchor output
 /// keyed to `operator_pubkey`. Spends a wallet-selected UTXO; signed in-process with
 /// `operator_keypair`.
 async fn build_v3_parent(
-    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    wallet: &Arc<RwLock<AnyOperatorWallet>>,
     operator_keypair: Keypair,
     operator_pubkey: XOnlyPublicKey,
     parent_fee_rate: FeeRate,
@@ -440,16 +442,19 @@ async fn cpfp_e2e_against_bitcoind() {
 /// Builds a fully-signed v3 parent whose single output is operator-owned (no anchor) —
 /// mirrors the shape of cooperative_payout / uncontested_payout / unstaking txs that use
 /// [`CpfpStrategy::ParentTxCombined`] in production.
+///
+/// The payout output is built from the wallet's production `payout_descriptor()` — the same
+/// script peers derive when they pay this operator. This is the regression tripwire for
+/// descriptor/signer mismatches: if the descriptor ever keys payouts to something the
+/// tap-tweaking wallet signer can't spend (e.g. the raw general key used verbatim as the
+/// output key), the child's payout-input signature fails real script validation below.
 async fn build_v3_payout_parent(
-    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    wallet: &Arc<RwLock<AnyOperatorWallet>>,
     operator_keypair: Keypair,
-    operator_pubkey: XOnlyPublicKey,
     parent_fee_rate: FeeRate,
     payout_value: Amount,
 ) -> Transaction {
-    let secp = Secp256k1::new();
-    let payout_script =
-        Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey();
+    let payout_script = wallet.read().await.payout_descriptor().to_script();
     let unsigned_tx = Transaction {
         version: Version(3),
         lock_time: absolute::LockTime::ZERO,
@@ -515,7 +520,6 @@ async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
     let parent = build_v3_payout_parent(
         &wallet,
         operator_keypair,
-        operator_pubkey,
         parent_fee_rate,
         Amount::from_btc(0.25).unwrap(),
     )
@@ -625,17 +629,18 @@ async fn cpfp_e2e_parent_tx_combined_against_bitcoind() {
 /// calling watchtower's slash share). The third one is the CPFP hook the production helper
 /// would discover via `CpfpKind::InferGeneralPayout`.
 async fn build_v3_mixed_parent(
-    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    wallet: &Arc<RwLock<AnyOperatorWallet>>,
     operator_keypair: Keypair,
-    operator_pubkey: XOnlyPublicKey,
     other_pubkey: XOnlyPublicKey,
     parent_fee_rate: FeeRate,
     other_value: Amount,
     operator_value: Amount,
 ) -> Transaction {
     let secp = Secp256k1::new();
-    let operator_script =
-        Address::p2tr(&secp, operator_pubkey, None, Network::Regtest).script_pubkey();
+    // The operator-owned output comes from the production payout descriptor, so this test
+    // simultaneously asserts that `first_general_payout_outpoint`'s script matching agrees
+    // with what the wallet actually asks peers to pay (descriptor ↔ matcher consistency).
+    let operator_script = wallet.read().await.payout_descriptor().to_script();
     let other_script = Address::p2tr(&secp, other_pubkey, None, Network::Regtest).script_pubkey();
     let unsigned_tx = Transaction {
         version: Version(3),
@@ -712,7 +717,6 @@ async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
     let parent = build_v3_mixed_parent(
         &wallet,
         operator_keypair,
-        operator_pubkey,
         other_pubkey,
         parent_fee_rate,
         Amount::from_btc(0.1).unwrap(),  // non-operator payout
@@ -840,7 +844,7 @@ async fn cpfp_e2e_infer_general_payout_against_bitcoind() {
 /// watchtower over an unspendable internal key, exactly as contest / bridge-proof-timeout
 /// transactions carry it in production.
 async fn build_v3_multi_anchor_parent(
-    wallet: &Arc<RwLock<OperatorWallet<NativeGeneralWallet>>>,
+    wallet: &Arc<RwLock<AnyOperatorWallet>>,
     operator_keypair: Keypair,
     anchor: &MultiAnchor,
     parent_fee_rate: FeeRate,

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -14,6 +14,26 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+# Fireblocks backend (optional; enabled via the `fireblocks` feature).
+hex = { workspace = true, optional = true }
+jsonwebtoken = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+
+[features]
+default = []
+# Compiles the Fireblocks `GeneralWallet` backend and its REST/JWT/serde deps.
+fireblocks = [
+  "dep:hex",
+  "dep:jsonwebtoken",
+  "dep:reqwest",
+  "dep:serde",
+  "dep:serde_json",
+  "dep:sha2",
+]
+
 [dev-dependencies]
 bdk_wallet = { workspace = true, features = ["test-utils"] }
 corepc-node.workspace = true

--- a/crates/operator-wallet/src/any.rs
+++ b/crates/operator-wallet/src/any.rs
@@ -101,6 +101,11 @@ impl AnyOperatorWallet {
         delegate!(self, w => w.local_chain_tip_height())
     }
 
+    /// See [`OperatorWallet::last_general_sync`].
+    pub const fn last_general_sync(&self) -> Option<(bool, std::time::Instant)> {
+        delegate!(self, w => w.last_general_sync())
+    }
+
     /// Lists the general wallet's UTXOs.
     ///
     /// Delegates to `GeneralWallet::list_utxos` on whichever backend is active. Exposed on the

--- a/crates/operator-wallet/src/any.rs
+++ b/crates/operator-wallet/src/any.rs
@@ -5,16 +5,26 @@
 //! startup from config. It forwards the full [`OperatorWallet`] surface the executors use to
 //! whichever variant is active; the Fireblocks variant is compiled only under the
 //! `fireblocks` feature.
+//!
+//! Method receivers mirror [`OperatorWallet`]: `&self` for everything except
+//! [`OperatorWallet::sync`], which needs `&mut self` because both backends' general-wallet
+//! sync takes `&mut self`. The interior funding lock inside the wallet serializes selection,
+//! so a caller that only funds
+//! or builds holds a shared guard; only sync (and callers keeping the old multi-step critical
+//! sections) take the exclusive guard.
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, time::Instant};
 
 use bdk_wallet::bitcoin::{Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, Witness};
 
 #[cfg(feature = "fireblocks")]
 use crate::general::fireblocks::FireblocksGeneralWallet;
 use crate::{
-    general::{native::NativeGeneralWallet, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo},
-    Error, GeneralUtxoPolicy, OperatorWallet,
+    general::{
+        native::NativeGeneralWallet, AnchorInfo, AnchorOwnership, GeneralWallet, ReplacedChild,
+        UtxoInfo,
+    },
+    Error, GeneralUtxoPolicy, Lease, LeaseOwner, LeasedPsbt, OperatorWallet,
 };
 
 /// An operator wallet whose general-wallet backend is selected at runtime.
@@ -77,18 +87,18 @@ impl AnyOperatorWallet {
     }
 
     /// See [`OperatorWallet::leased_outpoints`].
-    pub const fn leased_outpoints(&self) -> &BTreeSet<OutPoint> {
+    pub fn leased_outpoints(&self) -> BTreeSet<OutPoint> {
         delegate!(self, w => w.leased_outpoints())
     }
 
-    /// See [`OperatorWallet::lease`].
-    pub fn lease(&mut self, outpoints: &[OutPoint]) {
-        delegate!(self, w => w.lease(outpoints));
+    /// See [`OperatorWallet::lease_committed`].
+    pub async fn lease_committed(&self, outpoints: Vec<OutPoint>, owner: LeaseOwner) {
+        delegate!(self, w => w.lease_committed(outpoints, owner).await)
     }
 
-    /// See [`OperatorWallet::release`].
-    pub fn release(&mut self, outpoints: &[OutPoint]) {
-        delegate!(self, w => w.release(outpoints));
+    /// See [`OperatorWallet::release_committed`].
+    pub fn release_committed(&self, outpoints: &[OutPoint]) {
+        delegate!(self, w => w.release_committed(outpoints));
     }
 
     /// See [`OperatorWallet::reserved_utxos_with_value`].
@@ -102,7 +112,7 @@ impl AnyOperatorWallet {
     }
 
     /// See [`OperatorWallet::last_general_sync`].
-    pub const fn last_general_sync(&self) -> Option<(bool, std::time::Instant)> {
+    pub const fn last_general_sync(&self) -> Option<(bool, Instant)> {
         delegate!(self, w => w.last_general_sync())
     }
 
@@ -116,53 +126,79 @@ impl AnyOperatorWallet {
     }
 
     /// See [`OperatorWallet::reserve_utxo_with_value`].
-    pub fn reserve_utxo_with_value(
-        &mut self,
+    pub async fn reserve_utxo_with_value(
+        &self,
         value: Amount,
+        owner: LeaseOwner,
         ignore: impl Fn(&UtxoInfo) -> bool,
-    ) -> (Option<OutPoint>, u64) {
-        delegate!(self, w => w.reserve_utxo_with_value(value, ignore))
+    ) -> (Option<(OutPoint, Lease)>, u64) {
+        delegate!(self, w => w.reserve_utxo_with_value(value, owner, ignore).await)
     }
 
-    /// See [`OperatorWallet::select_and_lease_general_utxo`].
-    pub fn select_and_lease_general_utxo(
-        &mut self,
+    /// See [`OperatorWallet::select_general_utxo`].
+    pub async fn select_general_utxo(
+        &self,
+        owner: LeaseOwner,
         predicate: impl Fn(&UtxoInfo) -> bool,
-    ) -> Option<UtxoInfo> {
-        delegate!(self, w => w.select_and_lease_general_utxo(predicate))
+    ) -> Option<(UtxoInfo, Lease)> {
+        delegate!(self, w => w.select_general_utxo(owner, predicate).await)
     }
 
     /// See [`OperatorWallet::fund_v3_transaction`].
     pub async fn fund_v3_transaction(
-        &mut self,
+        &self,
         unsigned_tx: Transaction,
         fee_rate: FeeRate,
         general_utxo_policy: GeneralUtxoPolicy,
-    ) -> Result<FundedPsbt, Error> {
-        delegate!(self, w => w.fund_v3_transaction(unsigned_tx, fee_rate, general_utxo_policy).await)
+        owner: LeaseOwner,
+    ) -> Result<LeasedPsbt, Error> {
+        delegate!(
+            self,
+            w => w
+                .fund_v3_transaction(unsigned_tx, fee_rate, general_utxo_policy, owner)
+                .await
+        )
     }
 
     /// See [`OperatorWallet::fund_v3_transaction_with_inputs`].
     pub async fn fund_v3_transaction_with_inputs(
-        &mut self,
+        &self,
         unsigned_tx: Transaction,
         inputs: &[OutPoint],
         fee_rate: FeeRate,
-    ) -> Result<FundedPsbt, Error> {
-        delegate!(self, w => w.fund_v3_transaction_with_inputs(unsigned_tx, inputs, fee_rate).await)
+        owner: LeaseOwner,
+    ) -> Result<LeasedPsbt, Error> {
+        delegate!(
+            self,
+            w => w
+                .fund_v3_transaction_with_inputs(unsigned_tx, inputs, fee_rate, owner)
+                .await
+        )
     }
 
     /// See [`OperatorWallet::build_cpfp_child`].
     pub async fn build_cpfp_child(
-        &mut self,
+        &self,
         parent: &Transaction,
         parent_fee: Amount,
         anchor: AnchorInfo,
+        anchor_ownership: AnchorOwnership,
         target_pkg_fee_rate: FeeRate,
-        replacing: Option<&[OutPoint]>,
-        prior_child_fee: Option<Amount>,
-    ) -> Result<FundedPsbt, Error> {
-        delegate!(self, w => w.build_cpfp_child(parent, parent_fee, anchor, target_pkg_fee_rate, replacing, prior_child_fee).await)
+        replaced: ReplacedChild<'_>,
+    ) -> Result<LeasedPsbt, Error> {
+        delegate!(
+            self,
+            w => w
+                .build_cpfp_child(
+                    parent,
+                    parent_fee,
+                    anchor,
+                    anchor_ownership,
+                    target_pkg_fee_rate,
+                    replaced,
+                )
+                .await
+        )
     }
 
     /// See [`OperatorWallet::sign_owned_inputs`].
@@ -177,13 +213,25 @@ impl AnyOperatorWallet {
 
     /// See [`OperatorWallet::create_reserved_utxos`].
     pub async fn create_reserved_utxos(
-        &mut self,
+        &self,
         fee_rate: FeeRate,
         utxo_value: Amount,
         quantity: usize,
         general_utxo_policy: GeneralUtxoPolicy,
-    ) -> Result<FundedPsbt, Error> {
-        delegate!(self, w => w.create_reserved_utxos(fee_rate, utxo_value, quantity, general_utxo_policy).await)
+        owner: LeaseOwner,
+    ) -> Result<LeasedPsbt, Error> {
+        delegate!(
+            self,
+            w => w
+                .create_reserved_utxos(
+                    fee_rate,
+                    utxo_value,
+                    quantity,
+                    general_utxo_policy,
+                    owner,
+                )
+                .await
+        )
     }
 
     /// See [`OperatorWallet::sync`].

--- a/crates/operator-wallet/src/any.rs
+++ b/crates/operator-wallet/src/any.rs
@@ -1,0 +1,188 @@
+//! Runtime-selected operator wallet backend.
+//!
+//! [`AnyOperatorWallet`] lets the binary hold a single, non-generic wallet handle (e.g. on
+//! `OutputHandles`) while choosing the general-wallet backend — native BDK or Fireblocks — at
+//! startup from config. It forwards the full [`OperatorWallet`] surface the executors use to
+//! whichever variant is active; the Fireblocks variant is compiled only under the
+//! `fireblocks` feature.
+
+use std::collections::BTreeSet;
+
+use bdk_wallet::bitcoin::{Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, Witness};
+
+#[cfg(feature = "fireblocks")]
+use crate::general::fireblocks::FireblocksGeneralWallet;
+use crate::{
+    general::{native::NativeGeneralWallet, AnchorInfo, FundedPsbt, GeneralWallet, UtxoInfo},
+    Error, GeneralUtxoPolicy, OperatorWallet,
+};
+
+/// An operator wallet whose general-wallet backend is selected at runtime.
+// The two variants differ in size (each embeds a different `GeneralWallet` backend), but the
+// handle is always held behind an `Arc<RwLock<…>>`, so the size delta never hits the stack.
+#[cfg_attr(
+    feature = "fireblocks",
+    expect(
+        clippy::large_enum_variant,
+        reason = "always Arc<RwLock<>>-boxed; size delta is irrelevant"
+    )
+)]
+#[derive(Debug)]
+pub enum AnyOperatorWallet {
+    /// Local BDK-backed general wallet (descriptor-only; signed downstream via secret-service).
+    Native(OperatorWallet<NativeGeneralWallet>),
+    /// Fireblocks-backed general wallet (RAW signing).
+    #[cfg(feature = "fireblocks")]
+    Fireblocks(OperatorWallet<FireblocksGeneralWallet>),
+}
+
+impl From<OperatorWallet<NativeGeneralWallet>> for AnyOperatorWallet {
+    fn from(wallet: OperatorWallet<NativeGeneralWallet>) -> Self {
+        Self::Native(wallet)
+    }
+}
+
+#[cfg(feature = "fireblocks")]
+impl From<OperatorWallet<FireblocksGeneralWallet>> for AnyOperatorWallet {
+    fn from(wallet: OperatorWallet<FireblocksGeneralWallet>) -> Self {
+        Self::Fireblocks(wallet)
+    }
+}
+
+/// Dispatches `$body` against whichever backend variant is active, binding it to `$w`.
+macro_rules! delegate {
+    ($self:expr, $w:ident => $body:expr) => {
+        match $self {
+            Self::Native($w) => $body,
+            #[cfg(feature = "fireblocks")]
+            Self::Fireblocks($w) => $body,
+        }
+    };
+}
+
+impl AnyOperatorWallet {
+    /// See [`OperatorWallet::general_script_pubkey`].
+    pub fn general_script_pubkey(&self) -> ScriptBuf {
+        delegate!(self, w => w.general_script_pubkey())
+    }
+
+    /// See [`OperatorWallet::payout_descriptor`].
+    pub fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
+        delegate!(self, w => w.payout_descriptor())
+    }
+
+    /// See [`OperatorWallet::reserved_script_pubkey`].
+    pub fn reserved_script_pubkey(&self) -> ScriptBuf {
+        delegate!(self, w => w.reserved_script_pubkey())
+    }
+
+    /// See [`OperatorWallet::leased_outpoints`].
+    pub const fn leased_outpoints(&self) -> &BTreeSet<OutPoint> {
+        delegate!(self, w => w.leased_outpoints())
+    }
+
+    /// See [`OperatorWallet::lease`].
+    pub fn lease(&mut self, outpoints: &[OutPoint]) {
+        delegate!(self, w => w.lease(outpoints));
+    }
+
+    /// See [`OperatorWallet::release`].
+    pub fn release(&mut self, outpoints: &[OutPoint]) {
+        delegate!(self, w => w.release(outpoints));
+    }
+
+    /// See [`OperatorWallet::reserved_utxos_with_value`].
+    pub fn reserved_utxos_with_value(&self, value: Amount) -> Vec<UtxoInfo> {
+        delegate!(self, w => w.reserved_utxos_with_value(value))
+    }
+
+    /// See [`OperatorWallet::local_chain_tip_height`].
+    pub fn local_chain_tip_height(&self) -> u32 {
+        delegate!(self, w => w.local_chain_tip_height())
+    }
+
+    /// Lists the general wallet's UTXOs.
+    ///
+    /// Delegates to `GeneralWallet::list_utxos` on whichever backend is active. Exposed on the
+    /// erased handle because `general()` returns a backend-specific type that callers holding an
+    /// [`AnyOperatorWallet`] cannot name.
+    pub fn list_general_utxos(&self) -> Vec<UtxoInfo> {
+        delegate!(self, w => w.general().list_utxos())
+    }
+
+    /// See [`OperatorWallet::reserve_utxo_with_value`].
+    pub fn reserve_utxo_with_value(
+        &mut self,
+        value: Amount,
+        ignore: impl Fn(&UtxoInfo) -> bool,
+    ) -> (Option<OutPoint>, u64) {
+        delegate!(self, w => w.reserve_utxo_with_value(value, ignore))
+    }
+
+    /// See [`OperatorWallet::select_and_lease_general_utxo`].
+    pub fn select_and_lease_general_utxo(
+        &mut self,
+        predicate: impl Fn(&UtxoInfo) -> bool,
+    ) -> Option<UtxoInfo> {
+        delegate!(self, w => w.select_and_lease_general_utxo(predicate))
+    }
+
+    /// See [`OperatorWallet::fund_v3_transaction`].
+    pub async fn fund_v3_transaction(
+        &mut self,
+        unsigned_tx: Transaction,
+        fee_rate: FeeRate,
+        general_utxo_policy: GeneralUtxoPolicy,
+    ) -> Result<FundedPsbt, Error> {
+        delegate!(self, w => w.fund_v3_transaction(unsigned_tx, fee_rate, general_utxo_policy).await)
+    }
+
+    /// See [`OperatorWallet::fund_v3_transaction_with_inputs`].
+    pub async fn fund_v3_transaction_with_inputs(
+        &mut self,
+        unsigned_tx: Transaction,
+        inputs: &[OutPoint],
+        fee_rate: FeeRate,
+    ) -> Result<FundedPsbt, Error> {
+        delegate!(self, w => w.fund_v3_transaction_with_inputs(unsigned_tx, inputs, fee_rate).await)
+    }
+
+    /// See [`OperatorWallet::build_cpfp_child`].
+    pub async fn build_cpfp_child(
+        &mut self,
+        parent: &Transaction,
+        parent_fee: Amount,
+        anchor: AnchorInfo,
+        target_pkg_fee_rate: FeeRate,
+        replacing: Option<&[OutPoint]>,
+        prior_child_fee: Option<Amount>,
+    ) -> Result<FundedPsbt, Error> {
+        delegate!(self, w => w.build_cpfp_child(parent, parent_fee, anchor, target_pkg_fee_rate, replacing, prior_child_fee).await)
+    }
+
+    /// See [`OperatorWallet::sign_owned_inputs`].
+    pub async fn sign_owned_inputs(
+        &self,
+        tx: &Transaction,
+        input_indices: &[usize],
+        prevouts: &[TxOut],
+    ) -> Result<Vec<Option<Witness>>, Error> {
+        delegate!(self, w => w.sign_owned_inputs(tx, input_indices, prevouts).await)
+    }
+
+    /// See [`OperatorWallet::create_reserved_utxos`].
+    pub async fn create_reserved_utxos(
+        &mut self,
+        fee_rate: FeeRate,
+        utxo_value: Amount,
+        quantity: usize,
+        general_utxo_policy: GeneralUtxoPolicy,
+    ) -> Result<FundedPsbt, Error> {
+        delegate!(self, w => w.create_reserved_utxos(fee_rate, utxo_value, quantity, general_utxo_policy).await)
+    }
+
+    /// See [`OperatorWallet::sync`].
+    pub async fn sync(&mut self) -> Result<(), Error> {
+        delegate!(self, w => w.sync().await)
+    }
+}

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -7,6 +7,8 @@
 //! filtering, cross-wallet transaction construction — lives on the composer
 //! [`crate::OperatorWallet<G>`] that wraps a `GeneralWallet`.
 
+#[cfg(feature = "fireblocks")]
+pub mod fireblocks;
 pub mod native;
 
 use std::error::Error as StdError;
@@ -14,7 +16,7 @@ use std::error::Error as StdError;
 use bdk_wallet::{
     bitcoin::{
         taproot::ControlBlock, Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut,
-        XOnlyPublicKey,
+        Witness, XOnlyPublicKey,
     },
     chain::ChainPosition,
 };
@@ -182,6 +184,20 @@ pub trait GeneralWallet: Send + Sync {
     /// may rotate for backends that mint fresh deposit addresses per call.
     fn script_pubkey(&self) -> ScriptBuf;
 
+    /// Returns the BOSD descriptor where bridge payouts to this operator should be directed.
+    ///
+    /// Backend-specific, because the operator must be able to *spend* what it receives:
+    /// - the native backend uses the wallet's own funding script ([`Self::script_pubkey`], the
+    ///   BIP-341 tweaked general key), so payouts arrive as ordinary wallet UTXOs and the
+    ///   tap-tweaking wallet signer can spend them — including the CPFP `ParentTxCombined` bump,
+    ///   which force-spends the still-unconfirmed payout output as a foreign UTXO;
+    /// - a Fireblocks backend points it at the vault's P2WPKH address.
+    ///
+    /// This is the assignee's own choice in the cooperative-payout flow — peers honour
+    /// whatever descriptor is broadcast (`CooperativePayoutTx` builds the output via
+    /// `Descriptor::to_script`), so it need not match other operators' backends.
+    fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor;
+
     /// Returns every UTXO this wallet currently controls (confirmed and unconfirmed). The
     /// caller is responsible for filtering anchors, leases, and other domain-specific
     /// exclusions before requesting funding.
@@ -234,6 +250,24 @@ pub trait GeneralWallet: Send + Sync {
         exclude: &[OutPoint],
         replaced: ReplacedChild<'_>,
     ) -> impl std::future::Future<Output = Result<FundedPsbt, Self::Error>> + Send;
+
+    /// Signs the wallet-owned inputs of `tx` at `input_indices`, returning a witness per index
+    /// for the inputs this backend holds key material for, or `None` for inputs the caller must
+    /// sign downstream (descriptor-only backends like the native wallet hold no keys and return
+    /// all `None`).
+    ///
+    /// `prevouts[i]` must be the output spent by `tx.input[i]` (indexed globally over all
+    /// inputs); signing backends read the relevant prevout's value + script to build the
+    /// sighash. This serves callers that build a transaction by hand — one with a non-wallet
+    /// input the funding helpers can't express (e.g. the unstaking-burn payout connector or the
+    /// persisted-then-resigned stake-funding reservation) — rather than via
+    /// [`Self::fund_v3_transaction`], which signs as it funds.
+    fn sign_owned_inputs(
+        &self,
+        tx: &Transaction,
+        input_indices: &[usize],
+        prevouts: &[TxOut],
+    ) -> impl std::future::Future<Output = Result<Vec<Option<Witness>>, Self::Error>> + Send;
 }
 
 /// A funded PSBT returned by [`GeneralWallet`] funding operations.

--- a/crates/operator-wallet/src/general/fireblocks.rs
+++ b/crates/operator-wallet/src/general/fireblocks.rs
@@ -55,6 +55,11 @@ const SIGN_POLL_INTERVAL: Duration = Duration::from_secs(2);
 /// signing latency depends on the workspace's Transaction Authorization Policy; an
 /// auto-approve rule keeps the wait well within budget.
 const SIGN_MAX_POLL_ATTEMPTS: u32 = 60;
+/// Wall-clock bound on one RAW-signing wait. The attempt cap alone does not bound time:
+/// each slow-but-successful poll can take up to [`HTTP_REQUEST_TIMEOUT`], so 60 attempts
+/// can hold the wallet lock for ~17 minutes. The deadline caps the wait whatever the
+/// per-poll latency is.
+const SIGN_MAX_DURATION: Duration = Duration::from_secs(180);
 /// Consecutive transient poll errors tolerated before abandoning a submitted RAW-signing
 /// transaction. The transaction already exists server-side, so a blip must not drop it on the
 /// first failure; only a sustained outage gives up (with the tx id, for operator reconciliation).
@@ -199,16 +204,30 @@ impl FireblocksGeneralWallet {
         // covering all non-mainnet networks. Require the exact asset id for the network so a
         // startup misconfig (wrong network, or a typo like `BTC_TES`/`ETH`) is caught here rather
         // than letting every signing request target the wrong asset server-side.
-        let expected_asset = if config.network == Network::Bitcoin {
-            "BTC"
-        } else {
-            "BTC_TEST"
-        };
-        if config.asset_id != expected_asset {
+        // Mainnet keeps the hard check: "BTC" is the one documented mainnet asset id, and
+        // a wrong id there points real funds at the wrong asset. Other networks only get a
+        // warning. Fireblocks does not document one fixed id per test network (signet in
+        // particular), the id feeds straight into the sync URL and the RAW-sign body, and
+        // a wrong id fails loudly on the first API call — so a hard check here blocks
+        // valid configurations without adding safety.
+        if config.network == Network::Bitcoin {
+            if config.asset_id != "BTC" {
+                return Err(FireblocksError::AssetMismatch(format!(
+                    "asset_id {:?} does not match network Bitcoin (expected \"BTC\")",
+                    config.asset_id
+                )));
+            }
+        } else if config.asset_id == "BTC" {
             return Err(FireblocksError::AssetMismatch(format!(
-                "asset_id {:?} does not match network {:?} (expected {expected_asset:?})",
-                config.asset_id, config.network
+                "asset_id \"BTC\" is the mainnet asset; network is {:?}",
+                config.network
             )));
+        } else if config.asset_id != "BTC_TEST" {
+            tracing::warn!(
+                asset_id = %config.asset_id,
+                network = ?config.network,
+                "asset_id is not \"BTC_TEST\"; the first API call validates it"
+            );
         }
 
         let address = config
@@ -381,7 +400,11 @@ impl FireblocksGeneralWallet {
 
         let subpath = format!("/transactions/{}", created.id);
         let mut consecutive_errors = 0u32;
+        let deadline = std::time::Instant::now() + SIGN_MAX_DURATION;
         for _ in 0..SIGN_MAX_POLL_ATTEMPTS {
+            if std::time::Instant::now() >= deadline {
+                break;
+            }
             match self
                 .signed_request::<dto::TransactionDetails>(Method::GET, &subpath, None)
                 .await

--- a/crates/operator-wallet/src/general/fireblocks.rs
+++ b/crates/operator-wallet/src/general/fireblocks.rs
@@ -142,12 +142,51 @@ pub enum FireblocksError {
     /// Transaction construction (selection / change / sighash) failed.
     #[error("tx build: {0}")]
     TxBuild(String),
+    /// `anchor.vout` indexes past the end of `parent.output`.
+    #[error("anchor vout {vout} out of range for parent with {parent_outputs} outputs")]
+    AnchorVoutOutOfRange {
+        /// The requested anchor vout.
+        vout: u32,
+        /// Number of outputs on `parent`.
+        parent_outputs: usize,
+    },
     /// Witness assembly from a returned signature failed.
     #[error("witness: {0}")]
     Witness(String),
     /// A signing request did not reach a usable signed state within the allotted time.
     #[error("signing timed out for tx {0}")]
     SigningTimeout(String),
+}
+
+impl crate::ErrorPermanence for FireblocksError {
+    fn is_permanent(&self) -> bool {
+        match self {
+            // Conditions of the configured operator: a bad API secret, a deposit address that
+            // does not parse, an asset id that does not match the network, and a JWT that will
+            // not build. None of these passes on a later attempt.
+            Self::SigningKey(_)
+            | Self::DepositAddress(_)
+            | Self::AssetMismatch(_)
+            | Self::Jwt(_) => true,
+            // A dead wallet and a failed attempt repeat the same way for a signed parent, so
+            // the caller stops bumping one that cannot carry a child at all. The output count
+            // of a signed parent never changes, so a parent that cannot hold the anchor vout
+            // cannot carry a child at all.
+            Self::Witness(_) | Self::AnchorVoutOutOfRange { .. } => true,
+            // Transport, an API error of either kind (4xx and 5xx both live in this variant),
+            // a body that will not decode, selection failing on thin funding, and a signing
+            // poll that ran out of time: each of these passes on a later attempt. `Api` is
+            // the mixed class — a bad credential is permanent, an outage is not — and the
+            // safe default for a bump is to keep trying: the duty schedule bounds the retry
+            // rate, while classifying a permanent halt for one parent on the cheap error
+            // strands its funds.
+            Self::Http(_)
+            | Self::Api(_)
+            | Self::Decode(_)
+            | Self::TxBuild(_)
+            | Self::SigningTimeout(_) => false,
+        }
+    }
 }
 
 /// A Fireblocks-backed general wallet.
@@ -553,7 +592,7 @@ impl GeneralWallet for FireblocksGeneralWallet {
     }
 
     async fn fund_v3_transaction(
-        &mut self,
+        &self,
         outputs: Vec<TxOut>,
         explicit_inputs: Option<&[OutPoint]>,
         fee_rate: FeeRate,
@@ -599,7 +638,7 @@ impl GeneralWallet for FireblocksGeneralWallet {
     }
 
     async fn build_cpfp_child(
-        &mut self,
+        &self,
         parent: &Transaction,
         parent_fee: Amount,
         anchor: AnchorInfo,
@@ -614,8 +653,9 @@ impl GeneralWallet for FireblocksGeneralWallet {
         let anchor_prevout = parent
             .output
             .get(anchor.vout() as usize)
-            .ok_or_else(|| {
-                FireblocksError::TxBuild(format!("anchor vout {} out of range", anchor.vout()))
+            .ok_or_else(|| FireblocksError::AnchorVoutOutOfRange {
+                vout: anchor.vout(),
+                parent_outputs: parent.output.len(),
             })?
             .clone();
         let anchor_outpoint = OutPoint {

--- a/crates/operator-wallet/src/general/fireblocks.rs
+++ b/crates/operator-wallet/src/general/fireblocks.rs
@@ -1,0 +1,747 @@
+//! Fireblocks-backed [`GeneralWallet`] implementation.
+//!
+//! Custodies the operator's general-purpose (fee-paying / earnings) wallet in a Fireblocks
+//! BTC vault account instead of a local BDK wallet. All bridge protocol keys (anchors,
+//! presigned-tx keys) remain in secret-service; Fireblocks only ever contributes a funding
+//! input + optional change to cover fees and to top up internal pools.
+//!
+//! ## Why RAW signing
+//!
+//! Fireblocks can produce a BTC transaction two ways. The `TRANSFER` + `inputsSelection`
+//! flow has Fireblocks build *and broadcast* its own transaction — unusable here, because we
+//! must inject a foreign Taproot anchor input, force v3/TRUC, control exact outputs, and get
+//! the PSBT back to package with the parent. So this backend uses **`RAW` signing**: it builds
+//! the unsigned bitcoin transaction itself (input selection, change, sighashes), sends the
+//! sighashes to Fireblocks for ECDSA signing, and assembles the witnesses.
+//!
+//! Fireblocks BTC is ECDSA secp256k1, so vault addresses are **P2WPKH**; funding witnesses are
+//! `[DER-sig + SIGHASH_ALL byte, compressed pubkey]`. The anchor input stays Taproot and is
+//! left unsigned for secret-service (per the [`GeneralWallet`] signing
+//! contract).
+//!
+//! ## Auth
+//!
+//! Every request carries `X-API-Key: <api key>` and `Authorization: Bearer <JWT>`, where the
+//! JWT is RS256-signed with the operator's Fireblocks API secret (an RSA private key) and
+//! carries `{ uri, nonce, iat, exp, sub = api key, bodyHash = SHA256(raw body) }`.
+
+mod auth;
+mod dto;
+mod sign;
+mod tx;
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    str::FromStr,
+    time::Duration,
+};
+
+use bdk_wallet::bitcoin::{
+    address::NetworkUnchecked, taproot::LeafVersion, Address, Amount, Denomination, FeeRate,
+    Network, OutPoint, Psbt, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness,
+};
+use reqwest::Method;
+use serde::de::DeserializeOwned;
+use thiserror::Error;
+
+use super::{AnchorInfo, FundedPsbt, GeneralWallet, ReplacedChild, UtxoInfo};
+
+/// How often to poll a RAW-signing transaction for completion.
+const SIGN_POLL_INTERVAL: Duration = Duration::from_secs(2);
+/// Maximum number of poll attempts before giving up on a RAW-signing transaction. The cap
+/// bounds attempts, not wall-clock time: ~2 min when every poll returns promptly, but a
+/// slow-but-answering endpoint can burn up to [`HTTP_REQUEST_TIMEOUT`] per poll. Fireblocks
+/// signing latency depends on the workspace's Transaction Authorization Policy; an
+/// auto-approve rule keeps the wait well within budget.
+const SIGN_MAX_POLL_ATTEMPTS: u32 = 60;
+/// Consecutive transient poll errors tolerated before abandoning a submitted RAW-signing
+/// transaction. The transaction already exists server-side, so a blip must not drop it on the
+/// first failure; only a sustained outage gives up (with the tx id, for operator reconciliation).
+const MAX_CONSECUTIVE_POLL_ERRORS: u32 = 5;
+/// Per-request HTTP timeout. Without it a hung Fireblocks endpoint would stall a request
+/// indefinitely — a hang is not an `Err`, so it would never count against
+/// [`MAX_CONSECUTIVE_POLL_ERRORS`] and could wedge the signing loop (and the wallet write-lock)
+/// past the intended ceiling. Kept comfortably above normal latency but bounded.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Connection + identity configuration for a Fireblocks BTC vault account.
+#[derive(Clone)]
+pub struct FireblocksConfig {
+    /// API host root, **without** the `/v1` path segment, e.g. `https://api.fireblocks.io`.
+    /// Requests append `/v1/<path>` themselves so the JWT `uri` claim and the request URL
+    /// stay in lockstep.
+    pub base_url: String,
+    /// Fireblocks API key (sent as the `X-API-Key` header).
+    pub api_key: String,
+    /// Vault account id holding the BTC asset.
+    pub vault_account_id: String,
+    /// Asset id for the network — `BTC` on mainnet, `BTC_TEST` on test networks.
+    pub asset_id: String,
+    /// Bitcoin network the vault operates on. Used to parse/validate the deposit address.
+    pub network: Network,
+    /// The vault account's BTC deposit address (P2WPKH). Operator-provided so
+    /// [`FireblocksGeneralWallet::script_pubkey`](super::GeneralWallet::script_pubkey) stays
+    /// synchronous and infallible.
+    pub deposit_address: String,
+    /// BIP44 address index (`bip44AddressIndex`) telling Fireblocks which derived key under the
+    /// vault to RAW-sign with. Must correspond to the configured `deposit_address`. `0` is the
+    /// vault's default address. The witness-assembly pubkey check catches mismatches at sign
+    /// time, but every signed input would error out — operators on a non-default address must
+    /// set this.
+    pub bip44_address_index: u32,
+    /// BIP44 change index (`bip44change`). `0` for receive addresses, `1` for internal/change.
+    pub bip44_change: u32,
+}
+
+impl fmt::Debug for FireblocksConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Redact the API key; everything else is non-secret operational config.
+        f.debug_struct("FireblocksConfig")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"<redacted>")
+            .field("vault_account_id", &self.vault_account_id)
+            .field("asset_id", &self.asset_id)
+            .field("network", &self.network)
+            .field("deposit_address", &self.deposit_address)
+            .field("bip44_address_index", &self.bip44_address_index)
+            .field("bip44_change", &self.bip44_change)
+            .finish()
+    }
+}
+
+/// Errors produced by the Fireblocks backend.
+#[derive(Debug, Error)]
+pub enum FireblocksError {
+    /// Failed to construct the RS256 signing key from the provided API secret PEM.
+    #[error("invalid Fireblocks API secret (RSA PEM): {0}")]
+    SigningKey(String),
+    /// The configured deposit address could not be parsed or did not match the network.
+    #[error("invalid deposit address: {0}")]
+    DepositAddress(String),
+    /// The configured `asset_id` is inconsistent with the configured Bitcoin network.
+    #[error("asset_id/network mismatch: {0}")]
+    AssetMismatch(String),
+    /// JWT construction failed.
+    #[error("jwt: {0}")]
+    Jwt(String),
+    /// HTTP transport error talking to the Fireblocks API.
+    #[error("http: {0}")]
+    Http(String),
+    /// Fireblocks returned a non-success status or an error body.
+    #[error("fireblocks api: {0}")]
+    Api(String),
+    /// A response body could not be deserialized into the expected shape.
+    #[error("decode response: {0}")]
+    Decode(String),
+    /// Transaction construction (selection / change / sighash) failed.
+    #[error("tx build: {0}")]
+    TxBuild(String),
+    /// Witness assembly from a returned signature failed.
+    #[error("witness: {0}")]
+    Witness(String),
+    /// A signing request did not reach a usable signed state within the allotted time.
+    #[error("signing timed out for tx {0}")]
+    SigningTimeout(String),
+}
+
+/// A Fireblocks-backed general wallet.
+///
+/// Holds the REST client + signing material and a cached snapshot of the vault's unspent
+/// inputs (refreshed by [`sync`](super::GeneralWallet::sync)).
+pub struct FireblocksGeneralWallet {
+    config: FireblocksConfig,
+    http: reqwest::Client,
+    /// RS256 signing key derived from the operator's Fireblocks API secret. Used to mint the
+    /// per-request JWT.
+    signing_key: jsonwebtoken::EncodingKey,
+    /// Receive script derived from the vault deposit address. Returned by `script_pubkey` and
+    /// used for change outputs.
+    script_pubkey: ScriptBuf,
+    /// BOSD payout descriptor (P2WPKH) for the vault address, prebuilt at construction so the
+    /// trait accessor is infallible.
+    payout_descriptor: bitcoin_bosd::Descriptor,
+    /// Snapshot of the vault's spendable UTXOs from the most recent `sync`.
+    cached_utxos: Vec<super::UtxoInfo>,
+}
+
+impl fmt::Debug for FireblocksGeneralWallet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FireblocksGeneralWallet")
+            .field("config", &self.config)
+            .field("signing_key", &"<redacted>")
+            .field("script_pubkey", &self.script_pubkey)
+            .field("cached_utxos", &self.cached_utxos.len())
+            .finish()
+    }
+}
+
+impl FireblocksGeneralWallet {
+    /// Builds a Fireblocks general wallet from `config` and the operator's API secret
+    /// (`api_secret_pem`, an RSA private key in PEM form used to sign request JWTs).
+    ///
+    /// Parses and network-checks the deposit address up-front so `script_pubkey` can be
+    /// infallible. Does not perform any network I/O — call
+    /// [`sync`](super::GeneralWallet::sync) to populate the UTXO cache.
+    pub fn new(
+        mut config: FireblocksConfig,
+        api_secret_pem: &[u8],
+    ) -> Result<Self, FireblocksError> {
+        let signing_key = jsonwebtoken::EncodingKey::from_rsa_pem(api_secret_pem)
+            .map_err(|e| FireblocksError::SigningKey(e.to_string()))?;
+
+        // Normalise away any trailing slash so `url_and_uri` produces `{base_url}/v1/...` rather
+        // than `{base_url}//v1/...`: the request path must match the JWT `uri` claim (`/v1/...`)
+        // exactly, and a stray slash from config would make Fireblocks reject every request.
+        config.base_url = config.base_url.trim_end_matches('/').to_string();
+
+        // Fireblocks uses a single mainnet BTC asset (`BTC`) and a single test asset (`BTC_TEST`)
+        // covering all non-mainnet networks. Require the exact asset id for the network so a
+        // startup misconfig (wrong network, or a typo like `BTC_TES`/`ETH`) is caught here rather
+        // than letting every signing request target the wrong asset server-side.
+        let expected_asset = if config.network == Network::Bitcoin {
+            "BTC"
+        } else {
+            "BTC_TEST"
+        };
+        if config.asset_id != expected_asset {
+            return Err(FireblocksError::AssetMismatch(format!(
+                "asset_id {:?} does not match network {:?} (expected {expected_asset:?})",
+                config.asset_id, config.network
+            )));
+        }
+
+        let address = config
+            .deposit_address
+            .parse::<Address<NetworkUnchecked>>()
+            .map_err(|e| FireblocksError::DepositAddress(e.to_string()))?
+            .require_network(config.network)
+            .map_err(|e| FireblocksError::DepositAddress(e.to_string()))?;
+        let script_pubkey = address.script_pubkey();
+
+        // The backend assumes a P2WPKH vault (Fireblocks BTC is ECDSA secp256k1). Validate
+        // up-front and build the payout descriptor from the witness-program hash so the trait
+        // accessor stays infallible and we don't couple to bosd's `bitcoin` version.
+        if !script_pubkey.is_p2wpkh() {
+            return Err(FireblocksError::DepositAddress(format!(
+                "deposit address must be P2WPKH (got {address})"
+            )));
+        }
+        let mut wpkh = [0u8; 20];
+        // P2WPKH scriptPubKey is `OP_0 PUSH20 <hash160>`; the 20-byte hash starts at byte 2.
+        wpkh.copy_from_slice(&script_pubkey.as_bytes()[2..22]);
+        let payout_descriptor = bitcoin_bosd::Descriptor::new_p2wpkh(&wpkh);
+
+        let http = reqwest::Client::builder()
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .build()
+            .map_err(|e| FireblocksError::Http(format!("building HTTP client: {e}")))?;
+
+        Ok(Self {
+            config,
+            http,
+            signing_key,
+            script_pubkey,
+            payout_descriptor,
+            cached_utxos: Vec::new(),
+        })
+    }
+
+    /// Builds the full request URL and the matching JWT `uri` claim for an API `subpath`
+    /// (the part after `/v1`, e.g. `/vault/accounts/0/BTC/unspent_inputs`).
+    fn url_and_uri(&self, subpath: &str) -> (String, String) {
+        let uri = format!("/v1{subpath}");
+        let url = format!("{}{}", self.config.base_url, uri);
+        (url, uri)
+    }
+
+    /// Issues an authenticated request to `subpath` and deserializes the JSON response into
+    /// `T`. `body` is the request body for `POST`/`PUT` (the same bytes are hashed into the
+    /// JWT); pass `None` for bodyless `GET`s.
+    ///
+    /// Non-2xx responses surface as [`FireblocksError::Api`] carrying the status + body;
+    /// deserialization failures as [`FireblocksError::Decode`].
+    async fn signed_request<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        subpath: &str,
+        body: Option<&str>,
+    ) -> Result<T, FireblocksError> {
+        let (url, uri) = self.url_and_uri(subpath);
+        let body_bytes = body.map_or(&b""[..], str::as_bytes);
+        let jwt = auth::build_jwt(&uri, body_bytes, &self.config.api_key, &self.signing_key)?;
+
+        let mut req = self
+            .http
+            .request(method, &url)
+            .header("X-API-Key", &self.config.api_key)
+            .bearer_auth(jwt);
+        if let Some(body) = body {
+            req = req
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(body.to_string());
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| FireblocksError::Http(e.to_string()))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| FireblocksError::Http(e.to_string()))?;
+        if !status.is_success() {
+            return Err(FireblocksError::Api(format!("{status}: {text}")));
+        }
+        serde_json::from_str(&text)
+            .map_err(|e| FireblocksError::Decode(format!("{e}; body={text}")))
+    }
+
+    /// Converts a Fireblocks unspent-input record into a backend-neutral [`UtxoInfo`],
+    /// deriving the `script_pubkey` from the record's address.
+    fn unspent_to_utxo_info(
+        &self,
+        u: &dto::UnspentInputsResponse,
+    ) -> Result<UtxoInfo, FireblocksError> {
+        let txid = Txid::from_str(&u.input.tx_hash)
+            .map_err(|e| FireblocksError::Decode(format!("bad txHash {}: {e}", u.input.tx_hash)))?;
+        let amount = Amount::from_str_in(&u.amount, Denomination::Bitcoin)
+            .map_err(|e| FireblocksError::Decode(format!("bad amount {}: {e}", u.amount)))?;
+        let script_pubkey = u
+            .address
+            .parse::<Address<NetworkUnchecked>>()
+            .map_err(|e| FireblocksError::Decode(format!("bad address {}: {e}", u.address)))?
+            .require_network(self.config.network)
+            .map_err(|e| {
+                FireblocksError::Decode(format!("address {} wrong network: {e}", u.address))
+            })?
+            .script_pubkey();
+        // Fireblocks reports confirmations as an unbounded integer; clamp to u32 (the depth at
+        // which the exact count stops mattering for any bridge predicate).
+        let confirmations = u32::try_from(u.confirmations).unwrap_or(u32::MAX);
+        Ok(UtxoInfo {
+            outpoint: OutPoint {
+                txid,
+                vout: u.input.index,
+            },
+            amount,
+            confirmations,
+            script_pubkey,
+        })
+    }
+
+    /// Signs `sighashes` via a Fireblocks `RAW` transaction: submits the messages, then polls
+    /// the transaction until the signatures are available (or it fails / times out). Returns
+    /// the signed messages keyed by the lowercase-hex sighash (`content`) that was requested, so
+    /// callers look each signature up by sighash rather than relying on response order.
+    async fn raw_sign(
+        &self,
+        sighashes: &[[u8; 32]],
+    ) -> Result<HashMap<String, dto::SignedMessage>, FireblocksError> {
+        // Lowercase-hex of each sighash; also the `content` we expect echoed back per message.
+        let expected: Vec<String> = sighashes.iter().map(hex::encode).collect();
+        let messages = expected
+            .iter()
+            .map(|content| dto::UnsignedRawMessage {
+                content: content.clone(),
+                bip44_address_index: self.config.bip44_address_index,
+                bip44_change: self.config.bip44_change,
+            })
+            .collect();
+        let request = dto::RawSignRequest {
+            operation: "RAW",
+            asset_id: self.config.asset_id.clone(),
+            source: dto::TransferPeer {
+                peer_type: "VAULT_ACCOUNT",
+                id: self.config.vault_account_id.clone(),
+            },
+            extra_parameters: dto::ExtraParameters {
+                raw_message_data: dto::RawMessageData {
+                    messages,
+                    algorithm: "MPC_ECDSA_SECP256K1",
+                },
+            },
+        };
+        // Sighashes within a single tx are unique by BIP-143 (each commits to its own
+        // outpoint). Guard the invariant so a `content` collision can't silently map two
+        // inputs onto one signature.
+        let unique: HashSet<&String> = expected.iter().collect();
+        if unique.len() != expected.len() {
+            return Err(FireblocksError::TxBuild(
+                "duplicate sighash among inputs to sign".into(),
+            ));
+        }
+
+        let body = serde_json::to_string(&request)
+            .map_err(|e| FireblocksError::TxBuild(format!("serialize raw-sign request: {e}")))?;
+        let created: dto::CreateTransactionResponse = self
+            .signed_request(Method::POST, "/transactions", Some(&body))
+            .await?;
+
+        let subpath = format!("/transactions/{}", created.id);
+        let mut consecutive_errors = 0u32;
+        for _ in 0..SIGN_MAX_POLL_ATTEMPTS {
+            match self
+                .signed_request::<dto::TransactionDetails>(Method::GET, &subpath, None)
+                .await
+            {
+                Ok(details) => {
+                    consecutive_errors = 0;
+                    if is_failure_status(&details.status) {
+                        return Err(FireblocksError::Api(format!(
+                            "raw-sign transaction {} reached failure status {}",
+                            created.id, details.status
+                        )));
+                    }
+                    // Index the returned signatures by their echoed `content` so callers bind
+                    // each signature to the input that requested it, not by positional order.
+                    let by_content: HashMap<String, dto::SignedMessage> = details
+                        .signed_messages
+                        .into_iter()
+                        .map(|m| (m.content.to_lowercase(), m))
+                        .collect();
+                    // Only done once *every* requested sighash has a matching signature —
+                    // guards against partial / incremental population mid-signing.
+                    if expected.iter().all(|c| by_content.contains_key(c)) {
+                        return Ok(by_content);
+                    }
+                }
+                Err(e) => {
+                    // The RAW transaction is already submitted server-side; a transient poll
+                    // failure must not abandon it. Tolerate a few consecutive blips, then give
+                    // up with the tx id so the operator can reconcile.
+                    consecutive_errors += 1;
+                    if consecutive_errors > MAX_CONSECUTIVE_POLL_ERRORS {
+                        return Err(FireblocksError::Api(format!(
+                            "polling raw-sign transaction {} failed after {consecutive_errors} consecutive errors: {e}",
+                            created.id
+                        )));
+                    }
+                    tracing::warn!(
+                        tx_id = %created.id,
+                        error = %e,
+                        "transient error polling raw-sign transaction; retrying"
+                    );
+                }
+            }
+            tokio::time::sleep(SIGN_POLL_INTERVAL).await;
+        }
+        Err(FireblocksError::SigningTimeout(created.id))
+    }
+
+    /// Populates `witness_utxo` on every PSBT input, RAW-signs the inputs at
+    /// `fb_input_indices`, and writes their P2WPKH witnesses. Inputs not listed (e.g. a CPFP
+    /// anchor) are left for downstream signing per the [`GeneralWallet`] contract.
+    ///
+    /// `prevouts[i]` must be the output spent by `psbt.unsigned_tx.input[i]`.
+    async fn sign_fb_inputs(
+        &self,
+        psbt: &mut Psbt,
+        fb_input_indices: &[usize],
+        prevouts: &[TxOut],
+    ) -> Result<(), FireblocksError> {
+        for (i, prevout) in prevouts.iter().enumerate() {
+            psbt.inputs[i].witness_utxo = Some(prevout.clone());
+        }
+        if fb_input_indices.is_empty() {
+            return Ok(());
+        }
+        let sighashes = fb_input_indices
+            .iter()
+            .map(|&i| tx::p2wpkh_sighash(&psbt.unsigned_tx, i, prevouts))
+            .collect::<Result<Vec<_>, _>>()?;
+        let signed = self.raw_sign(&sighashes).await?;
+        for (sighash, &i) in sighashes.iter().zip(fb_input_indices) {
+            // Look the signature up by the sighash we asked Fireblocks to sign (not by order).
+            let content = hex::encode(sighash);
+            let msg = signed.get(&content).ok_or_else(|| {
+                FireblocksError::Api(format!("no signature returned for input {i}"))
+            })?;
+            // `assemble_p2wpkh_witness` also verifies the signing pubkey controls this prevout and
+            // that the signature verifies against `sighash`.
+            let witness = sign::assemble_p2wpkh_witness(
+                &msg.signature.full_sig,
+                &msg.public_key,
+                &prevouts[i].script_pubkey,
+                sighash,
+            )?;
+            psbt.inputs[i].final_script_witness = Some(witness);
+        }
+        Ok(())
+    }
+}
+
+/// Whether a Fireblocks transaction status is terminal-failure (so polling should stop).
+fn is_failure_status(status: &str) -> bool {
+    matches!(
+        status,
+        "FAILED" | "REJECTED" | "BLOCKED" | "CANCELLED" | "CANCELLING" | "TIMEOUT"
+    )
+}
+
+impl GeneralWallet for FireblocksGeneralWallet {
+    type Error = FireblocksError;
+
+    async fn sync(&mut self) -> Result<(), Self::Error> {
+        let subpath = format!(
+            "/vault/accounts/{}/{}/unspent_inputs",
+            self.config.vault_account_id, self.config.asset_id
+        );
+        let resp: dto::GetUnspentInputsResponse =
+            self.signed_request(Method::GET, &subpath, None).await?;
+        let all = resp
+            .iter()
+            .map(|u| self.unspent_to_utxo_info(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        // Enforce the single-address assumption at the source: only retain UTXOs at the
+        // configured deposit address, so `list_utxos` and explicit-input callers never see a
+        // UTXO this backend can't sign with the vault's primary key. (This also filters out
+        // protocol anchors — they are keyed to musig2 / watchtower keys, never the vault
+        // address. The composer's anchor exclusion is value-based, not script-based — it
+        // drops any unconfirmed UTXO at exactly the anchor value — so for this backend it
+        // can only ever bite on a 330-sat vault change output, and only until it confirms.)
+        let total = all.len();
+        self.cached_utxos = all
+            .into_iter()
+            .filter(|u| u.script_pubkey == self.script_pubkey)
+            .collect();
+        if self.cached_utxos.len() != total {
+            tracing::warn!(
+                dropped = total - self.cached_utxos.len(),
+                "ignoring vault UTXOs not at the configured deposit address (single-address assumption)"
+            );
+        }
+        Ok(())
+    }
+
+    fn script_pubkey(&self) -> ScriptBuf {
+        self.script_pubkey.clone()
+    }
+
+    fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
+        // Earnings land in the Fireblocks vault (P2WPKH), where the operator can spend them
+        // via Fireblocks ECDSA signing — the same address used for funding.
+        self.payout_descriptor.clone()
+    }
+
+    fn list_utxos(&self) -> Vec<UtxoInfo> {
+        self.cached_utxos.clone()
+    }
+
+    async fn fund_v3_transaction(
+        &mut self,
+        outputs: Vec<TxOut>,
+        explicit_inputs: Option<&[OutPoint]>,
+        fee_rate: FeeRate,
+        exclude: &[OutPoint],
+    ) -> Result<FundedPsbt, Self::Error> {
+        let change_spk = self.script_pubkey.clone();
+        let (funding, change) = match explicit_inputs {
+            Some(inputs) => tx::funding_from_explicit(
+                &self.cached_utxos,
+                inputs,
+                &outputs,
+                &change_spk,
+                fee_rate,
+            )?,
+            None => {
+                let exclude_set: HashSet<OutPoint> = exclude.iter().copied().collect();
+                tx::select_funding(
+                    &self.cached_utxos,
+                    &exclude_set,
+                    &self.script_pubkey,
+                    &outputs,
+                    &change_spk,
+                    fee_rate,
+                )?
+            }
+        };
+
+        let txins: Vec<TxIn> = funding.iter().map(|f| tx::txin(f.outpoint)).collect();
+        let prevouts: Vec<TxOut> = funding.iter().map(|f| f.prevout.clone()).collect();
+        let change_output = change.map(|value| TxOut {
+            value,
+            script_pubkey: change_spk,
+        });
+        let unsigned = tx::build_unsigned_v3(&txins, outputs, change_output);
+        let mut psbt = Psbt::from_unsigned_tx(unsigned)
+            .map_err(|e| FireblocksError::TxBuild(format!("psbt from unsigned tx: {e}")))?;
+
+        // Every input is a Fireblocks-controlled funding input.
+        let fb_indices: Vec<usize> = (0..funding.len()).collect();
+        self.sign_fb_inputs(&mut psbt, &fb_indices, &prevouts)
+            .await?;
+        Ok(FundedPsbt { psbt })
+    }
+
+    async fn build_cpfp_child(
+        &mut self,
+        parent: &Transaction,
+        parent_fee: Amount,
+        anchor: AnchorInfo,
+        target_pkg_fee_rate: FeeRate,
+        exclude: &[OutPoint],
+        // Of the two `ReplacedChild` obligations, only the fee floor needs work here. The
+        // selection obligation holds without code: this backend's UTXO cache comes from
+        // the Fireblocks API and carries no local spent-marking, so the prior child's
+        // inputs stay selectable as long as the API reports them.
+        replaced: ReplacedChild<'_>,
+    ) -> Result<FundedPsbt, Self::Error> {
+        let anchor_prevout = parent
+            .output
+            .get(anchor.vout() as usize)
+            .ok_or_else(|| {
+                FireblocksError::TxBuild(format!("anchor vout {} out of range", anchor.vout()))
+            })?
+            .clone();
+        let anchor_outpoint = OutPoint {
+            txid: parent.compute_txid(),
+            vout: anchor.vout(),
+        };
+        let change_spk = self.script_pubkey.clone();
+        // cast: tx vsize is bounded by the 4 MWU consensus limit, far inside u64.
+        let parent_vsize = parent.vsize() as u64;
+
+        // If the combined output pays our own vault script, it's the operator's P2WPKH payout
+        // (the `ParentTxCombined` case) which Fireblocks signs itself. Otherwise it's a foreign
+        // keyed-Taproot anchor (`AnchorBearing`) left unsigned for secret-service.
+        let combined_is_ours = anchor_prevout.script_pubkey == self.script_pubkey;
+
+        let mut exclude_set: HashSet<OutPoint> = exclude.iter().copied().collect();
+        // Never re-select the combined input as a funding input.
+        exclude_set.insert(anchor_outpoint);
+
+        let (funding, child_output_value) = tx::select_cpfp_funding(
+            &self.cached_utxos,
+            &exclude_set,
+            &self.script_pubkey,
+            anchor_prevout.value,
+            // Only a foreign anchor contributes a non-P2WPKH witness to the child; `None`
+            // means the combined input is our own vault output, which Fireblocks signs as
+            // P2WPKH.
+            (!combined_is_ours).then_some(&anchor),
+            parent_vsize,
+            parent_fee,
+            target_pkg_fee_rate,
+            replaced.fee,
+            &change_spk,
+        )?;
+
+        // Input 0 is the combined input; inputs 1.. are the Fireblocks funding inputs.
+        let mut txins = Vec::with_capacity(funding.len() + 1);
+        let mut prevouts = Vec::with_capacity(funding.len() + 1);
+        txins.push(tx::txin(anchor_outpoint));
+        prevouts.push(anchor_prevout);
+        for f in &funding {
+            txins.push(tx::txin(f.outpoint));
+            prevouts.push(f.prevout.clone());
+        }
+
+        let child_output = TxOut {
+            value: child_output_value,
+            script_pubkey: change_spk,
+        };
+        let unsigned = tx::build_unsigned_v3(&txins, vec![child_output], None);
+        let mut psbt = Psbt::from_unsigned_tx(unsigned)
+            .map_err(|e| FireblocksError::TxBuild(format!("psbt from unsigned tx: {e}")))?;
+
+        if combined_is_ours {
+            // The payout output is ours: every input (payout + funding) is an FB-signed P2WPKH.
+            let fb_indices: Vec<usize> = (0..=funding.len()).collect();
+            self.sign_fb_inputs(&mut psbt, &fb_indices, &prevouts)
+                .await?;
+        } else {
+            // Fireblocks signs the funding inputs; the anchor input (0) is left unsigned for the
+            // operator's secret-service to sign. What it needs to do that differs by anchor
+            // shape: a key-path anchor needs `tap_internal_key`, while a `MultiAnchor` leaf is
+            // satisfied script-path and the caller assembles the witness from the leaf script and
+            // control block it already holds.
+            let fb_indices: Vec<usize> = (1..=funding.len()).collect();
+            self.sign_fb_inputs(&mut psbt, &fb_indices, &prevouts)
+                .await?;
+            match &anchor {
+                AnchorInfo::KeyPath { internal_key, .. } => {
+                    psbt.inputs[0].tap_internal_key = Some(*internal_key);
+                }
+                AnchorInfo::ScriptPath {
+                    leaf_script,
+                    control_block,
+                    ..
+                } => {
+                    psbt.inputs[0].tap_scripts.insert(
+                        control_block.clone(),
+                        (leaf_script.clone(), LeafVersion::TapScript),
+                    );
+                }
+            }
+        }
+        Ok(FundedPsbt { psbt })
+    }
+
+    async fn sign_owned_inputs(
+        &self,
+        tx: &Transaction,
+        input_indices: &[usize],
+        prevouts: &[TxOut],
+    ) -> Result<Vec<Option<Witness>>, Self::Error> {
+        if input_indices.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sighashes = input_indices
+            .iter()
+            .map(|&i| tx::p2wpkh_sighash(tx, i, prevouts))
+            .collect::<Result<Vec<_>, _>>()?;
+        let signed = self.raw_sign(&sighashes).await?;
+        let mut witnesses = Vec::with_capacity(input_indices.len());
+        for (sighash, &i) in sighashes.iter().zip(input_indices) {
+            // Match by the sighash we asked Fireblocks to sign, then verify the returned pubkey
+            // controls this prevout (assemble_p2wpkh_witness checks hash160 == witness program).
+            let content = hex::encode(sighash);
+            let msg = signed.get(&content).ok_or_else(|| {
+                FireblocksError::Api(format!("no signature returned for input {i}"))
+            })?;
+            let witness = sign::assemble_p2wpkh_witness(
+                &msg.signature.full_sig,
+                &msg.public_key,
+                &prevouts[i].script_pubkey,
+                sighash,
+            )?;
+            witnesses.push(Some(witness));
+        }
+        Ok(witnesses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_statuses_are_terminal() {
+        for s in [
+            "FAILED",
+            "REJECTED",
+            "BLOCKED",
+            "CANCELLED",
+            "CANCELLING",
+            "TIMEOUT",
+        ] {
+            assert!(is_failure_status(s), "{s} should be terminal-failure");
+        }
+    }
+
+    #[test]
+    fn non_failure_statuses_keep_polling() {
+        for s in [
+            "SUBMITTED",
+            "PENDING_SIGNATURE",
+            "BROADCASTING",
+            "COMPLETED",
+            "CONFIRMING",
+            "",
+        ] {
+            assert!(!is_failure_status(s), "{s} should not be terminal-failure");
+        }
+    }
+}

--- a/crates/operator-wallet/src/general/fireblocks/auth.rs
+++ b/crates/operator-wallet/src/general/fireblocks/auth.rs
@@ -1,0 +1,223 @@
+//! Fireblocks request authentication: per-request RS256 JWT + body hashing.
+//!
+//! Every Fireblocks API call carries two credentials:
+//! - `X-API-Key: <api key>` (added by the caller), and
+//! - `Authorization: Bearer <JWT>`, where the JWT is RS256-signed with the operator's API secret
+//!   (an RSA private key) and proves possession of that key plus integrity of the request body.
+//!
+//! ## Claims
+//!
+//! Per the Fireblocks API authentication scheme, the JWT carries:
+//! - `uri`   — the request path **including query string**, host excluded (e.g.
+//!   `/v1/vault/accounts/0/BTC/unspent_inputs`). Must match the request exactly.
+//! - `nonce` — a value unique per request (replay protection).
+//! - `iat`   — issued-at, unix seconds.
+//! - `exp`   — expiry, unix seconds. Fireblocks rejects tokens valid for more than ~30s, so we use
+//!   `iat + TOKEN_TTL_SECS` (a few seconds under that ceiling to absorb clock skew).
+//! - `sub`   — the API key.
+//! - `bodyHash` — lowercase hex of `SHA256(raw request body)`. For bodyless requests (GET), this is
+//!   the SHA256 of the empty string.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use super::FireblocksError;
+
+/// JWT token lifetime. Fireblocks rejects tokens whose `exp - iat` exceeds ~30s, so we stay a
+/// few seconds under that ceiling to absorb clock skew and request-flight time.
+const TOKEN_TTL_SECS: u64 = 25;
+
+/// Per-process counter that disambiguates tokens minted at the same clock reading.
+static NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// The Fireblocks JWT claim set. Field names match the wire format exactly.
+#[derive(Debug, Serialize)]
+struct Claims {
+    uri: String,
+    nonce: u64,
+    iat: u64,
+    exp: u64,
+    sub: String,
+    #[serde(rename = "bodyHash")]
+    body_hash: String,
+}
+
+/// Lowercase-hex SHA256 of `body`. For GET/bodyless requests pass an empty slice.
+pub(super) fn body_hash(body: &[u8]) -> String {
+    let digest = Sha256::digest(body);
+    hex::encode(digest)
+}
+
+/// Builds a signed RS256 JWT for a request to `uri` carrying `body`.
+///
+/// `uri` is the path + query string with the host excluded (e.g.
+/// `/v1/vault/accounts/0/BTC/unspent_inputs`). `api_key` becomes the `sub` claim. `signing_key`
+/// is the RS256 key built from the operator's API secret PEM.
+pub(super) fn build_jwt(
+    uri: &str,
+    body: &[u8],
+    api_key: &str,
+    signing_key: &EncodingKey,
+) -> Result<String, FireblocksError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| FireblocksError::Jwt(format!("system clock before unix epoch: {e}")))?
+        .as_secs();
+
+    let claims = build_claims(uri, body, api_key, now);
+
+    jsonwebtoken::encode(&Header::new(Algorithm::RS256), &claims, signing_key)
+        .map_err(|e| FireblocksError::Jwt(e.to_string()))
+}
+
+/// Assembles the Fireblocks claim set for a request. Pure (no signing, no clock read) so the
+/// claim-construction logic — `uri`, `bodyHash`, the `iat`/`exp` window, the per-request nonce
+/// — can be unit-tested without any key material. The RS256 signing itself is delegated to
+/// `jsonwebtoken::encode` in [`build_jwt`].
+fn build_claims(uri: &str, body: &[u8], api_key: &str, now_secs: u64) -> Claims {
+    Claims {
+        uri: uri.to_string(),
+        nonce: next_nonce(),
+        iat: now_secs,
+        exp: now_secs + TOKEN_TTL_SECS,
+        sub: api_key.to_string(),
+        body_hash: body_hash(body),
+    }
+}
+
+/// Produces a per-request nonce: the nanosecond wall clock plus a process-monotonic counter.
+///
+/// The nanosecond base makes nonces unique across process restarts (a fresh process reads a
+/// later clock), while the counter disambiguates requests that read the same nanosecond. A
+/// counter-only scheme would reset to 0 on restart and could replay a nonce within
+/// Fireblocks' validity window, getting the request rejected.
+fn next_nonce() -> u64 {
+    // Truncating u128 nanos to u64 is intentional and harmless: it only needs to be unique
+    // within Fireblocks' short validity window, and the counter disambiguates ties. u64 nanos
+    // don't wrap until ~year 2554.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let counter = NONCE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    nanos.wrapping_add(counter)
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonwebtoken::{DecodingKey, Validation};
+
+    use super::*;
+
+    #[test]
+    fn body_hash_matches_known_vectors() {
+        // SHA256("") and SHA256("hello") — fixed reference values.
+        assert_eq!(
+            body_hash(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            body_hash(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn claims_carry_expected_fields_and_window() {
+        let uri = "/v1/vault/accounts/0/BTC/unspent_inputs";
+        let api_key = "test-api-key";
+        let now = 1_700_000_000;
+
+        let claims = build_claims(uri, b"", api_key, now);
+
+        assert_eq!(claims.uri, uri);
+        assert_eq!(claims.sub, api_key);
+        // bodyHash of an empty body is SHA256("").
+        assert_eq!(
+            claims.body_hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(claims.iat, now);
+        assert_eq!(claims.exp - claims.iat, TOKEN_TTL_SECS);
+    }
+
+    #[test]
+    fn nonces_are_unique_across_rapid_calls() {
+        // Rapid calls may read the same nanosecond; the counter must disambiguate them.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..10_000 {
+            assert!(seen.insert(next_nonce()), "nonce collision");
+        }
+    }
+
+    /// Throwaway 2048-bit RSA key pair (PKCS#8 / SPKI PEM), not a secret. It exists only to
+    /// pin the `jsonwebtoken` crypto provider: with no provider feature compiled in,
+    /// the default provider's signer factory panics on the first `encode` call.
+    const TEST_RSA_PRIVATE_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCMNfum0ipMfWIS
+eowAEix26JaYdgLNzn/xQUMBNmRJFe4Fx308Du/8UJcqrl1L2daqU3oAvtZxl7jI
+S9qXHGbCbGNyAypL/BR69xKVZJi8FGH6rJyN+dI1xW/CbnOo9w96ZotxM43XGofF
+0zOd3pAfICrH5hmCvx+bRH7zOYJAKve6G8lZGS6F57spgv2Ez+3Y0rXTkTJoEw47
+X6kdsouRZzD2KxMzzZGtAxG2mIzjozQCokb8RBxpQeytQwg4Tnm5uLIr/IrKOs9q
+XXaHyiO+hvj3iBzQbb4vPdIOh719vmAlmZOskDRKe9Y2lVJqlLZJohTirRf2eRb1
+lkJE+PdTAgMBAAECggEANnHl6Nb2TuJnOUa143crJfdWNxioKRO1MdEGPEvLMGgg
+F8Vpl28zeFYxBQVVPBV4WoZ0uyJfshdYzQpLdN819exRx118SKo3p7IWWMWJ24rM
+qyLo3eay3mdu6OCr7+IT9BMqtYfv3aWzMDm9cuGQNE3w3tO2d0NQ+iFkbH0Z22Fg
+wRP+QyTXEBK/k+lIsCPAmiytjUPwOeO6p3dfbyGKtBE894oZ8d/LH03FV6vPRRYY
+rBDmN3MOO6jZ3fg2MsllbFwDmqX1UQT9+5EWdZAwXYm/nv544aGZL/P7hMjSUdev
+9xi8mMu9pG41+6/HpVe7hCBeJoHJodCrO1hcFX8xNQKBgQDDUJThjwH89HnqyBr4
+RBcAc8eDquIRgV2CyJ5oU5WGs0ErLf8HAklXo9MDf1dMBGKY1NNfhVx84PZFCQiG
+lb3H3CevRm+a1HE10XyZWCD47g1VPk3SFQsRUVtaRdwxd9bXF6ACBaQ3ugkXw+N0
+5bMihRfBdw00zuZE3QzdrHv8nwKBgQC3xmoJQtlmn3gMTGnZsNdrnMVOGEWmPfYB
+eYt4hjjI9QZE8q2MlqhdmGlQGzo+FOQhnjAEGwDQwGRD5eV4snfn7tL/R1VmJld9
+Wr1sjE6/c6O9+0SA6/AfyUvNMljbR8ygyDwyQdXQ5OOwLfsChZYoRJlut9yBMZ61
+6K1zugTUzQKBgAg/C7omPpA+hjM6daELxujW+pJ9kYPpsVgHPmDrPoHsaZD4JS9X
+kl8n5I3eP4JPIRaQzcfXqpr/KIarpfeAtP2ONwK4d5fS5mC+UoNq7CF2c4uo0MJQ
+7yGxDKlYD77q72AveCr9r/xGV4HwXFcgJ5sKgYFClIUpQyGfL57gXG/DAoGATtgU
+ZBbHGM0v/u7Ftvy031lqGQA22YTZx3YzDSlgsW7WGryXEqsMXuNlw1V7HmluGrI4
+XXqMVgNEwRCf67F92gbPhXBARkwK2yAUBr8HhgIB7R8hG8KdybVeDRIdpy5dr1lY
+4iL2reGVgd+oQkO30VzlCuhc9Rypv9esmuri6b0CgYEAnts5srGMWKsT+yyMRuyd
+knTG8XP5pEbxVCbdV2b6t5BlqaWWdWX6n+uZPlOTXJfcLVe5n7LMpWg4FVTnfuje
+afEvdqCMi8LXMu7558emcDGHDCvXt9OBO/aSsjEPAWtBT+g4bqHTSSdLaRhYqyj4
+xib2bRSsBtnKKKFsk4Rr09g=
+-----END PRIVATE KEY-----
+"#;
+    const TEST_RSA_PUBLIC_PEM: &str = r#"-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjDX7ptIqTH1iEnqMABIs
+duiWmHYCzc5/8UFDATZkSRXuBcd9PA7v/FCXKq5dS9nWqlN6AL7WcZe4yEvalxxm
+wmxjcgMqS/wUevcSlWSYvBRh+qycjfnSNcVvwm5zqPcPemaLcTON1xqHxdMznd6Q
+HyAqx+YZgr8fm0R+8zmCQCr3uhvJWRkuhee7KYL9hM/t2NK105EyaBMOO1+pHbKL
+kWcw9isTM82RrQMRtpiM46M0AqJG/EQcaUHsrUMIOE55ubiyK/yKyjrPal12h8oj
+vob494gc0G2+Lz3SDoe9fb5gJZmTrJA0SnvWNpVSapS2SaIU4q0X9nkW9ZZCRPj3
+UwIDAQAB
+-----END PUBLIC KEY-----
+"#;
+
+    #[test]
+    fn build_jwt_signs_and_verifies() {
+        let signing_key = EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_PEM.as_bytes())
+            .expect("test key must parse");
+
+        let uri = "/v1/vault/accounts/0/BTC/unspent_inputs";
+        let token = build_jwt(uri, b"", "test-api-key", &signing_key)
+            .expect("encode panics if no jsonwebtoken provider is compiled in");
+
+        let verification_key =
+            DecodingKey::from_rsa_pem(TEST_RSA_PUBLIC_PEM.as_bytes()).expect("test key must parse");
+        let data = jsonwebtoken::decode::<serde_json::Value>(
+            &token,
+            &verification_key,
+            &Validation::new(Algorithm::RS256),
+        )
+        .expect("the RS256 signature must verify against the public key");
+
+        assert_eq!(data.claims["uri"], uri);
+        assert_eq!(data.claims["sub"], "test-api-key");
+    }
+}

--- a/crates/operator-wallet/src/general/fireblocks/dto.rs
+++ b/crates/operator-wallet/src/general/fireblocks/dto.rs
@@ -1,0 +1,190 @@
+//! Serde DTOs mirroring the Fireblocks REST API schemas this backend touches.
+//!
+//! Field names use `rename_all = "camelCase"` to match the wire format. Only the fields the
+//! backend actually consumes are modelled; unknown fields are ignored on deserialization.
+
+use serde::{Deserialize, Serialize};
+
+/// One unspent input reference (`UnspentInput` in the Fireblocks schema).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct UnspentInput {
+    /// Funding transaction id (hex).
+    pub tx_hash: String,
+    /// Output index within `tx_hash`.
+    pub index: u32,
+}
+
+/// One element of the `GET …/unspent_inputs` response (`UnspentInputsResponse`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct UnspentInputsResponse {
+    /// The outpoint (`txHash` + `index`).
+    pub input: UnspentInput,
+    /// Address holding the UTXO; the source for its `script_pubkey`.
+    pub address: String,
+    /// Value as a decimal BTC string (e.g. `"0.5"`).
+    pub amount: String,
+    /// Confirmation count as of the query.
+    pub confirmations: u64,
+}
+
+/// Response body of `GET /v1/vault/accounts/{id}/{asset}/unspent_inputs`.
+pub(super) type GetUnspentInputsResponse = Vec<UnspentInputsResponse>;
+
+// ── RAW signing: request ─────────────────────────────────────────────────────
+
+/// Body of `POST /v1/transactions` for a `RAW` signing operation.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RawSignRequest {
+    /// Always `"RAW"`.
+    pub operation: &'static str,
+    /// Asset id (`BTC` / `BTC_TEST`) — selects the signing key family.
+    pub asset_id: String,
+    /// Vault account the signing key lives in.
+    pub source: TransferPeer,
+    /// Carries the raw messages to sign.
+    pub extra_parameters: ExtraParameters,
+}
+
+/// A transfer peer reference (here, the signing vault account).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TransferPeer {
+    /// Always `"VAULT_ACCOUNT"` for this backend.
+    #[serde(rename = "type")]
+    pub peer_type: &'static str,
+    /// Vault account id.
+    pub id: String,
+}
+
+/// `extraParameters` wrapper carrying the raw message data.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ExtraParameters {
+    pub raw_message_data: RawMessageData,
+}
+
+/// The set of messages (sighashes) to sign and the algorithm to use.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RawMessageData {
+    pub messages: Vec<UnsignedRawMessage>,
+    /// `MPC_ECDSA_SECP256K1` for Bitcoin.
+    pub algorithm: &'static str,
+}
+
+/// One message to sign: a hex-encoded 32-byte sighash that Fireblocks signs **as-is**, plus the
+/// BIP44 derivation indices telling Fireblocks which derived key under the vault to sign with.
+///
+/// Without `bip44AddressIndex`/`bip44change` Fireblocks signs with the vault's default key, which
+/// only matches the configured `deposit_address` for the default vault address — operators using
+/// a non-default address would get back a pubkey that doesn't control the prevout and
+/// `assemble_p2wpkh_witness` would (correctly) reject it. Sending the indices explicitly lets
+/// the backend spend any vault address.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct UnsignedRawMessage {
+    pub content: String,
+    pub bip44_address_index: u32,
+    /// Fireblocks names this field with a lowercase `c` (`bip44change`); the explicit rename
+    /// overrides the struct-level `camelCase` so we don't end up sending `bip44Change`.
+    #[serde(rename = "bip44change")]
+    pub bip44_change: u32,
+}
+
+// ── RAW signing: response ────────────────────────────────────────────────────
+
+/// Response of `POST /v1/transactions` — the created transaction's id (its initial `status`
+/// is ignored; we poll the transaction detail endpoint for the signed result).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CreateTransactionResponse {
+    pub id: String,
+}
+
+/// A `GET /v1/transactions/{id}` detail response (subset).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TransactionDetails {
+    pub status: String,
+    /// Per-message signatures, populated once the transaction reaches a signed state. Matched
+    /// back to inputs by each message's echoed `content`, not by position — do not rely on
+    /// ordering here.
+    #[serde(default)]
+    pub signed_messages: Vec<SignedMessage>,
+}
+
+/// One signed message: the echoed content, the signing public key, and the signature.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SignedMessage {
+    /// The signed message echoed back — the hex sighash we submitted. Used to match each
+    /// signature to the input that requested it (rather than trusting positional order).
+    pub content: String,
+    /// Compressed public key (hex) the message was signed with.
+    pub public_key: String,
+    pub signature: SignatureData,
+}
+
+/// The ECDSA signature returned for a signed message.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SignatureData {
+    /// `r || s`, 64 bytes hex.
+    pub full_sig: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_unspent_inputs_response() {
+        // Shape per the Fireblocks swagger `UnspentInputsResponse` schema, with an extra
+        // unknown field to confirm forward-compatibility.
+        let json = r#"[
+            {
+                "input": { "txHash": "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899", "index": 2 },
+                "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+                "amount": "0.12345678",
+                "confirmations": 6,
+                "status": "CONFIRMED",
+                "someFutureField": true
+            }
+        ]"#;
+
+        let parsed: GetUnspentInputsResponse = serde_json::from_str(json).expect("parses");
+        assert_eq!(parsed.len(), 1);
+        let u = &parsed[0];
+        assert_eq!(
+            u.input.tx_hash,
+            "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+        );
+        assert_eq!(u.input.index, 2);
+        assert_eq!(u.address, "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq");
+        assert_eq!(u.amount, "0.12345678");
+        assert_eq!(u.confirmations, 6);
+    }
+
+    #[test]
+    fn unsigned_raw_message_serializes_with_fireblocks_field_names() {
+        // Pin the exact wire names: Fireblocks expects `bip44AddressIndex` (camelCase) and
+        // `bip44change` (all lowercase) — `rename_all = "camelCase"` would otherwise emit
+        // `bip44Change`, which Fireblocks would silently ignore and fall back to the default key.
+        let msg = UnsignedRawMessage {
+            content: "deadbeef".to_string(),
+            bip44_address_index: 5,
+            bip44_change: 1,
+        };
+        let v: serde_json::Value = serde_json::to_value(&msg).expect("serializes");
+        assert_eq!(v["content"], "deadbeef");
+        assert_eq!(v["bip44AddressIndex"], 5);
+        assert_eq!(v["bip44change"], 1);
+        assert!(
+            v.get("bip44Change").is_none(),
+            "must not emit `bip44Change` (camelCase) — Fireblocks would ignore it"
+        );
+    }
+}

--- a/crates/operator-wallet/src/general/fireblocks/sign.rs
+++ b/crates/operator-wallet/src/general/fireblocks/sign.rs
@@ -1,0 +1,265 @@
+//! Witness assembly from Fireblocks ECDSA signatures.
+//!
+//! Fireblocks returns a raw `r || s` ECDSA signature (`fullSig`, 64 bytes hex) plus the
+//! signing public key for each message. For a P2WPKH input the witness is
+//! `[DER(sig) || SIGHASH_ALL, compressed_pubkey]`, so this converts the compact signature to
+//! DER, low-S-normalises it (Bitcoin consensus requires low-S), appends the sighash-type byte,
+//! and pairs it with the pubkey.
+//!
+//! Crucially it also performs two checks against the untrusted RAW-signing response before
+//! trusting the witness — RAW signing lets Fireblocks choose the signing key and returns a bare
+//! `r||s`, so a wrong key or a signature that doesn't match the sighash would otherwise yield a
+//! structurally valid but invalid witness that only fails at broadcast:
+//! 1. the returned pubkey actually controls the input — `hash160(pubkey)` must equal the input's
+//!    P2WPKH witness program; and
+//! 2. the signature actually verifies against the `sighash` we asked Fireblocks to sign.
+
+use bdk_wallet::bitcoin::{
+    ecdsa,
+    secp256k1::{self, ecdsa::Signature as SecpSignature, Message, Secp256k1},
+    CompressedPublicKey, EcdsaSighashType, Script, ScriptBuf, Witness,
+};
+
+use super::FireblocksError;
+
+/// Builds the P2WPKH witness for one input from Fireblocks' `fullSig` (hex `r||s`), the signing
+/// public key (hex, compressed), and the `sighash` that was sent for signing. Low-S-normalises
+/// the signature before DER-encoding, checks the pubkey hashes to `expected_script`'s witness
+/// program, and verifies the signature against `sighash` under that pubkey.
+pub(super) fn assemble_p2wpkh_witness(
+    full_sig_hex: &str,
+    public_key_hex: &str,
+    expected_script: &Script,
+    sighash: &[u8; 32],
+) -> Result<Witness, FireblocksError> {
+    let sig_bytes = hex::decode(full_sig_hex)
+        .map_err(|e| FireblocksError::Witness(format!("signature hex: {e}")))?;
+    let mut signature = SecpSignature::from_compact(&sig_bytes)
+        .map_err(|e| FireblocksError::Witness(format!("compact signature: {e}")))?;
+    // Bitcoin requires low-S; Fireblocks usually returns low-S already, but normalise to be safe.
+    signature.normalize_s();
+
+    let ecdsa_sig = ecdsa::Signature {
+        signature,
+        sighash_type: EcdsaSighashType::All,
+    };
+
+    let pubkey_bytes = hex::decode(public_key_hex)
+        .map_err(|e| FireblocksError::Witness(format!("pubkey hex: {e}")))?;
+    // Validate it parses as a public key so we fail here rather than at broadcast.
+    let pubkey = secp256k1::PublicKey::from_slice(&pubkey_bytes)
+        .map_err(|e| FireblocksError::Witness(format!("pubkey: {e}")))?;
+    let compressed = CompressedPublicKey::from_slice(&pubkey_bytes)
+        .map_err(|e| FireblocksError::Witness(format!("compressed pubkey: {e}")))?;
+
+    // The signing key must actually control this input: its P2WPKH script must match the
+    // prevout we're spending. Guards against Fireblocks signing with the wrong vault key.
+    let derived_script = ScriptBuf::new_p2wpkh(&compressed.wpubkey_hash());
+    if derived_script != *expected_script {
+        return Err(FireblocksError::Witness(format!(
+            "signing pubkey does not control the input: derived script {derived_script:?} != prevout script {expected_script:?}"
+        )));
+    }
+
+    // The signature must actually verify against the sighash we asked Fireblocks to sign — catch a
+    // bad/garbled `fullSig` here rather than letting an invalid witness fail at broadcast. ECDSA
+    // verification is malleability-agnostic, so the low-S-normalised signature still verifies.
+    Secp256k1::verification_only()
+        .verify_ecdsa(&Message::from_digest(*sighash), &signature, &pubkey)
+        .map_err(|e| {
+            FireblocksError::Witness(format!(
+                "signature does not verify against the sighash: {e}"
+            ))
+        })?;
+
+    let mut witness = Witness::new();
+    witness.push(ecdsa_sig.to_vec());
+    witness.push(&pubkey_bytes);
+    Ok(witness)
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
+
+    use super::*;
+
+    /// Returns a real signature, the compressed pubkey hex, the P2WPKH script the pubkey
+    /// controls, and the signed sighash — so the happy-path test feeds a matching
+    /// `expected_script` and the signature verifies.
+    fn sig_pubkey_script(sk_byte: u8, msg_byte: u8) -> (String, String, ScriptBuf, [u8; 32]) {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[sk_byte; 32]).unwrap();
+        let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
+        let sighash = [msg_byte; 32];
+        let sig = secp.sign_ecdsa(&Message::from_digest(sighash), &sk);
+        let compressed = CompressedPublicKey(pk);
+        let script = ScriptBuf::new_p2wpkh(&compressed.wpubkey_hash());
+        (
+            hex::encode(sig.serialize_compact()),
+            hex::encode(pk.serialize()),
+            script,
+            sighash,
+        )
+    }
+
+    #[test]
+    fn assembles_witness_with_der_sig_and_pubkey() {
+        let (full_sig_hex, pubkey_hex, script, sighash) = sig_pubkey_script(0x11, 0x22);
+        let witness = assemble_p2wpkh_witness(&full_sig_hex, &pubkey_hex, &script, &sighash)
+            .expect("assembles");
+        let items: Vec<&[u8]> = witness.iter().collect();
+        assert_eq!(items.len(), 2, "P2WPKH witness has 2 items");
+        // Item 0: DER signature ending in the SIGHASH_ALL byte; item 1: the 33-byte pubkey.
+        assert_eq!(*items[0].last().unwrap(), EcdsaSighashType::All as u8);
+        assert_eq!(items[0][0], 0x30, "DER sequence tag");
+        assert_eq!(items[1].len(), 33);
+    }
+
+    #[test]
+    fn rejects_pubkey_that_does_not_control_the_input() {
+        let (full_sig_hex, pubkey_hex, _script, sighash) = sig_pubkey_script(0x11, 0x22);
+        // A script for a *different* key — the returned pubkey must not satisfy it.
+        let (_, _, other_script, _) = sig_pubkey_script(0x99, 0x22);
+        let err = assemble_p2wpkh_witness(&full_sig_hex, &pubkey_hex, &other_script, &sighash)
+            .unwrap_err();
+        assert!(matches!(err, FireblocksError::Witness(_)));
+    }
+
+    #[test]
+    fn rejects_signature_that_does_not_verify_against_the_sighash() {
+        // Correct key + controlling script, but a sighash the signature was not made for.
+        let (full_sig_hex, pubkey_hex, script, _) = sig_pubkey_script(0x11, 0x22);
+        let wrong_sighash = [0x77u8; 32];
+        let err = assemble_p2wpkh_witness(&full_sig_hex, &pubkey_hex, &script, &wrong_sighash)
+            .unwrap_err();
+        assert!(matches!(err, FireblocksError::Witness(_)));
+    }
+
+    #[test]
+    fn rejects_malformed_signature_hex() {
+        let (_, _, script, sighash) = sig_pubkey_script(0x11, 0x22);
+        assert!(assemble_p2wpkh_witness("not-hex", "00", &script, &sighash).is_err());
+        // Right hex, wrong length for a compact signature.
+        assert!(assemble_p2wpkh_witness("aabb", "00", &script, &sighash).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_pubkey() {
+        let (full_sig_hex, _, script, sighash) = sig_pubkey_script(0x33, 0x44);
+        assert!(assemble_p2wpkh_witness(&full_sig_hex, "deadbeef", &script, &sighash).is_err());
+    }
+
+    /// A high-S compact signature must be normalized to low-S before DER-encoding (Bitcoin
+    /// consensus rejects high-S). `sign_ecdsa` always returns low-S, so flip it to its high-S
+    /// counterpart `(r, n - s)`, feed that through, and confirm the assembled DER signature
+    /// carries the original low-S `s`.
+    #[test]
+    fn normalizes_high_s_signature() {
+        // secp256k1 group order n, big-endian.
+        const N: [u8; 32] = [
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C,
+            0xD0, 0x36, 0x41, 0x41,
+        ];
+
+        /// Big-endian `a - b` for 32-byte values, assuming `a >= b`.
+        fn sub_be(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
+            let mut out = [0u8; 32];
+            let mut borrow = 0i16;
+            for i in (0..32).rev() {
+                let diff = a[i] as i16 - b[i] as i16 - borrow;
+                if diff < 0 {
+                    out[i] = (diff + 256) as u8;
+                    borrow = 1;
+                } else {
+                    out[i] = diff as u8;
+                    borrow = 0;
+                }
+            }
+            out
+        }
+
+        let (low_s_hex, pubkey_hex, script, sighash) = sig_pubkey_script(0x55, 0x66);
+        let low_compact: [u8; 32 * 2] = hex::decode(&low_s_hex).unwrap().try_into().unwrap();
+        let low_s: [u8; 32] = low_compact[32..].try_into().unwrap();
+
+        // High-S form: r unchanged, s -> n - s.
+        let high_s = sub_be(&N, &low_s);
+        let mut high_compact = low_compact;
+        high_compact[32..].copy_from_slice(&high_s);
+
+        let witness =
+            assemble_p2wpkh_witness(&hex::encode(high_compact), &pubkey_hex, &script, &sighash)
+                .expect("assembles even when handed a high-S signature");
+        let items: Vec<&[u8]> = witness.iter().collect();
+        let der = &items[0][..items[0].len() - 1];
+        let assembled_s = SecpSignature::from_der(der)
+            .expect("der")
+            .serialize_compact()[32..]
+            .to_vec();
+        assert_eq!(
+            assembled_s, low_s,
+            "high-S input must be normalized back to the low-S form"
+        );
+    }
+
+    /// End-to-end: sign a real BIP-143 sighash for a P2WPKH spend (standing in for Fireblocks),
+    /// assemble the witness, and confirm the DER signature it carries verifies against that
+    /// sighash under the signing key. This pins the load-bearing property of RAW signing — that
+    /// the assembled witness is actually valid for the transaction being spent.
+    #[test]
+    fn assembled_witness_signature_verifies_against_the_sighash() {
+        use bdk_wallet::bitcoin::{
+            absolute::LockTime, transaction::Version, Amount, OutPoint, Sequence, Transaction,
+            TxIn, TxOut,
+        };
+
+        use crate::general::fireblocks::tx;
+
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x42; 32]).unwrap();
+        let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
+        let compressed = CompressedPublicKey(pk);
+        let spk = ScriptBuf::new_p2wpkh(&compressed.wpubkey_hash());
+
+        let prevout = TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: spk.clone(),
+        };
+        let spending_tx = Transaction {
+            version: Version(3),
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(90_000),
+                script_pubkey: spk.clone(),
+            }],
+        };
+
+        let sighash = tx::p2wpkh_sighash(&spending_tx, 0, &[prevout]).expect("sighash");
+        let msg = Message::from_digest(sighash);
+        let sig = secp.sign_ecdsa(&msg, &sk);
+
+        let witness = assemble_p2wpkh_witness(
+            &hex::encode(sig.serialize_compact()),
+            &hex::encode(pk.serialize()),
+            &spk,
+            &sighash,
+        )
+        .expect("assembles");
+
+        // Drop the trailing SIGHASH_ALL byte, parse the DER signature, and verify it against the
+        // sighash under the signing pubkey.
+        let items: Vec<&[u8]> = witness.iter().collect();
+        let der = &items[0][..items[0].len() - 1];
+        let parsed = SecpSignature::from_der(der).expect("der signature");
+        secp.verify_ecdsa(&msg, &parsed, &pk)
+            .expect("witness signature verifies against the sighash");
+    }
+}

--- a/crates/operator-wallet/src/general/fireblocks/tx.rs
+++ b/crates/operator-wallet/src/general/fireblocks/tx.rs
@@ -1,0 +1,951 @@
+//! Unsigned-transaction construction for the Fireblocks backend: input selection, fee /
+//! change computation, and BIP-143 sighash derivation.
+//!
+//! Fireblocks doesn't build Bitcoin transactions for us (we use RAW signing), so this module
+//! does the work a BDK wallet would: pick P2WPKH inputs, size the fee from a predicted weight,
+//! add a change output when it clears dust, and emit the unsigned v3 (TRUC) transaction plus
+//! the per-input sighashes to sign.
+
+use std::collections::HashSet;
+
+use bdk_wallet::bitcoin::{
+    hashes::Hash,
+    transaction::{predict_weight, InputWeightPrediction, Version},
+    Amount, EcdsaSighashType, FeeRate, OutPoint, Script, ScriptBuf, Sequence, Transaction, TxIn,
+    TxOut, Witness,
+};
+
+use super::FireblocksError;
+use crate::general::{AnchorInfo, UtxoInfo};
+
+/// A chosen funding input: its outpoint and the prevout it spends (value + P2WPKH script).
+#[derive(Debug, Clone)]
+pub(super) struct FundingInput {
+    pub outpoint: OutPoint,
+    pub prevout: TxOut,
+}
+
+/// Greedily selects P2WPKH funding inputs (largest first) to cover `recipient_total` plus the
+/// transaction fee at `fee_rate`, optionally appending a change output to `change_spk`.
+///
+/// Only UTXOs whose `script_pubkey == deposit_spk` are eligible: the backend assumes a
+/// single-address vault so every input signs with the same key (see the module docs on
+/// `fireblocks.rs`). `exclude` and anchors-via-`deposit_spk` filtering are applied by the
+/// caller through `exclude`.
+///
+/// Returns the selected inputs and the change amount (`None` when the remainder is below the
+/// change output's dust threshold, in which case it is absorbed into the fee).
+pub(super) fn select_funding(
+    candidates: &[UtxoInfo],
+    exclude: &HashSet<OutPoint>,
+    deposit_spk: &Script,
+    recipient_outputs: &[TxOut],
+    change_spk: &Script,
+    fee_rate: FeeRate,
+) -> Result<(Vec<FundingInput>, Option<Amount>), FireblocksError> {
+    let recipient_total = recipient_outputs
+        .iter()
+        .try_fold(Amount::ZERO, |acc, o| acc.checked_add(o.value))
+        .ok_or_else(|| FireblocksError::TxBuild("recipient output total overflows".into()))?;
+
+    // Eligible UTXOs: at the deposit address, not excluded. Largest first to minimise input
+    // count (and thus fee); equal values tie-break by outpoint so a rebuild after a re-sync
+    // selects the same inputs in the same order and reproduces the same txid. The vault
+    // endpoint's response order is not a guarantee, and a same-fee rebuild with a different
+    // input order is a different txid the mempool rejects as a non-paying replacement.
+    let mut eligible: Vec<&UtxoInfo> = candidates
+        .iter()
+        .filter(|u| u.script_pubkey == *deposit_spk && !exclude.contains(&u.outpoint))
+        .collect();
+    eligible.sort_by_key(|u| (std::cmp::Reverse(u.amount), u.outpoint));
+
+    let recipient_lens: Vec<usize> = recipient_outputs
+        .iter()
+        .map(|o| o.script_pubkey.len())
+        .collect();
+    let change_dust = change_spk.minimal_non_dust();
+
+    let mut selected: Vec<FundingInput> = Vec::new();
+    let mut total_in = Amount::ZERO;
+
+    for u in eligible {
+        selected.push(FundingInput {
+            outpoint: u.outpoint,
+            prevout: TxOut {
+                value: u.amount,
+                script_pubkey: u.script_pubkey.clone(),
+            },
+        });
+        total_in = total_in
+            .checked_add(u.amount)
+            .ok_or_else(|| FireblocksError::TxBuild("input total overflows".into()))?;
+
+        // Fee if we add a change output, and if we don't.
+        let fee_with_change = fee_for(
+            selected.len(),
+            &recipient_lens,
+            Some(change_spk.len()),
+            fee_rate,
+        )?;
+        let fee_no_change = fee_for(selected.len(), &recipient_lens, None, fee_rate)?;
+
+        // Enough to cover outputs + fee with a change output that clears dust?
+        if let Some(rem) = total_in
+            .checked_sub(recipient_total)
+            .and_then(|r| r.checked_sub(fee_with_change))
+        {
+            if rem >= change_dust {
+                return Ok((selected, Some(rem)));
+            }
+        }
+        // Enough to cover outputs + fee with no change (remainder absorbed into fee)?
+        if recipient_total
+            .checked_add(fee_no_change)
+            .is_some_and(|need| total_in >= need)
+        {
+            return Ok((selected, None));
+        }
+    }
+
+    Err(FireblocksError::TxBuild(format!(
+        "insufficient funds: have {total_in}, need {recipient_total} + fee"
+    )))
+}
+
+/// Builds [`FundingInput`]s for an explicit input set, looking each outpoint up in `candidates`,
+/// and computes the change amount (dropping change below dust into the fee).
+///
+/// `candidates` is the synced UTXO snapshot, which is already filtered to the single deposit
+/// address (see `sync` in `fireblocks.rs`), so every found input is implicitly P2WPKH at that
+/// address; an outpoint not at the deposit address simply isn't in `candidates` and errors below.
+///
+/// Errors if any requested outpoint is absent from `candidates`, or if the chosen inputs can't
+/// cover `recipient_outputs` plus the fee at `fee_rate`.
+pub(super) fn funding_from_explicit(
+    candidates: &[UtxoInfo],
+    explicit_inputs: &[OutPoint],
+    recipient_outputs: &[TxOut],
+    change_spk: &Script,
+    fee_rate: FeeRate,
+) -> Result<(Vec<FundingInput>, Option<Amount>), FireblocksError> {
+    let mut funding = Vec::with_capacity(explicit_inputs.len());
+    let mut total_in = Amount::ZERO;
+    for op in explicit_inputs {
+        let u = candidates
+            .iter()
+            .find(|u| u.outpoint == *op)
+            .ok_or_else(|| {
+                FireblocksError::TxBuild(format!("explicit input {op} not in wallet UTXO set"))
+            })?;
+        funding.push(FundingInput {
+            outpoint: *op,
+            prevout: TxOut {
+                value: u.amount,
+                script_pubkey: u.script_pubkey.clone(),
+            },
+        });
+        total_in = total_in
+            .checked_add(u.amount)
+            .ok_or_else(|| FireblocksError::TxBuild("input total overflows".into()))?;
+    }
+
+    let recipient_total = recipient_outputs
+        .iter()
+        .try_fold(Amount::ZERO, |acc, o| acc.checked_add(o.value))
+        .ok_or_else(|| FireblocksError::TxBuild("recipient output total overflows".into()))?;
+    let recipient_lens: Vec<usize> = recipient_outputs
+        .iter()
+        .map(|o| o.script_pubkey.len())
+        .collect();
+    let fee_with_change = fee_for(
+        funding.len(),
+        &recipient_lens,
+        Some(change_spk.len()),
+        fee_rate,
+    )?;
+    let fee_no_change = fee_for(funding.len(), &recipient_lens, None, fee_rate)?;
+
+    let need_no_change = recipient_total
+        .checked_add(fee_no_change)
+        .ok_or_else(|| FireblocksError::TxBuild("recipient total + fee overflows".into()))?;
+    if total_in < need_no_change {
+        return Err(FireblocksError::TxBuild(format!(
+            "explicit inputs total {total_in} cannot cover {recipient_total} + fee"
+        )));
+    }
+    let change = total_in
+        .checked_sub(recipient_total)
+        .and_then(|r| r.checked_sub(fee_with_change))
+        .filter(|rem| *rem >= change_spk.minimal_non_dust());
+    Ok((funding, change))
+}
+
+/// Selects P2WPKH funding inputs (from `candidates` at `deposit_spk`, largest first) for a CPFP
+/// child so the `[parent, child]` package reaches `target_pkg_fee_rate`. The child spends the
+/// combined input (value `combined_value`) plus the selected inputs and pays a single change
+/// output; its fee is the package shortfall after the parent's own fee, floored at 1 sat/vB of
+/// the child's own vbytes (a sub-1-sat/vB v3 child is nonstandard under BIP-431/TRUC and
+/// `submitpackage` would reject the whole package).
+///
+/// `anchor` distinguishes the two combined-input shapes for the fee estimate: `None` means the
+/// combined input is the operator's own P2WPKH payout (every input is P2WPKH); `Some` means it
+/// is a foreign Taproot anchor whose witness shape the [`AnchorInfo`] describes. Encoding this
+/// as one parameter rather than a `bool` plus an `Option` makes the previously-representable
+/// contradiction ("not our payout, but also no anchor") impossible to construct.
+///
+/// Returns the funding inputs (possibly empty when the combined input alone covers the fee) and
+/// the child's output (change) value.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "cohesive CPFP fee-selection inputs; bundling into a struct would only add indirection"
+)]
+pub(super) fn select_cpfp_funding(
+    candidates: &[UtxoInfo],
+    exclude: &HashSet<OutPoint>,
+    deposit_spk: &Script,
+    combined_value: Amount,
+    anchor: Option<&AnchorInfo>,
+    parent_vsize: u64,
+    parent_fee: Amount,
+    target_pkg_fee_rate: FeeRate,
+    prior_child_fee: Option<Amount>,
+    change_spk: &Script,
+) -> Result<(Vec<FundingInput>, Amount), FireblocksError> {
+    let dust = change_spk.minimal_non_dust();
+    let change_len = change_spk.len();
+    // No foreign anchor means the combined input is the operator's own P2WPKH payout.
+    let combined_is_p2wpkh = anchor.is_none();
+
+    // Child output (change) for `n_funding` P2WPKH funding inputs contributing `funding_total`;
+    // `None` if it can't clear dust or the arithmetic overflows.
+    let try_fit = |n_funding: usize, funding_total: Amount| -> Option<Amount> {
+        let n_p2wpkh = n_funding + usize::from(combined_is_p2wpkh);
+        let child_vsize = cpfp_child_vsize(n_p2wpkh, anchor, change_len);
+        let package_fee = target_pkg_fee_rate.fee_vb(parent_vsize.saturating_add(child_vsize))?;
+        // The child makes up the package shortfall after the parent's fee, but must pay at least
+        // 1 sat/vB on its own vbytes. If the parent already overpays the target, floor the child
+        // to its own size. Same ≥1-sat/vB child floor as the native backend (`native.rs`
+        // build_cpfp_child), computed here on the actual predicted child vsize.
+        let shortfall = package_fee.checked_sub(parent_fee).unwrap_or(Amount::ZERO);
+        // Three floors, same as the native backend: the package shortfall, the child's own
+        // 1 sat/vB relay floor, and the BIP-125 rule 4 replacement floor (the replaced
+        // child's fee plus 1 sat/vB over this child's vbytes).
+        let rbf_floor = prior_child_fee
+            .and_then(|prior| prior.checked_add(Amount::from_sat(child_vsize)))
+            .unwrap_or(Amount::ZERO);
+        let child_fee = shortfall.max(Amount::from_sat(child_vsize)).max(rbf_floor);
+        combined_value
+            .checked_add(funding_total)
+            .and_then(|t| t.checked_sub(child_fee))
+            .filter(|out| *out >= dust)
+    };
+
+    // The combined input alone may already cover the package fee — common when CPFP-ing a payout
+    // whose value dwarfs the bump fee.
+    if let Some(child_output) = try_fit(0, Amount::ZERO) {
+        return Ok((Vec::new(), child_output));
+    }
+
+    // Largest first, equal values tie-broken by outpoint: a CPFP rebuild after a re-sync
+    // must select the same inputs in the same order so the resubmitted child deduplicates
+    // by txid instead of surfacing as a same-fee BIP-125 replacement the mempool rejects.
+    let mut eligible: Vec<&UtxoInfo> = candidates
+        .iter()
+        .filter(|u| u.script_pubkey == *deposit_spk && !exclude.contains(&u.outpoint))
+        .collect();
+    eligible.sort_by_key(|u| (std::cmp::Reverse(u.amount), u.outpoint));
+
+    let mut selected: Vec<FundingInput> = Vec::new();
+    let mut funding_total = Amount::ZERO;
+    for u in eligible {
+        selected.push(FundingInput {
+            outpoint: u.outpoint,
+            prevout: TxOut {
+                value: u.amount,
+                script_pubkey: u.script_pubkey.clone(),
+            },
+        });
+        funding_total = funding_total
+            .checked_add(u.amount)
+            .ok_or_else(|| FireblocksError::TxBuild("input total overflows".into()))?;
+        if let Some(child_output) = try_fit(selected.len(), funding_total) {
+            return Ok((selected, child_output));
+        }
+    }
+    Err(FireblocksError::TxBuild(
+        "insufficient funds to build CPFP child at target package fee rate".into(),
+    ))
+}
+
+/// Predicted fee for a transaction with `n_p2wpkh_inputs` P2WPKH inputs, the given recipient
+/// output script lengths, and an optional change output of `change_spk_len` bytes.
+pub(super) fn fee_for(
+    n_p2wpkh_inputs: usize,
+    recipient_output_lens: &[usize],
+    change_spk_len: Option<usize>,
+    fee_rate: FeeRate,
+) -> Result<Amount, FireblocksError> {
+    let inputs = std::iter::repeat_n(InputWeightPrediction::P2WPKH_MAX, n_p2wpkh_inputs);
+    let output_lens = recipient_output_lens.iter().copied().chain(change_spk_len);
+    let weight = predict_weight(inputs, output_lens);
+    fee_rate
+        .fee_wu(weight)
+        .ok_or_else(|| FireblocksError::TxBuild("fee computation overflowed".into()))
+}
+
+/// Predicted vsize of a CPFP child with `n_p2wpkh` P2WPKH inputs, optionally preceded by a
+/// foreign anchor input, plus a single change output. `anchor` is `None` for the
+/// `ParentTxCombined` case, where the combined input is the operator's own vault output and every
+/// input is therefore P2WPKH.
+///
+/// The anchor's witness size is derived from the anchor itself rather than assumed. A key-path
+/// anchor is a bare 64-byte signature, but a `MultiAnchor` leaf is satisfied script-path and also
+/// carries the leaf script and control block — roughly three times the witness. This matters more
+/// here than in the native backend: this prediction is turned into an *absolute* child fee by
+/// [`select_cpfp_funding`], so under-predicting silently lands the package below the target fee
+/// rate, whereas BDK is handed a fee *rate* and sizes to it.
+pub(super) fn cpfp_child_vsize(
+    n_p2wpkh: usize,
+    anchor: Option<&AnchorInfo>,
+    change_spk_len: usize,
+) -> u64 {
+    let anchor_prediction = anchor.map(|anchor| match anchor {
+        AnchorInfo::KeyPath { .. } => InputWeightPrediction::P2TR_KEY_DEFAULT_SIGHASH,
+        AnchorInfo::ScriptPath {
+            leaf_script,
+            control_block,
+            ..
+        } => {
+            InputWeightPrediction::new(0, [64, leaf_script.len(), control_block.serialize().len()])
+        }
+    });
+    let inputs = anchor_prediction.into_iter().chain(std::iter::repeat_n(
+        InputWeightPrediction::P2WPKH_MAX,
+        n_p2wpkh,
+    ));
+    predict_weight(inputs, [change_spk_len]).to_vbytes_ceil()
+}
+
+/// Assembles the unsigned v3 (TRUC) transaction from already-chosen inputs and outputs.
+///
+/// Inputs are emitted in the given order with empty witnesses and RBF-signalling sequences;
+/// `recipient_outputs` come first, followed by the change output (if `change` is `Some`).
+pub(super) fn build_unsigned_v3(
+    inputs: &[TxIn],
+    recipient_outputs: Vec<TxOut>,
+    change: Option<TxOut>,
+) -> Transaction {
+    let mut output = recipient_outputs;
+    if let Some(change) = change {
+        output.push(change);
+    }
+    Transaction {
+        version: Version(3),
+        lock_time: bdk_wallet::bitcoin::absolute::LockTime::ZERO,
+        input: inputs.to_vec(),
+        output,
+    }
+}
+
+/// Builds a [`TxIn`] spending `outpoint` with an RBF-signalling sequence and an empty witness.
+pub(super) const fn txin(outpoint: OutPoint) -> TxIn {
+    TxIn {
+        previous_output: outpoint,
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::new(),
+    }
+}
+
+/// Computes the BIP-143 sighash (SIGHASH_ALL) for the P2WPKH input at `input_index` of `tx`.
+/// `prevouts[i]` must be the output spent by `tx.input[i]`.
+pub(super) fn p2wpkh_sighash(
+    tx: &Transaction,
+    input_index: usize,
+    prevouts: &[TxOut],
+) -> Result<[u8; 32], FireblocksError> {
+    let prevout = prevouts
+        .get(input_index)
+        .ok_or_else(|| FireblocksError::TxBuild(format!("no prevout for input {input_index}")))?;
+    let mut cache = bdk_wallet::bitcoin::sighash::SighashCache::new(tx);
+    let sighash = cache
+        .p2wpkh_signature_hash(
+            input_index,
+            &prevout.script_pubkey,
+            prevout.value,
+            EcdsaSighashType::All,
+        )
+        .map_err(|e| {
+            FireblocksError::TxBuild(format!("p2wpkh sighash (input {input_index}): {e}"))
+        })?;
+    Ok(sighash.to_byte_array())
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::bitcoin::{hashes::Hash, key::Secp256k1, Address, Network, Txid};
+
+    use super::*;
+
+    fn deposit_spk() -> ScriptBuf {
+        let kp =
+            bdk_wallet::bitcoin::key::Keypair::from_seckey_slice(&Secp256k1::new(), &[7u8; 32])
+                .unwrap();
+        // A P2WPKH address derived from the compressed key.
+        let pk = bdk_wallet::bitcoin::PublicKey::new(kp.public_key());
+        Address::p2wpkh(
+            &bdk_wallet::bitcoin::CompressedPublicKey(pk.inner),
+            Network::Regtest,
+        )
+        .script_pubkey()
+    }
+
+    fn utxo(spk: &ScriptBuf, sats: u64, seed: u8) -> UtxoInfo {
+        UtxoInfo {
+            outpoint: OutPoint {
+                txid: Txid::from_byte_array([seed; 32]),
+                vout: 0,
+            },
+            amount: Amount::from_sat(sats),
+            confirmations: 1,
+            script_pubkey: spk.clone(),
+        }
+    }
+
+    #[test]
+    fn selects_single_input_with_change() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 100_000, 1)];
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(40_000),
+            script_pubkey: spk.clone(),
+        }];
+        let (inputs, change) = select_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .expect("selection succeeds");
+        assert_eq!(inputs.len(), 1);
+        // Change should be present and well under the 60k surplus (after fee).
+        let change = change.expect("change present");
+        assert!(change > Amount::ZERO && change < Amount::from_sat(60_000));
+    }
+
+    #[test]
+    fn skips_utxos_not_at_deposit_address() {
+        let spk = deposit_spk();
+        let other = ScriptBuf::from_hex("0014000000000000000000000000000000000000beef").unwrap();
+        let candidates = vec![utxo(&other, 100_000, 2)];
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(10_000),
+            script_pubkey: spk.clone(),
+        }];
+        let err = select_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FireblocksError::TxBuild(_)));
+    }
+
+    #[test]
+    fn insufficient_funds_errors() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 5_000, 3)];
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(10_000),
+            script_pubkey: spk.clone(),
+        }];
+        assert!(select_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn selects_multiple_inputs_when_one_is_short() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 30_000, 1), utxo(&spk, 30_000, 2)];
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(45_000),
+            script_pubkey: spk.clone(),
+        }];
+        let (inputs, _change) = select_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .expect("two inputs cover the recipient");
+        assert_eq!(inputs.len(), 2);
+    }
+
+    #[test]
+    fn absorbs_sub_dust_remainder_into_fee() {
+        let spk = deposit_spk();
+        // Pick an input value that leaves only a few sats over recipient+fee — below the change
+        // dust threshold, so the remainder is absorbed into the fee (no change output).
+        let recipient_value = 40_000u64;
+        let fee = fee_for(1, &[spk.len()], None, FeeRate::from_sat_per_vb(2).unwrap())
+            .unwrap()
+            .to_sat();
+        let candidates = vec![utxo(&spk, recipient_value + fee + 10, 4)];
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(recipient_value),
+            script_pubkey: spk.clone(),
+        }];
+        let (inputs, change) = select_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .expect("covers recipient + fee");
+        assert_eq!(inputs.len(), 1);
+        assert!(
+            change.is_none(),
+            "sub-dust remainder must be absorbed into the fee"
+        );
+    }
+
+    #[test]
+    fn keeps_change_exactly_at_dust_threshold() {
+        let spk = deposit_spk();
+        let rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let recipient_value = 40_000u64;
+        let dust = spk.minimal_non_dust().to_sat();
+        // Fee for the single-input, one-recipient-plus-change layout this selection produces.
+        let fee = fee_for(1, &[spk.len()], Some(spk.len()), rate)
+            .unwrap()
+            .to_sat();
+        // Fund exactly recipient + fee + dust, so the remainder lands precisely on the inclusive
+        // `>= dust` boundary and must be kept as change.
+        let candidates = vec![utxo(&spk, recipient_value + fee + dust, 5)];
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(recipient_value),
+            script_pubkey: spk.clone(),
+        }];
+        let (inputs, change) =
+            select_funding(&candidates, &HashSet::new(), &spk, &recipient, &spk, rate)
+                .expect("covers recipient + fee + dust change");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(
+            change.expect("change at the dust boundary is kept"),
+            Amount::from_sat(dust)
+        );
+    }
+
+    #[test]
+    fn excludes_listed_outpoints() {
+        let spk = deposit_spk();
+        let u = utxo(&spk, 100_000, 7);
+        let mut exclude = HashSet::new();
+        exclude.insert(u.outpoint);
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(10_000),
+            script_pubkey: spk.clone(),
+        }];
+        assert!(select_funding(
+            &[u],
+            &exclude,
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .is_err());
+    }
+
+    /// Equal-value UTXOs must select in a stable, outpoint-sorted order regardless of the
+    /// order the vault endpoint returned them in. A rebuild that walked the raw response
+    /// order could emit the same-fee transaction with a different txid, which the mempool
+    /// rejects as a non-paying BIP-125 replacement instead of deduplicating.
+    #[test]
+    fn equal_value_utxos_select_in_stable_outpoint_order() {
+        let spk = deposit_spk();
+        // Deliberately not in outpoint order: the response order must not leak through.
+        let candidates = vec![
+            utxo(&spk, 50_000, 9),
+            utxo(&spk, 50_000, 1),
+            utxo(&spk, 50_000, 5),
+        ];
+        // Two inputs cover this; the third stays unselected.
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(80_000),
+            script_pubkey: spk.clone(),
+        }];
+        let (inputs, _) = select_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .expect("selection succeeds");
+        let mut expected: Vec<OutPoint> = candidates.iter().map(|u| u.outpoint).collect();
+        expected.sort();
+        expected.truncate(2);
+        let picked: Vec<OutPoint> = inputs.iter().map(|i| i.outpoint).collect();
+        assert_eq!(
+            picked, expected,
+            "equal-value inputs must select in outpoint order"
+        );
+    }
+
+    /// Same stable-order pin for the CPFP funding selection: with two equal-value
+    /// candidates and a one-input shortfall, the lower outpoint wins every time.
+    #[test]
+    fn cpfp_equal_value_utxos_select_lowest_outpoint() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 50_000, 9), utxo(&spk, 50_000, 1)];
+        let (funding, _) = select_cpfp_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            Amount::from_sat(400), // tiny combined input: our own P2WPKH payout (no anchor)
+            None,
+            150,
+            Amount::ZERO,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            None,
+            &spk,
+        )
+        .expect("a funding input covers the shortfall");
+        let expected = candidates.iter().map(|u| u.outpoint).min().unwrap();
+        assert_eq!(funding.len(), 1);
+        assert_eq!(
+            funding[0].outpoint, expected,
+            "equal-value CPFP funding must pick the lowest outpoint"
+        );
+    }
+
+    #[test]
+    fn explicit_funding_with_change() {
+        let spk = deposit_spk();
+        let u = utxo(&spk, 100_000, 1);
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(40_000),
+            script_pubkey: spk.clone(),
+        }];
+        let (inputs, change) = funding_from_explicit(
+            std::slice::from_ref(&u),
+            &[u.outpoint],
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .expect("explicit input covers recipient");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].outpoint, u.outpoint);
+        assert!(change.expect("change present") > Amount::ZERO);
+    }
+
+    #[test]
+    fn explicit_funding_change_at_and_below_dust_boundary() {
+        let spk = deposit_spk();
+        let rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let recipient_value = 40_000u64;
+        let dust = spk.minimal_non_dust().to_sat();
+        let fee = fee_for(1, &[spk.len()], Some(spk.len()), rate)
+            .unwrap()
+            .to_sat();
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(recipient_value),
+            script_pubkey: spk.clone(),
+        }];
+
+        // Exactly at the inclusive `>= dust` boundary: change is kept.
+        let at = utxo(&spk, recipient_value + fee + dust, 1);
+        let (_, change) = funding_from_explicit(
+            std::slice::from_ref(&at),
+            &[at.outpoint],
+            &recipient,
+            &spk,
+            rate,
+        )
+        .expect("covers recipient + fee + dust");
+        assert_eq!(
+            change.expect("change at dust boundary kept"),
+            Amount::from_sat(dust)
+        );
+
+        // One sat below dust: remainder is absorbed into the fee (no change output).
+        let below = utxo(&spk, recipient_value + fee + dust - 1, 2);
+        let (_, change) = funding_from_explicit(
+            std::slice::from_ref(&below),
+            &[below.outpoint],
+            &recipient,
+            &spk,
+            rate,
+        )
+        .expect("covers recipient + fee");
+        assert!(
+            change.is_none(),
+            "sub-dust remainder is absorbed into the fee"
+        );
+    }
+
+    #[test]
+    fn explicit_funding_missing_input_errors() {
+        let spk = deposit_spk();
+        let present = utxo(&spk, 100_000, 1);
+        let missing = utxo(&spk, 100_000, 2);
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(10_000),
+            script_pubkey: spk.clone(),
+        }];
+        let err = funding_from_explicit(
+            &[present],
+            &[missing.outpoint],
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FireblocksError::TxBuild(_)));
+    }
+
+    #[test]
+    fn explicit_funding_insufficient_errors() {
+        let spk = deposit_spk();
+        let u = utxo(&spk, 5_000, 1);
+        let recipient = vec![TxOut {
+            value: Amount::from_sat(10_000),
+            script_pubkey: spk.clone(),
+        }];
+        assert!(funding_from_explicit(
+            std::slice::from_ref(&u),
+            &[u.outpoint],
+            &recipient,
+            &spk,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn cpfp_combined_input_alone_covers_fee() {
+        let spk = deposit_spk();
+        // A large own-payout combined input dwarfs the bump fee, so no funding is pulled.
+        let (funding, child_output) = select_cpfp_funding(
+            &[],
+            &HashSet::new(),
+            &spk,
+            Amount::from_sat(100_000), // combined value: our own P2WPKH payout (no anchor)
+            None,
+            150,          // parent vsize
+            Amount::ZERO, // parent fee
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            None,
+            &spk,
+        )
+        .expect("combined input alone covers the fee");
+        assert!(funding.is_empty());
+        assert!(child_output >= spk.minimal_non_dust());
+    }
+
+    #[test]
+    fn cpfp_pulls_funding_when_combined_is_short() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 50_000, 9)];
+        let (funding, child_output) = select_cpfp_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            Amount::from_sat(400), // tiny combined input: our own P2WPKH payout (no anchor)
+            None,
+            150,
+            Amount::ZERO,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            None,
+            &spk,
+        )
+        .expect("a funding input covers the shortfall");
+        assert_eq!(funding.len(), 1);
+        assert!(child_output >= spk.minimal_non_dust());
+    }
+
+    #[test]
+    fn cpfp_foreign_taproot_anchor_pulls_funding() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 50_000, 9)];
+        let (funding, child_output) = select_cpfp_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            Amount::from_sat(330), // foreign keyed-Taproot anchor value
+            Some(&super::anchor_vsize_tests::key_path_anchor()),
+            150,
+            Amount::ZERO,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            None,
+            &spk,
+        )
+        .expect("funding covers the package fee");
+        assert_eq!(funding.len(), 1);
+        assert!(child_output >= spk.minimal_non_dust());
+    }
+
+    /// Same shape as the keyed-anchor test but with a script-path (`MultiAnchor`-leaf) anchor,
+    /// so the funding-selection path is exercised with the larger witness prediction that
+    /// commit bb338dc2 introduced — previously no test reached it.
+    #[test]
+    fn cpfp_script_path_anchor_pulls_funding() {
+        let spk = deposit_spk();
+        let candidates = vec![utxo(&spk, 50_000, 9)];
+        let (funding, child_output) = select_cpfp_funding(
+            &candidates,
+            &HashSet::new(),
+            &spk,
+            Amount::from_sat(330),
+            Some(&super::anchor_vsize_tests::script_path_anchor()),
+            150,
+            Amount::ZERO,
+            FeeRate::from_sat_per_vb(2).unwrap(),
+            None,
+            &spk,
+        )
+        .expect("funding covers the package fee");
+        assert_eq!(funding.len(), 1);
+        assert!(child_output >= spk.minimal_non_dust());
+    }
+
+    #[test]
+    fn cpfp_insufficient_funds_errors() {
+        let spk = deposit_spk();
+        let err = select_cpfp_funding(
+            &[],
+            &HashSet::new(),
+            &spk,
+            Amount::from_sat(330),
+            Some(&super::anchor_vsize_tests::key_path_anchor()),
+            150,
+            Amount::ZERO,
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            None,
+            &spk,
+        )
+        .unwrap_err();
+        assert!(matches!(err, FireblocksError::TxBuild(_)));
+    }
+}
+
+#[cfg(test)]
+mod anchor_vsize_tests {
+    use bdk_wallet::bitcoin::{
+        key::Secp256k1,
+        opcodes, script,
+        taproot::{LeafVersion, TaprootBuilder},
+        Network, ScriptBuf, XOnlyPublicKey,
+    };
+
+    use super::*;
+
+    fn watchtower_leaf(byte: u8) -> ScriptBuf {
+        let kp = bdk_wallet::bitcoin::key::Keypair::from_seckey_slice(
+            &Secp256k1::new(),
+            &[byte.max(1); 32],
+        )
+        .unwrap();
+        let (xonly, _): (XOnlyPublicKey, _) = kp.x_only_public_key();
+        script::Builder::new()
+            .push_slice(xonly.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script()
+    }
+
+    /// Builds a 3-leaf tree and returns the `ScriptPath` anchor for leaf 0.
+    pub(super) fn script_path_anchor() -> AnchorInfo {
+        let secp = Secp256k1::new();
+        let leaves: Vec<ScriptBuf> = (0..3).map(watchtower_leaf).collect();
+        let mut builder = TaprootBuilder::new();
+        for (i, leaf) in leaves.iter().enumerate() {
+            let depth = if i < 2 { 2 } else { 1 };
+            builder = builder.add_leaf(depth as u8, leaf.clone()).unwrap();
+        }
+        let internal = watchtower_leaf(99);
+        let internal_key = XOnlyPublicKey::from_slice(&internal.as_bytes()[1..33]).unwrap();
+        let spend_info = builder.finalize(&secp, internal_key).unwrap();
+        let control_block = spend_info
+            .control_block(&(leaves[0].clone(), LeafVersion::TapScript))
+            .unwrap();
+        AnchorInfo::ScriptPath {
+            vout: 0,
+            leaf_script: leaves[0].clone(),
+            control_block,
+        }
+    }
+
+    pub(super) fn key_path_anchor() -> AnchorInfo {
+        let internal = watchtower_leaf(42);
+        AnchorInfo::KeyPath {
+            vout: 0,
+            internal_key: XOnlyPublicKey::from_slice(&internal.as_bytes()[1..33]).unwrap(),
+        }
+    }
+
+    fn change_len() -> usize {
+        bdk_wallet::bitcoin::Address::p2wpkh(
+            &bdk_wallet::bitcoin::CompressedPublicKey(
+                bdk_wallet::bitcoin::key::Keypair::from_seckey_slice(&Secp256k1::new(), &[3u8; 32])
+                    .unwrap()
+                    .public_key(),
+            ),
+            Network::Regtest,
+        )
+        .script_pubkey()
+        .len()
+    }
+
+    /// A script-path anchor carries a leaf script and control block on top of the signature, so
+    /// the child is materially larger than a key-path one. `select_cpfp_funding` turns this vsize
+    /// into an *absolute* fee, so predicting the key-path size for a script-path anchor lands the
+    /// whole package under the target fee rate — silently, on the time-critical contest path.
+    #[test]
+    fn script_path_anchor_predicts_larger_child_than_key_path() {
+        let change = change_len();
+        let key_path = cpfp_child_vsize(1, Some(&key_path_anchor()), change);
+        let script_path = cpfp_child_vsize(1, Some(&script_path_anchor()), change);
+
+        assert!(
+            script_path > key_path,
+            "script-path child ({script_path} vB) must be predicted larger than key-path \
+             ({key_path} vB); equality means the anchor witness is being ignored"
+        );
+        // Sig is shared; the extra is the leaf script (~34 B) + control block (~65 B at depth 2),
+        // each with a length prefix, all at witness discount.
+        assert!(
+            (script_path - key_path) >= 24,
+            "expected at least ~24 vB of extra witness, got {}",
+            script_path - key_path
+        );
+    }
+
+    /// No anchor at all (`ParentTxCombined`) must be smaller still — every input is P2WPKH.
+    #[test]
+    fn absent_anchor_predicts_smallest_child() {
+        let change = change_len();
+        assert!(
+            cpfp_child_vsize(1, None, change)
+                < cpfp_child_vsize(1, Some(&key_path_anchor()), change)
+        );
+    }
+}

--- a/crates/operator-wallet/src/general/fireblocks/tx.rs
+++ b/crates/operator-wallet/src/general/fireblocks/tx.rs
@@ -25,6 +25,10 @@ pub(super) struct FundingInput {
     pub prevout: TxOut,
 }
 
+/// BIP-431 caps a v3 transaction that has an unconfirmed v3 ancestor at this size. The CPFP
+/// child always has such an ancestor: the parent it exists to pay for.
+const TRUC_CHILD_MAX_VBYTES: u64 = 1000;
+
 /// Greedily selects P2WPKH funding inputs (largest first) to cover `recipient_total` plus the
 /// transaction fee at `fee_rate`, optionally appending a change output to `change_spk`.
 ///
@@ -246,18 +250,33 @@ pub(super) fn select_cpfp_funding(
         return Ok((Vec::new(), child_output));
     }
 
+    // Confirmed funding only. The child already has one unconfirmed parent (the CPFP
+    // parent itself), and TRUC caps a v3 child of an unconfirmed v3 parent at that one
+    // ancestor. A second unconfirmed input makes the whole package unrelayable. The native
+    // backend applies the same rule in `is_spendable_funding`.
+    //
     // Largest first, equal values tie-broken by outpoint: a CPFP rebuild after a re-sync
     // must select the same inputs in the same order so the resubmitted child deduplicates
     // by txid instead of surfacing as a same-fee BIP-125 replacement the mempool rejects.
     let mut eligible: Vec<&UtxoInfo> = candidates
         .iter()
-        .filter(|u| u.script_pubkey == *deposit_spk && !exclude.contains(&u.outpoint))
+        .filter(|u| {
+            u.script_pubkey == *deposit_spk && u.confirmations > 0 && !exclude.contains(&u.outpoint)
+        })
         .collect();
     eligible.sort_by_key(|u| (std::cmp::Reverse(u.amount), u.outpoint));
 
     let mut selected: Vec<FundingInput> = Vec::new();
     let mut funding_total = Amount::ZERO;
     for u in eligible {
+        // Stop before the child breaks the TRUC size limit. BIP-431 caps a v3 transaction
+        // with an unconfirmed v3 ancestor at 1000 vB. A child past that limit cannot enter
+        // any mempool, so a clean insufficient-funds error beats an unrelayable build. The
+        // native backend applies the same bound in `select_funding`.
+        let next_n_p2wpkh = selected.len() + 1 + usize::from(combined_is_p2wpkh);
+        if cpfp_child_vsize(next_n_p2wpkh, anchor, change_len) > TRUC_CHILD_MAX_VBYTES {
+            break;
+        }
         selected.push(FundingInput {
             outpoint: u.outpoint,
             prevout: TxOut {
@@ -410,6 +429,99 @@ mod tests {
             confirmations: 1,
             script_pubkey: spk.clone(),
         }
+    }
+
+    fn unconfirmed_utxo(spk: &ScriptBuf, sats: u64, seed: u8) -> UtxoInfo {
+        UtxoInfo {
+            confirmations: 0,
+            ..utxo(spk, sats, seed)
+        }
+    }
+
+    /// A wallet of dust cannot fund past the TRUC size limit. BIP-431 caps the child at
+    /// 1000 vB, which roughly 14 P2WPKH inputs exceed. The selection must stop with a
+    /// clean error instead of a child that no mempool accepts. A single large UTXO under
+    /// the same demand builds, so the size bound is the only difference under test.
+    #[test]
+    fn cpfp_funding_stops_at_the_truc_size_limit() {
+        let spk = deposit_spk();
+        let combined = Amount::from_sat(500);
+        // A high target that many small inputs cannot satisfy inside 1000 vB.
+        let target = FeeRate::from_sat_per_vb(500).unwrap();
+
+        let dust_wallet: Vec<UtxoInfo> = (0..40).map(|i| utxo(&spk, 3_000, i as u8)).collect();
+        let err = select_cpfp_funding(
+            &dust_wallet,
+            &HashSet::new(),
+            &spk,
+            combined,
+            None,
+            150,
+            Amount::ZERO,
+            target,
+            None,
+            &spk,
+        );
+        assert!(err.is_err(), "a dust wallet must stop at the size bound");
+
+        let single_large = vec![utxo(&spk, 10_000_000, 1)];
+        let ok = select_cpfp_funding(
+            &single_large,
+            &HashSet::new(),
+            &spk,
+            combined,
+            None,
+            150,
+            Amount::ZERO,
+            target,
+            None,
+            &spk,
+        );
+        assert!(
+            ok.is_ok(),
+            "one large input under the same demand must build"
+        );
+    }
+
+    /// CPFP funding must not select unconfirmed UTXOs. The child already has one
+    /// unconfirmed parent, and a second unconfirmed input breaks the TRUC one-parent-
+    /// one-child shape: bitcoind rejects the whole package. The confirmed twin of the
+    /// same candidate set builds, so the filter is the only difference under test.
+    #[test]
+    fn cpfp_funding_skips_unconfirmed_utxos() {
+        let spk = deposit_spk();
+        let combined = Amount::from_sat(500);
+        let target = FeeRate::from_sat_per_vb(20).unwrap();
+
+        let unconfirmed = vec![unconfirmed_utxo(&spk, 100_000, 1)];
+        let err = select_cpfp_funding(
+            &unconfirmed,
+            &HashSet::new(),
+            &spk,
+            combined,
+            None,
+            150,
+            Amount::ZERO,
+            target,
+            None,
+            &spk,
+        );
+        assert!(err.is_err(), "an unconfirmed-only wallet must not fund");
+
+        let confirmed = vec![utxo(&spk, 100_000, 1)];
+        let ok = select_cpfp_funding(
+            &confirmed,
+            &HashSet::new(),
+            &spk,
+            combined,
+            None,
+            150,
+            Amount::ZERO,
+            target,
+            None,
+            &spk,
+        );
+        assert!(ok.is_ok(), "the confirmed twin must fund");
     }
 
     #[test]

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -12,8 +12,8 @@ use std::{
 
 use bdk_wallet::{
     bitcoin::{
-        psbt::Input as PsbtInput, taproot::LeafVersion, Amount, FeeRate, Network, OutPoint, Psbt,
-        ScriptBuf, Transaction, TxOut, XOnlyPublicKey,
+        psbt::Input as PsbtInput, taproot::LeafVersion, Address, Amount, FeeRate, Network,
+        OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Witness, XOnlyPublicKey,
     },
     descriptor,
     error::CreateTxError,
@@ -156,6 +156,31 @@ impl GeneralWallet for NativeGeneralWallet {
         self.script_pubkey.clone()
     }
 
+    fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
+        // The wallet's own receive script (the BIP-341 tap-tweaked general key), wrapped as
+        // a BOSD descriptor — the same construction `OperatorWallet::descriptor()` used
+        // before this became backend-specific. Deriving it from the receive script makes
+        // divergence structurally impossible: payouts land on an ordinary wallet UTXO that
+        // BDK tracks, and the tap-tweaking wallet signer can spend (and CPFP-bump) it.
+        //
+        // Wrapping the *raw* general key instead would be subtly catastrophic: BOSD treats
+        // a P2TR payload as the already-tweaked OUTPUT key (`dangerous_assume_tweaked`), so
+        // the payout output would be keyed to an untweaked point — invisible to the BDK
+        // descriptor and unspendable by every signer wired in production (they all
+        // tap-tweak).
+        //
+        // Known window (STR-3427, lease lifecycle): because payouts are ordinary wallet
+        // UTXOs, an in-mempool payout output is auto-selectable as funding by a concurrent
+        // duty until a bump child spends it — leases only cover child-selected funding
+        // inputs, never the payout outpoint itself. Bounded consequence: the duty tx ends
+        // up as the parent's de-facto TRUC child (it pays real fees, so the parent still
+        // confirms) and any later explicit bump bounces off RBF against it, noisily.
+        let address = Address::from_script(&self.script_pubkey, self.wallet.network())
+            .expect("wallet receive script is a standard P2TR script");
+        bitcoin_bosd::Descriptor::try_from(address)
+            .expect("standard address converts to a BOSD descriptor")
+    }
+
     fn list_utxos(&self) -> Vec<UtxoInfo> {
         let wallet = lock_wallet(&self.wallet);
         let tip = wallet.latest_checkpoint().height();
@@ -200,6 +225,17 @@ impl GeneralWallet for NativeGeneralWallet {
             exclude,
             replaced,
         )
+    }
+
+    async fn sign_owned_inputs(
+        &self,
+        _tx: &Transaction,
+        input_indices: &[usize],
+        _prevouts: &[TxOut],
+    ) -> Result<Vec<Option<Witness>>, Self::Error> {
+        // Descriptor-only: this backend holds no key material, so it signs nothing — the caller
+        // signs these inputs downstream via secret-service.
+        Ok(vec![None; input_indices.len()])
     }
 }
 

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -158,8 +158,8 @@ impl GeneralWallet for NativeGeneralWallet {
 
     fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
         // The wallet's own receive script (the BIP-341 tap-tweaked general key), wrapped as
-        // a BOSD descriptor — the same construction `OperatorWallet::descriptor()` used
-        // before this became backend-specific. Deriving it from the receive script makes
+        // a BOSD descriptor — the same construction the operator wallet used before this
+        // became backend-specific. Deriving it from the receive script makes
         // divergence structurally impossible: payouts land on an ordinary wallet UTXO that
         // BDK tracks, and the tap-tweaking wallet signer can spend (and CPFP-bump) it.
         //
@@ -175,7 +175,8 @@ impl GeneralWallet for NativeGeneralWallet {
         // inputs, never the payout outpoint itself. Bounded consequence: the duty tx ends
         // up as the parent's de-facto TRUC child (it pays real fees, so the parent still
         // confirms) and any later explicit bump bounces off RBF against it, noisily.
-        let address = Address::from_script(&self.script_pubkey, self.wallet.network())
+        let wallet = lock_wallet(&self.wallet);
+        let address = Address::from_script(&self.script_pubkey, wallet.network())
             .expect("wallet receive script is a standard P2TR script");
         bitcoin_bosd::Descriptor::try_from(address)
             .expect("standard address converts to a BOSD descriptor")

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -13,6 +13,7 @@
 //! Methods on [`OperatorWallet`] are `&mut self`. Callers serialize via an outer lock when
 //! they need a multi-step critical section (e.g. DB-lookup-then-fund-then-persist).
 
+pub mod any;
 pub mod config;
 pub mod general;
 pub mod leases;
@@ -28,6 +29,7 @@ use serial_test as _;
 use thiserror::Error;
 
 pub use crate::{
+    any::AnyOperatorWallet,
     config::OperatorWalletConfig,
     general::{
         native::NativeGeneralWallet, AnchorInfo, AnchorOwnership, FundedPsbt, GeneralWallet,

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -23,7 +23,7 @@
 //! Callers still take the exclusive outer lock for a multi-step critical section, such as a
 //! database lookup, then funding, then a write.
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc, time::Instant};
 
 use bdk_wallet::{
     bitcoin::{
@@ -116,6 +116,14 @@ pub struct OperatorWallet<G: GeneralWallet> {
     /// paths take it as well, so that an await added to one of them later cannot open the gap
     /// without notice.
     funding: TokioMutex<()>,
+    /// Outcome and time of the most recent general-backend sync attempt. `None` before
+    /// the first attempt. Kept per-backend because the reserved wallet's chain tip
+    /// advances even while the general backend fails every sync (the two sync
+    /// independently inside [`Self::sync`]), so the tip alone cannot represent
+    /// general-backend health. The timestamp lets the probe report a stale verdict as
+    /// degraded: syncs are duty-driven, so an old success on an idle bridge is a weaker
+    /// signal than a fresh one.
+    last_general_sync: Option<(bool, Instant)>,
 }
 
 impl<G: GeneralWallet> OperatorWallet<G> {
@@ -150,6 +158,7 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             config,
             leases: Arc::new(LeaseSet::with_committed(initial_leases)),
             funding: TokioMutex::new(()),
+            last_general_sync: None,
         }
     }
 
@@ -221,10 +230,22 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     ///
     /// This is a non-mutating, in-memory read: it neither contacts the backend nor takes any
     /// internal write path, so health probes can observe sync progress through a shared read
-    /// lock without serializing against wallet-dependent duties. Both the general and reserved
-    /// wallets advance together in [`sync`](Self::sync), so the reserved tip is representative.
+    /// lock without serializing against wallet-dependent duties. The tip covers the reserved
+    /// wallet only: the general backend syncs independently inside [`sync`](Self::sync) and
+    /// can fail while this tip advances — probe [`Self::last_general_sync`] for it.
     pub fn local_chain_tip_height(&self) -> u32 {
         self.reserved.latest_checkpoint().height()
+    }
+
+    /// Outcome and time of the most recent general-backend sync attempt, or `None` before
+    /// the first.
+    ///
+    /// The reserved tip ([`Self::local_chain_tip_height`]) keeps advancing while the general
+    /// backend fails, because the two backends sync independently. A health probe that reads
+    /// only the tip therefore reports a dead general backend (bad Fireblocks credentials, an
+    /// API outage) as healthy forever. This is the general backend's own signal.
+    pub const fn last_general_sync(&self) -> Option<(bool, Instant)> {
+        self.last_general_sync
     }
 
     // ── Reserved-wallet UTXO lookup ─────────────────────────────────────────
@@ -476,7 +497,9 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         let mut attempt = 0u32;
         loop {
             let mut err: Option<Error> = None;
-            if let Err(e) = self.general.sync().await {
+            let general_result = self.general.sync().await;
+            self.last_general_sync = Some((general_result.is_ok(), Instant::now()));
+            if let Err(e) = general_result {
                 err = Some(Error::from_general(e));
             }
             if let Err(e) = self

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -27,7 +27,8 @@ use std::{collections::BTreeSet, sync::Arc};
 
 use bdk_wallet::{
     bitcoin::{
-        Address, Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey,
+        Address, Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Witness,
+        XOnlyPublicKey,
     },
     descriptor, KeychainKind, Wallet,
 };
@@ -163,6 +164,14 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// Returns the general wallet's receive script.
     pub fn general_script_pubkey(&self) -> ScriptBuf {
         self.general.script_pubkey()
+    }
+
+    /// Returns the BOSD descriptor where bridge payouts to this operator should be directed.
+    /// Delegates to the backend so the destination matches the custodian that can spend it
+    /// (native general-key P2TR vs. Fireblocks vault P2WPKH). See
+    /// [`GeneralWallet::payout_descriptor`].
+    pub fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
+        self.general.payout_descriptor()
     }
 
     /// Returns the reserved wallet's receive script.
@@ -390,6 +399,22 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             psbt: funded.psbt,
             lease,
         })
+    }
+
+    /// Signs the general-wallet-owned inputs of `tx` at `input_indices`. Returns a witness per
+    /// index for inputs the backend can sign (e.g. Fireblocks), or `None` for inputs the caller
+    /// must sign downstream (the native descriptor-only backend returns all `None`). See
+    /// [`GeneralWallet::sign_owned_inputs`]. `prevouts[i]` is the output spent by `tx.input[i]`.
+    pub async fn sign_owned_inputs(
+        &self,
+        tx: &Transaction,
+        input_indices: &[usize],
+        prevouts: &[TxOut],
+    ) -> Result<Vec<Option<Witness>>, Error> {
+        self.general
+            .sign_owned_inputs(tx, input_indices, prevouts)
+            .await
+            .map_err(Error::from_general)
     }
 
     // ── Cross-wallet (general → reserved) ──────────────────────────────────

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -27,12 +27,10 @@ use std::{collections::BTreeSet, sync::Arc, time::Instant};
 
 use bdk_wallet::{
     bitcoin::{
-        Address, Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Witness,
-        XOnlyPublicKey,
+        Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Witness, XOnlyPublicKey,
     },
     descriptor, KeychainKind, Wallet,
 };
-use bitcoin_bosd::Descriptor;
 use tokio::{sync::Mutex as TokioMutex, time::sleep};
 use tracing::{error, info, warn};
 
@@ -186,12 +184,6 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// Returns the reserved wallet's receive script.
     pub fn reserved_script_pubkey(&self) -> ScriptBuf {
         self.reserved_script_pubkey.clone()
-    }
-
-    /// Returns a BOSD descriptor for the general wallet's current receive script.
-    pub fn descriptor(&self) -> Result<Descriptor, Error> {
-        let address = Address::from_script(&self.general_script_pubkey(), self.config.network)?;
-        Descriptor::try_from(address).map_err(Error::Descriptor)
     }
 
     // ── Lease bookkeeping ───────────────────────────────────────────────────

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -157,6 +157,27 @@ fn sign_and_finalize(mut psbt: Psbt, keypair: Keypair) -> Transaction {
     psbt.extract_tx().expect("extract")
 }
 
+/// The payout descriptor and the wallet's own receive script must be the SAME script:
+/// payouts then arrive as ordinary wallet UTXOs (BDK tracks them) and are spent — including
+/// CPFP force-spends of the unconfirmed payout — with the same tap-tweaking signer as any
+/// funding input. A payout descriptor keyed to anything the funding descriptor doesn't
+/// watch (e.g. the raw, untweaked general key, which BOSD would use verbatim as the output
+/// key) silently strands every payout: invisible to the wallet and unspendable by the
+/// production signers.
+#[tokio::test]
+#[serial]
+async fn payout_descriptor_is_the_wallet_receive_script() {
+    let bitcoind = setup_bitcoind();
+    let (wallet, _kp, _pk) =
+        build_operator_wallet(&bitcoind, 1, 2, 1, Amount::from_btc(0.5).unwrap()).await;
+
+    assert_eq!(
+        wallet.payout_descriptor().to_script(),
+        wallet.general_script_pubkey(),
+        "native payout descriptor must resolve to the funding wallet's own script"
+    );
+}
+
 #[tokio::test]
 #[serial]
 async fn committed_leases_survive_until_an_explicit_release() {

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -561,6 +561,19 @@ impl GeneralWallet for YieldingGeneralWallet {
     ) -> Result<operator_wallet::FundedPsbt, Self::Error> {
         unreachable!("this test does not build CPFP children")
     }
+
+    fn payout_descriptor(&self) -> bitcoin_bosd::Descriptor {
+        unreachable!("this test does not resolve payout descriptors")
+    }
+
+    async fn sign_owned_inputs(
+        &self,
+        _tx: &Transaction,
+        _input_indices: &[usize],
+        _prevouts: &[bdk_wallet::bitcoin::TxOut],
+    ) -> Result<Vec<Option<bdk_wallet::bitcoin::Witness>>, Self::Error> {
+        unreachable!("this test does not sign owned inputs")
+    }
 }
 
 /// Two funding calls that run at the same time must not select one general-wallet UTXO twice.

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -364,6 +364,7 @@ pub(crate) const fn executor_error_class(error: &ExecutorError) -> &'static str 
         ExecutorError::ProofErr(_) => "proof_generation",
         ExecutorError::InvalidTxStructure(_) => "invalid_transaction_structure",
         ExecutorError::FeeRateTooHigh { .. } => "fee_rate_too_high",
+        ExecutorError::StakeFundingTxInMempool(_) => "stake_funding_tx_in_mempool",
     }
 }
 


### PR DESCRIPTION
## Description

Adds a Fireblocks-custodied general wallet as an alternative to the native BDK backend, selected at startup. When the optional `[operator_wallet.fireblocks]` config section is absent, the native backend is used (default, unchanged behavior). The reserved wallet stays native regardless.

**RAW signing, not TRANSFER.** Fireblocks doesn't build the bitcoin tx for us: the bridge constructs the unsigned v3/TRUC transaction itself (input selection, change, sighashes), sends the sighashes to Fireblocks for ECDSA signing, and assembles the P2WPKH witnesses. This is the only flow that lets us inject a foreign Taproot anchor input, force v3, control exact outputs, and get the PSBT back to package with the parent for CPFP.

All bridge protocol keys (anchors, presigned-tx keys) remain in secret-service. Fireblocks only ever contributes a funding input + optional change to cover fees / top up internal pools, and receives earnings at the vault address.

Key pieces:
- `GeneralWallet` trait gains `payout_descriptor()` and `sign_owned_inputs()`; backend erasure via an `AnyOperatorWallet` enum keeps the executor pipeline non-generic (Fireblocks variant gated behind a `fireblocks` cargo feature).
- CPFP general-payout detection is backend-aware (matches the active backend's receive script: native BIP86 P2TR vs. Fireblocks vault P2WPKH), so CPFP works for both backends.
- All funding/signing call sites honor the signing contract: use the backend-produced witness if present, otherwise secret-service-sign.

Security / robustness:
- Per-request RS256 JWT (`uri`/`nonce`/`iat`/`exp`/`bodyHash`) + `X-API-Key`; API secret read from a file path and redacted in `Debug` (never in the config body or logs).
- RAW-sign responses are matched by echoed sighash content (not order, with a duplicate-sighash guard); each assembled witness is verified to (a) be controlled by the prevout's witness program and (b) verify against the sighash before it's trusted.
- Exact `asset_id`/network validation, P2WPKH deposit-address enforcement, `base_url` trailing-slash normalization, and `deny_unknown_fields` on the wallet config so a typo can't silently downgrade a Fireblocks operator to native.

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)

## Notes to Reviewers

- **Stacked on #572** — base branch is `azz/str-3439-cpfp-rbf`; review only the top commits.
- Neither maintainer has a Fireblocks account, so the backend is validated against the Fireblocks swagger spec via unit tests (JWT/auth, DTO serde, witness assembly incl. a real BIP-143 sighash round-trip and high-S normalization, and the funding/CPFP selection + dust-boundary math). The live RAW-sign submit→poll path is not covered by an integration test.
- The operator-facing setup guide is intentionally deferred to a follow-up.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Part of the operator-wallet / Fireblocks epic (STR-3434).