### PR TITLE
chore(deps): bump asm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3063,7 +3063,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5870,7 +5870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7220,7 +7220,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10910,7 +10910,7 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -10937,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -10951,7 +10951,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "borsh",
  "serde",
@@ -10972,10 +10972,11 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
+ "bitcoin-bosd 0.10.0",
  "serde",
  "ssz",
  "ssz_derive",
@@ -10990,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
@@ -11012,7 +11013,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "borsh",
  "serde",
@@ -11023,7 +11024,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -11043,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11063,10 +11064,11 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
+ "bitcoin-bosd 0.10.0",
  "rand_chacha 0.9.0",
  "serde",
  "ssz",
@@ -11076,7 +11078,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-msgs",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
  "strata-asm-proto-checkpoint-msgs",
  "strata-btc-types",
  "strata-codec",
@@ -11088,26 +11090,27 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
+ "bitcoin-bosd 0.10.0",
  "ssz",
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
  "strata-crypto",
 ]
 
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.10.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
  "strata-btc-types",
  "strata-codec",
  "strata-l1-txfmt",
@@ -11134,7 +11137,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.10.0",
@@ -11151,7 +11154,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -11167,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -11180,7 +11183,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -11195,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "borsh",
  "serde",
@@ -11215,12 +11218,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
  "strata-asm-proof-types",
  "strata-asm-proto-bridge-v1",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
  "strata-asm-proto-checkpoint-types",
  "strata-asm-worker",
 ]
@@ -11228,7 +11232,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -11241,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -11254,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -11739,7 +11743,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11756,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin-bosd 0.10.0",
  "ssz",
@@ -11766,7 +11770,7 @@ dependencies = [
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-asm-params",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
  "strata-asm-proto-checkpoint-types",
  "strata-btc-types",
  "strata-codec",
@@ -12058,7 +12062,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-arb"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",
@@ -13401,7 +13405,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,20 +89,20 @@ strata-mosaic-client-api = { path = "crates/mosaic-client-api" }
 # Dependencies from alpenlabs/alpen pinned to commit 2c6ae209 (main @ 2026-05-13)
 strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10" }
 
-# Dependencies from alpenlabs/asm pinned to commit dc6432ff (main @ 2026-05-13)
-asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
-strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "dc6432ffef44597c7db2447077f1e0fd677bff42" }
+# Dependencies from alpenlabs/asm pinned to commit 1495f9c8 (main @ 2026-05-25)
+asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
 
 # Dependencies from alpenlabs/mosaic pinned to commit 0fc9ba8d (main @ 2026-04-20)
 mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "0fc9ba8d2359c7509b8ebf65e8aa5d423704b505" }

--- a/crates/asm-events/src/client.rs
+++ b/crates/asm-events/src/client.rs
@@ -22,7 +22,7 @@ use btc_tracker::event::{BlockEvent, BlockStatus};
 use futures::StreamExt;
 use jsonrpsee::http_client::HttpClient;
 use strata_asm_proto_bridge_v1::AssignmentEntry;
-use strata_asm_rpc::traits::AssignmentsApiClient;
+use strata_asm_rpc::traits::AsmStateApiClient;
 use strata_bridge_primitives::subscription::Subscription;
 use thiserror::Error;
 use tokio::{

--- a/docker/vol/asm-runner/asm-params-sample.json
+++ b/docker/vol/asm-runner/asm-params-sample.json
@@ -67,7 +67,8 @@
                 "denomination": 1000000000,
                 "assignment_duration": 288,
                 "operator_fee": 10000000,
-                "recovery_delay": 1008
+                "recovery_delay": 1008,
+                "safe_harbour_address": "00"
             }
         }
     ]

--- a/functional-tests/envs/asm_config.py
+++ b/functional-tests/envs/asm_config.py
@@ -12,3 +12,5 @@ class AsmEnvConfig:
     assignment_duration: int = 10_000
     operator_fee: int = 10_000_000
     recovery_delay: int = 1_008
+    # Hex-encoded bitcoin-bosd Descriptor; "00" = empty OP_RETURN, deactivated at init.
+    safe_harbour_address: str = "00"

--- a/functional-tests/factory/bridge_operator/asm_cfg.py
+++ b/functional-tests/factory/bridge_operator/asm_cfg.py
@@ -41,6 +41,7 @@ def build_asm_params(
         assignment_duration=cfg.assignment_duration,
         operator_fee=cfg.operator_fee,
         recovery_delay=cfg.recovery_delay,
+        safe_harbour_address=cfg.safe_harbour_address,
     )
 
 

--- a/functional-tests/factory/common/asm_params.py
+++ b/functional-tests/factory/common/asm_params.py
@@ -73,6 +73,7 @@ class BridgeSubprotocol:
     assignment_duration: int
     operator_fee: int
     recovery_delay: int
+    safe_harbour_address: str
 
 
 @dataclass
@@ -177,6 +178,7 @@ def build_asm_params(
     assignment_duration: int = 10_000,
     operator_fee: int = 100_000_000,
     recovery_delay: int = 1_008,
+    safe_harbour_address: str = "00",
 ) -> AsmParams:
     compressed_keys = [f"02{key}" for key in musig2_keys]
     admin = AdminSubprotocol(
@@ -207,6 +209,7 @@ def build_asm_params(
         assignment_duration=assignment_duration,
         operator_fee=operator_fee,
         recovery_delay=recovery_delay,
+        safe_harbour_address=safe_harbour_address,
     )
     return AsmParams(
         magic=magic,

--- a/guest-builder/sp1/guest-bridge-proof/Cargo.lock
+++ b/guest-builder/sp1/guest-bridge-proof/Cargo.lock
@@ -2200,7 +2200,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -2227,7 +2227,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "borsh",
  "serde",
@@ -2262,10 +2262,11 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
+ "bitcoin-bosd 0.10.0",
  "serde",
  "ssz",
  "ssz_derive",
@@ -2280,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
@@ -2302,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -2322,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2342,10 +2343,11 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
+ "bitcoin-bosd 0.10.0",
  "rand_chacha 0.9.0",
  "serde",
  "ssz",
@@ -2367,8 +2369,9 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
+ "bitcoin-bosd 0.10.0",
  "ssz",
  "ssz_derive",
  "strata-asm-common",
@@ -2380,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2396,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.10.0",
@@ -2413,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -2429,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -2442,7 +2445,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -2457,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "borsh",
  "serde",
@@ -2477,7 +2480,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -2490,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -2562,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2579,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=dc6432ffef44597c7db2447077f1e0fd677bff42#dc6432ffef44597c7db2447077f1e0fd677bff42"
+source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
 dependencies = [
  "bitcoin-bosd 0.10.0",
  "ssz",

--- a/guest-builder/sp1/stub/asm-params.json
+++ b/guest-builder/sp1/stub/asm-params.json
@@ -67,7 +67,8 @@
                 "denomination": 1000000000,
                 "assignment_duration": 10000,
                 "operator_fee": 10000000,
-                "recovery_delay": 1008
+                "recovery_delay": 1008,
+                "safe_harbour_address": "00"
             }
         }
     ]


### PR DESCRIPTION
## Description
* bump asm to `1495f9c8`

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

### Notes to reviewers
Couldn't bump to v0.1-alpha.10 because `dev-cli/bridge_in` depends on alpen (`strata-ol-bridge-types::DepositDescriptor`), and alpen still pins `strata-common` at rc21. alpha.10 requires rc23 — so alpen needs to bump `strata-common` rc21→rc23 (and the companion `ssz-gen` v0.15→v0.16 + `bitcoin-bosd` v0.10→v0.11) first.