### PR TITLE
chore(deps): bump asm to v0.1-alpha.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ dependencies = [
  "derive_more 2.0.1",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -968,7 +968,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1117,7 +1117,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1129,7 +1129,7 @@ version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99fce0350197dcd4ba4e9a7dd43915d908c0eb0e7352755791709a705e1c76b6"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2436,8 +2436,8 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-bosd"
-version = "0.10.0"
-source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.10.0#a55e1e7c85a4d2ce12a8f9a3f875f10996ccc495"
+version = "0.11.0"
+source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.11.0#2fc97b87088059762ead689cb67d8f118aa86160"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2616,20 +2616,21 @@ checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.4.2",
+ "constant_time_eq",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if 1.0.4",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -3144,12 +3145,6 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
@@ -3441,36 +3436,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -3489,22 +3460,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -3764,7 +3724,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitcoincore-rpc",
  "clap",
  "hex",
@@ -4732,7 +4692,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5341,13 +5301,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5375,7 +5336,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "log",
  "num-format",
@@ -6508,7 +6469,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "ipnet",
  "metrics",
  "metrics-util 0.19.1",
@@ -6639,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "moho-recursive-proof"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-types",
  "ssz",
@@ -6648,14 +6609,14 @@ dependencies = [
  "strata-predicate",
  "thiserror 2.0.18",
  "tree_hash",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
 [[package]]
 name = "moho-runtime-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-runtime-interface",
  "moho-types",
@@ -6666,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "moho-runtime-interface"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-types",
  "ssz",
@@ -6676,7 +6637,7 @@ dependencies = [
 [[package]]
 name = "moho-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "hex",
  "sha2 0.11.0",
@@ -6690,7 +6651,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -7220,7 +7181,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7264,7 +7225,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "memchr",
  "ruzstd",
 ]
@@ -7846,7 +7807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -8008,9 +7969,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
@@ -8814,7 +8775,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.17.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -8882,9 +8843,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -8969,7 +8930,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9058,7 +9019,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9317,7 +9278,7 @@ dependencies = [
  "terrors",
  "tikv-jemallocator",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
 ]
 
@@ -9516,6 +9477,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9537,7 +9507,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.0.3",
  "serde_core",
@@ -9552,7 +9522,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9711,8 +9681,8 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sizzle-parser"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -10820,11 +10790,11 @@ dependencies = [
 
 [[package]]
 name = "ssz"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "smallvec",
  "ssz_primitives",
@@ -10833,8 +10803,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_codegen"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -10846,25 +10816,25 @@ dependencies = [
  "ssz_primitives",
  "ssz_types",
  "syn 2.0.117",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tree_hash",
  "tree_hash_derive",
 ]
 
 [[package]]
 name = "ssz_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "ssz_primitives"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "hex",
  "rand 0.8.5",
@@ -10873,10 +10843,10 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "ssz",
@@ -10912,7 +10882,7 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -10939,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -10953,7 +10923,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "borsh",
  "serde",
@@ -10974,14 +10944,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
  "serde",
  "ssz",
  "ssz_derive",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-btc-types",
  "strata-btc-verification",
  "strata-crypto",
@@ -10993,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
@@ -11008,25 +10978,25 @@ dependencies = [
  "strata-btc-verification",
  "strata-predicate",
  "tree_hash",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
 [[package]]
 name = "strata-asm-proof-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "borsh",
  "serde",
  "strata-identifiers",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -11036,6 +11006,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-admin-txs",
  "strata-asm-proto-bridge-v1-msgs",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-asm-proto-checkpoint-msgs",
  "strata-crypto",
  "strata-identifiers",
@@ -11046,7 +11017,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11055,6 +11026,7 @@ dependencies = [
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-params",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-crypto",
  "strata-identifiers",
  "strata-l1-envelope-fmt",
@@ -11066,11 +11038,10 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
  "rand_chacha 0.9.0",
  "serde",
  "ssz",
@@ -11080,7 +11051,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-msgs",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-asm-proto-checkpoint-msgs",
  "strata-btc-types",
  "strata-codec",
@@ -11092,27 +11063,26 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "bitcoin-bosd 0.10.0",
  "ssz",
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-crypto",
 ]
 
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-btc-types",
  "strata-codec",
  "strata-l1-txfmt",
@@ -11122,10 +11092,10 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8#4f37c74fc1347f1bca799613455d63fd86dfa4e0"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10#65ac3aa2e8ad4472f8aa5c3cb4362ea44fa1e03b"
 dependencies = [
  "arbitrary",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitvec",
  "borsh",
  "serde",
@@ -11139,10 +11109,11 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
- "bitcoin-bosd 0.10.0",
+ "bitcoin",
+ "bitcoin-bosd 0.11.0",
  "bitvec",
  "borsh",
  "serde",
@@ -11156,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -11172,7 +11143,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -11185,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -11200,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "borsh",
  "serde",
@@ -11212,6 +11183,7 @@ dependencies = [
  "strata-asm-manifest-types",
  "strata-codec",
  "strata-identifiers",
+ "strata-msg-fmt",
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
@@ -11220,13 +11192,13 @@ dependencies = [
 [[package]]
 name = "strata-asm-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
  "strata-asm-proof-types",
  "strata-asm-proto-bridge-v1",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-asm-proto-checkpoint-types",
  "strata-asm-worker",
 ]
@@ -11234,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -11247,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -11260,7 +11232,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -11328,9 +11300,9 @@ dependencies = [
  "strata-tasks",
  "tikv-jemallocator",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -11357,7 +11329,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "hex",
  "libp2p",
  "secp256k1 0.29.1",
@@ -11365,7 +11337,7 @@ dependencies = [
  "strata-l1-txfmt",
  "strata-logging",
  "strata-predicate",
- "toml",
+ "toml 0.8.23",
  "tracing",
 ]
 
@@ -11400,7 +11372,7 @@ dependencies = [
  "strata-bridge-proof-common",
  "strata-btc-types",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
@@ -11430,7 +11402,7 @@ dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitcoind-async-client",
  "borsh",
  "btc-tracker",
@@ -11464,8 +11436,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
+ "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -11488,7 +11460,7 @@ name = "strata-bridge-orchestrator"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "btc-tracker",
  "futures",
  "libp2p-identity",
@@ -11542,7 +11514,7 @@ name = "strata-bridge-p2p-types"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "libp2p-identity",
  "musig2",
  "proptest",
@@ -11563,7 +11535,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitcoin-script",
  "futures",
  "hex",
@@ -11581,7 +11553,7 @@ dependencies = [
  "strata-predicate",
  "thiserror 2.0.18",
  "tokio",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -11605,7 +11577,7 @@ dependencies = [
  "strata-codec",
  "strata-merkle",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
@@ -11625,9 +11597,9 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
- "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido-sp1-groth16-verifier 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-sp1-host",
 ]
 
@@ -11649,7 +11621,7 @@ name = "strata-bridge-sm"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "musig2",
  "proptest",
  "secp256k1 0.29.1",
@@ -11667,7 +11639,7 @@ dependencies = [
  "strata-predicate",
  "thiserror 2.0.18",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -11688,7 +11660,7 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitcoind-async-client",
  "corepc-node",
  "hex",
@@ -11709,7 +11681,7 @@ version = "0.1.0"
 dependencies = [
  "algebra",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "futures",
  "secp256k1 0.29.1",
  "serde",
@@ -11725,7 +11697,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11745,7 +11717,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11762,9 +11734,9 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "ssz",
  "ssz_codegen",
  "ssz_derive",
@@ -11772,10 +11744,9 @@ dependencies = [
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-asm-params",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef)",
  "strata-asm-proto-checkpoint-types",
  "strata-btc-types",
- "strata-codec",
  "strata-crypto",
  "strata-identifiers",
  "strata-predicate",
@@ -11788,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -11797,7 +11768,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -11806,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "borsh",
  "ssz",
@@ -11817,7 +11788,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11837,7 +11808,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11858,7 +11829,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -11867,7 +11838,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11879,7 +11850,7 @@ dependencies = [
 [[package]]
 name = "strata-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc24#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
@@ -11893,7 +11864,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11913,7 +11884,7 @@ dependencies = [
 [[package]]
 name = "strata-metrics"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc24#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "metrics",
  "metrics-exporter-otel",
@@ -11957,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -11965,14 +11936,14 @@ dependencies = [
 [[package]]
 name = "strata-ol-bridge-types"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=17c44e8615b6a06496f417534fadf9b1ca306e01#17c44e8615b6a06496f417534fadf9b1ca306e01"
 dependencies = [
  "arbitrary",
  "borsh",
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.8)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.10)",
  "strata-codec",
  "strata-identifiers",
  "strata-primitives",
@@ -11998,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -12020,10 +11991,10 @@ dependencies = [
 [[package]]
 name = "strata-primitives"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10#2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=17c44e8615b6a06496f417534fadf9b1ca306e01#17c44e8615b6a06496f417534fadf9b1ca306e01"
 dependencies = [
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "borsh",
  "hex",
  "serde",
@@ -12036,11 +12007,11 @@ dependencies = [
 [[package]]
 name = "strata-service"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "anyhow",
  "futures",
- "opentelemetry 0.31.0",
+ "metrics",
  "serde",
  "serde_json",
  "strata-tasks",
@@ -12052,7 +12023,7 @@ dependencies = [
 [[package]]
 name = "strata-tasks"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -12064,7 +12035,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-arb"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",
@@ -12276,7 +12247,7 @@ dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.8.23",
  "version-compare",
 ]
 
@@ -12308,7 +12279,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12567,9 +12538,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -12582,13 +12568,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.10.0",
- "toml_datetime",
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -12598,12 +12593,21 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.11",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -12611,6 +12615,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -12725,7 +12735,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -12895,8 +12905,8 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
@@ -12908,10 +12918,10 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "quote",
  "syn 2.0.117",
 ]
@@ -13794,6 +13804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14103,20 +14119,20 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "async-trait",
  "bincode",
  "borsh",
  "serde",
  "ssz",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "tracing",
 ]
@@ -14124,7 +14140,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "async-trait",
  "bincode",
@@ -14132,7 +14148,7 @@ dependencies = [
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -14153,7 +14169,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "blake3",
  "borsh",
@@ -14161,14 +14177,14 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "substrate-bn",
- "thiserror 1.0.69",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "thiserror 2.0.18",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
 name = "zkaleido-sp1-host"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "async-trait",
  "bincode",
@@ -14176,10 +14192,11 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9",
+ "sp1-core-executor",
  "sp1-sdk",
  "sp1-verifier",
  "tokio",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,23 +86,23 @@ strata-bridge-tx-graph = { path = "crates/tx-graph" }
 strata-mosaic-client = { path = "crates/mosaic-client" }
 strata-mosaic-client-api = { path = "crates/mosaic-client-api" }
 
-# Dependencies from alpenlabs/alpen pinned to commit 2c6ae209 (main @ 2026-05-13)
-strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "2c6ae209dd5f2ed71e6f9f7b721ea7ab21190e10" }
+# Dependencies from alpenlabs/alpen pinned to commit 17c44e86 (main @ 2026-06-01)
+strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "17c44e8615b6a06496f417534fadf9b1ca306e01" }
 
-# Dependencies from alpenlabs/asm pinned to commit 1495f9c8 (main @ 2026-05-25)
-asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
-strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b" }
+# Dependencies from alpenlabs/asm pinned to commit b84eb28a (main @ 2026-06-02)
+asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
+strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "b84eb28a71b99ed54e128ca282ed8f637c2e88ef" }
 
 # Dependencies from alpenlabs/mosaic pinned to commit 0fc9ba8d (main @ 2026-04-20)
 mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "0fc9ba8d2359c7509b8ebf65e8aa5d423704b505" }
@@ -110,19 +110,19 @@ mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "0fc9ba8d2
 mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "0fc9ba8d2359c7509b8ebf65e8aa5d423704b505" }
 
 # Dependencies from alpenlabs/strata-common
-strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-codec = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc24" }
-strata-merkle = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
-strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc24" }
-strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21", features = [
+strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-codec = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-merkle = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
+strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23", features = [
   "all",
 ] }
-strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc21" }
+strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc23" }
 
 strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git", tag = "v0.3.7", features = [
   "quic",
@@ -131,19 +131,19 @@ strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git", tag = "v0.3.
 ], default-features = false }
 
 # Dependencies from alpenlabs/ssz-gen
-ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
-ssz_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
+ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
+ssz_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 
 # Dependencies from alpenlabs/moho
-moho-recursive-proof = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.6" }
-moho-runtime-interface = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.6" }
-moho-types = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.6" }
+moho-recursive-proof = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.7" }
+moho-runtime-interface = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.7" }
+moho-types = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.7" }
 
 # Dependencies from alpenlabs/zkaleido
-zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.2" }
-zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.2" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.2" }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.2" }
+zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
 
 # external deps
 alloy = { version = "2.0.4", features = ["full", "node-bindings"] }
@@ -163,7 +163,7 @@ blake3 = "1.8.3"
 # TODO: <https://alpenlabs.atlassian.net/browse/STR-2658>
 # Update `btc-tracker` and `tx-driver` tests when upgrading `bitcoin` to >=0.33.0.
 bitcoin = { version = "0.32.9", features = ["rand-std", "serde"] }
-bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", tag = "v0.10.0", features = [
+bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", tag = "v0.11.0", features = [
   "address",
 ] }
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }

--- a/bin/dev-cli/src/handlers/checkpoint/mock_checkpoint.rs
+++ b/bin/dev-cli/src/handlers/checkpoint/mock_checkpoint.rs
@@ -10,7 +10,6 @@ use strata_asm_proto_checkpoint_types::{
     CheckpointTip, L2BlockRange, OLLog, SimpleWithdrawalIntentLogData, TerminalHeaderComplement,
 };
 use strata_bridge_primitives::constants::BRIDGE_DENOMINATION;
-use strata_codec::encode_to_vec;
 use strata_crypto::hash;
 use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
 use strata_test_utils_arb::ArbitraryGenerator;
@@ -93,10 +92,7 @@ impl MockCheckpointBuilder {
                 )
                 .unwrap();
 
-                OLLog::new(
-                    BRIDGE_GATEWAY_ACCT_SERIAL,
-                    encode_to_vec(&log_data).unwrap(),
-                )
+                OLLog::from_log(BRIDGE_GATEWAY_ACCT_SERIAL, &log_data).unwrap()
             })
             .collect();
 

