### PR TITLE
fix(gsm): prevent panic on stale coop path failure signal

### DIFF
--- a/crates/bridge-sm/src/graph/tests/deposit_signal.rs
+++ b/crates/bridge-sm/src/graph/tests/deposit_signal.rs
@@ -20,6 +20,7 @@ mod tests {
             },
         },
         signals::DepositToGraph,
+        state_machine::StateMachine,
         testing::{fixtures::TEST_DEPOSIT_IDX, test_transition},
     };
 
@@ -31,6 +32,22 @@ mod tests {
                 operator: TEST_POV_IDX,
             },
         })
+    }
+
+    fn is_after_fulfilled_state(state: &GraphState) -> bool {
+        matches!(
+            state,
+            GraphState::Claimed { .. }
+                | GraphState::Contested { .. }
+                | GraphState::BridgeProofPosted { .. }
+                | GraphState::BridgeProofTimedout { .. }
+                | GraphState::CounterProofPosted { .. }
+                | GraphState::AllNackd { .. }
+                | GraphState::Acked { .. }
+                | GraphState::Withdrawn { .. }
+                | GraphState::Slashed { .. }
+                | GraphState::Aborted { .. }
+        )
     }
 
     #[test]
@@ -98,10 +115,40 @@ mod tests {
     }
 
     #[test]
+    fn test_stale_coop_payout_failed_after_fulfilled_is_rejected() {
+        let cfg = test_graph_sm_cfg();
+
+        for initial_state in all_state_variants()
+            .into_iter()
+            .filter(is_after_fulfilled_state)
+        {
+            let state_name = initial_state.to_string();
+            let mut sm = crate::graph::tests::create_sm(initial_state.clone());
+
+            let result = sm.process_event(cfg.clone(), coop_payout_failed_event());
+
+            assert!(
+                matches!(
+                    &result,
+                    Err(GSMError::Rejected { reason, .. })
+                        if reason.contains("stale cooperative payout failure")
+                ),
+                "expected stale cooperative payout failure to be rejected in {state_name}, got {result:?}"
+            );
+            assert_eq!(
+                sm.state(),
+                &initial_state,
+                "rejected stale cooperative payout failure must not mutate {state_name}"
+            );
+        }
+    }
+
+    #[test]
     fn test_coop_payout_failed_from_non_fulfilled_states() {
         let non_fulfilled_states: Vec<GraphState> = all_state_variants()
             .into_iter()
             .filter(|s| !matches!(s, GraphState::Fulfilled { .. }))
+            .filter(|s| !is_after_fulfilled_state(s))
             .collect();
 
         for state in non_fulfilled_states {

--- a/crates/bridge-sm/src/graph/transitions/deposit_signal.rs
+++ b/crates/bridge-sm/src/graph/transitions/deposit_signal.rs
@@ -40,6 +40,10 @@ impl GraphSM {
     ) -> GSMResult<GSMOutput> {
         // Extract context values before the match to avoid borrow conflicts
         let graph_ctx = self.context().clone();
+        let event = DepositToGraph::CooperativePayoutFailed {
+            assignee,
+            graph_idx,
+        };
 
         match self.state_mut() {
             GraphState::Fulfilled {
@@ -63,15 +67,21 @@ impl GraphSM {
 
                 Ok(GSMOutput::with_duties(duties))
             }
-            _ => Err(GSMError::invalid_event(
-                self.state().clone(),
-                DepositToGraph::CooperativePayoutFailed {
-                    assignee,
-                    graph_idx,
-                }
-                .into(),
-                None,
+            state @ (GraphState::Claimed { .. }
+            | GraphState::Contested { .. }
+            | GraphState::BridgeProofPosted { .. }
+            | GraphState::BridgeProofTimedout { .. }
+            | GraphState::CounterProofPosted { .. }
+            | GraphState::AllNackd { .. }
+            | GraphState::Acked { .. }
+            | GraphState::Withdrawn { .. }
+            | GraphState::Slashed { .. }
+            | GraphState::Aborted { .. }) => Err(GSMError::rejected(
+                state.clone(),
+                event.into(),
+                "stale cooperative payout failure after graph left Fulfilled",
             )),
+            state => Err(GSMError::invalid_event(state.clone(), event.into(), None)),
         }
     }
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR fixes a bug where if one of the operators' configs disallows cooperative path and proceeds directly to posting a claim transaction, other operators (waiting on the cooperative path) to panic as they receive a cooperative path failed signal in post-`Fulfilled` states.

Codex was used to implement the fix and the regression test.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3492