### PR TITLE
feat(bin/bridge,mosaic-client): propagate actual setup errors from mosaic

### DIFF
--- a/bin/strata-bridge/src/mode/services/mosaic_client.rs
+++ b/bin/strata-bridge/src/mode/services/mosaic_client.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use async_trait::async_trait;
 use futures::future;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
@@ -139,10 +139,15 @@ pub(crate) async fn run_mosaic_setup(
 
     future::try_join_all(pairs.into_iter().map(|(idx, role)| async move {
         info!(%idx, ?role, "starting mosaic setup");
-        client.ensure_mosaic_setup(idx, role).await.map_err(|e| {
-            error!(%idx, ?role, %e, "mosaic setup failed");
-            anyhow!("mosaic setup failed for operator {idx} role {role:?}: {e}")
-        })?;
+        client
+            .ensure_mosaic_setup(idx, role)
+            .await
+            .inspect_err(|source| {
+                error!(%idx, ?role, err = %source, "mosaic setup failed");
+            })
+            .context(format!(
+                "mosaic setup failed for operator {idx} role {role}"
+            ))?;
         info!(%idx, ?role, "mosaic setup complete");
         Ok::<(), anyhow::Error>(())
     }))

--- a/crates/mosaic-client-api/src/error.rs
+++ b/crates/mosaic-client-api/src/error.rs
@@ -55,15 +55,15 @@ impl MosaicError {
 #[derive(Debug, thiserror::Error)]
 pub enum MosaicSetupError {
     /// The setup was explicitly aborted.
-    #[error("mosaic setup aborted: {0}")]
+    #[error("mosaic setup aborted: {0}; manual intervention required")]
     Aborted(String),
 
     /// The mosaic setup is missing.
-    #[error("mosaic setup missing: {0}|{1}")]
+    #[error("mosaic setup missing for operator {0} role {1}")]
     SetupMissing(OperatorIdx, Role),
 
     /// An RPC communication error during setup.
-    #[error("mosaic RPC error")]
+    #[error("mosaic setup RPC error: {0}")]
     RpcError(#[source] Box<dyn Error + Send + Sync + 'static>),
 }
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR adds a `Display` impl to the `MosaicSetupError` enum and then logs it explicitly at the bridge binary level.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
This is a quality of life improvement flagged by the infra team to help with troubleshooting setup issues.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3456