--- a/docker/vol/asm-runner/asm-params-sample.json
+++ b/docker/vol/asm-runner/asm-params-sample.json
@@ -36,15 +36,26 @@
                     ],
                     "threshold": 1
                 },
+                "strata_security_council": {
+                    "keys": [
+                        "02b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d",
+                        "021e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4",
+                        "02a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba"
+                    ],
+                    "threshold": 1
+                },
                 "confirmation_depths": {
                     "strata_admin_multisig_update": 144,
                     "strata_seq_manager_multisig_update": 144,
                     "alpen_admin_multisig_update": 144,
+                    "strata_security_council_multisig_update": 144,
                     "operator_update": 144,
                     "sequencer_update": 144,
                     "ol_stf_vk_update": 144,
                     "asm_stf_vk_update": 144,
-                    "ee_stf_vk_update": 144
+                    "ee_stf_vk_update": 144,
+                    "defcon3": 144,
+                    "safe_harbour_address_update": 144
                 },
                 "max_seqno_gap": 10
             }
@@ -68,7 +79,7 @@
                 "assignment_duration": 288,
                 "operator_fee": 10000000,
                 "recovery_delay": 1008,
-                "safe_harbour_address": "00"
+                "safe_harbour_address": "040f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"
             }
         }
     ]

