### PR TITLE
feat(gsm): abort GSM upon DRT reclaim by user

### DIFF
--- a/bin/strata-bridge/src/mode/rpc_server/monitoring.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/monitoring.rs
@@ -224,9 +224,15 @@ pub(super) const fn reimbursement_status(state: &GraphState) -> RpcReimbursement
         GraphState::Slashed { claim_txid, .. } => RpcReimbursementStatus::Slashed {
             claim_txid: *claim_txid,
         },
-        GraphState::Aborted { claim_txid, .. } => RpcReimbursementStatus::Aborted {
+        GraphState::Aborted {
+            claim_txid: Some(claim_txid),
+            ..
+        } => RpcReimbursementStatus::Aborted {
             claim_txid: *claim_txid,
         },
+        GraphState::Aborted {
+            claim_txid: None, ..
+        } => RpcReimbursementStatus::NotStarted,
         _ => RpcReimbursementStatus::NotStarted,
     }
 }

--- a/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
@@ -992,12 +992,22 @@ fn reimbursement_status_reports_each_graph_state() {
         (
             "Aborted",
             GraphState::Aborted {
-                claim_txid,
+                claim_txid: Some(claim_txid),
                 reason: AbortReason::PayoutConnectorSpent {
                     spending_txid: generate_txid(),
                 },
             },
             RpcReimbursementStatus::Aborted { claim_txid },
+        ),
+        (
+            "AbortedWithoutClaim",
+            GraphState::Aborted {
+                claim_txid: None,
+                reason: AbortReason::PayoutConnectorSpent {
+                    spending_txid: generate_txid(),
+                },
+            },
+            RpcReimbursementStatus::NotStarted,
         ),
     ];
 

--- a/crates/bridge-sm/src/deposit/tests/deposit/process_drt_takeback.rs
+++ b/crates/bridge-sm/src/deposit/tests/deposit/process_drt_takeback.rs
@@ -4,6 +4,7 @@ mod tests {
     use std::str::FromStr;
 
     use bitcoin::OutPoint;
+    use strata_bridge_test_utils::musig2::generate_agg_nonce;
 
     use crate::{
         deposit::{
@@ -12,8 +13,16 @@ mod tests {
             state::DepositState,
             tests::*,
         },
+        signals::{DepositSignal, DepositToGraph},
         testing::{fixtures::*, transition::*},
     };
+
+    fn deposit_request_taken_back_signal(takeback_txid: bitcoin::Txid) -> DepositSignal {
+        DepositSignal::ToGraph(DepositToGraph::DepositRequestTakenBack {
+            deposit_idx: TEST_DEPOSIT_IDX,
+            takeback_txid,
+        })
+    }
 
     #[test]
     fn test_drt_takeback_from_created() {
@@ -25,13 +34,14 @@ mod tests {
         };
 
         let tx = test_takeback_tx(outpoint);
+        let takeback_txid = tx.compute_txid();
 
         test_deposit_transition(DepositTransition {
             from_state: state,
             event: DepositEvent::UserTakeBack(UserTakeBackEvent { tx }),
             expected_state: DepositState::Aborted,
             expected_duties: vec![],
-            expected_signals: vec![],
+            expected_signals: vec![deposit_request_taken_back_signal(takeback_txid)],
         });
     }
 
@@ -46,12 +56,60 @@ mod tests {
         };
 
         let tx = test_takeback_tx(outpoint);
+        let takeback_txid = tx.compute_txid();
 
         let mut sm = create_sm(state);
         let result = sm.process_drt_takeback(UserTakeBackEvent { tx });
 
-        assert!(result.is_ok());
+        let output = result.expect("valid DRT takeback must abort DSM");
         assert_eq!(sm.state(), &DepositState::Aborted);
+        assert_eq!(output.duties, vec![]);
+        assert_eq!(
+            output.signals,
+            vec![deposit_request_taken_back_signal(takeback_txid)]
+        );
+    }
+
+    #[test]
+    fn test_drt_takeback_from_deposit_nonces_collected() {
+        let state = DepositState::DepositNoncesCollected {
+            deposit_transaction: test_deposit_txn(),
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            claim_txids: BTreeMap::new(),
+            agg_nonce: generate_agg_nonce(),
+            pubnonces: BTreeMap::new(),
+            partial_signatures: BTreeMap::new(),
+        };
+
+        let tx = test_takeback_tx(OutPoint::default());
+        let takeback_txid = tx.compute_txid();
+
+        test_deposit_transition(DepositTransition {
+            from_state: state,
+            event: DepositEvent::UserTakeBack(UserTakeBackEvent { tx }),
+            expected_state: DepositState::Aborted,
+            expected_duties: vec![],
+            expected_signals: vec![deposit_request_taken_back_signal(takeback_txid)],
+        });
+    }
+
+    #[test]
+    fn test_drt_takeback_from_deposit_partials_collected() {
+        let state = DepositState::DepositPartialsCollected {
+            deposit_transaction: test_deposit_txn().as_ref().clone(),
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+        };
+
+        let tx = test_takeback_tx(OutPoint::default());
+        let takeback_txid = tx.compute_txid();
+
+        test_deposit_transition(DepositTransition {
+            from_state: state,
+            event: DepositEvent::UserTakeBack(UserTakeBackEvent { tx }),
+            expected_state: DepositState::Aborted,
+            expected_duties: vec![],
+            expected_signals: vec![deposit_request_taken_back_signal(takeback_txid)],
+        });
     }
 
     #[test]

--- a/crates/bridge-sm/src/deposit/transitions/deposit.rs
+++ b/crates/bridge-sm/src/deposit/transitions/deposit.rs
@@ -17,7 +17,7 @@ use crate::{
         machine::{DSMOutput, DepositSM},
         state::DepositState,
     },
-    signals::{DepositSignal, GraphToDeposit},
+    signals::{DepositSignal, DepositToGraph, GraphToDeposit},
     state_machine::{SMOutput, StateMutation},
 };
 
