### PR TITLE
ci(guest-publish): manual workflow to publish SP1 bridge guest ELFs and vkeys

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-m

--- a/.github/scripts/guest_publish.py
+++ b/.github/scripts/guest_publish.py
@@ -20,6 +20,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import urllib.request
@@ -154,6 +155,9 @@ EXPECTED_ARTIFACTS = (
     "counterproof-vkey.bin",
 )
 
+# Copied verbatim into the artifact so the bundle is self-describing after GHA retention evicts the run page.
+BUNDLED_INPUTS = ("asm-params.json", "asm-vk.json", "moho-vk.json")
+
 
 def sha256_hex(path: Path) -> str:
     """Return the SHA-256 of `path` as a lowercase hex digest."""
@@ -165,8 +169,9 @@ def sha256_hex(path: Path) -> str:
 
 
 def cmd_summarize() -> None:
-    """Env: ELF_DIR, ASM_TAG, ASM_PARAMS_URL, GITHUB_REF, GITHUB_SHA, GITHUB_STEP_SUMMARY."""
+    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_PARAMS_URL, GITHUB_REF, GITHUB_SHA, GITHUB_STEP_SUMMARY."""
     elf_dir = Path(os.environ["ELF_DIR"])
+    inputs_dir = Path(os.environ["INPUTS_DIR"])
     asm_tag = os.environ["ASM_TAG"]
     asm_params_url = os.environ["ASM_PARAMS_URL"]
     github_ref = os.environ.get("GITHUB_REF", "")
@@ -180,7 +185,31 @@ def cmd_summarize() -> None:
 
     bridge_predicate = (elf_dir / "bridge-proof.predicate").read_text().strip()
     counter_predicate = (elf_dir / "counterproof.predicate").read_text().strip()
-    digests = [(name, sha256_hex(elf_dir / name)) for name in EXPECTED_ARTIFACTS]
+    digests = dict((name, sha256_hex(elf_dir / name)) for name in EXPECTED_ARTIFACTS)
+
+    # Copy the exact input bytes alongside the ELFs so the bundle is
+    # self-describing — a consumer can rebuild from these to verify.
+    for name in BUNDLED_INPUTS:
+        src = inputs_dir / name
+        if not src.is_file():
+            fail(f"expected input missing: {src}")
+        shutil.copyfile(src, elf_dir / name)
+    input_digests = {name: sha256_hex(elf_dir / name) for name in BUNDLED_INPUTS}
+
+    manifest = {
+        "schema": 1,
+        "asm_tag": asm_tag,
+        "asm_params_url": asm_params_url,
+        "strata_bridge": {"ref": github_ref, "sha": github_sha},
+        "predicates": {
+            "bridge_proof": bridge_predicate,
+            "counterproof": counter_predicate,
+        },
+        "sha256": {**digests, **input_digests},
+    }
+    (elf_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
 
     lines: list[str] = [
         "## SP1 bridge guest publish",
@@ -188,6 +217,10 @@ def cmd_summarize() -> None:
         f"- asm tag (alpenlabs/asm): `{asm_tag}`",
         f"- asm-params source: `{asm_params_url}`",
         f"- strata-bridge ref: `{github_ref}` @ `{github_sha}`",
+        "",
+        "Artifact also contains `manifest.json` plus the verbatim input JSONs"
+        f" ({', '.join(f'`{n}`' for n in BUNDLED_INPUTS)}) so the bundle is"
+        " self-describing once the run page expires.",
         "",
         "### Predicates",
         "",
@@ -197,7 +230,8 @@ def cmd_summarize() -> None:
         "### SHA-256",
         "",
         "```",
-        *(f"{digest}  {name}" for name, digest in digests),
+        *(f"{digest}  {name}" for name, digest in digests.items()),
+        *(f"{digest}  {name}" for name, digest in input_digests.items()),
         "```",
         "",
     ]

--- a/.github/scripts/guest_publish.py
+++ b/.github/scripts/guest_publish.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""guest_publish.py — Helpers for the "Publish SP1 Bridge Guests" workflow.
+
+Bundles three concerns that the workflow chains together so each workflow step
+is one line. Pure-stdlib so it runs on every GitHub-hosted runner without an
+install step.
+
+Subcommands:
+    validate    Verify workflow_dispatch inputs before any network/build work.
+    fetch       Download asm-vk.json, moho-vk.json, asm-params.json into $OUTPUT_DIR.
+    summarize   Verify built artifacts and append a traceability block to
+                $GITHUB_STEP_SUMMARY.
+
+Each subcommand reads its inputs from environment variables documented on the
+per-command function.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def fail(message: str) -> None:
+    """Print a GHA `::error::` annotation and exit non-zero."""
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---- validate --------------------------------------------------------------
+
+ASM_TAG_RE = re.compile(r"^[A-Za-z0-9._/-]{1,200}$")
+REF_RE = re.compile(r"^[A-Za-z0-9._/@:-]+$")
+WHITESPACE_RE = re.compile(r"\s")
+# github.com /blob/ URLs serve HTML, not raw JSON — reject early so the
+# JSON-validation step doesn't fail later with a more confusing error.
+BLOB_URL_RE = re.compile(r"^https://github\.com/[^/]+/[^/]+/blob/")
+
+BLOB_HINT = (
+    "asm_params_url is a github.com /blob/ view URL (returns HTML). "
+    "Use the raw URL: replace 'github.com' with 'raw.githubusercontent.com' "
+    "and drop '/blob' (or click the 'Raw' button on GitHub)."
+)
+
+
+def cmd_validate() -> None:
+    """Env: INPUT_ASM_TAG, INPUT_ASM_PARAMS_URL, INPUT_REF (optional)."""
+    asm_tag = os.environ["INPUT_ASM_TAG"]
+    asm_params_url = os.environ["INPUT_ASM_PARAMS_URL"]
+    ref = os.environ.get("INPUT_REF", "")
+
+    if WHITESPACE_RE.search(asm_tag):
+        fail("asm_tag must not contain whitespace")
+    if not ASM_TAG_RE.fullmatch(asm_tag):
+        fail("asm_tag contains unsupported characters (allowed: [A-Za-z0-9._/-])")
+
+    if WHITESPACE_RE.search(asm_params_url):
+        fail("asm_params_url must not contain whitespace")
+    if not asm_params_url.startswith("https://"):
+        fail("asm_params_url must start with https://")
+    if len(asm_params_url) > 2048:
+        fail("asm_params_url exceeds 2048 chars")
+    if BLOB_URL_RE.match(asm_params_url):
+        fail(BLOB_HINT)
+
+    if ref:
+        if WHITESPACE_RE.search(ref):
+            fail("ref must not contain whitespace")
+        if not REF_RE.fullmatch(ref):
+            fail("ref contains unsupported characters")
+
+
+# ---- fetch -----------------------------------------------------------------
+
+ASM_REPO = "alpenlabs/asm"
+VK_FILES = ("asm-vk.json", "moho-vk.json")
+
+
+def fetch_vks(asm_tag: str, output_dir: Path) -> None:
+    """Pull the two `*-vk.json` files from the alpenlabs/asm release via `gh`.
+
+    Assumes alpenlabs/asm is public. If this 404s on a tag known to exist, the
+    repo is likely private — provision a PAT/App installation token with
+    `Contents: read` on alpenlabs/asm and route it via GH_TOKEN.
+    """
+    cmd = ["gh", "release", "download", asm_tag, "--repo", ASM_REPO]
+    for name in VK_FILES:
+        cmd += ["--pattern", name]
+    cmd += ["--dir", str(output_dir)]
+    subprocess.run(cmd, check=True)
+    for name in VK_FILES:
+        if not (output_dir / name).is_file():
+            fail(f"missing {name} in {ASM_REPO} release {asm_tag}")
+
+
+def fetch_asm_params(asm_params_url: str, output_path: Path) -> None:
+    """Download asm-params.json from $ASM_PARAMS_URL and JSON-validate it.
+
+    A github.com /blob/ URL would 200 OK with HTML; the JSON decode below catches
+    that and fails with a clear error rather than letting build.rs panic on it.
+    """
+    # Defense in depth — `validate` already enforces https://, but re-check here
+    # so this subcommand is safe to run outside the workflow too.
+    if urlparse(asm_params_url).scheme != "https":
+        fail("asm_params_url must be https")
+
+    req = urllib.request.Request(
+        asm_params_url,
+        headers={"User-Agent": "strata-bridge-ci/1"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        body = resp.read()
+    if not body:
+        fail(f"asm-params.json from {asm_params_url} is empty")
+    try:
+        json.loads(body)
+    except json.JSONDecodeError as e:
+        fail(
+            f"asm-params.json is not valid JSON ({e}); a github.com /blob/ URL "
+            "returns HTML — use the raw URL instead"
+        )
+    output_path.write_bytes(body)
+
+
+def cmd_fetch() -> None:
+    """Env: ASM_TAG, ASM_PARAMS_URL, OUTPUT_DIR, GH_TOKEN."""
+    asm_tag = os.environ["ASM_TAG"]
+    asm_params_url = os.environ["ASM_PARAMS_URL"]
+    output_dir = Path(os.environ["OUTPUT_DIR"])
+    # `gh` reads GH_TOKEN itself; we only verify it's present so a missing token
+    # fails fast with a clear error instead of an interactive gh auth prompt.
+    if not os.environ.get("GH_TOKEN"):
+        fail("GH_TOKEN must be set")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    fetch_vks(asm_tag, output_dir)
+    fetch_asm_params(asm_params_url, output_dir / "asm-params.json")
+
+
+# ---- summarize -------------------------------------------------------------
+
+EXPECTED_ARTIFACTS = (
+    "bridge-proof.elf",
+    "bridge-proof.predicate",
+    "bridge-proof-vkey.bin",
+    "counterproof.elf",
+    "counterproof.predicate",
+    "counterproof-vkey.bin",
+)
+
+
+def sha256_hex(path: Path) -> str:
+    """Return the SHA-256 of `path` as a lowercase hex digest."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def cmd_summarize() -> None:
+    """Env: ELF_DIR, ASM_TAG, ASM_PARAMS_URL, GITHUB_REF, GITHUB_SHA, GITHUB_STEP_SUMMARY."""
+    elf_dir = Path(os.environ["ELF_DIR"])
+    asm_tag = os.environ["ASM_TAG"]
+    asm_params_url = os.environ["ASM_PARAMS_URL"]
+    github_ref = os.environ.get("GITHUB_REF", "")
+    github_sha = os.environ.get("GITHUB_SHA", "")
+    summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+
+    for name in EXPECTED_ARTIFACTS:
+        p = elf_dir / name
+        if not p.is_file() or p.stat().st_size == 0:
+            fail(f"expected artifact missing or empty: {p}")
+
+    bridge_predicate = (elf_dir / "bridge-proof.predicate").read_text().strip()
+    counter_predicate = (elf_dir / "counterproof.predicate").read_text().strip()
+    digests = [(name, sha256_hex(elf_dir / name)) for name in EXPECTED_ARTIFACTS]
+
+    lines: list[str] = [
+        "## SP1 bridge guest publish",
+        "",
+        f"- asm tag (alpenlabs/asm): `{asm_tag}`",
+        f"- asm-params source: `{asm_params_url}`",
+        f"- strata-bridge ref: `{github_ref}` @ `{github_sha}`",
+        "",
+        "### Predicates",
+        "",
+        f"- bridge-proof: `{bridge_predicate}`",
+        f"- counterproof: `{counter_predicate}`",
+        "",
+        "### SHA-256",
+        "",
+        "```",
+        *(f"{digest}  {name}" for name, digest in digests),
+        "```",
+        "",
+    ]
+
+    with summary_path.open("a", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+# ---- entry point -----------------------------------------------------------
+
+COMMANDS = {
+    "validate": cmd_validate,
+    "fetch": cmd_fetch,
+    "summarize": cmd_summarize,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Helpers for the Publish SP1 Bridge Guests workflow.",
+    )
+    parser.add_argument(
+        "command",
+        choices=sorted(COMMANDS),
+        help="Which step to run; inputs come from env vars (see module docstring).",
+    )
+    args = parser.parse_args()
+    COMMANDS[args.command]()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/guest_publish.py
+++ b/.github/scripts/guest_publish.py
@@ -36,7 +36,11 @@ def fail(message: str) -> None:
 
 # ---- validate --------------------------------------------------------------
 
-ASM_TAG_RE = re.compile(r"^[A-Za-z0-9._/-]{1,200}$")
+# No `/` — git tags and `gh release download` accept it, but
+# actions/upload-artifact rejects names containing `/`, and the artifact name
+# embeds asm_tag directly. Reject here so the failure is fast, not after the
+# ~90-minute guest build.
+ASM_TAG_RE = re.compile(r"^[A-Za-z0-9._-]{1,200}$")
 REF_RE = re.compile(r"^[A-Za-z0-9._/@:-]+$")
 WHITESPACE_RE = re.compile(r"\s")
 # github.com /blob/ URLs serve HTML, not raw JSON — reject early so the
@@ -59,7 +63,7 @@ def cmd_validate() -> None:
     if WHITESPACE_RE.search(asm_tag):
         fail("asm_tag must not contain whitespace")
     if not ASM_TAG_RE.fullmatch(asm_tag):
-        fail("asm_tag contains unsupported characters (allowed: [A-Za-z0-9._/-])")
+        fail("asm_tag contains unsupported characters (allowed: [A-Za-z0-9._-])")
 
     if WHITESPACE_RE.search(asm_params_url):
         fail("asm_params_url must not contain whitespace")
@@ -169,13 +173,16 @@ def sha256_hex(path: Path) -> str:
 
 
 def cmd_summarize() -> None:
-    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_PARAMS_URL, GITHUB_REF, GITHUB_SHA, GITHUB_STEP_SUMMARY."""
+    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_PARAMS_URL, BRIDGE_REF, BRIDGE_SHA, GITHUB_STEP_SUMMARY."""
     elf_dir = Path(os.environ["ELF_DIR"])
     inputs_dir = Path(os.environ["INPUTS_DIR"])
     asm_tag = os.environ["ASM_TAG"]
     asm_params_url = os.environ["ASM_PARAMS_URL"]
-    github_ref = os.environ.get("GITHUB_REF", "")
-    github_sha = os.environ.get("GITHUB_SHA", "")
+    # Caller resolves these from `inputs.ref || github.ref` + `git rev-parse HEAD`
+    # post-checkout. We can't fall back to GITHUB_REF/GITHUB_SHA because those
+    # always describe the dispatch event, not the (possibly overridden) build ref.
+    bridge_ref = os.environ["BRIDGE_REF"]
+    bridge_sha = os.environ["BRIDGE_SHA"]
     summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
 
     for name in EXPECTED_ARTIFACTS:
@@ -200,7 +207,7 @@ def cmd_summarize() -> None:
         "schema": 1,
         "asm_tag": asm_tag,
         "asm_params_url": asm_params_url,
-        "strata_bridge": {"ref": github_ref, "sha": github_sha},
+        "strata_bridge": {"ref": bridge_ref, "sha": bridge_sha},
         "predicates": {
             "bridge_proof": bridge_predicate,
             "counterproof": counter_predicate,
@@ -216,7 +223,7 @@ def cmd_summarize() -> None:
         "",
         f"- asm tag (alpenlabs/asm): `{asm_tag}`",
         f"- asm-params source: `{asm_params_url}`",
-        f"- strata-bridge ref: `{github_ref}` @ `{github_sha}`",
+        f"- strata-bridge ref: `{bridge_ref}` @ `{bridge_sha}`",
         "",
         "Artifact also contains `manifest.json` plus the verbatim input JSONs"
         f" ({', '.join(f'`{n}`' for n in BUNDLED_INPUTS)}) so the bundle is"

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -1,0 +1,135 @@
+name: Publish SP1 Bridge Guests
+
+on:
+  workflow_dispatch:
+    inputs:
+      asm_tag:
+        description: Tag in alpenlabs/asm whose release ships asm-vk.json and moho-vk.json (e.g. v0.1-alpha.11).
+        required: true
+        type: string
+      asm_params_url:
+        description: HTTPS URL to fetch asm-params.json from (use raw.githubusercontent.com or a release-asset URL, not a github.com /blob/ view URL).
+        required: true
+        type: string
+      ref:
+        description: strata-bridge git ref to build. Defaults to the branch selected in the UI.
+        required: false
+        type: string
+  push:
+    branches:
+      - mdteach/ci-vk-pipeline
+    paths:
+      - .github/workflows/publish-sp1-bridge-guests.yml
+
+env:
+  CARGO_TERM_COLOR: always
+  SP1_VERSION: v6.2.0
+  EFFECTIVE_ASM_TAG: ${{ inputs.asm_tag || 'v0.1-alpha.11' }}
+  EFFECTIVE_ASM_PARAMS_URL: ${{ inputs.asm_params_url || 'https://raw.githubusercontent.com/alpenlabs/strata-bridge/refs/heads/main/guest-builder/sp1/stub/asm-params.json' }}
+
+concurrency:
+  # `env.*` is not available in concurrency expressions, so the fallback is inlined here.
+  group: publish-sp1-bridge-guests-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag || 'v0.1-alpha.11' }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  extract-rust-version:
+    name: Extract toolchain version
+    runs-on: ubuntu-latest
+    outputs:
+      nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Extract Rust version
+        id: extract-version
+        uses: ./.github/actions/extract-rust-version
+
+  publish-sp1-bridge-guests:
+    name: Build and publish SP1 bridge-proof and counterproof ELFs
+    runs-on: ubuntu-latest
+    needs: extract-rust-version
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Validate manual inputs
+        env:
+          INPUT_ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
+          INPUT_ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: python3 .github/scripts/guest_publish.py validate
+
+      - name: Install Rust toolchain
+        env:
+          RUST_NIGHTLY: ${{ needs.extract-rust-version.outputs.nightly-version }}
+        run: |
+          rustup toolchain install "$RUST_NIGHTLY" --profile minimal
+          rustup default "$RUST_NIGHTLY"
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Install SP1 toolchain
+        run: |
+          curl -fsSL --proto '=https' --tlsv1.2 https://sp1.succinct.xyz | bash
+          ~/.sp1/bin/sp1up --version "$SP1_VERSION"
+          echo "$HOME/.sp1/bin" >> "$GITHUB_PATH"
+
+      - name: Verify SP1 toolchain
+        run: cargo prove --version
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+
+      - name: Pre-build SP1 core runner binary
+        run: |
+          cargo install sp1-core-executor-runner-binary --version 6.2.0 --root "$RUNNER_TEMP/sp1-core-runner" --force
+          echo "SP1_CORE_RUNNER_OVERRIDE_BINARY=$RUNNER_TEMP/sp1-core-runner/bin/sp1-core-executor-runner-binary" >> "$GITHUB_ENV"
+
+      - name: Fetch asm-vk, moho-vk, asm-params
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
+          ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
+          OUTPUT_DIR: ${{ runner.temp }}/bridge-genesis
+        run: python3 .github/scripts/guest_publish.py fetch
+
+      - name: Build SP1 bridge-proof and counterproof guests
+        env:
+          BRIDGE_PROOF_ASM_PARAMS_PATH: ${{ runner.temp }}/bridge-genesis/asm-params.json
+          BRIDGE_PROOF_ASM_VK_PATH: ${{ runner.temp }}/bridge-genesis/asm-vk.json
+          BRIDGE_PROOF_MOHO_VK_PATH: ${{ runner.temp }}/bridge-genesis/moho-vk.json
+        run: |
+          set -euo pipefail
+          unset SKIP_PARAMS
+          cargo build --locked -p strata-bridge-sp1-guest-builder --release --features build-elf
+
+      - name: Verify artifacts and emit traceability summary
+        env:
+          ELF_DIR: guest-builder/sp1/elfs
+          ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
+          ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
+        run: python3 .github/scripts/guest_publish.py summarize
+
+      - name: Upload elfs/ as workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sp1-bridge-guests-${{ env.EFFECTIVE_ASM_TAG }}-${{ github.run_id }}
+          path: guest-builder/sp1/elfs/
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -57,6 +57,10 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || github.ref }}
 