--- a/functional-tests/envs/asm_config.py
+++ b/functional-tests/envs/asm_config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from constants import ASM_MAGIC_BYTES
+from factory.common.asm_params import DEFAULT_SAFE_HARBOUR_ADDRESS
 
 
 @dataclass
@@ -12,5 +13,7 @@ class AsmEnvConfig:
     assignment_duration: int = 10_000
     operator_fee: int = 10_000_000
     recovery_delay: int = 1_008
-    # Hex-encoded bitcoin-bosd Descriptor; "00" = empty OP_RETURN, deactivated at init.
-    safe_harbour_address: str = "00"
+    # Hex-encoded bitcoin-bosd Descriptor. The new asm requires a P2TR (type tag 0x04)
+    # descriptor; the address is held deactivated at init and toggled by the security
+    # council via Defcon signals.
+    safe_harbour_address: str = DEFAULT_SAFE_HARBOUR_ADDRESS

--- a/functional-tests/factory/common/asm_params.py
+++ b/functional-tests/factory/common/asm_params.py
@@ -13,8 +13,9 @@ from constants import ASM_MAGIC_BYTES
 DIFFICULTY_ADJUSTMENT_INTERVAL = 2016
 
 # Default P2TR bosd descriptor used as the initial safe harbour address. Matches the
