### PR TITLE
fix(gsm): accept contested payout while counterproof is outstanding

### DIFF
--- a/crates/bridge-sm/src/graph/tests/process_payout.rs
+++ b/crates/bridge-sm/src/graph/tests/process_payout.rs
@@ -12,7 +12,7 @@ mod tests {
             INITIAL_BLOCK_HEIGHT, LATER_BLOCK_HEIGHT, TEST_POV_IDX, dummy_proof_receipt,
             mock_states::{
                 all_nackd_state, assigned_state, bridge_proof_posted_state, claimed_state,
-                contested_state,
+                contested_state, counter_proof_posted_state,
             },
             test_deposit_params, test_graph_invalid_transition, test_graph_summary,
             test_graph_transition, test_recipient_desc,
@@ -165,6 +165,35 @@ mod tests {
     fn test_payout_from_contested_rejected_invalid_txid() {
         test_graph_invalid_transition(GraphInvalidTransition {
             from_state: contested_state(),
+            event: GraphEvent::PayoutConfirmed(PayoutConfirmedEvent {
+                payout_txid: generate_txid(),
+            }),
+            expected_error: |e| matches!(e, GSMError::Rejected { .. }),
+        });
+    }
+
+    #[test]
+    fn test_payout_from_counter_proof_posted() {
+        let graph_summary = test_graph_summary();
+        let claim_txid = graph_summary.claim;
+        let payout_txid = graph_summary.contested_payout;
+
+        test_graph_transition(GraphTransition {
+            from_state: counter_proof_posted_state(),
+            event: GraphEvent::PayoutConfirmed(PayoutConfirmedEvent { payout_txid }),
+            expected_state: GraphState::Withdrawn {
+                claim_txid,
+                payout_txid,
+            },
+            expected_duties: vec![],
+            expected_signals: vec![],
+        });
+    }
+
+    #[test]
+    fn test_payout_from_counter_proof_posted_rejected_invalid_txid() {
+        test_graph_invalid_transition(GraphInvalidTransition {
+            from_state: counter_proof_posted_state(),
             event: GraphEvent::PayoutConfirmed(PayoutConfirmedEvent {
                 payout_txid: generate_txid(),
             }),

--- a/crates/bridge-sm/src/graph/transitions/payout.rs
+++ b/crates/bridge-sm/src/graph/transitions/payout.rs
@@ -109,6 +109,36 @@ impl GraphSM {
                 self.state().clone(),
                 payout_event.into(),
             )),
+            // A watchtower liveness fault can leave a counterproof unacked
+            // past the ACK timelock, allowing the operator to spend the
+            // contested payout connector before the GSM has observed an ACK
+            // or NACK. Treat the on-chain contested payout as authoritative
+            // and finalize as `Withdrawn`; any other txid is still rejected.
+            // Without this branch the event falls through to `InvalidEvent`,
+            // which the orchestrator escalates to a fatal
+            // `InvariantViolation` and crashes the node.
+            GraphState::CounterProofPosted { graph_summary, .. } => {
+                if payout_event.payout_txid != graph_summary.contested_payout {
+                    return Err(GSMError::rejected(
+                        self.state().clone(),
+                        payout_event.into(),
+                        "Invalid contested payout transaction",
+                    ));
+                }
+
+                warn!(
+                    graph_idx = ?self.context().graph_idx(),
+                    payout_txid = %payout_event.payout_txid,
+                    "Contested payout posted while counterproof still outstanding"
+                );
+
+                self.state = GraphState::Withdrawn {
+                    claim_txid: graph_summary.claim,
+                    payout_txid: payout_event.payout_txid,
+                };
+
+                Ok(GSMOutput::new())
+            }
             _ => Err(GSMError::invalid_event(
                 self.state().clone(),
                 payout_event.into(),


### PR DESCRIPTION
## Description
A watchtower liveness fault can leave a counterproof unacked past the ACK timelock; when the operator then spends the contested payout connector, `process_payout` now transitions to `Withdrawn` instead of emitting `InvalidEvent`, which the orchestrator was escalating to a fatal `InvariantViolation` and crashing the node.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update
