### PR TITLE
feat(sp1): enable blake3 on counterproof guest-env

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -22,6 +22,11 @@ default:
 build:
     cargo build --workspace --features "{{features}}" --profile "{{profile}}" --lib --bins --examples --tests --benches
 
+# Build the SP1 guest ELF using bundled stub params (skips reading real params)
+[group('build')]
+build-stub-elf:
+    SKIP_PARAMS=1 cargo build -p strata-bridge-sp1-guest-builder --release --features build-elf
+
 # Run unit tests
 [group('test')]
 test-unit: ensure-cargo-nextest

--- a/guest-builder/sp1/README.md
+++ b/guest-builder/sp1/README.md
@@ -42,6 +42,12 @@ verify the program **compiles** without provisioning real inputs.
 SKIP_PARAMS=1 cargo build -p strata-bridge-sp1-guest-builder --release --features build-elf
 ```
 
+Or via the `.justfile` recipe:
+
+```bash
+just build-stub-elf
+```
+
 ## Build flow
 
 The guest ELF is built only when you pass **`--release --features build-elf`**.

--- a/guest-builder/sp1/guest-counterproof/Cargo.lock
+++ b/guest-builder/sp1/guest-counterproof/Cargo.lock
@@ -1965,6 +1965,7 @@ version = "6.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dea6f1d7c79d27c9890c39786b68061c5a82b4c21669aafc98ae95337d792f"
 dependencies = [
+ "blake3",
  "cfg-if",
  "critical-section",
  "embedded-alloc",

--- a/guest-builder/sp1/guest-counterproof/Cargo.toml
+++ b/guest-builder/sp1/guest-counterproof/Cargo.toml
@@ -8,7 +8,9 @@ version = "0.1.0"
 [dependencies]
 ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 strata-bridge-counterproof = { path = "../../../crates/proofs/bridge-counterproof" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.3", features = [
+  "blake3",
+] }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0" }


### PR DESCRIPTION
## Description
Turns on the `blake3` feature of `zkaleido-sp1-guest-env` for the counterproof guest

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update