-# upstream asm functional-tests value for bc1ppuxgmd6n4j73wdp688p08a8rte97dkn5n70r2ym6kgsw0v3c5ensrytduf.
-# Encoded as type tag 0x04 (P2A/P2TR) followed by the 32-byte x-only pubkey.
+# upstream asm functional-tests value for the P2TR address
+# bc1ppuxgmd6n4j73wdp688p08a8rte97dkn5n70r2ym6kgsw0v3c5ensrytduf, encoded as type tag
+# 0x04 (P2A/P2TR) followed by the 32-byte x-only pubkey.
 DEFAULT_SAFE_HARBOUR_ADDRESS = "040f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"
 
 # A callable that returns the verbose ``getblockheader`` response (a dict with at least

--- a/functional-tests/factory/common/asm_params.py
+++ b/functional-tests/factory/common/asm_params.py
@@ -12,6 +12,11 @@ from constants import ASM_MAGIC_BYTES
 # (mainnet, testnet, signet, regtest) per Bitcoin Core's consensus params.
 DIFFICULTY_ADJUSTMENT_INTERVAL = 2016
 
+# Default P2TR bosd descriptor used as the initial safe harbour address. Matches the
+# upstream asm functional-tests value for bc1ppuxgmd6n4j73wdp688p08a8rte97dkn5n70r2ym6kgsw0v3c5ensrytduf.
+# Encoded as type tag 0x04 (P2A/P2TR) followed by the 32-byte x-only pubkey.
+DEFAULT_SAFE_HARBOUR_ADDRESS = "040f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"
+
 # A callable that returns the verbose ``getblockheader`` response (a dict with at least
 # ``hash``, ``bits``, and ``time`` fields) for the block at a given height.
 BlockHeaderFetcher = Callable[[int], dict[str, Any]]
@@ -42,11 +47,14 @@ class ConfirmationDepths:
     strata_admin_multisig_update: int
     strata_seq_manager_multisig_update: int
     alpen_admin_multisig_update: int
+    strata_security_council_multisig_update: int
     operator_update: int
     sequencer_update: int
     ol_stf_vk_update: int
     asm_stf_vk_update: int
     ee_stf_vk_update: int
+    defcon3: int
+    safe_harbour_address_update: int
 
 
 @dataclass
@@ -54,6 +62,7 @@ class AdminSubprotocol:
     strata_administrator: ThresholdConfig
     strata_sequencer_manager: ThresholdConfig
     alpen_administrator: ThresholdConfig
+    strata_security_council: ThresholdConfig
     confirmation_depths: ConfirmationDepths
     max_seqno_gap: int
 
@@ -118,6 +127,7 @@ class AsmParams:
             strata_administrator=ThresholdConfig(**admin_d["strata_administrator"]),
             strata_sequencer_manager=ThresholdConfig(**admin_d["strata_sequencer_manager"]),
             alpen_administrator=ThresholdConfig(**admin_d["alpen_administrator"]),
+            strata_security_council=ThresholdConfig(**admin_d["strata_security_council"]),
             confirmation_depths=ConfirmationDepths(**admin_d["confirmation_depths"]),
             max_seqno_gap=admin_d["max_seqno_gap"],
         )
@@ -178,22 +188,26 @@ def build_asm_params(
     assignment_duration: int = 10_000,
     operator_fee: int = 100_000_000,
     recovery_delay: int = 1_008,
-    safe_harbour_address: str = "00",
+    safe_harbour_address: str = DEFAULT_SAFE_HARBOUR_ADDRESS,
 ) -> AsmParams:
     compressed_keys = [f"02{key}" for key in musig2_keys]
     admin = AdminSubprotocol(
         strata_administrator=ThresholdConfig(keys=compressed_keys, threshold=1),
         strata_sequencer_manager=ThresholdConfig(keys=compressed_keys, threshold=1),
         alpen_administrator=ThresholdConfig(keys=compressed_keys, threshold=1),
+        strata_security_council=ThresholdConfig(keys=compressed_keys, threshold=1),
         confirmation_depths=ConfirmationDepths(
             strata_admin_multisig_update=144,
             strata_seq_manager_multisig_update=144,
             alpen_admin_multisig_update=144,
+            strata_security_council_multisig_update=144,
             operator_update=144,
             sequencer_update=144,
             ol_stf_vk_update=144,
             asm_stf_vk_update=144,
             ee_stf_vk_update=144,
+            defcon3=144,
+            safe_harbour_address_update=144,
         ),
         max_seqno_gap=10,
     )

--- a/guest-builder/sp1/guest-bridge-proof/Cargo.lock
+++ b/guest-builder/sp1/guest-bridge-proof/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
  "hex-conservative",
  "secp256k1",
  "serde",
- "ssz 0.16.0",
+ "ssz",
  "ssz_types",
 ]
 
@@ -529,36 +529,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -576,22 +552,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -770,12 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,7 +895,7 @@ dependencies = [
 name = "guest-sp1-bridge-proof"
 version = "0.1.0"
 dependencies = [
- "ssz 0.15.0",
+ "ssz",
  "strata-bridge-proof",
  "zkaleido-sp1-guest-env",
 ]
@@ -1069,15 +1028,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1194,8 +1144,8 @@ version = "0.1.0"
 source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-types",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-merkle",
  "strata-predicate",
  "thiserror 2.0.18",
@@ -1211,8 +1161,8 @@ source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b
 dependencies = [
  "moho-runtime-interface",
  "moho-types",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
 ]
 
 [[package]]
@@ -1221,7 +1171,7 @@ version = "0.1.0"
 source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-types",
- "ssz 0.16.0",
+ "ssz",
  "strata-predicate",
 ]
 