@@ -51,11 +51,17 @@ impl DepositSM {
         let is_different_tx = takeback.tx.compute_txid() != self.context().deposit_outpoint().txid;
 
         if spends_deposit_request && is_different_tx {
+            let takeback_txid = takeback.tx.compute_txid();
             self.state = DepositState::Aborted;
 
             return Ok(SMOutput {
                 duties: vec![],
-                signals: vec![],
+                signals: vec![DepositSignal::ToGraph(
+                    DepositToGraph::DepositRequestTakenBack {
+                        deposit_idx: self.context().deposit_idx,
+                        takeback_txid,
+                    },
+                )],
                 state_mutation: StateMutation::Mutated,
             });
         }

--- a/crates/bridge-sm/src/graph/state.rs
+++ b/crates/bridge-sm/src/graph/state.rs
@@ -35,6 +35,11 @@ pub enum AbortReason {
         /// Txid of the transaction that consumed the stake outpoint.
         spending_txid: Txid,
     },
+    /// The deposit request transaction was taken back by the user.
+    DepositRequestTakenBack {
+        /// Txid of the transaction that consumed the deposit request output.
+        spending_txid: Txid,
+    },
     /// Both the payout connector and the stake outpoint have been consumed.
     Both {
         /// Txid of the transaction that consumed the payout connector.

--- a/crates/bridge-sm/src/graph/state.rs
+++ b/crates/bridge-sm/src/graph/state.rs
@@ -471,8 +471,9 @@ pub enum GraphState {
     /// dependencies has been consumed by something other than the
     /// expected transaction.
     Aborted {
-        /// The txid of the claim transaction associated with this reimbursement path.
-        claim_txid: Txid,
+        /// The txid of the claim transaction associated with this reimbursement path, if one
+        /// exists.
+        claim_txid: Option<Txid>,
 
         /// Why the graph was aborted, including the txid(s) of the
         /// triggering on-chain spend(s).
@@ -639,8 +640,9 @@ impl GraphState {
             | GraphState::AllNackd { claim_txid, .. }
             | GraphState::Acked { claim_txid, .. }
             | GraphState::Slashed { claim_txid, .. }
-            | GraphState::Aborted { claim_txid, .. }
             | GraphState::Withdrawn { claim_txid, .. } => Some(*claim_txid),
+
+            GraphState::Aborted { claim_txid, .. } => *claim_txid,
 
             GraphState::Created { .. } => None,
         }

--- a/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof_timeout.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof_timeout.rs
@@ -146,7 +146,7 @@ fn aborts_when_stake_already_spent_in_contested() {
             bridge_proof_timeout_block_height: u64::MAX,
         }),
         expected_state: GraphState::Aborted {
-            claim_txid,
+            claim_txid: Some(claim_txid),
             reason: AbortReason::StakeSpent {
                 spending_txid: stake_spending_txid,
             },
@@ -174,7 +174,7 @@ fn aborts_when_stake_already_spent_in_counterproof_posted() {
             bridge_proof_timeout_block_height: u64::MAX,
         }),
         expected_state: GraphState::Aborted {
-            claim_txid,
+            claim_txid: Some(claim_txid),
             reason: AbortReason::StakeSpent {
                 spending_txid: stake_spending_txid,
             },

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof_ack.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof_ack.rs
@@ -159,7 +159,7 @@ fn aborts_when_stake_already_spent() {
             counterprover_idx: TEST_NONPOV_IDX,
         }),
         expected_state: GraphState::Aborted {
-            claim_txid,
+            claim_txid: Some(claim_txid),
             reason: AbortReason::StakeSpent {
                 spending_txid: stake_spending_txid,
             },

--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof_nackd.rs
@@ -221,7 +221,7 @@ fn final_nack_aborts_when_payout_connector_spent() {
         from_state,
         event: GraphEvent::CounterProofNackConfirmed(nack_event(SECOND_NONPOV_IDX)),
         expected_state: GraphState::Aborted {
-            claim_txid,
+            claim_txid: Some(claim_txid),
             reason: AbortReason::PayoutConnectorSpent {
                 spending_txid: connector_spending_txid,
             },

--- a/crates/bridge-sm/src/graph/tests/deposit_signal.rs
+++ b/crates/bridge-sm/src/graph/tests/deposit_signal.rs
@@ -1,7 +1,8 @@
-//! Unit Tests for process_deposit_signal (CooperativePayoutFailed from Deposit SM)
+//! Unit tests for signals received from the Deposit SM.
 #[cfg(test)]
 mod tests {
-    use strata_bridge_primitives::types::GraphIdx;
+    use bitcoin::Txid;
+    use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
     use strata_bridge_test_utils::bitcoin::generate_txid;
 
     use crate::{
@@ -10,11 +11,11 @@ mod tests {
             errors::GSMError,
             events::GraphEvent,
             machine::{GraphSM, generate_game_graph},
-            state::GraphState,
+            state::{AbortReason, GraphState},
             tests::{
                 FULFILLMENT_BLOCK_HEIGHT, GraphInvalidTransition, GraphTransition,
                 INITIAL_BLOCK_HEIGHT, TEST_POV_IDX, create_nonpov_sm, get_state,
-                mock_states::{all_state_variants, fulfilled_state},
+                mock_states::{all_state_variants, fulfilled_state, pre_signing_states},
                 test_deposit_params, test_graph_invalid_transition, test_graph_sm_cfg,
                 test_graph_sm_ctx, test_graph_summary,
             },
@@ -34,6 +35,16 @@ mod tests {
         })
     }
 
+    fn deposit_request_taken_back_event(
+        deposit_idx: DepositIdx,
+        takeback_txid: Txid,
+    ) -> GraphEvent {
+        GraphEvent::DepositMessage(DepositToGraph::DepositRequestTakenBack {
+            deposit_idx,
+            takeback_txid,
+        })
+    }
+
     fn is_after_fulfilled_state(state: &GraphState) -> bool {
         matches!(
             state,
@@ -48,6 +59,142 @@ mod tests {
                 | GraphState::Slashed { .. }
                 | GraphState::Aborted { .. }
         )
+    }
+
+    fn is_pre_assignment_state(state: &GraphState) -> bool {
+        matches!(
+            state,
+            GraphState::Created { .. }
+                | GraphState::GraphGenerated { .. }
+                | GraphState::AdaptorsVerified { .. }
+                | GraphState::NoncesCollected { .. }
+                | GraphState::GraphSigned { .. }
+        )
+    }
+
+    #[test]
+    fn test_deposit_request_taken_back_aborts_pre_assignment_states() {
+        let cfg = test_graph_sm_cfg();
+        let takeback_txid = generate_txid();
+        let mut states = vec![GraphState::Created {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+        }];
+        states.extend(pre_signing_states());
+
+        for from_state in states {
+            let expected_claim_txid = from_state.claim_txid();
+
+            test_transition::<GraphSM, _, _, _, _, _, _, _>(
+                crate::graph::tests::create_sm,
+                get_state,
+                cfg.clone(),
+                GraphTransition {
+                    from_state,
+                    event: deposit_request_taken_back_event(TEST_DEPOSIT_IDX, takeback_txid),
+                    expected_state: GraphState::Aborted {
+                        claim_txid: expected_claim_txid,
+                        reason: AbortReason::DepositRequestTakenBack {
+                            spending_txid: takeback_txid,
+                        },
+                    },
+                    expected_duties: vec![],
+                    expected_signals: vec![],
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn test_duplicate_deposit_request_taken_back_is_rejected() {
+        let cfg = test_graph_sm_cfg();
+        let takeback_txid = generate_txid();
+        let from_state = GraphState::Aborted {
+            claim_txid: None,
+            reason: AbortReason::DepositRequestTakenBack {
+                spending_txid: takeback_txid,
+            },
+        };
+        let mut sm = crate::graph::tests::create_sm(from_state.clone());
+
+        let result = sm.process_event(
+            cfg,
+            deposit_request_taken_back_event(TEST_DEPOSIT_IDX, takeback_txid),
+        );
+
+        assert!(
+            matches!(result, Err(GSMError::Duplicate { .. })),
+            "expected duplicate deposit request takeback, got {result:?}"
+        );
+        assert_eq!(
+            sm.state(),
+            &from_state,
+            "duplicate deposit request takeback must not mutate state"
+        );
+    }
+
+    #[test]
+    fn test_deposit_request_taken_back_after_pre_assignment_is_invalid() {
+        let cfg = test_graph_sm_cfg();
+        let takeback_txid = generate_txid();
+
+        for initial_state in all_state_variants()
+            .into_iter()
+            .filter(|state| !is_pre_assignment_state(state))
+        {
+            let state_name = initial_state.to_string();
+            let mut sm = crate::graph::tests::create_sm(initial_state.clone());
+
+            let result = sm.process_event(
+                cfg.clone(),
+                deposit_request_taken_back_event(TEST_DEPOSIT_IDX, takeback_txid),
+            );
+
+            assert!(
+                matches!(
+                    &result,
+                    Err(GSMError::InvalidEvent {
+                        reason: Some(reason),
+                        ..
+                    }) if reason.contains("requires explicit reorg recovery")
+                ),
+                "expected deposit request takeback to be invalid in {state_name}, got {result:?}"
+            );
+            assert_eq!(
+                sm.state(),
+                &initial_state,
+                "invalid deposit request takeback must not mutate {state_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_deposit_request_taken_back_for_different_deposit_is_invalid() {
+        let cfg = test_graph_sm_cfg();
+        let from_state = GraphState::Created {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+        };
+        let mut sm = crate::graph::tests::create_sm(from_state.clone());
+
+        let result = sm.process_event(
+            cfg,
+            deposit_request_taken_back_event(TEST_DEPOSIT_IDX + 1, generate_txid()),
+        );
+
+        assert!(
+            matches!(
+                &result,
+                Err(GSMError::InvalidEvent {
+                    reason: Some(reason),
+                    ..
+                }) if reason.contains("different deposit")
+            ),
+            "expected misrouted deposit request takeback to be invalid, got {result:?}"
+        );
+        assert_eq!(
+            sm.state(),
+            &from_state,
+            "invalid deposit request takeback must not mutate state"
+        );
     }
 
     #[test]

--- a/crates/bridge-sm/src/graph/tests/mock_states.rs
+++ b/crates/bridge-sm/src/graph/tests/mock_states.rs
@@ -412,7 +412,7 @@ pub(super) fn terminal_states() -> Vec<GraphState> {
             slash_txid: graph_summary.slash,
         },
         GraphState::Aborted {
-            claim_txid: graph_summary.claim,
+            claim_txid: Some(graph_summary.claim),
             reason: AbortReason::PayoutConnectorSpent {
                 spending_txid: generate_spending_tx(
                     OutPoint {

--- a/crates/bridge-sm/src/graph/tests/process_payout_connector_spent.rs
+++ b/crates/bridge-sm/src/graph/tests/process_payout_connector_spent.rs
@@ -242,6 +242,9 @@ fn prepare_replay(variant: GraphState) -> (GraphState, Transaction) {
             AbortReason::StakeSpent { .. } => {
                 panic!("classifier should not request replay for Aborted::StakeSpent")
             }
+            AbortReason::DepositRequestTakenBack { .. } => {
+                panic!("classifier should not request replay for Aborted::DepositRequestTakenBack")
+            }
         }
     }
 

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use bitcoin::{Transaction, Txid, hashes::Hash};
+use bitcoin::Transaction;
 use strata_bridge_primitives::{proof::verify_bridge_proof, types::OperatorIdx};
 use strata_bridge_tx_graph::{
     game_graph::{GameConnectors, GameGraphSummary},
@@ -307,7 +307,7 @@ impl GraphSM {
                 // abort directly instead of entering a state with no exit.
                 if let Some(spending_txid) = stake_spent {
                     self.state = GraphState::Aborted {
-                        claim_txid: graph_summary.claim,
+                        claim_txid: Some(graph_summary.claim),
                         reason: AbortReason::StakeSpent { spending_txid },
                     };
                     return Ok(GSMOutput::default());
@@ -346,7 +346,7 @@ impl GraphSM {
 
                 if let Some(spending_txid) = stake_spent {
                     self.state = GraphState::Aborted {
-                        claim_txid: graph_summary.claim,
+                        claim_txid: Some(graph_summary.claim),
                         reason: AbortReason::StakeSpent { spending_txid },
                     };
                     return Ok(GSMOutput::default());
@@ -436,7 +436,7 @@ impl GraphSM {
                     // directly instead of entering a state with no exit.
                     if let Some(spending_txid) = payout_connector_spent {
                         self.state = GraphState::Aborted {
-                            claim_txid: graph_summary.claim,
+                            claim_txid: Some(graph_summary.claim),
                             reason: AbortReason::PayoutConnectorSpent { spending_txid },
                         };
                         return Ok(GSMOutput::new());
@@ -537,7 +537,7 @@ impl GraphSM {
                 // directly instead of entering a state with no exit.
                 if let Some(spending_txid) = stake_spent {
                     self.state = GraphState::Aborted {
-                        claim_txid: graph_summary.claim,
+                        claim_txid: Some(graph_summary.claim),
                         reason: AbortReason::StakeSpent { spending_txid },
                     };
                     return Ok(GSMOutput::new());
@@ -602,12 +602,10 @@ impl GraphSM {
         // slash and unstake observations.
         if self.state.expected_slash_txid() == Some(spend_txid) {
             self.state = GraphState::Slashed {
-                // use a sentinel value if no claim exists.
-                // NOTE: (@Rajil1213) in practice, this should never happen
-                // but since this information is extracted from the state whose impl is not
-                // exhaustively checked here, we need to handle the possibility of missing claim
-                // txid.
-                claim_txid: self.state.claim_txid().unwrap_or(Txid::all_zeros()),
+                claim_txid: self
+                    .state
+                    .claim_txid()
+                    .expect("slashing states must have a claim txid"),
                 slash_txid: spend_txid,
             };
             return Ok(GSMOutput::new());
@@ -622,7 +620,7 @@ impl GraphSM {
             GraphState::BridgeProofTimedout { .. } | GraphState::Acked { .. }
         ) {
             self.state = GraphState::Aborted {
-                claim_txid: self.state.claim_txid().unwrap_or(Txid::all_zeros()),
+                claim_txid: self.state.claim_txid(),
                 reason: AbortReason::StakeSpent {
                     spending_txid: spend_txid,
                 },
@@ -635,7 +633,7 @@ impl GraphSM {
         // abort.
         if let Some(payout_connector_spending_txid) = self.state.payout_connector_spent_txid() {
             self.state = GraphState::Aborted {
-                claim_txid: self.state.claim_txid().unwrap_or(Txid::all_zeros()),
+                claim_txid: self.state.claim_txid(),
                 reason: AbortReason::Both {
                     stake_spending_txid: spend_txid,
                     payout_connector_spending_txid,

--- a/crates/bridge-sm/src/graph/transitions/deposit_signal.rs
+++ b/crates/bridge-sm/src/graph/transitions/deposit_signal.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
-use strata_bridge_primitives::types::GraphIdx;
+use bitcoin::Txid;
+use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
 
 use crate::{
     graph::{
@@ -8,7 +9,7 @@ use crate::{
         duties::GraphDuty,
         errors::{GSMError, GSMResult},
         machine::{GSMOutput, GraphSM, generate_game_graph},
-        state::GraphState,
+        state::{AbortReason, GraphState},
     },
     signals::DepositToGraph,
 };
@@ -25,6 +26,64 @@ impl GraphSM {
                 assignee,
                 graph_idx,
             } => self.process_coop_payout_failed(cfg, assignee, graph_idx),
+            DepositToGraph::DepositRequestTakenBack {
+                deposit_idx,
+                takeback_txid,
+            } => self.process_deposit_request_taken_back(deposit_idx, takeback_txid),
+        }
+    }
+
+    /// Processes the user's deposit request takeback signal from the Deposit SM.
+    fn process_deposit_request_taken_back(
+        &mut self,
+        deposit_idx: DepositIdx,
+        takeback_txid: Txid,
+    ) -> GSMResult<GSMOutput> {
+        let event = DepositToGraph::DepositRequestTakenBack {
+            deposit_idx,
+            takeback_txid,
+        };
+
+        if self.context().graph_idx().deposit != deposit_idx {
+            return Err(GSMError::invalid_event(
+                self.state().clone(),
+                event.into(),
+                Some("deposit request takeback routed to graph for different deposit".to_string()),
+            ));
+        }
+
+        match self.state() {
+            GraphState::Created { .. }
+            | GraphState::GraphGenerated { .. }
+            | GraphState::AdaptorsVerified { .. }
+            | GraphState::NoncesCollected { .. }
+            | GraphState::GraphSigned { .. } => {
+                self.state = GraphState::Aborted {
+                    claim_txid: self.state.claim_txid(),
+                    reason: AbortReason::DepositRequestTakenBack {
+                        spending_txid: takeback_txid,
+                    },
+                };
+                Ok(GSMOutput::new())
+            }
+            state @ GraphState::Aborted {
+                reason:
+                    AbortReason::DepositRequestTakenBack {
+                        spending_txid: prior_txid,
+                    },
+                ..
+            } if *prior_txid == takeback_txid => {
+                Err(GSMError::duplicate(state.clone(), event.into()))
+            }
+            state => Err(GSMError::invalid_event(
+                state.clone(),
+                event.into(),
+                Some(
+                    "deposit request takeback after graph left pre-assignment requires explicit \
+                     reorg recovery"
+                        .to_string(),
+                ),
+            )),
         }
     }
 

--- a/crates/bridge-sm/src/graph/transitions/payout.rs
+++ b/crates/bridge-sm/src/graph/transitions/payout.rs
@@ -1,4 +1,4 @@
-use bitcoin::{Txid, hashes::Hash};
+use bitcoin::Txid;
 use tracing::{info, warn};
 
 use crate::{
@@ -215,7 +215,7 @@ impl GraphSM {
         // abort.
         if let Some(stake_spending_txid) = self.state.stake_spent_txid() {
             self.state = GraphState::Aborted {
-                claim_txid: self.state.claim_txid().unwrap_or(Txid::all_zeros()),
+                claim_txid: self.state.claim_txid(),
                 reason: AbortReason::Both {
                     stake_spending_txid,
                     payout_connector_spending_txid: spending_txid,
@@ -242,7 +242,7 @@ impl GraphSM {
         match self.state() {
             GraphState::AllNackd { .. } => {
                 self.state = GraphState::Aborted {
-                    claim_txid: self.state.claim_txid().unwrap_or(Txid::all_zeros()),
+                    claim_txid: self.state.claim_txid(),
                     reason: AbortReason::PayoutConnectorSpent { spending_txid },
                 };
                 Ok(GSMOutput::new())

--- a/crates/bridge-sm/src/signals.rs
+++ b/crates/bridge-sm/src/signals.rs
@@ -62,6 +62,13 @@ pub enum DepositToGraph {
         /// The index of the target graph for which the cooperative payout failed.
         graph_idx: GraphIdx,
     },
+    /// Indicates that the deposit request transaction was taken back by the user.
+    DepositRequestTakenBack {
+        /// The index of the deposit whose request transaction was taken back.
+        deposit_idx: DepositIdx,
+        /// The transaction that spent the deposit request output.
+        takeback_txid: Txid,
+    },
 }
 
 /// The signals that need to be sent from the Graph State Machine to the [Deposit State

--- a/crates/db/src/fdb/bridge_db.rs
+++ b/crates/db/src/fdb/bridge_db.rs
@@ -693,7 +693,7 @@ mod tests {
                 0 => GraphState::Created { last_block_height: block_height },
                 1 => GraphState::Withdrawn { claim_txid: txid, payout_txid: txid },
                 2 => GraphState::Aborted {
-                    claim_txid: txid,
+                    claim_txid: Some(txid),
                     reason: AbortReason::PayoutConnectorSpent { spending_txid: txid },
                 },
                 _ => {

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -183,12 +183,17 @@ mod tests {
     use bitcoin::{Amount, OutPoint, hashes::sha256};
     use strata_bridge_primitives::types::GraphIdx;
     use strata_bridge_sm::{
-        deposit::events::{DepositEvent, NewBlockEvent as DepositNewBlock},
+        deposit::{
+            events::{DepositEvent, NewBlockEvent as DepositNewBlock, UserTakeBackEvent},
+            state::DepositState,
+        },
         graph::{
             context::GraphSMCtx,
             events::{GraphEvent, NewBlockEvent as GraphNewBlock},
+            state::{AbortReason, GraphState},
         },
     };
+    use strata_bridge_test_utils::bitcoin::generate_spending_tx;
     use strata_bridge_tx_graph::transactions::prelude::DepositData;
 
     use super::*;
@@ -362,6 +367,108 @@ mod tests {
         let (_, tracker) = applicator.finish();
         let batches = tracker.into_batches();
         assert!(!batches.is_empty());
+    }
+
+    #[test]
+    fn deposit_request_takeback_signal_aborts_all_deposit_graphs() {
+        let mut registry = test_populated_registry(2);
+        let deposit_idx = 0;
+        let takeback_tx =
+            generate_spending_tx(OutPoint::default(), &[vec![0u8; 64], vec![1u8; 32]]);
+        let takeback_txid = takeback_tx.compute_txid();
+
+        let mut applicator = Applicator::new(&mut registry);
+        applicator
+            .apply_batch(vec![(
+                SMId::Deposit(deposit_idx),
+                SMEvent::Deposit(Box::new(DepositEvent::UserTakeBack(UserTakeBackEvent {
+                    tx: takeback_tx,
+                }))),
+            )])
+            .unwrap();
+
+        assert_eq!(
+            applicator
+                .registry()
+                .get_deposit(&deposit_idx)
+                .expect("deposit SM must exist")
+                .state(),
+            &DepositState::Aborted,
+            "DRT takeback must abort deposit {deposit_idx}"
+        );
+
+        for operator in 0..N_TEST_OPERATORS as u32 {
+            let graph_idx = GraphIdx {
+                deposit: deposit_idx,
+                operator,
+            };
+            let graph_state = applicator
+                .registry()
+                .get_graph(&graph_idx)
+                .expect("graph SM must exist")
+                .state();
+
+            assert!(
+                matches!(
+                    graph_state,
+                    GraphState::Aborted {
+                        claim_txid: None,
+                        reason: AbortReason::DepositRequestTakenBack { spending_txid },
+                    } if *spending_txid == takeback_txid
+                ),
+                "expected graph {graph_idx:?} to abort from DRT takeback, got {graph_state:?}"
+            );
+        }
+
+        for operator in 0..N_TEST_OPERATORS as u32 {
+            let graph_idx = GraphIdx {
+                deposit: 1,
+                operator,
+            };
+            let graph_state = applicator
+                .registry()
+                .get_graph(&graph_idx)
+                .expect("other deposit graph SM must exist")
+                .state();
+            assert!(
+                matches!(graph_state, GraphState::Created { .. }),
+                "DRT takeback for deposit {deposit_idx} must not mutate graph {graph_idx:?}"
+            );
+        }
+
+        let (_, tracker) = applicator.finish();
+        let batches = tracker.into_batches();
+        assert_eq!(
+            batches.len(),
+            1,
+            "DRT takeback cascade must be persisted as one atomic batch"
+        );
+
+        let batch = &batches[0];
+        assert!(
+            batch.contains(&SMId::Deposit(deposit_idx)),
+            "persistence batch must include aborted deposit {deposit_idx}"
+        );
+        for operator in 0..N_TEST_OPERATORS as u32 {
+            let graph_idx = GraphIdx {
+                deposit: deposit_idx,
+                operator,
+            };
+            assert!(
+                batch.contains(&SMId::Graph(graph_idx)),
+                "persistence batch must include aborted graph {graph_idx:?}"
+            );
+        }
+        for operator in 0..N_TEST_OPERATORS as u32 {
+            let graph_idx = GraphIdx {
+                deposit: 1,
+                operator,
+            };
+            assert!(
+                !batch.contains(&SMId::Graph(graph_idx)),
+                "persistence batch must not include unaffected graph {graph_idx:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/orchestrator/src/signals_router.rs
+++ b/crates/orchestrator/src/signals_router.rs
@@ -28,6 +28,16 @@ pub fn route_signal(registry: &SMRegistry, signal: Signal) -> Vec<(SMId, SMEvent
                         .map(|graph_id| (graph_id.into(), event.clone()))
                         .collect()
                 }
+                msg @ DepositToGraph::DepositRequestTakenBack { deposit_idx, .. } => {
+                    let event: SMEvent = GraphEvent::DepositMessage(msg).into();
+
+                    registry
+                        .get_graph_ids()
+                        .into_iter()
+                        .filter(|id| id.deposit == deposit_idx)
+                        .map(|graph_id| (graph_id.into(), event.clone()))
+                        .collect()
+                }
             },
         },
 
@@ -119,6 +129,61 @@ mod tests {
             }
             other => panic!("expected Graph SM ID, got {other}"),
         }
+    }
+
+    #[test]
+    fn deposit_request_taken_back_routes_to_all_graphs_for_deposit() {
+        let registry = test_populated_registry(3);
+        let deposit_idx = 1;
+        let signal = Signal::FromDeposit(DepositSignal::ToGraph(
+            DepositToGraph::DepositRequestTakenBack {
+                deposit_idx,
+                takeback_txid: generate_txid(),
+            },
+        ));
+
+        let targets = route_signal(&registry, signal);
+
+        assert_eq!(targets.len(), 3);
+        let mut graph_ids: Vec<_> = targets
+            .into_iter()
+            .map(|(id, _event)| match id {
+                SMId::Graph(graph_idx) => graph_idx,
+                other => panic!("expected Graph SM ID, got {other}"),
+            })
+            .collect();
+        graph_ids.sort();
+        assert_eq!(
+            graph_ids,
+            vec![
+                GraphIdx {
+                    deposit: deposit_idx,
+                    operator: 0,
+                },
+                GraphIdx {
+                    deposit: deposit_idx,
+                    operator: 1,
+                },
+                GraphIdx {
+                    deposit: deposit_idx,
+                    operator: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn deposit_request_taken_back_no_matching_deposit() {
+        let registry = test_populated_registry(1);
+        let signal = Signal::FromDeposit(DepositSignal::ToGraph(
+            DepositToGraph::DepositRequestTakenBack {
+                deposit_idx: 99,
+                takeback_txid: generate_txid(),
+            },
+        ));
+
+        let targets = route_signal(&registry, signal);
+        assert!(targets.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR adds handling of DRT recovery by a user in the GSM. In the current implementation, only the DSM moves to the `Aborted` state while the GSM remains unaffected. This PR updates this logic so that a signal is emitted by the DSM when it moves to the `Aborted` state which results in the GSM also getting aborted. Some changes have been made to the `AbortReason` struct and `Aborted` state in the GSM to accomodate this.

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
The corresponding design doc PR is https://github.com/alpenlabs/bridge-sm-design-docs/pull/30.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3757