### PR TITLE
feat(docker): add SP1 cargo-feature build-args for bridge and asm

### DIFF
--- a/.github/scripts/build_matrix.py
+++ b/.github/scripts/build_matrix.py
@@ -77,6 +77,7 @@ def app_matrix() -> list[dict]:
             "local_tag": "strata-bridge:latest",
             "trivy_scanners": "vuln,secret,misconfig",
             "trivy_timeout": "15m",
+            "build_args": "--build-arg BRIDGE_FEATURES=--features=sp1",
         })
 
     if _flag("BUILD_ASM_RUNNER"):
@@ -89,6 +90,7 @@ def app_matrix() -> list[dict]:
             "local_tag": "strata-asm-runner:latest",
             "trivy_scanners": "vuln,secret,misconfig",
             "trivy_timeout": "15m",
+            "build_args": "--build-arg ASM_FEATURES=--features=sp1",
         })
 
     if _flag("BUILD_SECRET_SERVICE"):
@@ -101,6 +103,7 @@ def app_matrix() -> list[dict]:
             "local_tag": "secret-service:latest",
             "trivy_scanners": "vuln,secret,misconfig",
             "trivy_timeout": "15m",
+            "build_args": "",
         })
 
     return items

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -322,6 +322,7 @@ jobs:
             --platform "${DOCKER_PLATFORM}" \
             --file "build-src/${{ matrix.dockerfile }}" \
             --tag "${{ matrix.local_tag }}" \
+            ${{ matrix.build_args }} \
             build-src
 
       # Hard gate — no image is pushed if CRITICAL or HIGH unfixed vulnerabilities are found.

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,6 +36,20 @@ docker build -f docker/base.Dockerfile . -t bridge-base:latest
 docker build -f docker/rt.Dockerfile . -t bridge-rt:latest
 ```
 
+## SP1 mode (optional)
+
+The bridge and asm-runner images each accept an optional cargo-feature build-arg
+(empty by default — `just docker` and plain `docker build` are unchanged):
+
+```sh
+docker build --build-arg BRIDGE_FEATURES="--features sp1" \
+  -f docker/strata-bridge/Dockerfile . -t strata-bridge:latest
+docker build --build-arg ASM_FEATURES="--features sp1" \
+  -f docker/asm-runner/Dockerfile . -t strata-asm-runner:latest
+```
+
+SP1 guest ELFs are still supplied at runtime via the existing config / volume flow.
+
 ## Running locally
 
 The local Docker stack includes:

--- a/docker/asm-runner/Dockerfile
+++ b/docker/asm-runner/Dockerfile
@@ -1,6 +1,8 @@
 # warning: run from repo root, NOT inside this dir
 FROM --platform=linux/amd64 bridge-base:latest AS builder
 
+ARG ASM_FEATURES=""
+
 # Copy the workspace Cargo.toml so the grep-extracted tag is the canonical source of truth.
 COPY Cargo.toml /tmp/Cargo.toml
 
@@ -10,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     if [ -z "$ASM_REV" ]; then \
         echo "ERROR: failed to extract asm rev from Cargo.toml" >&2; exit 1; \
     fi && \
-    cargo install --git https://github.com/alpenlabs/asm --rev "$ASM_REV" --root /app strata-asm-runner
+    cargo install --git https://github.com/alpenlabs/asm --rev "$ASM_REV" --root /app strata-asm-runner ${ASM_FEATURES}
 
 FROM --platform=linux/amd64 bridge-rt:latest AS runtime
 

--- a/docker/strata-bridge/Dockerfile
+++ b/docker/strata-bridge/Dockerfile
@@ -1,6 +1,8 @@
 # warning: run from repo root, NOT inside this dir
 FROM --platform=linux/amd64 bridge-base:latest AS builder
 
+ARG BRIDGE_FEATURES=""
+
 # It's already in the builder but this is so docker knows when to rebuild this image
 COPY bin/strata-bridge bin/strata-bridge
 
@@ -8,7 +10,7 @@ COPY bin/strata-bridge bin/strata-bridge
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/app/target \
-    cargo b -r -p strata-bridge
+    cargo b -r -p strata-bridge ${BRIDGE_FEATURES}
 
 RUN --mount=type=cache,target=/app/target cp /app/target/release/strata-bridge /app/strata-bridge
 


### PR DESCRIPTION
## Description
Adds opt-in `BRIDGE_FEATURES` / `ASM_FEATURES` build-args so the bridge and asm-runner images can be built with `--features sp1`. Existing builds are unchanged; usage is documented in `docker/README.md`.


<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update