@@ -1232,10 +1182,10 @@ source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b
 dependencies = [
  "hex",
  "sha2 0.11.0",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-merkle",
  "strata-predicate",
@@ -2160,17 +2110,6 @@ dependencies = [
 
 [[package]]
 name = "ssz"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
-dependencies = [
- "itertools 0.13.0",
- "smallvec",
- "ssz_primitives 0.15.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "ssz"
 version = "0.16.0"
 source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
@@ -2178,7 +2117,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "smallvec",
- "ssz_primitives 0.16.0",
+ "ssz_primitives",
  "thiserror 2.0.18",
 ]
 
@@ -2192,9 +2131,9 @@ dependencies = [
  "quote",
  "serde",
  "sizzle-parser",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "syn 2.0.117",
  "toml",
@@ -2204,32 +2143,12 @@ dependencies = [
 
 [[package]]
 name = "ssz_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
-dependencies = [
- "darling 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ssz_derive"
 version = "0.16.0"
 source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "ssz_primitives"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
-dependencies = [
- "hex",
- "rand 0.8.6",
- "ruint",
 ]
 
 [[package]]
@@ -2250,8 +2169,8 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_derive",
- "ssz 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz",
+ "ssz_primitives",
  "thiserror 2.0.18",
  "tree_hash",
 ]
@@ -2270,10 +2189,10 @@ dependencies = [
  "bitcoin",
  "borsh",
  "serde",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-btc-types",
@@ -2310,10 +2229,10 @@ source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca28
 dependencies = [
  "borsh",
  "serde",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-codec",
  "strata-crypto",
@@ -2332,8 +2251,8 @@ dependencies = [
  "arbitrary",
  "bitcoin",
  "serde",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-proto-bridge-v1-types",
  "strata-btc-types",
  "strata-btc-verification",
@@ -2352,8 +2271,8 @@ dependencies = [
  "moho-runtime-impl",
  "moho-runtime-interface",
  "moho-types",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-spec",
@@ -2371,8 +2290,8 @@ version = "0.1.0"
 source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-params",
@@ -2394,8 +2313,8 @@ dependencies = [
  "arbitrary",
  "bitcoin",
  "hex",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-common",
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-types",
@@ -2416,8 +2335,8 @@ dependencies = [
  "bitcoin",
  "rand_chacha 0.9.0",
  "serde",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-params",
@@ -2437,8 +2356,8 @@ name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
 source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
  "strata-asm-proto-bridge-v1-types",
@@ -2472,8 +2391,8 @@ dependencies = [
  "bitvec",
  "borsh",
  "serde",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-btc-types",
  "strata-identifiers",
  "thiserror 2.0.18",
@@ -2500,8 +2419,8 @@ name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
 source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-checkpoint-txs",
  "strata-btc-types",
@@ -2530,10 +2449,10 @@ source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca28
 dependencies = [
  "borsh",
  "serde",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-codec",
@@ -2580,8 +2499,8 @@ dependencies = [
  "moho-runtime-interface",
  "moho-types",
  "serde_json",
- "ssz 0.15.0",
- "ssz_derive 0.15.0",
+ "ssz",
+ "ssz_derive",
  "strata-asm-params",
  "strata-asm-proof-impl",
  "strata-asm-proto-bridge-v1",
@@ -2620,8 +2539,8 @@ dependencies = [
  "borsh",
  "num_enum",
  "serde",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-codec",
  "strata-identifiers",
  "strata-l1-txfmt",
@@ -2638,8 +2557,8 @@ dependencies = [
  "bitcoin",
  "borsh",
  "serde",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-btc-types",
  "strata-crypto",
  "strata-identifiers",
@@ -2652,10 +2571,10 @@ version = "0.1.0"
 source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin-bosd 0.11.0",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-asm-params",
@@ -2695,8 +2614,8 @@ version = "0.1.0"
 source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "borsh",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-codec",
 ]
 
@@ -2713,8 +2632,8 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2 0.10.9",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
+ "ssz",
+ "ssz_derive",
  "strata-identifiers",
  "thiserror 2.0.18",
  "zeroize",
@@ -2732,9 +2651,9 @@ dependencies = [
  "int-enum",
  "paste",
  "serde",
- "ssz 0.16.0",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-codec",
  "tree_hash",
@@ -2771,10 +2690,10 @@ dependencies = [
  "digest 0.10.7",
  "serde",
  "sha2 0.10.9",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "strata-codec",
  "thiserror 2.0.18",
@@ -2801,10 +2720,10 @@ dependencies = [
  "k256",
  "serde",
  "signature",
- "ssz 0.16.0",
+ "ssz",
  "ssz_codegen",
- "ssz_derive 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz_derive",
+ "ssz_primitives",
  "ssz_types",
  "thiserror 2.0.18",
  "tree_hash",
@@ -3039,8 +2958,8 @@ dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
  "smallvec",
- "ssz 0.16.0",
- "ssz_primitives 0.16.0",
+ "ssz",
+ "ssz_primitives",
  "thiserror 2.0.18",
 ]
 
@@ -3049,7 +2968,7 @@ name = "tree_hash_derive"
 version = "0.16.0"
 source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "quote",
  "syn 2.0.117",
 ]
@@ -3204,7 +3123,7 @@ dependencies = [
  "bincode",
  "borsh",
  "serde",
- "ssz 0.16.0",
+ "ssz",
  "thiserror 2.0.18",
 ]
 

--- a/guest-builder/sp1/guest-bridge-proof/Cargo.lock
+++ b/guest-builder/sp1/guest-bridge-proof/Cargo.lock
@@ -195,15 +195,15 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-bosd"
-version = "0.10.0"
-source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.10.0#a55e1e7c85a4d2ce12a8f9a3f875f10996ccc495"
+version = "0.11.0"
+source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.11.0#2fc97b87088059762ead689cb67d8f118aa86160"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "hex-conservative",
  "secp256k1",
  "serde",
- "ssz",
+ "ssz 0.16.0",
  "ssz_types",
 ]
 
@@ -533,8 +533,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -552,12 +562,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -902,7 +936,7 @@ dependencies = [
 name = "guest-sp1-bridge-proof"
 version = "0.1.0"
 dependencies = [
- "ssz",
+ "ssz 0.15.0",
  "strata-bridge-proof",
  "zkaleido-sp1-guest-env",
 ]
@@ -1157,58 +1191,58 @@ dependencies = [
 [[package]]
 name = "moho-recursive-proof"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-types",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-merkle",
  "strata-predicate",
  "thiserror 2.0.18",
  "tree_hash",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
 [[package]]
 name = "moho-runtime-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-runtime-interface",
  "moho-types",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
 ]
 
 [[package]]
 name = "moho-runtime-interface"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "moho-types",
- "ssz",
+ "ssz 0.16.0",
  "strata-predicate",
 ]
 
 [[package]]
 name = "moho-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.6#e3345559b2b91c653ff16c3d90efded1f0e54172"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.7#9ad844684468f4b28ec4874f9658bdbcf617f7b2"
 dependencies = [
  "hex",
  "sha2 0.11.0",
- "ssz",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-merkle",
  "strata-predicate",
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -1546,7 +1580,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1877,11 +1911,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1943,8 +1977,8 @@ dependencies = [
 
 [[package]]
 name = "sizzle-parser"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2129,27 +2163,38 @@ name = "ssz"
 version = "0.15.0"
 source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
 dependencies = [
- "hex",
  "itertools 0.13.0",
+ "smallvec",
+ "ssz_primitives 0.15.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ssz"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
+dependencies = [
+ "hex",
+ "itertools 0.14.0",
  "serde",
  "smallvec",
- "ssz_primitives",
+ "ssz_primitives 0.16.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ssz_codegen"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
  "serde",
  "sizzle-parser",
- "ssz",
- "ssz_derive",
- "ssz_primitives",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "syn 2.0.117",
  "toml",
@@ -2162,7 +2207,17 @@ name = "ssz_derive"
 version = "0.15.0"
 source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
 dependencies = [
- "darling",
+ "darling 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ssz_derive"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
+dependencies = [
+ "darling 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -2178,15 +2233,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+name = "ssz_primitives"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "itertools 0.13.0",
+ "hex",
+ "rand 0.8.6",
+ "ruint",
+]
+
+[[package]]
+name = "ssz_types"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
+dependencies = [
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
- "ssz",
- "ssz_primitives",
+ "ssz 0.16.0",
+ "ssz_primitives 0.16.0",
  "thiserror 2.0.18",
  "tree_hash",
 ]
@@ -2200,15 +2265,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "borsh",
  "serde",
- "ssz",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-btc-types",
@@ -2227,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -2241,14 +2306,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "borsh",
  "serde",
- "ssz",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-codec",
  "strata-crypto",
@@ -2262,14 +2327,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
  "serde",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
+ "strata-asm-proto-bridge-v1-types",
  "strata-btc-types",
  "strata-btc-verification",
  "strata-crypto",
@@ -2281,14 +2346,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
  "moho-runtime-interface",
  "moho-types",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-spec",
@@ -2296,23 +2361,24 @@ dependencies = [
  "strata-btc-verification",
  "strata-predicate",
  "tree_hash",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-params",
  "strata-asm-proto-admin-txs",
  "strata-asm-proto-bridge-v1-msgs",
+ "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-msgs",
  "strata-crypto",
  "strata-identifiers",
@@ -2323,15 +2389,16 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "hex",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-asm-common",
  "strata-asm-params",
+ "strata-asm-proto-bridge-v1-types",
  "strata-crypto",
  "strata-identifiers",
  "strata-l1-envelope-fmt",
@@ -2343,15 +2410,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
  "rand_chacha 0.9.0",
  "serde",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-asm-common",
  "strata-asm-logs",
  "strata-asm-params",
@@ -2369,11 +2435,10 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "bitcoin-bosd 0.10.0",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
  "strata-asm-proto-bridge-v1-types",
@@ -2383,11 +2448,11 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-types",
  "strata-btc-types",
@@ -2399,15 +2464,16 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
- "bitcoin-bosd 0.10.0",
+ "bitcoin",
+ "bitcoin-bosd 0.11.0",
  "bitvec",
  "borsh",
  "serde",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-btc-types",
  "strata-identifiers",
  "thiserror 2.0.18",
@@ -2416,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -2432,10 +2498,10 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-asm-common",
  "strata-asm-proto-checkpoint-txs",
  "strata-btc-types",
@@ -2445,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -2460,18 +2526,19 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "borsh",
  "serde",
- "ssz",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-codec",
  "strata-identifiers",
+ "strata-msg-fmt",
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
@@ -2480,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -2493,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -2513,8 +2580,8 @@ dependencies = [
  "moho-runtime-interface",
  "moho-types",
  "serde_json",
- "ssz",
- "ssz_derive",
+ "ssz 0.15.0",
+ "ssz_derive 0.15.0",
  "strata-asm-params",
  "strata-asm-proof-impl",
  "strata-asm-proto-bridge-v1",
@@ -2524,7 +2591,7 @@ dependencies = [
  "strata-codec",
  "strata-merkle",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -2538,14 +2605,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2553,8 +2620,8 @@ dependencies = [
  "borsh",
  "num_enum",
  "serde",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-codec",
  "strata-identifiers",
  "strata-l1-txfmt",
@@ -2565,14 +2632,14 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "borsh",
  "serde",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-btc-types",
  "strata-crypto",
  "strata-identifiers",
@@ -2582,20 +2649,19 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b#1495f9c8ef0c81e1b8a9a046fe1574a8b6a92f1b"
+source = "git+https://github.com/alpenlabs/asm.git?rev=b84eb28a71b99ed54e128ca282ed8f637c2e88ef#b84eb28a71b99ed54e128ca282ed8f637c2e88ef"
 dependencies = [
- "bitcoin-bosd 0.10.0",
- "ssz",
+ "bitcoin-bosd 0.11.0",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-types",
  "strata-btc-types",
- "strata-codec",
  "strata-crypto",
  "strata-identifiers",
  "strata-predicate",
@@ -2608,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -2617,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2626,18 +2692,18 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "borsh",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-codec",
 ]
 
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2647,8 +2713,8 @@ dependencies = [
  "secp256k1",
  "serde",
  "sha2 0.10.9",
- "ssz",
- "ssz_derive",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
  "strata-identifiers",
  "thiserror 2.0.18",
  "zeroize",
@@ -2657,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2666,9 +2732,9 @@ dependencies = [
  "int-enum",
  "paste",
  "serde",
- "ssz",
- "ssz_derive",
- "ssz_primitives",
+ "ssz 0.16.0",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-codec",
  "tree_hash",
@@ -2678,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -2687,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2699,16 +2765,16 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "borsh",
  "digest 0.10.7",
  "serde",
  "sha2 0.10.9",
- "ssz",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "strata-codec",
  "thiserror 2.0.18",
@@ -2719,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -2727,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2735,10 +2801,10 @@ dependencies = [
  "k256",
  "serde",
  "signature",
- "ssz",
+ "ssz 0.16.0",
  "ssz_codegen",
- "ssz_derive",
- "ssz_primitives",
+ "ssz_derive 0.16.0",
+ "ssz_primitives 0.16.0",
  "ssz_types",
  "thiserror 2.0.18",
  "tree_hash",
@@ -2885,23 +2951,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -2915,28 +2975,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -2945,14 +2991,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -2987,23 +3033,23 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "digest 0.10.7",
  "sha2 0.10.9",
  "smallvec",
- "ssz",
- "ssz_primitives",
+ "ssz 0.16.0",
+ "ssz_primitives 0.16.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3072,15 +3118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3161,20 +3198,20 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "async-trait",
  "bincode",
  "borsh",
  "serde",
- "ssz",
- "thiserror 1.0.69",
+ "ssz 0.16.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "tracing",
 ]
@@ -3182,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3190,7 +3227,7 @@ dependencies = [
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -3211,13 +3248,13 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "bincode",
  "cfg-if",
  "serde",
  "sp1-zkvm",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]

--- a/guest-builder/sp1/guest-bridge-proof/Cargo.toml
+++ b/guest-builder/sp1/guest-bridge-proof/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 [workspace]
 
 [dependencies]
-ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
+ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 strata-bridge-proof = { path = "../../../crates/proofs/bridge-proof", default-features = false }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.2" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0" }

--- a/guest-builder/sp1/guest-counterproof/Cargo.lock
+++ b/guest-builder/sp1/guest-counterproof/Cargo.lock
@@ -125,8 +125,8 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-bosd"
-version = "0.10.0"
-source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.10.0#a55e1e7c85a4d2ce12a8f9a3f875f10996ccc495"
+version = "0.11.0"
+source = "git+https://github.com/alpenlabs/bitcoin-bosd?tag=v0.11.0#2fc97b87088059762ead689cb67d8f118aa86160"
 dependencies = [
  "bitcoin",
  "hex-conservative",
@@ -298,9 +298,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -439,11 +439,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -453,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -631,12 +630,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
@@ -879,15 +872,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -990,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1332,7 +1316,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1759,11 +1743,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1798,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1830,8 +1814,8 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sizzle-parser"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -1844,9 +1828,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8abf7cfad18c0580576e8adc01f7fa27b1cb19432e451e82950c9a445a7cfc"
+checksum = "6d7e25239ac2fe1cbc2ed5114844209d70361c8d55ef812cb935c90d6f771b5b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1855,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c327e0927fabf9c0ae9a7b0333027dc04431e5981ab80d7bbe994d6c4ce35fc1"
+checksum = "1243ca619a3f4c07f536a060d1fd2c6f779d5b0e4cfeee3acee4d1f76ae35cb4"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -1870,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c263e731bb694d4465eedae7ecd6faf1f277198e751f3c209a1c4186d80d1b6b"
+checksum = "594a3251b7fbbabf7e0ba1e5c2f563c2797fc2d51982c0208ce70b2f52b8fbe4"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -1883,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8cdc74f04d13e738b4628312b16dfec6a2e547bde697c8bdcf556884c6e91f"
+checksum = "1ccc675284794435dd053d5e7415089bbd08fccf92cd91e044ea3213821dfb5c"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -1898,27 +1882,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aedfc3bf87cf2694bd108c039d663c346c7bb807491a7db6701eb9dff5c6e5d"
+checksum = "7f77602b918f667f970d017293189f9e60ba056d1933c9f717634877838297bc"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30e6e332c3cb103541bed9f5f477b769df1b5fb6076b5e2386569c94b1475dc"
+checksum = "592ded42eb74fd87d2ce13592906cf86f201128dd18e2aa5a35d298bc3534dcb"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb1de854325a8c36a1bdfee5514e1d4c9f39290ae19eeaecb21ca6ee88d96d6"
+checksum = "108bf1769132b782218e3606b8e2f310741fb89d1745234b59ff17d9e7ab8700"
 dependencies = [
  "p3-symmetric",
 ]
@@ -1931,9 +1915,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1941,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d5f56efe1d2a980d0f46083863ef4fdf715ed70cc32668c9e5725af145b8d9"
+checksum = "20e8b776b02a868c482b70b5dca58204f27fc860dbbe5eda70437299367f494c"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -1953,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ad00052921b993af682403b378c8fe23c40382f9790f093c8fac0f30433c5e"
+checksum = "f20c3dd3131b1285420ca25a37f507915ab609887d6dda73973396a0faa719c1"
 dependencies = [
  "bincode",
  "blake3",
@@ -1977,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.2.2"
+version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5732e5c4cf9e607f224a0b1a0fd90515897f731eaba33939bf9d5dcdecf4f8"
+checksum = "c2dea6f1d7c79d27c9890c39786b68061c5a82b4c21669aafc98ae95337d792f"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -2012,11 +1996,11 @@ dependencies = [
 
 [[package]]
 name = "ssz"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "smallvec",
  "ssz_primitives",
@@ -2025,8 +2009,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_codegen"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -2045,8 +2029,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "darling",
  "quote",
@@ -2055,8 +2039,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_primitives"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "hex",
  "rand 0.8.6",
@@ -2065,10 +2049,10 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_derive",
  "ssz",
@@ -2109,7 +2093,7 @@ dependencies = [
  "strata-bridge-proof-common",
  "strata-btc-types",
  "strata-predicate",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -2120,7 +2104,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "bitcoin",
- "bitcoin-bosd 0.10.0",
+ "bitcoin-bosd 0.11.0",
  "bitcoin-script",
  "hex",
  "libp2p-identity",
@@ -2133,7 +2117,7 @@ dependencies = [
  "strata-identifiers",
  "strata-predicate",
  "thiserror 2.0.18",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -2147,14 +2131,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
  "zkaleido-native-adapter",
 ]
 
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2174,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -2183,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -2192,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2212,7 +2196,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2233,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2245,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc21#bb060d613880d8d4c8decd0e7544acb54e4d5a25"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc23#f93a3b7c4f2381dca87354aa59ebadbc4bc40755"
 dependencies = [
  "borsh",
  "hex",
@@ -2417,23 +2401,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -2447,28 +2425,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -2477,14 +2441,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -2519,8 +2483,8 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "digest",
  "sha2",
@@ -2532,8 +2496,8 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.15.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.15.0#6e4b99ef2831ea3a97b8cb98a88c06206395f337"
+version = "0.16.0"
+source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.16.0#a43cb62e88b22a4626dddc158bcd09b298c103e7"
 dependencies = [
  "darling",
  "quote",
@@ -2542,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -2566,9 +2530,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2663,15 +2627,6 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -2696,18 +2651,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2748,25 +2703,25 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "bincode",
  "borsh",
  "serde",
  "ssz",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "bincode",
  "k256",
  "rand_core 0.6.4",
  "serde",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]
 
 [[package]]
@@ -2787,11 +2742,11 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2#c2683cf676490decc045d9a91d6c8b5740138f1c"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3#ded58de1eb51a0738fd48fa09dd8519763735262"
 dependencies = [
  "bincode",
  "cfg-if",
  "serde",
  "sp1-zkvm",
- "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.2)",
+ "zkaleido 0.1.0 (git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.3)",
 ]

--- a/guest-builder/sp1/guest-counterproof/Cargo.toml
+++ b/guest-builder/sp1/guest-counterproof/Cargo.toml
@@ -6,9 +6,9 @@ version = "0.1.0"
 [workspace]
 
 [dependencies]
-ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.15.0" }
+ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 strata-bridge-counterproof = { path = "../../../crates/proofs/bridge-counterproof" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.2" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0" }

--- a/guest-builder/sp1/stub/asm-params.json
+++ b/guest-builder/sp1/stub/asm-params.json
@@ -36,15 +36,26 @@
                     ],
                     "threshold": 1
                 },
+                "strata_security_council": {
+                    "keys": [
+                        "02ac407ba319846e25d69c1c0cb2a845ab75ef93ad2e9e846cdc5cf6da766e00b2",
+                        "02c8200b381f7dd57f4c474d2bea56747fdfba32f2d20463f4269a1cf06a1acd77",
+                        "02ae12cceeee9d4888766b1abb0531f8c66c0629bfc4fabe97e3c0d5d9b4dd3fd7"
+                    ],
+                    "threshold": 1
+                },
                 "confirmation_depths": {
                     "strata_admin_multisig_update": 144,
                     "strata_seq_manager_multisig_update": 144,
                     "alpen_admin_multisig_update": 144,
+                    "strata_security_council_multisig_update": 144,
                     "operator_update": 144,
                     "sequencer_update": 144,
                     "ol_stf_vk_update": 144,
                     "asm_stf_vk_update": 144,
-                    "ee_stf_vk_update": 144
+                    "ee_stf_vk_update": 144,
+                    "defcon3": 144,
+                    "safe_harbour_address_update": 144
                 },
                 "max_seqno_gap": 10
             }
@@ -68,7 +79,7 @@
                 "assignment_duration": 10000,
                 "operator_fee": 10000000,
                 "recovery_delay": 1008,
-                "safe_harbour_address": "00"
+                "safe_harbour_address": "040f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"
             }
         }
     ]


### PR DESCRIPTION
## Description
* bump asm to `b84eb28a` (v0.1-alpha.11) and align workspace: alpen `17c44e86`, strata-common rc23, moho v0.1-alpha.7, zkaleido v0.1-beta.3, ssz-gen v0.16, bitcoin-bosd v0.11.
* update `asm-params` (stub, docker sample, fn-tests factory) for the new security-council role and P2TR-only safe-harbour address.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update