+      - name: Resolve checked-out commit
+        id: resolve-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Validate manual inputs
         env:
           INPUT_ASM_TAG: ${{ inputs.asm_tag }}
@@ -117,6 +121,8 @@ jobs:
           INPUTS_DIR: ${{ runner.temp }}/bridge-genesis
           ASM_TAG: ${{ inputs.asm_tag }}
           ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
+          BRIDGE_REF: ${{ inputs.ref || github.ref }}
+          BRIDGE_SHA: ${{ steps.resolve-sha.outputs.sha }}
         run: python3 .github/scripts/guest_publish.py summarize
 
       - name: Upload elfs/ as workflow artifact

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -15,21 +15,13 @@ on:
         description: strata-bridge git ref to build. Defaults to the branch selected in the UI.
         required: false
         type: string
-  push:
-    branches:
-      - mdteach/ci-vk-pipeline
-    paths:
-      - .github/workflows/publish-sp1-bridge-guests.yml
 
 env:
   CARGO_TERM_COLOR: always
   SP1_VERSION: v6.2.0
-  EFFECTIVE_ASM_TAG: ${{ inputs.asm_tag || 'v0.1-alpha.11' }}
-  EFFECTIVE_ASM_PARAMS_URL: ${{ inputs.asm_params_url || 'https://raw.githubusercontent.com/alpenlabs/strata-bridge/refs/heads/main/guest-builder/sp1/stub/asm-params.json' }}
 
 concurrency:
-  # `env.*` is not available in concurrency expressions, so the fallback is inlined here.
-  group: publish-sp1-bridge-guests-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag || 'v0.1-alpha.11' }}
+  group: publish-sp1-bridge-guests-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
   cancel-in-progress: false
 
 permissions: {}
@@ -67,8 +59,8 @@ jobs:
 
       - name: Validate manual inputs
         env:
-          INPUT_ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
-          INPUT_ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
+          INPUT_ASM_TAG: ${{ inputs.asm_tag }}
+          INPUT_ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
           INPUT_REF: ${{ inputs.ref }}
         run: python3 .github/scripts/guest_publish.py validate
 
@@ -104,8 +96,8 @@ jobs:
       - name: Fetch asm-vk, moho-vk, asm-params
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
-          ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
+          ASM_TAG: ${{ inputs.asm_tag }}
+          ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
           OUTPUT_DIR: ${{ runner.temp }}/bridge-genesis
         run: python3 .github/scripts/guest_publish.py fetch
 
@@ -123,14 +115,14 @@ jobs:
         env:
           ELF_DIR: guest-builder/sp1/elfs
           INPUTS_DIR: ${{ runner.temp }}/bridge-genesis
-          ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
-          ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
+          ASM_TAG: ${{ inputs.asm_tag }}
+          ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
         run: python3 .github/scripts/guest_publish.py summarize
 
       - name: Upload elfs/ as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sp1-bridge-guests-${{ env.EFFECTIVE_ASM_TAG }}-${{ github.run_id }}
