### PR TITLE
refactor(bridge): adopt GameIndex on mosaic client API and align counterproof output ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11969,7 +11969,6 @@ version = "0.1.0"
 dependencies = [
  "algebra",
  "async-trait",
- "hex",
  "mosaic-rpc-api",
  "mosaic-rpc-types",
  "strata-bridge-primitives",

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -1,7 +1,5 @@
 //! Executors for uncontested payout graph duties.
 
-use std::num::NonZero;
-
 use algebra::predicate;
 use bitcoin::{
     OutPoint, TapSighashType, TxOut, Txid, XOnlyPublicKey,
@@ -18,7 +16,7 @@ use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
 use strata_bridge_primitives::{
     operator_table::OperatorTable,
     scripts::taproot::{TaprootTweak, TaprootWitness, create_message_hash},
-    types::{GraphIdx, OperatorIdx},
+    types::{GameIndex, GraphIdx, OperatorIdx},
 };
 use strata_bridge_sm::graph::{context::GraphSMCtx, machine::generate_game_graph};
 use strata_bridge_tx_graph::{
@@ -55,6 +53,9 @@ pub(super) async fn generate_graph_data(
         "generating graph data"
     );
 
+    let game_index = GameIndex::try_from(graph_idx.deposit)
+        .expect("deposit index does not overflow when mapped to game index");
+
     let funding_outpoint = ensure_claim_funding_outpoint(cfg, output_handles, graph_idx).await?;
     info!(?graph_idx, %funding_outpoint, "funding outpoint acquired");
 
@@ -62,6 +63,7 @@ pub(super) async fn generate_graph_data(
         output_handles.mosaic_client.as_ref(),
         &output_handles.operator_table,
         graph_idx,
+        game_index,
     )
     .await?;
     info!(
@@ -79,8 +81,7 @@ pub(super) async fn generate_graph_data(
         operator_table: output_handles.operator_table.clone(),
     };
     let deposit_params = DepositParams {
-        game_index: NonZero::new(graph_idx.deposit + 1)
-            .expect("(deposit index + 1) is always non-zero"),
+        game_index: game_index.into(),
         claim_funds: funding_outpoint,
         deposit_outpoint,
         adaptor_pubkeys: adaptor_pubkeys
@@ -103,6 +104,7 @@ pub(super) async fn generate_graph_data(
         output_handles.mosaic_client.as_ref(),
         &output_handles.operator_table,
         graph_idx,
+        game_index,
         &game_graph,
     )
     .await?;
@@ -225,6 +227,7 @@ async fn fetch_graph_keys(
     mosaic_client: &dyn MosaicClientApi,
     operator_table: &OperatorTable,
     graph_idx: GraphIdx,
+    game_index: GameIndex,
 ) -> Result<(Vec<XOnlyPubKey>, Vec<XOnlyPubKey>), ExecutorError> {
     let owner_idx = graph_idx.operator;
 
@@ -234,9 +237,9 @@ async fn fetch_graph_keys(
     let mut adaptor_pubkeys = Vec::new();
     let mut fault_pubkeys = Vec::new();
     for watchtower in watchtower_idxs(operator_table, owner_idx) {
-        info!(?graph_idx, %watchtower, "fetching adaptor pubkey from mosaic");
+        info!(?graph_idx, %game_index, %watchtower, "fetching adaptor pubkey from mosaic");
         let adaptor = mosaic_client
-            .get_adaptor_pubkey(watchtower, graph_idx.deposit)
+            .get_adaptor_pubkey(watchtower, game_index)
             .await
             .map_err(|e| ExecutorError::MosaicErr(format!("get_adaptor_pubkey: {e:?}")))?
             .ok_or_else(|| {
@@ -246,7 +249,7 @@ async fn fetch_graph_keys(
             })?;
         adaptor_pubkeys.push(adaptor.into());
 
-        info!(?graph_idx, %watchtower, "fetching fault pubkey from mosaic");
+        info!(?graph_idx, %game_index, %watchtower, "fetching fault pubkey from mosaic");
         let fault_pubkey = mosaic_client
             .get_fault_pubkey(watchtower, Role::Evaluator)
             .await
@@ -273,12 +276,14 @@ async fn init_evaluator_with_peers(
     mosaic_client: &dyn MosaicClientApi,
     operator_table: &OperatorTable,
     graph_idx: GraphIdx,
+    game_index: GameIndex,
     game_graph: &GameGraph,
 ) -> Result<(), ExecutorError> {
     for (slot, watchtower_idx) in watchtower_idxs(operator_table, graph_idx.operator).enumerate() {
         let sighashes = game_graph.counterproofs[slot].counterproof.sighashes();
         info!(
             ?graph_idx,
+            %game_index,
             %watchtower_idx,
             n_sighashes = sighashes.len(),
             "computed counterproof sighashes"
@@ -296,12 +301,12 @@ async fn init_evaluator_with_peers(
                 ))
             })?;
 
-        info!(?graph_idx, %watchtower_idx, "calling mosaic init_evaluator_deposit");
+        info!(?graph_idx, %game_index, %watchtower_idx, "calling mosaic init_evaluator_deposit");
         mosaic_client
-            .init_evaluator_deposit(watchtower_idx, graph_idx.deposit, deposit_sighashes)
+            .init_evaluator_deposit(watchtower_idx, game_index, deposit_sighashes)
             .await
             .map_err(|e| ExecutorError::MosaicErr(format!("init_evaluator_deposit: {e:?}")))?;
-        info!(?graph_idx, %watchtower_idx, "mosaic init_evaluator_deposit ok");
+        info!(?graph_idx, %game_index, %watchtower_idx, "mosaic init_evaluator_deposit ok");
     }
 
     Ok(())
@@ -331,6 +336,7 @@ fn watchtower_idxs(
 pub(super) async fn verify_adaptors(
     output_handles: &OutputHandles,
     graph_idx: GraphIdx,
+    game_index: GameIndex,
     watchtower_idx: OperatorIdx,
     sighashes: &[Message],
     adaptor_pubkey: XOnlyPublicKey,
@@ -338,6 +344,7 @@ pub(super) async fn verify_adaptors(
 ) -> Result<(), ExecutorError> {
     info!(
         ?graph_idx,
+        %game_index,
         %watchtower_idx,
         num_sighashes = sighashes.len(),
         "verifying adaptor signatures"
@@ -378,7 +385,7 @@ pub(super) async fn verify_adaptors(
         .mosaic_client
         .init_garbler_deposit(
             graph_idx.operator,
-            graph_idx.deposit,
+            game_index,
             deposit_sighashes,
             adaptor_pubkey,
         )
@@ -387,6 +394,7 @@ pub(super) async fn verify_adaptors(
 
     info!(
         ?graph_idx,
+        %game_index,
         %watchtower_idx,
         "mosaic init_garbler_deposit ok; awaiting AdaptorsVerified event"
     );

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -50,13 +50,13 @@ pub(super) async fn generate_and_publish_counterproof(
     .await?;
 
     // Complete adaptor signatures via mosaic (we are the garbler/watchtower).
-    info!(%deposit_idx, %operator_idx, "completing adaptor signatures via mosaic for graph");
+    info!(%deposit_idx, %game_index, %operator_idx, "completing adaptor signatures via mosaic for graph");
     let completed_sigs = output_handles
         .mosaic_client
-        .complete_adaptor_sigs(operator_idx, deposit_idx, counterproof_data)
+        .complete_adaptor_sigs(operator_idx, game_index.into(), counterproof_data)
         .await
         .map_err(|e| {
-            warn!(?e, "failed to complete adaptor sigs for counterproof");
+            warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to complete adaptor sigs for counterproof");
             ExecutorError::MosaicErr(format!("complete_adaptor_sigs: {e:?}"))
         })?;
 
@@ -64,7 +64,7 @@ pub(super) async fn generate_and_publish_counterproof(
     // data (n_data = N_DEPOSIT + N_WITHDRAWAL wires), so we need ALL completed adaptor sigs.
     let operator_signatures = completed_sigs.to_vec();
 
-    info!(%deposit_idx, %operator_idx, "signing and publishing counterproof tx for graph");
+    info!(%deposit_idx, %game_index, %operator_idx, "signing and publishing counterproof tx for graph");
 
     // Assemble witness and finalize.
     let witness = ContestCounterproofWitness {
@@ -106,7 +106,7 @@ async fn generate_counterproof(
     )
     .await?;
 
-    info!(%deposit_idx, %operator_idx, "generating counterproof for graph");
+    info!(%deposit_idx, %game_index, %operator_idx, "generating counterproof for graph");
     let prove_start = std::time::Instant::now();
     let counterproof_data = match output_handles.counterproof_host.clone() {
         BridgeCounterproofHost::Native(host) => {
@@ -123,6 +123,7 @@ async fn generate_counterproof(
     };
     info!(
         %deposit_idx,
+        %game_index,
         %operator_idx,
         elapsed = ?prove_start.elapsed(),
         "counterproof generated for graph",

--- a/crates/bridge-exec/src/graph/counterproof_nack.rs
+++ b/crates/bridge-exec/src/graph/counterproof_nack.rs
@@ -4,7 +4,7 @@ use bitcoin::{TxOut, hashes::Hash};
 use btc_tracker::event::TxStatus;
 use strata_bridge_primitives::{
     scripts::taproot::TaprootTweak,
-    types::{DepositIdx, OperatorIdx},
+    types::{DepositIdx, GameIndex, OperatorIdx},
 };
 use strata_bridge_tx_graph::{fee, transactions::prelude::CounterproofNackTx};
 use strata_mosaic_client_api::types::{CompletedSignatures, Sighash, Tweak};
@@ -18,11 +18,12 @@ use crate::{
 pub(super) async fn publish_counterproof_nack(
     output_handles: &OutputHandles,
     deposit_idx: DepositIdx,
+    game_index: GameIndex,
     counterprover_idx: OperatorIdx,
     completed_signatures: CompletedSignatures,
     mut counterproof_nack_tx: CounterproofNackTx,
 ) -> Result<(), ExecutorError> {
-    info!(%deposit_idx, %counterprover_idx, "preparing counterproof nack");
+    info!(%deposit_idx, %game_index, %counterprover_idx, "preparing counterproof nack");
 
     // Single output: forward the connector's dust value (minus the nack tx fee) back to the
     // operator's general wallet. The connector script is `minimal_non_dust` P2TR plus the
@@ -40,6 +41,7 @@ pub(super) async fn publish_counterproof_nack(
         output_handles,
         counterprover_idx,
         deposit_idx,
+        game_index,
         completed_signatures,
         counterproof_nack_tx,
     )
@@ -51,6 +53,7 @@ async fn sign_and_broadcast_nack(
     output_handles: &OutputHandles,
     counterprover_idx: OperatorIdx,
     deposit_idx: DepositIdx,
+    game_index: GameIndex,
     completed_signatures: CompletedSignatures,
     nack_tx: CounterproofNackTx,
 ) -> Result<(), ExecutorError> {
@@ -67,20 +70,20 @@ async fn sign_and_broadcast_nack(
         }
     };
 
-    info!(%deposit_idx, %counterprover_idx, "calling mosaic evaluate_and_sign");
+    info!(%deposit_idx, %game_index, %counterprover_idx, "calling mosaic evaluate_and_sign");
     let evaluate_and_sign_start = std::time::Instant::now();
     let wt_fault_signature = output_handles
         .mosaic_client
         .evaluate_and_sign(
             counterprover_idx,
-            deposit_idx,
+            game_index,
             completed_signatures,
             sighash,
             tweak,
         )
         .await
         .map_err(|e| {
-            warn!(%deposit_idx, %counterprover_idx, ?e, "evaluate_and_sign failed");
+            warn!(%deposit_idx, %game_index, %counterprover_idx, ?e, "evaluate_and_sign failed");
             ExecutorError::MosaicErr(format!("evaluate_and_sign: {e:?}"))
         })?
         .ok_or_else(|| {
@@ -90,6 +93,7 @@ async fn sign_and_broadcast_nack(
         })?;
     info!(
         %deposit_idx,
+        %game_index,
         %counterprover_idx,
         elapsed = ?evaluate_and_sign_start.elapsed(),
         "mosaic evaluate_and_sign completed",
@@ -97,7 +101,7 @@ async fn sign_and_broadcast_nack(
 
     let signed_tx = nack_tx.finalize_partial(wt_fault_signature);
 
-    info!(%deposit_idx, %counterprover_idx, "publishing counterproof nack transaction");
+    info!(%deposit_idx, %game_index, %counterprover_idx, "publishing counterproof nack transaction");
     publish_signed_transaction(
         &output_handles.tx_driver,
         &signed_tx,

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -13,6 +13,7 @@ mod utils;
 use std::sync::Arc;
 
 use strata_bridge_p2p_types::{NagRequest, NagRequestPayload};
+use strata_bridge_primitives::types::GameIndex;
 use strata_bridge_sm::graph::duties::GraphDuty;
 use tracing::info;
 
@@ -64,9 +65,12 @@ pub async fn execute_graph_duty(
             adaptor_pubkey,
             fault_pubkey,
         } => {
+            let game_index = GameIndex::try_from(graph_idx.deposit)
+                .expect("deposit index does not overflow when mapped to game index");
             verify_adaptors(
                 &output_handles,
                 *graph_idx,
+                game_index,
                 *watchtower_idx,
                 sighashes,
                 *adaptor_pubkey,
@@ -197,9 +201,12 @@ pub async fn execute_graph_duty(
             completed_signatures,
             counterproof_nack_tx,
         } => {
+            let game_index = GameIndex::try_from(*deposit_idx)
+                .expect("deposit index does not overflow when mapped to game index");
             publish_counterproof_nack(
                 &output_handles,
                 *deposit_idx,
+                game_index,
                 *counterprover_idx,
                 *completed_signatures,
                 counterproof_nack_tx.clone(),

--- a/crates/mosaic-client-api/src/api.rs
+++ b/crates/mosaic-client-api/src/api.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use strata_bridge_primitives::subscription::Subscription;
+use strata_bridge_primitives::{subscription::Subscription, types::GameIndex};
 
 use crate::{MosaicError, MosaicEvent, MosaicSetupError, types::*};
 
@@ -70,7 +70,7 @@ pub trait MosaicClientApi: Send + Sync + 'static {
     async fn get_adaptor_pubkey(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
     ) -> Result<Option<PubKey>, MosaicError>;
 
     /// Initializes a deposit on an evaluator tableset and returns after deposit is accepted by
@@ -80,7 +80,7 @@ pub trait MosaicClientApi: Send + Sync + 'static {
     async fn init_evaluator_deposit(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         sighashes: DepositSighashes,
     ) -> Result<(), MosaicError>;
 
@@ -96,7 +96,7 @@ pub trait MosaicClientApi: Send + Sync + 'static {
     async fn init_garbler_deposit(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         sighashes: DepositSighashes,
         adaptor_pubkey: PubKey,
     ) -> Result<(), MosaicError>;
@@ -111,7 +111,7 @@ pub trait MosaicClientApi: Send + Sync + 'static {
         &self,
         operator_idx: OperatorIdx,
         role: Role,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
     ) -> Result<(), MosaicError>;
 
     /// Garbler side: completes adaptor signatures for a contested withdrawal.
@@ -124,7 +124,7 @@ pub trait MosaicClientApi: Send + Sync + 'static {
     async fn complete_adaptor_sigs(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         counterproof: G16ProofRaw,
     ) -> Result<CompletedSignatures, MosaicError>;
 
@@ -140,7 +140,7 @@ pub trait MosaicClientApi: Send + Sync + 'static {
     async fn evaluate_and_sign(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         completed_signatures: CompletedSignatures,
         sighash: Sighash,
         tweak: Option<Tweak>,

--- a/crates/mosaic-client-api/src/error.rs
+++ b/crates/mosaic-client-api/src/error.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 
-use strata_bridge_primitives::types::OperatorIdx;
+use strata_bridge_primitives::types::{GameIndex, OperatorIdx};
 
-use crate::types::{DepositIdx, Role};
+use crate::types::Role;
 
 /// Errors arising from mosaic operations.
 #[derive(Debug, thiserror::Error)]
@@ -14,14 +14,14 @@ pub enum MosaicError {
     #[error("mosaic setup missing: {0}|{1}")]
     SetupMissing(OperatorIdx, Role),
     /// The deposit was aborted before completion.
-    #[error("deposit {0} aborted")]
-    DepositAborted(DepositIdx),
+    #[error("game {0} aborted")]
+    DepositAborted(GameIndex),
     /// The deposit was not seen within timeout.
     #[error("deposit missing: {0}|{1}|{2}")]
-    DepositMissing(OperatorIdx, Role, DepositIdx),
+    DepositMissing(OperatorIdx, Role, GameIndex),
     /// The deposit has already been withdrawn.
-    #[error("deposit {0} already withdrawn")]
-    DepositWithdrawn(DepositIdx),
+    #[error("game {0} already withdrawn")]
+    DepositWithdrawn(GameIndex),
     /// The deposit is in an unexpected state.
     #[error("unexpected deposit state: {0}")]
     UnexpectedDepositState(String),
@@ -34,8 +34,8 @@ pub enum MosaicError {
         actual: String,
     },
     /// The fault secret is missing when it should have been available.
-    #[error("fault secret unexpectedly missing for deposit {0}")]
-    UnexpectedMissingFinalSecret(DepositIdx),
+    #[error("fault secret unexpectedly missing for game {0}")]
+    UnexpectedMissingFinalSecret(GameIndex),
     /// An RPC communication error with the mosaic service.
     #[error("mosaic RPC error")]
     RpcError(#[source] Box<dyn Error + Send + Sync + 'static>),

--- a/crates/mosaic-client/Cargo.toml
+++ b/crates/mosaic-client/Cargo.toml
@@ -15,6 +15,5 @@ mosaic-rpc-api.workspace = true
 mosaic-rpc-types.workspace = true
 
 async-trait.workspace = true
-hex.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/mosaic-client/src/client.rs
+++ b/crates/mosaic-client/src/client.rs
@@ -128,13 +128,13 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         game_index: GameIndex,
     ) -> Result<Option<PubKey>, MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Evaluator, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
-        let rpc_deposit_id = deposit_id.into();
+        let game_id = self.provider.resolve_game_id(game_index);
+        let rpc_game_id = game_id.into();
         let rpc = self.rpc.clone();
         let pubkey = retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.evaluator_get_adaptor_pubkey(tableset_id, rpc_deposit_id)
+                rpc.evaluator_get_adaptor_pubkey(tableset_id, rpc_game_id)
                     .await
                     .map_err(MosaicError::rpc_error)
             }
@@ -152,9 +152,9 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         sighashes: DepositSighashes,
     ) -> Result<(), MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Evaluator, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
+        let game_id = self.provider.resolve_game_id(game_index);
         let deposit_inputs: DepositInputs = game_index.get().to_le_bytes();
-        let rpc_deposit_id = deposit_id.into();
+        let rpc_game_id = game_id.into();
 
         // If the deposit is already initialized (e.g. after a bridge restart), mosaic rejects a
         // second init with `DuplicateDeposit`. Skip the init RPC in that case but still fall
@@ -166,7 +166,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         let preexisting_status = retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.get_deposit_status(tableset_id, rpc_deposit_id)
+                rpc.get_deposit_status(tableset_id, rpc_game_id)
                     .await
                     .map_err(MosaicError::rpc_error)
             }
@@ -184,7 +184,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                 let rpc = rpc.clone();
                 let deposit_config = deposit_config.clone();
                 async move {
-                    rpc.init_evaluator_deposit(tableset_id, rpc_deposit_id, deposit_config)
+                    rpc.init_evaluator_deposit(tableset_id, rpc_game_id, deposit_config)
                         .await
                         .map_err(MosaicError::rpc_error)
                 }
@@ -199,7 +199,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         let status = retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.get_deposit_status(tableset_id, rpc_deposit_id)
+                rpc.get_deposit_status(tableset_id, rpc_game_id)
                     .await
                     .map_err(MosaicError::rpc_error)
                     .and_then(|maybe_status| {
@@ -237,9 +237,9 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         adaptor_pubkey: PubKey,
     ) -> Result<(), MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Garbler, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
+        let game_id = self.provider.resolve_game_id(game_index);
         let deposit_inputs: DepositInputs = game_index.get().to_le_bytes();
-        let rpc_deposit_id = deposit_id.into();
+        let rpc_game_id = game_id.into();
 
         // If the deposit is already initialized (e.g. after a bridge restart), mosaic rejects a
         // second init with `DuplicateDeposit`. Skip the init RPC in that case and fall through to
@@ -249,7 +249,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         let preexisting_status = retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.get_deposit_status(tableset_id, rpc_deposit_id)
+                rpc.get_deposit_status(tableset_id, rpc_game_id)
                     .await
                     .map_err(MosaicError::rpc_error)
             }
@@ -268,7 +268,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                 let rpc = rpc.clone();
                 let deposit_config = deposit_config.clone();
                 async move {
-                    rpc.init_garbler_deposit(tableset_id, rpc_deposit_id, deposit_config)
+                    rpc.init_garbler_deposit(tableset_id, rpc_game_id, deposit_config)
                         .await
                         .map_err(MosaicError::rpc_error)
                 }
@@ -283,7 +283,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         let status = retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.get_deposit_status(tableset_id, rpc_deposit_id)
+                rpc.get_deposit_status(tableset_id, rpc_game_id)
                     .await
                     .map_err(MosaicError::rpc_error)
                     .and_then(|maybe_status| {
@@ -336,14 +336,14 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         game_index: GameIndex,
     ) -> Result<(), MosaicError> {
         let tableset_id = self.get_tableset_id(role, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
+        let game_id = self.provider.resolve_game_id(game_index);
 
         let rpc = self.rpc.clone();
-        let rpc_deposit_id = deposit_id.into();
+        let rpc_game_id = game_id.into();
         retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.mark_deposit_withdrawn(tableset_id, rpc_deposit_id)
+                rpc.mark_deposit_withdrawn(tableset_id, rpc_game_id)
                     .await
                     .map_err(MosaicError::rpc_error)
             }
@@ -361,8 +361,8 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         counterproof: G16ProofRaw,
     ) -> Result<CompletedSignatures, MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Garbler, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
-        let rpc_deposit_id = deposit_id.into();
+        let game_id = self.provider.resolve_game_id(game_index);
+        let rpc_game_id = game_id.into();
         let withdrawal_inputs: WithdrawalInputs = counterproof.0;
 
         let rpc = self.rpc.clone();
@@ -370,14 +370,14 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         retry_with(self.default_retry_strategy(), move || {
             let rpc = rpc.clone();
             async move {
-                rpc.complete_adaptor_sigs(tableset_id, rpc_deposit_id, rpc_withdrawal_inputs)
+                rpc.complete_adaptor_sigs(tableset_id, rpc_game_id, rpc_withdrawal_inputs)
                     .await
                     .map_err(MosaicError::rpc_error)
             }
         })
         .await?;
 
-        self.poll_until_consumed(tableset_id, deposit_id, operator_idx, Role::Garbler)
+        self.poll_until_consumed(tableset_id, game_id, operator_idx, Role::Garbler)
             .await?;
 
         let rpc = self.rpc.clone();
@@ -405,8 +405,8 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         tweak: Option<Tweak>,
     ) -> Result<Option<Signature>, MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Evaluator, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
-        let rpc_deposit_id = deposit_id.into();
+        let game_id = self.provider.resolve_game_id(game_index);
+        let rpc_game_id = game_id.into();
 
         let rpc = self.rpc.clone();
         let withdrawal_config = EvaluatorWithdrawalConfig {
@@ -417,7 +417,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
             let rpc = rpc.clone();
             let withdrawal_config = withdrawal_config.clone();
             async move {
-                rpc.evaluate_tableset(tableset_id, rpc_deposit_id, withdrawal_config)
+                rpc.evaluate_tableset(tableset_id, rpc_game_id, withdrawal_config)
                     .await
                     .map_err(MosaicError::rpc_error)
             }
@@ -425,7 +425,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         .await?;
 
         let success = self
-            .poll_until_consumed(tableset_id, deposit_id, operator_idx, Role::Evaluator)
+            .poll_until_consumed(tableset_id, game_id, operator_idx, Role::Evaluator)
             .await?;
 
         if !success {

--- a/crates/mosaic-client/src/client.rs
+++ b/crates/mosaic-client/src/client.rs
@@ -4,7 +4,7 @@ use mosaic_rpc_types::{
     DepositStatus, EvaluatorDepositConfig, EvaluatorWithdrawalConfig, GarblerDepositConfig,
     RpcTablesetStatus,
 };
-use strata_bridge_primitives::subscription::Subscription;
+use strata_bridge_primitives::{subscription::Subscription, types::GameIndex};
 use strata_mosaic_client_api::{
     MosaicClientApi, MosaicError, MosaicEvent, MosaicSetupError, types::*,
 };
@@ -121,14 +121,14 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Ok(pubkey)
     }
 
-    #[instrument(skip_all, fields(%operator_idx, %deposit_idx))]
+    #[instrument(skip_all, fields(%operator_idx, %game_index))]
     async fn get_adaptor_pubkey(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
     ) -> Result<Option<PubKey>, MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Evaluator, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
+        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
         let rpc_deposit_id = deposit_id.into();
         let rpc = self.rpc.clone();
         let pubkey = retry_with(self.default_retry_strategy(), move || {
@@ -144,16 +144,16 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Ok(pubkey)
     }
 
-    #[instrument(skip_all, fields(%operator_idx, %deposit_idx))]
+    #[instrument(skip_all, fields(%operator_idx, %game_index))]
     async fn init_evaluator_deposit(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         sighashes: DepositSighashes,
     ) -> Result<(), MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Evaluator, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
-        let deposit_inputs: DepositInputs = deposit_idx.to_le_bytes();
+        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
+        let deposit_inputs: DepositInputs = game_index.get().to_le_bytes();
         let rpc_deposit_id = deposit_id.into();
 
         // If the deposit is already initialized (e.g. after a bridge restart), mosaic rejects a
@@ -204,7 +204,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                     .map_err(MosaicError::rpc_error)
                     .and_then(|maybe_status| {
                         maybe_status.ok_or_else(|| {
-                            MosaicError::DepositMissing(operator_idx, Role::Evaluator, deposit_idx)
+                            MosaicError::DepositMissing(operator_idx, Role::Evaluator, game_index)
                         })
                     })
             }
@@ -217,28 +217,28 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         // [`MosaicEvent::AdaptorsVerified`].
         match status {
             DepositStatus::Aborted { reason } => {
-                error!(%deposit_idx, %reason, "evaluator deposit aborted on mosaic");
-                Err(MosaicError::DepositAborted(deposit_idx))
+                error!(%game_index, %reason, "evaluator deposit aborted on mosaic");
+                Err(MosaicError::DepositAborted(game_index))
             }
             DepositStatus::UncontestedWithdrawal | DepositStatus::Consumed { .. } => {
-                error!(%deposit_idx, "evaluator deposit is already withdrawn");
-                Err(MosaicError::DepositWithdrawn(deposit_idx))
+                error!(%game_index, "evaluator deposit is already withdrawn");
+                Err(MosaicError::DepositWithdrawn(game_index))
             }
             DepositStatus::Incomplete { .. } | DepositStatus::Ready => Ok(()),
         }
     }
 
-    #[instrument(skip_all, fields(%operator_idx, %deposit_idx))]
+    #[instrument(skip_all, fields(%operator_idx, %game_index))]
     async fn init_garbler_deposit(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         sighashes: DepositSighashes,
         adaptor_pubkey: PubKey,
     ) -> Result<(), MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Garbler, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
-        let deposit_inputs: DepositInputs = deposit_idx.to_le_bytes();
+        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
+        let deposit_inputs: DepositInputs = game_index.get().to_le_bytes();
         let rpc_deposit_id = deposit_id.into();
 
         // If the deposit is already initialized (e.g. after a bridge restart), mosaic rejects a
@@ -288,7 +288,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                     .map_err(MosaicError::rpc_error)
                     .and_then(|maybe_status| {
                         maybe_status.ok_or_else(|| {
-                            MosaicError::DepositMissing(operator_idx, Role::Garbler, deposit_idx)
+                            MosaicError::DepositMissing(operator_idx, Role::Garbler, game_index)
                         })
                     })
             }
@@ -297,12 +297,12 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
 
         match status {
             DepositStatus::Aborted { reason } => {
-                error!(%deposit_idx, %reason, "deposit aborted on mosaic");
-                return Err(MosaicError::DepositAborted(deposit_idx));
+                error!(%game_index, %reason, "deposit aborted on mosaic");
+                return Err(MosaicError::DepositAborted(game_index));
             }
             DepositStatus::UncontestedWithdrawal | DepositStatus::Consumed { .. } => {
-                error!(%deposit_idx, "deposit is already withdrawn");
-                return Err(MosaicError::DepositWithdrawn(deposit_idx));
+                error!(%game_index, "deposit is already withdrawn");
+                return Err(MosaicError::DepositWithdrawn(game_index));
             }
             DepositStatus::Incomplete { details } => {
                 // The slow path: we know the deposit exists, but mosaic is not ready yet.
@@ -312,13 +312,13 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                 self.watched_deposits
                     .lock()
                     .await
-                    .insert((tableset_id, operator_idx, deposit_idx), 0);
+                    .insert((tableset_id, operator_idx, game_index), 0);
             }
             DepositStatus::Ready => {
                 // The fast path: init already observed `Ready`, so emit immediately rather than
                 // waiting for the next poll interval. Reuse the poller helper so both paths clear
                 // any stale watch entry before emitting and therefore cannot double-emit later.
-                self.emit_adaptors_verified(tableset_id, operator_idx, deposit_idx)
+                self.emit_adaptors_verified(tableset_id, operator_idx, game_index)
                     .await;
             }
         }
@@ -328,15 +328,15 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
 
     // ---- Withdrawal ----
 
-    #[instrument(skip_all, fields(%operator_idx, %role, %deposit_idx))]
+    #[instrument(skip_all, fields(%operator_idx, %role, %game_index))]
     async fn mark_deposit_withdrawn(
         &self,
         operator_idx: OperatorIdx,
         role: Role,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
     ) -> Result<(), MosaicError> {
         let tableset_id = self.get_tableset_id(role, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
+        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
 
         let rpc = self.rpc.clone();
         let rpc_deposit_id = deposit_id.into();
@@ -353,15 +353,15 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Ok(())
     }
 
-    #[instrument(skip_all, fields(%operator_idx, %deposit_idx))]
+    #[instrument(skip_all, fields(%operator_idx, %game_index))]
     async fn complete_adaptor_sigs(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         counterproof: G16ProofRaw,
     ) -> Result<CompletedSignatures, MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Garbler, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
+        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
         let rpc_deposit_id = deposit_id.into();
         let withdrawal_inputs: WithdrawalInputs = counterproof.0;
 
@@ -395,17 +395,17 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Ok(completed_sigs)
     }
 
-    #[instrument(skip_all, fields(%operator_idx, %deposit_idx))]
+    #[instrument(skip_all, fields(%operator_idx, %game_index))]
     async fn evaluate_and_sign(
         &self,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         completed_signatures: CompletedSignatures,
         sighash: Sighash,
         tweak: Option<Tweak>,
     ) -> Result<Option<Signature>, MosaicError> {
         let tableset_id = self.get_tableset_id(Role::Evaluator, operator_idx).await?;
-        let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
+        let deposit_id = self.provider.resolve_deposit_id(game_index.get());
         let rpc_deposit_id = deposit_id.into();
 
         let rpc = self.rpc.clone();
@@ -442,7 +442,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                 rpc.sign_with_fault_secret(tableset_id, sighash.into(), tweak.map(Into::into))
                     .await
                     .map_err(MosaicError::rpc_error)?
-                    .ok_or_else(|| MosaicError::UnexpectedMissingFinalSecret(deposit_idx))
+                    .ok_or_else(|| MosaicError::UnexpectedMissingFinalSecret(game_index))
             }
         })
         .await?;

--- a/crates/mosaic-client/src/client.rs
+++ b/crates/mosaic-client/src/client.rs
@@ -377,7 +377,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         })
         .await?;
 
-        self.poll_until_consumed(tableset_id, game_id, operator_idx, Role::Garbler)
+        self.poll_until_consumed(tableset_id, game_index, operator_idx, Role::Garbler)
             .await?;
 
         let rpc = self.rpc.clone();
@@ -425,7 +425,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         .await?;
 
         let success = self
-            .poll_until_consumed(tableset_id, game_id, operator_idx, Role::Evaluator)
+            .poll_until_consumed(tableset_id, game_index, operator_idx, Role::Evaluator)
             .await?;
 
         if !success {

--- a/crates/mosaic-client/src/lib.rs
+++ b/crates/mosaic-client/src/lib.rs
@@ -37,7 +37,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use algebra::retry::{Strategy, retry_with};
 use mosaic_rpc_api::MosaicRpcClient;
 use mosaic_rpc_types::{RpcTablesetId, RpcTablesetStatus};
-use strata_bridge_primitives::types::OperatorIdx;
+use strata_bridge_primitives::types::{GameIndex, OperatorIdx};
 use strata_mosaic_client_api::{MosaicError, MosaicEvent, types::*};
 use tokio::sync::{Mutex, RwLock, mpsc};
 use tracing::{debug, error, info};
@@ -51,7 +51,7 @@ pub(crate) mod util;
 
 pub use resolver::*;
 
-type WatchDepositKey = (RpcTablesetId, OperatorIdx, DepositIdx);
+type WatchDepositKey = (RpcTablesetId, OperatorIdx, GameIndex);
 
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(2);
 const DEFAULT_MAX_RETRIES: usize = 5;

--- a/crates/mosaic-client/src/lib.rs
+++ b/crates/mosaic-client/src/lib.rs
@@ -5,8 +5,8 @@
 //! deposits, and event broadcasting.
 //!
 //! The client is generic over a [`MosaicIdResolver`] which resolves
-//! bridge-native identifiers (`OperatorIdx`, `DepositIdx`) to mosaic-native
-//! ones (`PeerId`, `DepositId`). All mosaic-specific input derivation
+//! bridge-native identifiers (`OperatorIdx`, `GameIndex`) to mosaic-native
+//! ones (`PeerId`, `GameId`). All mosaic-specific input derivation
 //! (setup inputs, deposit inputs, withdrawal inputs) is handled internally.
 //!
 //! # Usage
@@ -201,13 +201,13 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
     }
 
     /// Polls `get_tableset_status` in a loop until the tableset reaches the
-    /// `Consumed` state, validating the deposit ID at each step.
+    /// `Consumed` state, validating the game ID at each step.
     ///
     /// Returns the `success` flag from the `Consumed` variant.
     async fn poll_until_consumed(
         &self,
         tableset_id: RpcTablesetId,
-        expected_deposit_id: DepositId,
+        expected_game_id: GameId,
         operator_idx: OperatorIdx,
         role: Role,
     ) -> Result<bool, MosaicError> {
@@ -242,16 +242,16 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                     continue;
                 }
                 RpcTablesetStatus::Contest { deposit } => {
-                    let actual_deposit_id: DepositId = deposit.into();
-                    if expected_deposit_id != actual_deposit_id {
+                    let actual_game_id: GameId = deposit.into();
+                    if expected_game_id != actual_game_id {
                         error!(
-                            expected = %hex::encode(expected_deposit_id),
-                            actual = %hex::encode(actual_deposit_id),
-                            "unexpected deposit_id being contested"
+                            expected = %hex::encode(expected_game_id),
+                            actual = %hex::encode(actual_game_id),
+                            "unexpected game_id being contested"
                         );
                         return Err(MosaicError::UnexpectedDepositContest {
-                            expected: hex::encode(expected_deposit_id),
-                            actual: hex::encode(actual_deposit_id),
+                            expected: hex::encode(expected_game_id),
+                            actual: hex::encode(actual_game_id),
                         });
                     }
                     debug!("waiting for transition from Contest");
@@ -259,16 +259,16 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                     continue;
                 }
                 RpcTablesetStatus::Consumed { deposit, success } => {
-                    let actual_deposit_id: DepositId = deposit.into();
-                    if expected_deposit_id != actual_deposit_id {
+                    let actual_game_id: GameId = deposit.into();
+                    if expected_game_id != actual_game_id {
                         error!(
-                            expected = %hex::encode(expected_deposit_id),
-                            actual = %hex::encode(actual_deposit_id),
-                            "unexpected deposit_id consumed"
+                            expected = %hex::encode(expected_game_id),
+                            actual = %hex::encode(actual_game_id),
+                            "unexpected game_id consumed"
                         );
                         return Err(MosaicError::UnexpectedDepositContest {
-                            expected: hex::encode(expected_deposit_id),
-                            actual: hex::encode(actual_deposit_id),
+                            expected: hex::encode(expected_game_id),
+                            actual: hex::encode(actual_game_id),
                         });
                     }
                     info!("setup consumed; signed adaptors should be ready");

--- a/crates/mosaic-client/src/lib.rs
+++ b/crates/mosaic-client/src/lib.rs
@@ -203,8 +203,8 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
     /// Polls `get_tableset_status` until the tableset is `Consumed`, checking the game
     /// index at each step. Returns the `success` flag from the `Consumed` variant.
     //
-    // TODO(STR-3754): the Contest/Consumed `deposit` field will become a raw `game_index: u32`.
-    // https://alpenlabs.atlassian.net/browse/STR-3754
+    // TODO: <https://alpenlabs.atlassian.net/browse/STR-3754>
+    // the Contest/Consumed `deposit` field will become a raw `game_index: u32`.
     async fn poll_until_consumed(
         &self,
         tableset_id: RpcTablesetId,

--- a/crates/mosaic-client/src/lib.rs
+++ b/crates/mosaic-client/src/lib.rs
@@ -200,14 +200,15 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Strategy::fixed_delay(self.retry_delay).with_max_retries(self.max_retries)
     }
 
-    /// Polls `get_tableset_status` in a loop until the tableset reaches the
-    /// `Consumed` state, validating the game ID at each step.
-    ///
-    /// Returns the `success` flag from the `Consumed` variant.
+    /// Polls `get_tableset_status` until the tableset is `Consumed`, checking the game
+    /// index at each step. Returns the `success` flag from the `Consumed` variant.
+    //
+    // TODO(STR-3754): the Contest/Consumed `deposit` field will become a raw `game_index: u32`.
+    // https://alpenlabs.atlassian.net/browse/STR-3754
     async fn poll_until_consumed(
         &self,
         tableset_id: RpcTablesetId,
-        expected_game_id: GameId,
+        expected_game_index: GameIndex,
         operator_idx: OperatorIdx,
         role: Role,
     ) -> Result<bool, MosaicError> {
@@ -241,34 +242,39 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                     tokio::time::sleep(self.retry_delay).await;
                     continue;
                 }
-                RpcTablesetStatus::Contest { deposit } => {
-                    let actual_game_id: GameId = deposit.into();
-                    if expected_game_id != actual_game_id {
+                RpcTablesetStatus::Contest {
+                    deposit: game_index,
+                } => {
+                    let actual_game_index = game_index.into_game_index();
+                    if expected_game_index != actual_game_index {
                         error!(
-                            expected = %hex::encode(expected_game_id),
-                            actual = %hex::encode(actual_game_id),
-                            "unexpected game_id being contested"
+                            expected = %expected_game_index,
+                            actual = %actual_game_index,
+                            "unexpected game_index being contested"
                         );
                         return Err(MosaicError::UnexpectedDepositContest {
-                            expected: hex::encode(expected_game_id),
-                            actual: hex::encode(actual_game_id),
+                            expected: expected_game_index.to_string(),
+                            actual: actual_game_index.to_string(),
                         });
                     }
                     debug!("waiting for transition from Contest");
                     tokio::time::sleep(self.retry_delay).await;
                     continue;
                 }
-                RpcTablesetStatus::Consumed { deposit, success } => {
-                    let actual_game_id: GameId = deposit.into();
-                    if expected_game_id != actual_game_id {
+                RpcTablesetStatus::Consumed {
+                    deposit: game_index,
+                    success,
+                } => {
+                    let actual_game_index = game_index.into_game_index();
+                    if expected_game_index != actual_game_index {
                         error!(
-                            expected = %hex::encode(expected_game_id),
-                            actual = %hex::encode(actual_game_id),
-                            "unexpected game_id consumed"
+                            expected = %expected_game_index,
+                            actual = %actual_game_index,
+                            "unexpected game_index consumed"
                         );
                         return Err(MosaicError::UnexpectedDepositContest {
-                            expected: hex::encode(expected_game_id),
-                            actual: hex::encode(actual_game_id),
+                            expected: expected_game_index.to_string(),
+                            actual: actual_game_index.to_string(),
                         });
                     }
                     info!("setup consumed; signed adaptors should be ready");

--- a/crates/mosaic-client/src/resolver.rs
+++ b/crates/mosaic-client/src/resolver.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
-use strata_bridge_primitives::types::{DepositIdx, OperatorIdx};
+use strata_bridge_primitives::types::{GameIndex, OperatorIdx};
 use strata_mosaic_client_api::MosaicError;
 
 /// Identify a mosaic node using their network id.
 pub type PeerId = [u8; 32];
-/// Identify a deposit on mosaic.
-pub type DepositId = [u8; 32];
+/// Identify a game on mosaic.
+pub type GameId = [u8; 32];
 /// Pubkey as bytes.
 pub type PubkeyBytes = [u8; 32];
 
@@ -24,11 +24,11 @@ pub trait MosaicIdResolver: Send + Sync + 'static {
         operator_idx: OperatorIdx,
     ) -> Result<PubkeyBytes, MosaicError>;
 
-    /// Resolve deposit index to its mosaic deposit id.
-    /// Default: copies deposit idx as be bytes.
-    fn resolve_deposit_id(&self, deposit_idx: DepositIdx) -> DepositId {
-        let mut deposit_id = [0u8; 32];
-        deposit_id[28..].copy_from_slice(&deposit_idx.to_be_bytes());
-        deposit_id
+    /// Resolve game index to its mosaic game id.
+    /// Default: copies game index as be bytes.
+    fn resolve_game_id(&self, game_idx: GameIndex) -> GameId {
+        let mut game_id = [0u8; 32];
+        game_id[28..].copy_from_slice(&game_idx.get().to_be_bytes());
+        game_id
     }
 }

--- a/crates/mosaic-client/src/resolver.rs
+++ b/crates/mosaic-client/src/resolver.rs
@@ -14,8 +14,8 @@ pub type PubkeyBytes = [u8; 32];
 
 /// Decodes a mosaic [`RpcDepositId`] into a bridge [`GameIndex`].
 //
-// TODO(STR-3754): drop this once mosaic exposes `game_index: u32` directly.
-// https://alpenlabs.atlassian.net/browse/STR-3754
+// TODO: <https://alpenlabs.atlassian.net/browse/STR-3754>
+// drop this once mosaic exposes `game_index: u32` directly.
 pub trait RpcDepositIdExt {
     /// Inverse of [`MosaicIdResolver::resolve_game_id`]'s default encoding.
     /// Panics if the encoded `u32` is zero.

--- a/crates/mosaic-client/src/resolver.rs
+++ b/crates/mosaic-client/src/resolver.rs
@@ -1,4 +1,7 @@
+use std::num::NonZero;
+
 use async_trait::async_trait;
+use mosaic_rpc_types::RpcDepositId;
 use strata_bridge_primitives::types::{GameIndex, OperatorIdx};
 use strata_mosaic_client_api::MosaicError;
 
@@ -8,6 +11,28 @@ pub type PeerId = [u8; 32];
 pub type GameId = [u8; 32];
 /// Pubkey as bytes.
 pub type PubkeyBytes = [u8; 32];
+
+/// Decodes a mosaic [`RpcDepositId`] into a bridge [`GameIndex`].
+//
+// TODO(STR-3754): drop this once mosaic exposes `game_index: u32` directly.
+// https://alpenlabs.atlassian.net/browse/STR-3754
+pub trait RpcDepositIdExt {
+    /// Inverse of [`MosaicIdResolver::resolve_game_id`]'s default encoding.
+    /// Panics if the encoded `u32` is zero.
+    fn into_game_index(self) -> GameIndex;
+}
+
+impl RpcDepositIdExt for RpcDepositId {
+    fn into_game_index(self) -> GameIndex {
+        let bytes: [u8; 32] = self.into();
+        let raw = u32::from_be_bytes(
+            bytes[28..32]
+                .try_into()
+                .expect("slice of 4 bytes is a [u8; 4]"),
+        );
+        GameIndex::from_nonzero(NonZero::new(raw).expect("mosaic invariant: game index is nonzero"))
+    }
+}
 
 /// Resolves bridge-internal indices to mosaic-native identifiers.
 ///

--- a/crates/mosaic-client/src/task.rs
+++ b/crates/mosaic-client/src/task.rs
@@ -58,13 +58,9 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
             debug!(count = snapshot.len(), "polling watched deposits");
 
             for (tableset_id, operator_idx, game_index) in snapshot {
-                let deposit_id = self.provider.resolve_deposit_id(game_index.get());
-                let rpc_deposit_id = deposit_id.into();
-                match self
-                    .rpc
-                    .get_deposit_status(tableset_id, rpc_deposit_id)
-                    .await
-                {
+                let game_id = self.provider.resolve_game_id(game_index);
+                let rpc_game_id = game_id.into();
+                match self.rpc.get_deposit_status(tableset_id, rpc_game_id).await {
                     Ok(Some(status)) => {
                         self.handle_watched_deposit_status(
                             tableset_id,

--- a/crates/mosaic-client/src/task.rs
+++ b/crates/mosaic-client/src/task.rs
@@ -1,7 +1,7 @@
 use mosaic_rpc_api::MosaicRpcClient;
 use mosaic_rpc_types::{DepositStatus, RpcTablesetId};
-use strata_bridge_primitives::types::{GraphIdx, OperatorIdx};
-use strata_mosaic_client_api::{MosaicEvent, types::*};
+use strata_bridge_primitives::types::{GameIndex, GraphIdx, OperatorIdx};
+use strata_mosaic_client_api::MosaicEvent;
 use tracing::{debug, error, info, warn};
 
 use crate::{MosaicClient, MosaicIdResolver};
@@ -18,14 +18,14 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         &self,
         tableset_id: RpcTablesetId,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
     ) {
-        let key = (tableset_id, operator_idx, deposit_idx);
-        info!(%operator_idx, %deposit_idx, "deposit adaptors verified");
+        let key = (tableset_id, operator_idx, game_index);
+        info!(%operator_idx, %game_index, "deposit adaptors verified");
         self.watched_deposits.lock().await.remove(&key);
         self.emit(MosaicEvent::AdaptorsVerified(GraphIdx {
             operator: operator_idx,
-            deposit: deposit_idx,
+            deposit: game_index.into(),
         }))
         .await;
     }
@@ -48,7 +48,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
             tokio::time::sleep(self.poll_interval).await;
 
             // Snapshot keys to avoid holding the lock during RPC calls.
-            let snapshot: Vec<(RpcTablesetId, OperatorIdx, DepositIdx)> =
+            let snapshot: Vec<(RpcTablesetId, OperatorIdx, GameIndex)> =
                 { self.watched_deposits.lock().await.keys().cloned().collect() };
 
             if snapshot.is_empty() {
@@ -57,8 +57,8 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
 
             debug!(count = snapshot.len(), "polling watched deposits");
 
-            for (tableset_id, operator_idx, deposit_idx) in snapshot {
-                let deposit_id = self.provider.resolve_deposit_id(deposit_idx);
+            for (tableset_id, operator_idx, game_index) in snapshot {
+                let deposit_id = self.provider.resolve_deposit_id(game_index.get());
                 let rpc_deposit_id = deposit_id.into();
                 match self
                     .rpc
@@ -69,7 +69,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                         self.handle_watched_deposit_status(
                             tableset_id,
                             operator_idx,
-                            deposit_idx,
+                            game_index,
                             status,
                         )
                         .await;
@@ -78,7 +78,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                         self.handle_watched_deposit_not_found(
                             tableset_id,
                             operator_idx,
-                            deposit_idx,
+                            game_index,
                         )
                         .await;
                     }
@@ -86,7 +86,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
                         self.handle_watched_deposit_rpc_error(
                             tableset_id,
                             operator_idx,
-                            deposit_idx,
+                            game_index,
                             rpc_err,
                         )
                         .await;
@@ -100,30 +100,30 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         &self,
         tableset_id: RpcTablesetId,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         status: DepositStatus,
     ) {
-        let key = (tableset_id, operator_idx, deposit_idx);
+        let key = (tableset_id, operator_idx, game_index);
         match status {
             DepositStatus::Ready => {
-                self.emit_adaptors_verified(tableset_id, operator_idx, deposit_idx)
+                self.emit_adaptors_verified(tableset_id, operator_idx, game_index)
                     .await;
             }
             DepositStatus::Aborted { reason } => {
-                error!(%operator_idx, %deposit_idx, %reason, "watched deposit aborted");
+                error!(%operator_idx, %game_index, %reason, "watched deposit aborted");
                 self.watched_deposits.lock().await.remove(&key);
             }
             DepositStatus::UncontestedWithdrawal => {
-                error!(%operator_idx, %deposit_idx, "watched deposit withdrawn");
+                error!(%operator_idx, %game_index, "watched deposit withdrawn");
                 self.watched_deposits.lock().await.remove(&key);
             }
             DepositStatus::Consumed { .. } => {
-                error!(%operator_idx, %deposit_idx, "watched deposit consumed");
+                error!(%operator_idx, %game_index, "watched deposit consumed");
                 self.watched_deposits.lock().await.remove(&key);
             }
             DepositStatus::Incomplete { details } => {
                 // Deposit exists but isn't ready yet — reset failure counter, keep watching.
-                debug!(%operator_idx, %deposit_idx, %details, "watched deposit still incomplete");
+                debug!(%operator_idx, %game_index, %details, "watched deposit still incomplete");
                 if let Some(counter) = self.watched_deposits.lock().await.get_mut(&key) {
                     *counter = 0;
                 }
@@ -135,16 +135,16 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         &self,
         tableset_id: RpcTablesetId,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
     ) {
-        let key = (tableset_id, operator_idx, deposit_idx);
+        let key = (tableset_id, operator_idx, game_index);
         let mut watched = self.watched_deposits.lock().await;
         if let Some(failure_count) = watched.get_mut(&key) {
             *failure_count += 1;
             if *failure_count >= self.max_retries {
                 warn!(
                     %operator_idx,
-                    %deposit_idx,
+                    %game_index,
                     attempts = *failure_count,
                     "watched deposit not found after max retries, removing"
                 );
@@ -152,7 +152,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
             } else {
                 debug!(
                     %operator_idx,
-                    %deposit_idx,
+                    %game_index,
                     attempt = *failure_count,
                     max = self.max_retries,
                     "watched deposit not found, will retry"
@@ -165,17 +165,17 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         &self,
         tableset_id: RpcTablesetId,
         operator_idx: OperatorIdx,
-        deposit_idx: DepositIdx,
+        game_index: GameIndex,
         rpc_err: impl std::error::Error,
     ) {
-        let key = (tableset_id, operator_idx, deposit_idx);
+        let key = (tableset_id, operator_idx, game_index);
         let mut watched = self.watched_deposits.lock().await;
         if let Some(failure_count) = watched.get_mut(&key) {
             *failure_count += 1;
             if *failure_count >= self.max_retries {
                 warn!(
                     %operator_idx,
-                    %deposit_idx,
+                    %game_index,
                     attempts = *failure_count,
                     %rpc_err,
                     "watched deposit RPC failed after max retries, removing"
@@ -184,7 +184,7 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
             } else {
                 debug!(
                     %operator_idx,
-                    %deposit_idx,
+                    %game_index,
                     attempt = *failure_count,
                     max = self.max_retries,
                     %rpc_err,

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -277,6 +277,32 @@ mod tests {
         );
     }
 
+    // Verifies DepositIdx <-> GameIndex round-trips and that u32::MAX overflows.
+    #[test]
+    fn game_index_try_from_deposit_idx() {
+        // Boundary: deposit 0 -> game 1.
+        let zero = GameIndex::try_from(0u32).expect("0 maps to game 1");
+        assert_eq!(zero.get(), 1);
+        assert_eq!(DepositIdx::from(zero), 0);
+
+        // Mid-range round-trip.
+        let mid = GameIndex::try_from(42u32).expect("42 maps to game 43");
+        assert_eq!(mid.get(), 43);
+        assert_eq!(DepositIdx::from(mid), 42);
+
+        // Largest valid deposit index: u32::MAX - 1 -> game u32::MAX.
+        let max_valid =
+            GameIndex::try_from(u32::MAX - 1).expect("u32::MAX - 1 maps to game u32::MAX");
+        assert_eq!(max_valid.get(), u32::MAX);
+        assert_eq!(DepositIdx::from(max_valid), u32::MAX - 1);
+
+        // Overflow: u32::MAX has no representable game index.
+        assert_eq!(
+            GameIndex::try_from(u32::MAX),
+            Err(DepositIdxOverflow(u32::MAX))
+        );
+    }
+
     #[cfg(feature = "proptest")]
     mod proptests {
         use proptest::prelude::*;

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -1,6 +1,6 @@
 //! Types that are used across the bridge.
 
-use std::{collections::BTreeMap, fmt, fmt::Display};
+use std::{collections::BTreeMap, fmt, fmt::Display, num::NonZero};
 
 use bitcoin::XOnlyPublicKey;
 use bitcoin_bosd::{Descriptor, DescriptorError, DescriptorType};
@@ -24,6 +24,62 @@ pub type WatchtowerIdx = u32;
 
 /// The index of a deposit.
 pub type DepositIdx = u32;
+
+/// Bridge v1 game index: [`DepositIdx`] + 1.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub struct GameIndex(NonZero<u32>);
+
+impl GameIndex {
+    /// Wraps a [`NonZero<u32>`] as a `GameIndex` without conversion.
+    pub const fn from_nonzero(value: NonZero<u32>) -> Self {
+        Self(value)
+    }
+
+    /// Returns the 1-indexed game number as a [`u32`].
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl Display for GameIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl From<NonZero<u32>> for GameIndex {
+    fn from(value: NonZero<u32>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<GameIndex> for NonZero<u32> {
+    fn from(value: GameIndex) -> Self {
+        value.0
+    }
+}
+
+/// [`DepositIdx`] cannot be mapped to a [`GameIndex`] because `idx + 1` overflows `u32`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("deposit index {0} overflows when mapped to game index")]
+pub struct DepositIdxOverflow(pub DepositIdx);
+
+impl TryFrom<DepositIdx> for GameIndex {
+    type Error = DepositIdxOverflow;
+
+    fn try_from(idx: DepositIdx) -> Result<Self, Self::Error> {
+        idx.checked_add(1)
+            .and_then(NonZero::new)
+            .map(Self)
+            .ok_or(DepositIdxOverflow(idx))
+    }
+}
+
+impl From<GameIndex> for DepositIdx {
+    fn from(value: GameIndex) -> Self {
+        value.0.get() - 1
+    }
+}
 
 /// A struct that represents the index of a peg out graph, which is a combination of a deposit index
 /// and an operator index.

--- a/crates/proofs/bridge-counterproof/src/statements.rs
+++ b/crates/proofs/bridge-counterproof/src/statements.rs
@@ -80,8 +80,8 @@ fn process_counterproof_inner(zkvm: &impl ZkVmEnv, genesis: &BridgeCounterproofG
 
     // 4: Commit public values.
     zkvm.commit_ssz(&CounterproofOutput {
-        game_idx,
         operator_pubkey,
+        game_idx,
     });
 }
 

--- a/crates/proofs/bridge-counterproof/src/types.rs
+++ b/crates/proofs/bridge-counterproof/src/types.rs
@@ -40,9 +40,9 @@ pub struct CounterproofInput {
 /// Public values committed by the counterproof.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct CounterproofOutput {
-    /// Echoed `game_idx` from the input.
-    pub game_idx: u32,
-
     /// Echoed operator master x-only pubkey.
     pub operator_pubkey: BitcoinXOnlyPublicKey,
+
+    /// Echoed `game_idx` from the input.
+    pub game_idx: u32,
 }

--- a/crates/proofs/bridge-counterproof/src/types.rs
+++ b/crates/proofs/bridge-counterproof/src/types.rs
@@ -38,6 +38,9 @@ pub struct CounterproofInput {
 }
 
 /// Public values committed by the counterproof.
+///
+/// NOTE: Field order is load-bearing — it must stay in sync with the public-params
+/// digest computed by the garbled circuit on the verifier side.
 #[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct CounterproofOutput {
     /// Echoed operator master x-only pubkey.

--- a/functional-tests/tests/contested_payout/fn_publish_counterproof_nack.py
+++ b/functional-tests/tests/contested_payout/fn_publish_counterproof_nack.py
@@ -13,7 +13,7 @@ from utils.bridge import get_bridge_nodes_and_rpcs
 from utils.deposit import (
     wait_until_deposit_status,
     wait_until_deposit_utxo_spent,
-    wait_until_drt_recognized,
+    wait_until_drts_recognized,
     wait_until_utxo_spent,
 )
 from utils.dev_cli import DevCli
@@ -24,8 +24,8 @@ from utils.utils import (
     wait_until,
 )
 from utils.withdrawal import (
-    wait_until_active_valid_claim,
     wait_until_bridge_proof_posted,
+    wait_until_claim_posted,
     wait_until_counter_proof_posted,
 )
 
@@ -41,9 +41,17 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
     runs the mosaic-backed `evaluate_and_sign` flow and publishes a counterproof NACK
     transaction. Once the NACKs and contested payout confirm, the deposit UTXO is spent.
 
+    Two deposits are created and the *second* one (deposit index 1) is contested. In
+    native proving mode the mosaic node runs the bundled "simple" garbled circuit whose
+    output is just the LSB of the deposit-input wire, and the bridge sets that wire to the
+    game index (`deposit_idx + 1`). The POV operator can only extract the fault secret
+    (and therefore sign the NACK) when that LSB is 0 — i.e. when the game index is even.
+    Deposit index 1 → game index 2 (even) satisfies this; deposit index 0 → game index 1
+    (odd) never would.
+
     Steps:
-    1. Complete a deposit
-    2. Submit a contest against the active claim
+    1. Complete two deposits
+    2. Assign a withdrawal to each, then contest the active claim on deposit index 1
     3. Wait for the bridge proof to be posted
     4. Wait for the counterproof to be posted by watchtowers
     5. Verify the deposit UTXO is spent after the NACK + contested-payout path completes
@@ -85,53 +93,77 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
             bridge_protocol_params=self.bridge_protocol_params,
         )
 
-        drt_txid = dev_cli.send_deposit_request()
-        self.logger.info(f"Broadcasted DRT: {drt_txid}")
-        deposit_id = wait_until_drt_recognized(bridge_rpc, drt_txid)
-        self.logger.info(f"DRT recognized, deposit_id: {deposit_id}")
+        # Contest the second deposit (index 1 → game index 2, even) so the POV operator's
+        # native-mode mosaic evaluation can extract the fault secret and sign the NACK.
+        contested_deposit_idx = 1
 
-        deposit_info = wait_until_deposit_status(bridge_rpc, deposit_id, RpcDepositStatusComplete)
-        assert deposit_info is not None, "Deposit did not complete"
-        self.logger.info("Deposit completed")
-        deposit_txid = deposit_info.get("status").get("deposit_txid")
-        self.logger.info(f"Deposit txid: {deposit_txid}")
+        drt_txids = [dev_cli.send_deposit_request() for _ in range(2)]
+        for i, drt_txid in enumerate(drt_txids):
+            self.logger.info(f"Broadcasted DRT[{i}]: {drt_txid}")
+
+        deposit_ids = wait_until_drts_recognized(bridge_rpc, drt_txids)
+        self.logger.info(f"DRTs recognized, deposit_ids: {deposit_ids}")
+
+        # Complete both deposits so the ASM can assign a withdrawal to each. Capture the
+        # contested deposit's txid — that is the UTXO we expect to be swept at the end.
+        contested_deposit_txid = None
+        for deposit_id in sorted(deposit_ids):
+            deposit_info = wait_until_deposit_status(
+                bridge_rpc, deposit_id, RpcDepositStatusComplete
+            )
+            assert deposit_info is not None, f"Deposit {deposit_id} did not complete"
+            if deposit_id == contested_deposit_idx:
+                contested_deposit_txid = deposit_info.get("status").get("deposit_txid")
+        assert contested_deposit_txid is not None, (
+            f"contested deposit {contested_deposit_idx} did not complete"
+        )
+        self.logger.info("Both deposits completed")
+        self.logger.info(
+            f"Contesting deposit {contested_deposit_idx}, txid: {contested_deposit_txid}"
+        )
 
         # Now post mock checkpoint so that a withdrawal is assigned
         recent_block_hash = bitcoin_rpc.proxy.getblockhash(bitcoin_rpc.proxy.getblockcount())
+        # One checkpoint creating two withdrawal commands. The ASM assigns the oldest
+        # unassigned deposit first, so this yields one assignment per deposit (indices 0
+        # and 1).
         ckp_l1_txn = dev_cli.send_mock_checkpoint_from_tip(
             asm_rpc,
             recent_block_hash,
             num_ol_slots=1,
+            num_withdrawals=2,
         )
         ckp_block_hash = wait_for_tx_confirmation(bitcoin_rpc, ckp_l1_txn)
         self.logger.info(f"Checkpoint tx {ckp_l1_txn} included in block {ckp_block_hash}")
 
-        # Wait for ASM to process the checkpoint, then wait for an active claim
+        # Wait for ASM to process the checkpoint, then wait for the contested deposit's claim
         wait_until(
-            lambda: len(asm_rpc.strata_asm_getAssignments(ckp_block_hash)) > 0,
+            lambda: len(asm_rpc.strata_asm_getAssignments(ckp_block_hash)) >= 2,
             timeout=300,
-            error_msg="ASM did not produce assignment",
+            error_msg="ASM did not produce assignments",
         )
 
-        active_claim = wait_until_active_valid_claim(bridge_rpc)
+        # Two withdrawals are in flight, so target the contested deposit directly (rather than
+        # assuming a single pending withdrawal).
+        active_claim = wait_until_claim_posted(bridge_rpc, contested_deposit_idx)
+        assigned_operator = active_claim.assigned_operator
+        claim_txid = active_claim.claim_txid
         self.logger.info(
             "Active claim %s for deposit %s assigned to operator %s",
-            active_claim.claim_txid,
-            active_claim.deposit_idx,
-            active_claim.assigned_operator,
+            claim_txid,
+            contested_deposit_idx,
+            assigned_operator,
         )
 
         claim_block_hash = wait_for_tx_confirmation(
             bitcoin_rpc,
-            active_claim.claim_txid,
+            claim_txid,
             timeout=300,
         )
-        self.logger.info(
-            f"Claim tx {active_claim.claim_txid} confirmed in block {claim_block_hash}"
-        )
+        self.logger.info(f"Claim tx {claim_txid} confirmed in block {claim_block_hash}")
 
         # Use a different operator's node to contest
-        contester_idx = (active_claim.assigned_operator + 1) % num_operators
+        contester_idx = (assigned_operator + 1) % num_operators
         contester_node = bridge_nodes[contester_idx]
         contester_rpc_url = f"http://127.0.0.1:{contester_node.props['rpc_port']}"
 
@@ -139,8 +171,8 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
         contester_seed = read_operator_key(contester_idx).SEED
 
         contest_txid = dev_cli.send_contest(
-            deposit_idx=active_claim.deposit_idx,
-            operator_idx=active_claim.assigned_operator,
+            deposit_idx=contested_deposit_idx,
+            operator_idx=assigned_operator,
             bridge_node_url=contester_rpc_url,
             contester_node_idx=contester_idx,
             seed=contester_seed,
@@ -154,14 +186,14 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
         self.logger.info(f"Contest tx {contest_txid} confirmed in block {contest_block_hash}")
 
         # The POV (assigned) operator's RPC observes the full game and emits the NACK duty.
-        pov_rpc = bridge_rpcs[active_claim.assigned_operator]
+        pov_rpc = bridge_rpcs[assigned_operator]
 
         # Wait for bridge proof to be posted by the assigned operator
-        wait_until_bridge_proof_posted(pov_rpc, active_claim.deposit_idx)
+        wait_until_bridge_proof_posted(pov_rpc, contested_deposit_idx)
         self.logger.info("Bridge proof posted")
 
         # With NeverAccept predicate, watchtowers reject the proof and publish counterproofs.
-        wait_until_counter_proof_posted(pov_rpc, active_claim.deposit_idx)
+        wait_until_counter_proof_posted(pov_rpc, contested_deposit_idx)
         self.logger.info("Counterproof posted — watchtowers rejected the invalid bridge proof")
 
         # Each watchtower spends one of contest's watchtower outputs with its counterproof.
@@ -187,7 +219,7 @@ class CounterproofNackPublishedOnInvalidCounterproofTest(StrataTestBase):
         # The ack/nack vout we checked above could've been spent by either an ACK or a NACK,
         # so seeing it spent isn't enough on its own. Waiting for the deposit to get swept is
         # what tells us the NACK actually fired — only the contested-payout path gets there.
-        wait_until_deposit_utxo_spent(bitcoin_rpc, deposit_txid, timeout=450)
+        wait_until_deposit_utxo_spent(bitcoin_rpc, contested_deposit_txid, timeout=450)
         self.logger.info("Deposit UTXO confirmed spent after counterproof NACK + contested payout")
 
         return True

--- a/functional-tests/utils/withdrawal.py
+++ b/functional-tests/utils/withdrawal.py
@@ -60,6 +60,49 @@ def wait_until_active_valid_claim(
     return result["active_claim"]
 
 
+def wait_until_claim_posted(
+    bridge_rpc,
+    deposit_idx: int,
+    timeout=300,
+) -> PendingWithdrawalClaim:
+    """Wait until the operator assigned to `deposit_idx` has posted an active claim.
+
+    Targets a specific deposit, so unlike [`wait_until_active_valid_claim`] it works when
+    several withdrawals are pending at once.
+    """
+    result: dict[str, PendingWithdrawalClaim | None] = {"active_claim": None}
+
+    def check_claim_posted():
+        data = bridge_rpc.stratabridge_pendingWithdrawalInfo(deposit_idx)
+        logging.info(f"Pending withdrawal info for {deposit_idx}: {data}")
+
+        if data is None:
+            return False
+
+        pending_withdrawal = RpcPendingWithdrawalInfo.from_json(data)
+        if pending_withdrawal.assigned_claim is None:
+            return False
+
+        result["active_claim"] = PendingWithdrawalClaim(
+            deposit_idx=deposit_idx,
+            assigned_operator=pending_withdrawal.assigned_operator,
+            claim_txid=pending_withdrawal.assigned_claim.claim_txid,
+        )
+        return True
+
+    wait_until(
+        check_claim_posted,
+        timeout=timeout,
+        step=1,
+        error_msg=(
+            f"Timeout after {timeout} seconds waiting for deposit {deposit_idx} active claim"
+        ),
+    )
+
+    assert result["active_claim"] is not None
+    return result["active_claim"]
+
+
 def wait_until_bridge_proof_posted(
     bridge_rpc,
     deposit_idx: int,


### PR DESCRIPTION
## Description
* Mosaic client API — replaces `DepositIdx` with a new `GameIndex` newtype (`NonZero<u32>`, equal to `DepositIdx + 1`) on every `MosaicClientApi` method.
* Reorders the fields of `CounterproofOutput` so `operator_pubkey` is committed before `game_idx`, both in the struct definition and in the `commit_ssz` call. This keeps proof public params and ckt public params processing in sync

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

### Note to reviewers
Created [STR-3754](https://alpenlabs.atlassian.net/browse/STR-3754)  to better sync game-index and deposit index


[STR-3754]: https://alpenlabs.atlassian.net/browse/STR-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