+          name: sp1-bridge-guests-${{ inputs.asm_tag }}-${{ github.run_id }}
           path: guest-builder/sp1/elfs/
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -53,7 +53,7 @@ jobs:
 
   publish-sp1-bridge-guests:
     name: Build and publish SP1 bridge-proof and counterproof ELFs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     needs: extract-rust-version
     timeout-minutes: 90
     permissions:
@@ -117,11 +117,12 @@ jobs:
         run: |
           set -euo pipefail
           unset SKIP_PARAMS
-          cargo build --locked -p strata-bridge-sp1-guest-builder --release --features build-elf
+          cargo build --locked -p strata-bridge-sp1-guest-builder --release --features docker-build
 
       - name: Verify artifacts and emit traceability summary
         env:
           ELF_DIR: guest-builder/sp1/elfs
+          INPUTS_DIR: ${{ runner.temp }}/bridge-genesis
           ASM_TAG: ${{ env.EFFECTIVE_ASM_TAG }}
           ASM_PARAMS_URL: ${{ env.EFFECTIVE_ASM_PARAMS_URL }}
         run: python3 .github/scripts/guest_publish.py summarize


### PR DESCRIPTION
## Description
* Adds a manual `workflow_dispatch` that fetches `asm-vk` / `moho-vk` / `asm-params` for a given `asm_tag` and builds the SP1 bridge-proof + counterproof guests via docker on `ubuntu-latest-m`.
* Uploads the ELFs together with the input JSONs and a `manifest.json` (traceability summary) as a single workflow artifact.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update