### PR TITLE
STR-3591: add bridge health endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11362,6 +11362,8 @@ dependencies = [
  "secret-service-client",
  "secret-service-proto",
  "serde",
+ "serde_json",
+ "strata-asm-rpc",
  "strata-bridge-asm-events",
  "strata-bridge-common",
  "strata-bridge-connectors",
@@ -11385,6 +11387,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml 0.8.23",
+ "tower 0.5.2",
  "tracing",
  "zkaleido",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,6 +255,7 @@ tokio-stream = "0.1.18"
 tokio-util = { version = "0.7.18", default-features = false, features = ["rt"] }
 
 toml = "0.8.20"
+tower = "0.5.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 zeroize = { version = "1.8.2", features = ["derive"] }

--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -48,9 +48,12 @@ metrics.workspace = true
 rustls-pemfile.workspace = true
 secp256k1.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+strata-asm-rpc.workspace = true
 strata-metrics.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tower.workspace = true
 tracing.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -28,6 +28,7 @@ strata-bridge-tx-graph.workspace = true
 strata-mosaic-client.workspace = true
 strata-mosaic-client-api.workspace = true
 
+strata-asm-rpc.workspace = true
 strata-p2p.workspace = true
 strata-tasks.workspace = true
 
@@ -49,7 +50,6 @@ rustls-pemfile.workspace = true
 secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-strata-asm-rpc.workspace = true
 strata-metrics.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/bin/strata-bridge/src/constants.rs
+++ b/bin/strata-bridge/src/constants.rs
@@ -11,3 +11,6 @@ pub(crate) const DEFAULT_THREAD_STACK_SIZE: usize = 100 * 1024 * 1024;
 /// The rationale is to use 10 minutes since on every new block that the orchestrator scans,
 /// it refreshes the state.
 pub(crate) const DEFAULT_RPC_CACHE_REFRESH_INTERVAL: Duration = Duration::from_secs(10 * 60);
+
+/// Default interval for bridge component health probes.
+pub(crate) const DEFAULT_HEALTH_PROBE_INTERVAL: Duration = Duration::from_secs(60);

--- a/bin/strata-bridge/src/constants.rs
+++ b/bin/strata-bridge/src/constants.rs
@@ -16,8 +16,9 @@ pub(crate) const DEFAULT_RPC_CACHE_REFRESH_INTERVAL: Duration = Duration::from_s
 pub(crate) const DEFAULT_HEALTH_PROBE_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Maximum time a single health probe waits on an external system before it is marked unhealthy.
-///
-/// Bounds every probe that performs network I/O so a hung backend cannot leave a component
-/// reporting a stale `ok` state indefinitely. Kept well below
-/// [`DEFAULT_HEALTH_PROBE_INTERVAL`] so a timed-out probe still resolves before the next tick.
 pub(crate) const DEFAULT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+const _: () = assert!(
+    DEFAULT_HEALTH_PROBE_TIMEOUT.as_secs() < DEFAULT_HEALTH_PROBE_INTERVAL.as_secs(),
+    "health probe timeout must be shorter than the probe interval"
+);

--- a/bin/strata-bridge/src/constants.rs
+++ b/bin/strata-bridge/src/constants.rs
@@ -14,3 +14,10 @@ pub(crate) const DEFAULT_RPC_CACHE_REFRESH_INTERVAL: Duration = Duration::from_s
 
 /// Default interval for bridge component health probes.
 pub(crate) const DEFAULT_HEALTH_PROBE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Maximum time a single health probe waits on an external system before it is marked unhealthy.
+///
+/// Bounds every probe that performs network I/O so a hung backend cannot leave a component
+/// reporting a stale `ok` state indefinitely. Kept well below
+/// [`DEFAULT_HEALTH_PROBE_INTERVAL`] so a timed-out probe still resolves before the next tick.
+pub(crate) const DEFAULT_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);

--- a/bin/strata-bridge/src/health.rs
+++ b/bin/strata-bridge/src/health.rs
@@ -1,0 +1,679 @@
+//! Bridge process health registry and `/healthz` response types.
+
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use chrono::{SecondsFormat, Utc};
+use jsonrpsee::server::{HttpBody, HttpRequest, HttpResponse};
+use metrics::{describe_gauge, gauge};
+use serde::Serialize;
+use tracing::error;
+
+/// HTTP path exposed for bridge health checks.
+pub(crate) const HEALTH_HTTP_PATH: &str = "/healthz";
+/// Process-level component name.
+pub(crate) const COMPONENT_PROCESS: &str = "process";
+/// Bitcoin RPC component name.
+pub(crate) const COMPONENT_BITCOIN_RPC: &str = "bitcoin_rpc";
+/// Bitcoin ZMQ component name.
+pub(crate) const COMPONENT_BITCOIN_ZMQ: &str = "bitcoin_zmq";
+/// ASM RPC component name.
+pub(crate) const COMPONENT_ASM_RPC: &str = "asm_rpc";
+/// ASM assignment feed component name.
+pub(crate) const COMPONENT_ASM_ASSIGNMENT_FEED: &str = "asm_assignment_feed";
+/// FoundationDB component name.
+pub(crate) const COMPONENT_FDB: &str = "fdb";
+/// P2P component name.
+pub(crate) const COMPONENT_P2P: &str = "p2p";
+/// Mosaic component name.
+pub(crate) const COMPONENT_MOSAIC: &str = "mosaic";
+/// Secret service component name.
+pub(crate) const COMPONENT_S2: &str = "s2";
+/// Operator wallet component name.
+pub(crate) const COMPONENT_WALLET: &str = "wallet";
+/// Bitcoin transaction driver component name.
+pub(crate) const COMPONENT_TX_DRIVER: &str = "tx_driver";
+/// Orchestrator component name.
+pub(crate) const COMPONENT_ORCHESTRATOR: &str = "orchestrator";
+/// RPC state cache component name.
+pub(crate) const COMPONENT_RPC_CACHE: &str = "rpc_cache";
+
+const ALL_COMPONENTS: &[&str] = &[
+    COMPONENT_PROCESS,
+    COMPONENT_BITCOIN_RPC,
+    COMPONENT_BITCOIN_ZMQ,
+    COMPONENT_ASM_RPC,
+    COMPONENT_ASM_ASSIGNMENT_FEED,
+    COMPONENT_FDB,
+    COMPONENT_P2P,
+    COMPONENT_MOSAIC,
+    COMPONENT_S2,
+    COMPONENT_WALLET,
+    COMPONENT_TX_DRIVER,
+    COMPONENT_ORCHESTRATOR,
+    COMPONENT_RPC_CACHE,
+];
+
+/// Low-cardinality health status for the bridge and its components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum HealthStatus {
+    /// Component is healthy.
+    Ok,
+
+    /// Component can not yet prove full readiness, but the process can still report health.
+    Degraded,
+
+    /// Component has observed a hard failure.
+    Unhealthy,
+}
+
+impl HealthStatus {
+    const fn as_label(self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::Degraded => "degraded",
+            Self::Unhealthy => "unhealthy",
+        }
+    }
+}
+
+/// Shared health state updated by bootstrap code and read by the RPC server.
+#[derive(Debug, Clone)]
+pub(crate) struct HealthRegistry {
+    components: Arc<RwLock<BTreeMap<&'static str, ComponentHealth>>>,
+}
+
+impl HealthRegistry {
+    /// Creates a registry with every known component explicitly marked as not initialized.
+    pub(crate) fn new() -> Self {
+        describe_gauge!(
+            "strata_bridge_health_component_status",
+            "Bridge component health status. Labels are intentionally limited to component and status."
+        );
+
+        let components = ALL_COMPONENTS
+            .iter()
+            .copied()
+            .map(|component| {
+                let health =
+                    ComponentHealth::new(component, HealthStatus::Unhealthy, "not_initialized");
+                emit_component_metric(component, health.status);
+                (component, health)
+            })
+            .collect();
+
+        Self {
+            components: Arc::new(RwLock::new(components)),
+        }
+    }
+
+    /// Marks a component as healthy and records a new last-success timestamp.
+    pub(crate) fn mark_ok(&self, component: &'static str, reason: impl Into<String>) {
+        self.set(component, HealthStatus::Ok, reason.into(), true);
+    }
+
+    /// Marks a component as degraded while preserving its previous last-success timestamp.
+    pub(crate) fn mark_degraded(&self, component: &'static str, reason: impl Into<String>) {
+        self.set(component, HealthStatus::Degraded, reason.into(), false);
+    }
+
+    /// Marks a component as unhealthy while preserving its previous last-success timestamp.
+    pub(crate) fn mark_unhealthy(&self, component: &'static str, reason: impl Into<String>) {
+        self.set(component, HealthStatus::Unhealthy, reason.into(), false);
+    }
+
+    /// Returns the current machine-readable health payload.
+    pub(crate) fn snapshot(&self) -> HealthSnapshot {
+        let components = match self.components.read() {
+            Ok(components) => components,
+            Err(poisoned) => {
+                error!("health registry read lock poisoned");
+                poisoned.into_inner()
+            }
+        };
+
+        let component_snapshots: Vec<_> = components
+            .values()
+            .cloned()
+            .map(ComponentHealthSnapshot::from)
+            .collect();
+        let status = aggregate_status(component_snapshots.iter().map(|component| component.status));
+
+        HealthSnapshot {
+            status,
+            checked_at: now_rfc3339(),
+            components: component_snapshots,
+        }
+    }
+
+    fn set(
+        &self,
+        component: &'static str,
+        status: HealthStatus,
+        reason: String,
+        update_last_success: bool,
+    ) {
+        let mut components = match self.components.write() {
+            Ok(components) => components,
+            Err(poisoned) => {
+                error!("health registry write lock poisoned");
+                poisoned.into_inner()
+            }
+        };
+
+        let (last_success_time, last_success_instant) = if update_last_success {
+            (Some(now_rfc3339()), Some(Instant::now()))
+        } else {
+            let previous = components
+                .get(component)
+                .map(|health| {
+                    (
+                        health.last_success_time.clone(),
+                        health.last_success_instant,
+                    )
+                })
+                .unwrap_or((None, None));
+            previous
+        };
+
+        components.insert(
+            component,
+            ComponentHealth {
+                component,
+                status,
+                reason,
+                last_success_time,
+                last_success_instant,
+            },
+        );
+        emit_component_metric(component, status);
+    }
+
+    /// Marks a component unhealthy if its last successful update is older than `max_age`.
+    pub(crate) fn mark_unhealthy_if_stale(
+        &self,
+        component: &'static str,
+        max_age: Duration,
+        reason: impl Into<String>,
+    ) {
+        let mut components = match self.components.write() {
+            Ok(components) => components,
+            Err(poisoned) => {
+                error!("health registry write lock poisoned");
+                poisoned.into_inner()
+            }
+        };
+
+        let health = components.entry(component).or_insert_with(|| {
+            ComponentHealth::new(component, HealthStatus::Degraded, "not_initialized")
+        });
+
+        if health
+            .last_success_instant
+            .is_some_and(|instant| instant.elapsed() <= max_age)
+        {
+            return;
+        }
+
+        health.status = HealthStatus::Unhealthy;
+        health.reason = reason.into();
+        emit_component_metric(component, HealthStatus::Unhealthy);
+    }
+}
+
+/// Tower layer that serves `GET /healthz` before JSON-RPC dispatch.
+#[derive(Debug, Clone)]
+pub(crate) struct HealthHttpLayer {
+    registry: HealthRegistry,
+}
+
+impl HealthHttpLayer {
+    /// Creates a health HTTP layer backed by the shared registry.
+    pub(crate) fn new(registry: HealthRegistry) -> Self {
+        Self { registry }
+    }
+}
+
+impl<S> tower::Layer<S> for HealthHttpLayer {
+    type Service = HealthHttpService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HealthHttpService {
+            inner,
+            registry: self.registry.clone(),
+        }
+    }
+}
+
+/// Service produced by [`HealthHttpLayer`].
+#[derive(Debug, Clone)]
+pub(crate) struct HealthHttpService<S> {
+    inner: S,
+    registry: HealthRegistry,
+}
+
+impl<S, B> tower::Service<HttpRequest<B>> for HealthHttpService<S>
+where
+    S: tower::Service<HttpRequest<B>, Response = HttpResponse> + Send + 'static,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = HttpResponse;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: HttpRequest<B>) -> Self::Future {
+        if request.uri().path() == HEALTH_HTTP_PATH {
+            let response = if request.method().as_str() == "GET" {
+                health_response(self.registry.snapshot())
+            } else {
+                method_not_allowed_response()
+            };
+            return Box::pin(async move { Ok(response) });
+        }
+
+        Box::pin(self.inner.call(request))
+    }
+}
+
+fn health_response(snapshot: HealthSnapshot) -> HttpResponse {
+    let status = http_status_for_health(snapshot.status);
+    match serde_json::to_vec(&snapshot) {
+        Ok(body) => response(status, "application/json; charset=utf-8", body),
+        Err(err) => {
+            error!(%err, "failed to serialize health snapshot");
+            response(
+                500,
+                "application/json; charset=utf-8",
+                br#"{"status":"unhealthy","reason":"health_snapshot_serialization_failed"}"#
+                    .to_vec(),
+            )
+        }
+    }
+}
+
+fn method_not_allowed_response() -> HttpResponse {
+    response(
+        405,
+        "application/json; charset=utf-8",
+        br#"{"error":"method_not_allowed"}"#.to_vec(),
+    )
+}
+
+fn response(status: u16, content_type: &'static str, body: Vec<u8>) -> HttpResponse {
+    HttpResponse::builder()
+        .status(status)
+        .header("content-type", content_type)
+        .header("cache-control", "no-store")
+        .body(HttpBody::from(body))
+        .expect("static health HTTP response should be valid")
+}
+
+fn http_status_for_health(status: HealthStatus) -> u16 {
+    match status {
+        HealthStatus::Ok | HealthStatus::Degraded => 200,
+        HealthStatus::Unhealthy => 503,
+    }
+}
+
+impl Default for HealthRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ComponentHealth {
+    component: &'static str,
+    status: HealthStatus,
+    reason: String,
+    last_success_time: Option<String>,
+    last_success_instant: Option<Instant>,
+}
+
+impl ComponentHealth {
+    fn new(component: &'static str, status: HealthStatus, reason: impl Into<String>) -> Self {
+        Self {
+            component,
+            status,
+            reason: reason.into(),
+            last_success_time: None,
+            last_success_instant: None,
+        }
+    }
+}
+
+/// Top-level `/healthz` response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct HealthSnapshot {
+    /// Aggregate bridge health status.
+    pub(crate) status: HealthStatus,
+
+    /// RFC 3339 timestamp when this snapshot was built.
+    pub(crate) checked_at: String,
+
+    /// Per-component health records.
+    pub(crate) components: Vec<ComponentHealthSnapshot>,
+}
+
+/// Per-component `/healthz` response entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ComponentHealthSnapshot {
+    /// Stable low-cardinality component name.
+    pub(crate) component: &'static str,
+
+    /// Current component health status.
+    pub(crate) status: HealthStatus,
+
+    /// Stable, operator-readable reason.
+    pub(crate) reason: String,
+
+    /// RFC 3339 timestamp of the last successful component update, if known.
+    pub(crate) last_success_time: Option<String>,
+}
+
+impl From<ComponentHealth> for ComponentHealthSnapshot {
+    fn from(health: ComponentHealth) -> Self {
+        Self {
+            component: health.component,
+            status: health.status,
+            reason: health.reason,
+            last_success_time: health.last_success_time,
+        }
+    }
+}
+
+fn aggregate_status(statuses: impl IntoIterator<Item = HealthStatus>) -> HealthStatus {
+    let mut aggregate = HealthStatus::Ok;
+
+    for status in statuses {
+        match status {
+            HealthStatus::Unhealthy => return HealthStatus::Unhealthy,
+            HealthStatus::Degraded => aggregate = HealthStatus::Degraded,
+            HealthStatus::Ok => {}
+        }
+    }
+
+    aggregate
+}
+
+fn emit_component_metric(component: &'static str, active_status: HealthStatus) {
+    for status in [
+        HealthStatus::Ok,
+        HealthStatus::Degraded,
+        HealthStatus::Unhealthy,
+    ] {
+        let value = if status == active_status { 1.0 } else { 0.0 };
+        gauge!(
+            "strata_bridge_health_component_status",
+            "component" => component,
+            "status" => status.as_label(),
+        )
+        .set(value);
+    }
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    use tower::{Layer, Service};
+
+    use super::*;
+
+    #[test]
+    fn new_registry_starts_unhealthy_for_all_components() {
+        let snapshot = HealthRegistry::new().snapshot();
+
+        assert_eq!(snapshot.status, HealthStatus::Unhealthy);
+        assert_eq!(snapshot.components.len(), ALL_COMPONENTS.len());
+        assert!(
+            snapshot
+                .components
+                .iter()
+                .all(|component| component.status == HealthStatus::Unhealthy)
+        );
+    }
+
+    #[test]
+    fn aggregate_status_prioritizes_unhealthy_then_degraded() {
+        assert_eq!(
+            aggregate_status([HealthStatus::Ok, HealthStatus::Degraded]),
+            HealthStatus::Degraded
+        );
+        assert_eq!(
+            aggregate_status([HealthStatus::Degraded, HealthStatus::Unhealthy]),
+            HealthStatus::Unhealthy
+        );
+    }
+
+    #[test]
+    fn ok_update_records_last_success_and_degraded_preserves_it() {
+        let registry = HealthRegistry::new();
+
+        registry.mark_ok(COMPONENT_PROCESS, "initialized");
+        let ok_snapshot = registry.snapshot();
+        let process = ok_snapshot
+            .components
+            .iter()
+            .find(|component| component.component == COMPONENT_PROCESS)
+            .expect("process component must exist");
+        let last_success = process.last_success_time.clone();
+        assert!(last_success.is_some());
+
+        registry.mark_degraded(COMPONENT_PROCESS, "test_degraded");
+        let degraded_snapshot = registry.snapshot();
+        let process = degraded_snapshot
+            .components
+            .iter()
+            .find(|component| component.component == COMPONENT_PROCESS)
+            .expect("process component must exist");
+
+        assert_eq!(process.status, HealthStatus::Degraded);
+        assert_eq!(process.last_success_time, last_success);
+    }
+
+    #[test]
+    fn snapshot_serializes_last_success_time_field() {
+        let registry = HealthRegistry::new();
+        registry.mark_ok(COMPONENT_PROCESS, "initialized");
+
+        let value = serde_json::to_value(registry.snapshot()).expect("snapshot must serialize");
+        let process = value["components"]
+            .as_array()
+            .expect("components must serialize as array")
+            .iter()
+            .find(|component| component["component"] == COMPONENT_PROCESS)
+            .expect("process component must exist");
+
+        assert!(process.get("last_success_time").is_some());
+        assert!(process.get("last_success_at").is_none());
+    }
+
+    #[test]
+    fn stale_check_preserves_fresh_component_and_marks_missing_success_unhealthy() {
+        let registry = HealthRegistry::new();
+
+        registry.mark_ok(COMPONENT_PROCESS, "initialized");
+        registry.mark_unhealthy_if_stale(
+            COMPONENT_PROCESS,
+            Duration::from_secs(60),
+            "process_stale",
+        );
+        let process = registry
+            .snapshot()
+            .components
+            .into_iter()
+            .find(|component| component.component == COMPONENT_PROCESS)
+            .expect("process component must exist");
+        assert_eq!(process.status, HealthStatus::Ok);
+
+        registry.mark_unhealthy_if_stale(
+            COMPONENT_ORCHESTRATOR,
+            Duration::from_secs(60),
+            "pipeline_stale",
+        );
+        let orchestrator = registry
+            .snapshot()
+            .components
+            .into_iter()
+            .find(|component| component.component == COMPONENT_ORCHESTRATOR)
+            .expect("orchestrator component must exist");
+        assert_eq!(orchestrator.status, HealthStatus::Unhealthy);
+        assert_eq!(orchestrator.reason, "pipeline_stale");
+    }
+
+    #[test]
+    fn asm_rpc_and_assignment_feed_health_are_independent() {
+        let registry = HealthRegistry::new();
+
+        registry.mark_unhealthy(COMPONENT_ASM_ASSIGNMENT_FEED, "assignments_fetch_failed");
+        registry.mark_ok(COMPONENT_ASM_RPC, "asm_rpc_reachable");
+
+        let snapshot = registry.snapshot();
+        let asm_rpc = snapshot
+            .components
+            .iter()
+            .find(|component| component.component == COMPONENT_ASM_RPC)
+            .expect("asm rpc component must exist");
+        let assignment_feed = snapshot
+            .components
+            .iter()
+            .find(|component| component.component == COMPONENT_ASM_ASSIGNMENT_FEED)
+            .expect("asm assignment feed component must exist");
+
+        assert_eq!(asm_rpc.status, HealthStatus::Ok);
+        assert_eq!(assignment_feed.status, HealthStatus::Unhealthy);
+        assert_eq!(assignment_feed.reason, "assignments_fetch_failed");
+    }
+
+    #[test]
+    fn health_status_maps_to_infra_http_status() {
+        assert_eq!(http_status_for_health(HealthStatus::Ok), 200);
+        assert_eq!(http_status_for_health(HealthStatus::Degraded), 200);
+        assert_eq!(http_status_for_health(HealthStatus::Unhealthy), 503);
+    }
+
+    #[tokio::test]
+    async fn health_http_layer_returns_503_for_unhealthy_snapshot() {
+        let registry = HealthRegistry::new();
+        let mut service = HealthHttpLayer::new(registry).layer(TestService);
+        let request = health_request("GET", HEALTH_HTTP_PATH);
+
+        let response = service.call(request).await.expect("health response");
+
+        assert_eq!(response.status().as_u16(), 503);
+        assert_json_health_headers(&response);
+    }
+
+    #[tokio::test]
+    async fn health_http_layer_returns_200_for_degraded_snapshot() {
+        let registry = HealthRegistry::new();
+        for component in ALL_COMPONENTS {
+            registry.mark_ok(component, "test_ok");
+        }
+        registry.mark_degraded(COMPONENT_P2P, "partial_peer_connectivity");
+        let mut service = HealthHttpLayer::new(registry).layer(TestService);
+        let request = health_request("GET", HEALTH_HTTP_PATH);
+
+        let response = service.call(request).await.expect("health response");
+
+        assert_eq!(response.status().as_u16(), 200);
+        assert_json_health_headers(&response);
+    }
+
+    #[tokio::test]
+    async fn health_http_layer_rejects_non_get_health_requests() {
+        let registry = HealthRegistry::new();
+        let mut service = HealthHttpLayer::new(registry).layer(TestService);
+        let request = health_request("POST", HEALTH_HTTP_PATH);
+
+        let response = service.call(request).await.expect("health response");
+
+        assert_eq!(response.status().as_u16(), 405);
+        assert_json_health_headers(&response);
+    }
+
+    #[tokio::test]
+    async fn health_http_layer_passes_through_non_health_requests() {
+        let registry = HealthRegistry::new();
+        let mut service = HealthHttpLayer::new(registry).layer(TestService);
+        let request = health_request("GET", "/");
+
+        let response = service.call(request).await.expect("inner response");
+
+        assert_eq!(response.status().as_u16(), 418);
+    }
+
+    #[derive(Clone)]
+    struct TestService;
+
+    impl tower::Service<HttpRequest<HttpBody>> for TestService {
+        type Response = HttpResponse;
+        type Error = Infallible;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: HttpRequest<HttpBody>) -> Self::Future {
+            Box::pin(async {
+                Ok(HttpResponse::builder()
+                    .status(418)
+                    .body(HttpBody::from("inner"))
+                    .expect("test response should be valid"))
+            })
+        }
+    }
+
+    fn health_request(method: &str, uri: &str) -> HttpRequest<HttpBody> {
+        HttpRequest::builder()
+            .method(method)
+            .uri(uri)
+            .body(HttpBody::from(Vec::new()))
+            .expect("test request should be valid")
+    }
+
+    fn assert_json_health_headers(response: &HttpResponse) {
+        assert_eq!(
+            response
+                .headers()
+                .get("cache-control")
+                .expect("cache-control header")
+                .to_str()
+                .expect("cache-control header value"),
+            "no-store"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .expect("content-type header")
+                .to_str()
+                .expect("content-type header value"),
+            "application/json; charset=utf-8"
+        );
+    }
+}

--- a/bin/strata-bridge/src/health.rs
+++ b/bin/strata-bridge/src/health.rs
@@ -171,7 +171,7 @@ impl HealthRegistry {
         let (last_success_time, last_success_instant) = if update_last_success {
             (Some(now_rfc3339()), Some(Instant::now()))
         } else {
-            let previous = components
+            components
                 .get(component)
                 .map(|health| {
                     (
@@ -179,8 +179,7 @@ impl HealthRegistry {
                         health.last_success_instant,
                     )
                 })
-                .unwrap_or((None, None));
-            previous
+                .unwrap_or((None, None))
         };
 
         components.insert(
@@ -236,7 +235,7 @@ pub(crate) struct HealthHttpLayer {
 
 impl HealthHttpLayer {
     /// Creates a health HTTP layer backed by the shared registry.
-    pub(crate) fn new(registry: HealthRegistry) -> Self {
+    pub(crate) const fn new(registry: HealthRegistry) -> Self {
         Self { registry }
     }
 }
@@ -320,7 +319,7 @@ fn response(status: u16, content_type: &'static str, body: Vec<u8>) -> HttpRespo
         .expect("static health HTTP response should be valid")
 }
 
-fn http_status_for_health(status: HealthStatus) -> u16 {
+const fn http_status_for_health(status: HealthStatus) -> u16 {
     match status {
         HealthStatus::Ok | HealthStatus::Degraded => 200,
         HealthStatus::Unhealthy => 503,

--- a/bin/strata-bridge/src/main.rs
+++ b/bin/strata-bridge/src/main.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, info, trace};
 mod args;
 mod config;
 mod constants;
+mod health;
 mod mode;
 mod observability;
 
@@ -67,6 +68,8 @@ fn main() {
     }
 
     info!(mode = %mode_label, network = %network_label, "starting bridge node");
+    let health_registry = health::HealthRegistry::new();
+    health_registry.mark_ok(health::COMPONENT_PROCESS, "process_started");
 
     // Initialize FDB client
     // Must happen once per process, before spawning tasks.
@@ -80,6 +83,7 @@ fn main() {
         .expect("should initialize FDB client");
     let fdb_client = Arc::new(fdb_client);
     debug!("FoundationDB client initialized");
+    health_registry.mark_ok(health::COMPONENT_FDB, "client_initialized");
 
     let task_manager = TaskManager::new(runtime_handle);
     task_manager.start_signal_listeners();
@@ -89,12 +93,14 @@ fn main() {
     match cli.mode {
         OperationMode::Operator => {
             let fdb = fdb_client.clone();
+            let health_registry = health_registry.clone();
             executor
                 .clone()
                 .spawn_critical_async("operator", async move {
                     #[cfg(feature = "memory_profiling")]
                     memory_pprof::setup_memory_profiling(3_000);
-                    operator::bootstrap(params, config, fdb, executor.clone()).await
+                    operator::bootstrap(params, config, fdb, executor.clone(), health_registry)
+                        .await
                 });
         }
         OperationMode::Watchtower => {

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -28,7 +28,7 @@ use crate::{
             mosaic_client::{init_mosaic_client, run_mosaic_setup, spawn_mosaic_poller},
             operator_table::init_operator_table,
             operator_wallet::{init_operator_wallet, spawn_initial_operator_wallet_sync},
-            orchestrator::{build_sm_config, init_orchestrator},
+            orchestrator::init_orchestrator,
             p2p_handles::{P2PHandles, init_p2p_handles},
             secret_service::init_secret_service_client,
         },
@@ -129,13 +129,7 @@ pub(crate) async fn bootstrap(
 
     let probe_interval = DEFAULT_HEALTH_PROBE_INTERVAL;
     let expected_peer_count = operator_table.cardinality().saturating_sub(1);
-    let sm_config = build_sm_config(&config, &params);
-    spawn_fdb_probe(
-        db.clone(),
-        sm_config,
-        probe_interval,
-        health_registry.clone(),
-    );
+    spawn_fdb_probe(db.clone(), probe_interval, health_registry.clone());
     spawn_bitcoin_rpc_probe(
         btc_rpc_client.clone(),
         probe_interval,

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -7,19 +7,28 @@ use strata_bridge_common::params::Params;
 use strata_bridge_db::fdb::client::FdbClient;
 use strata_tasks::TaskExecutor;
 use tokio::sync::RwLock;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use crate::{
     config::Config,
+    constants::DEFAULT_HEALTH_PROBE_INTERVAL,
+    health::{
+        COMPONENT_ASM_RPC, COMPONENT_BITCOIN_RPC, COMPONENT_MOSAIC, COMPONENT_P2P, COMPONENT_S2,
+        COMPONENT_WALLET, HealthRegistry,
+    },
     mode::{
         rpc_server::init_rpc_server,
         services::{
             asm_rpc::init_asm_rpc_client,
             btc_client::init_btc_rpc_client,
+            health_probes::{
+                spawn_asm_rpc_probe, spawn_bitcoin_rpc_probe, spawn_fdb_probe, spawn_mosaic_probe,
+                spawn_p2p_probe, spawn_s2_probe, spawn_wallet_probe,
+            },
             mosaic_client::{init_mosaic_client, run_mosaic_setup, spawn_mosaic_poller},
             operator_table::init_operator_table,
             operator_wallet::{init_operator_wallet, spawn_initial_operator_wallet_sync},
-            orchestrator::init_orchestrator,
+            orchestrator::{build_sm_config, init_orchestrator},
             p2p_handles::{P2PHandles, init_p2p_handles},
             secret_service::init_secret_service_client,
         },
@@ -31,6 +40,7 @@ pub(crate) async fn bootstrap(
     config: Config,
     db: Arc<FdbClient>,
     executor: TaskExecutor,
+    health_registry: HealthRegistry,
 ) -> anyhow::Result<()> {
     info!("starting operator loop");
     debug!(
@@ -50,12 +60,14 @@ pub(crate) async fn bootstrap(
     let pov_p2p_key = operator_table.pov_p2p_key();
     let agg_key = operator_table.aggregated_btc_key();
     info!(%pov_idx, %pov_p2p_key, %pov_btc_key, %agg_key, "operator table initialized");
+    health_registry.mark_ok(COMPONENT_S2, "operator_table_loaded");
 
     debug!("initializing operator wallet");
     let initialized_wallet = init_operator_wallet(&config, &params, &s2_client, &db).await?;
     let claim_funding_utxo_value = initialized_wallet.claim_funding_utxo_value;
     let operator_wallet = Arc::new(RwLock::new(initialized_wallet.wallet));
     info!(%claim_funding_utxo_value, "operator wallet initialized");
+    health_registry.mark_ok(COMPONENT_WALLET, "wallet_initialized");
 
     debug!("spawning initial operator wallet sync");
     let sync_wallet = operator_wallet.clone();
@@ -68,10 +80,12 @@ pub(crate) async fn bootstrap(
     let btc_rpc_client = init_btc_rpc_client(&config)?;
     let cur_height = btc_rpc_client.get_block_count().await?;
     info!(%cur_height, "bitcoin client initialized and synced");
+    health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "block_count_read");
 
     debug!("initializing asm rpc client");
     let asm_rpc_client = init_asm_rpc_client(&config.asm_rpc);
     info!("asm rpc client initialized");
+    health_registry.mark_degraded(COMPONENT_ASM_RPC, "client_initialized_not_checked");
 
     debug!("initializing p2p client");
     let P2PHandles {
@@ -81,9 +95,18 @@ pub(crate) async fn bootstrap(
         keypair,
     } = init_p2p_handles(&config, &params, &s2_client, &executor).await?;
     info!("p2p client initialized, connected to swarm and listening");
+    health_registry.mark_ok(COMPONENT_P2P, "swarm_initialized");
 
     debug!("starting rpc server");
-    init_rpc_server(&params, &config, db.clone(), command_handle, &executor).await?;
+    init_rpc_server(
+        &params,
+        &config,
+        db.clone(),
+        command_handle.clone(),
+        &executor,
+        health_registry.clone(),
+    )
+    .await?;
     info!(addr=%config.rpc.rpc_addr, "rpc server started and listening for requests");
 
     debug!("initializing mosaic client");
@@ -93,10 +116,53 @@ pub(crate) async fn bootstrap(
         operator_table.pov_idx(),
     ));
     info!("mosaic client initialized");
+    health_registry.mark_degraded(COMPONENT_MOSAIC, "setup_pending");
 
     debug!("running mosaic setup for all operator pairs");
-    run_mosaic_setup(mosaic_client.as_ref(), &operator_table).await?;
+    if let Err(err) = run_mosaic_setup(mosaic_client.as_ref(), &operator_table).await {
+        health_registry.mark_unhealthy(COMPONENT_MOSAIC, "setup_failed");
+        error!(%err, "mosaic setup failed");
+        return Err(err);
+    }
     info!("mosaic setup complete for all operator pairs");
+    health_registry.mark_ok(COMPONENT_MOSAIC, "setup_complete");
+
+    let probe_interval = DEFAULT_HEALTH_PROBE_INTERVAL;
+    let expected_peer_count = operator_table.cardinality().saturating_sub(1);
+    let sm_config = build_sm_config(&config, &params);
+    spawn_fdb_probe(
+        db.clone(),
+        sm_config,
+        probe_interval,
+        health_registry.clone(),
+    );
+    spawn_bitcoin_rpc_probe(
+        btc_rpc_client.clone(),
+        probe_interval,
+        health_registry.clone(),
+    );
+    spawn_asm_rpc_probe(
+        asm_rpc_client.clone(),
+        probe_interval,
+        health_registry.clone(),
+    );
+    spawn_p2p_probe(
+        command_handle.clone(),
+        expected_peer_count,
+        probe_interval,
+        health_registry.clone(),
+    );
+    spawn_mosaic_probe(
+        mosaic_client.clone(),
+        probe_interval,
+        health_registry.clone(),
+    );
+    spawn_s2_probe(s2_client.clone(), probe_interval, health_registry.clone());
+    spawn_wallet_probe(
+        operator_wallet.clone(),
+        probe_interval,
+        health_registry.clone(),
+    );
 
     debug!("starting orchestrator pipeline");
     let mosaic_poller_client = mosaic_client.clone();
@@ -115,6 +181,7 @@ pub(crate) async fn bootstrap(
         asm_rpc_client,
         db.clone(),
         &executor,
+        health_registry.clone(),
     )
     .await?;
 

--- a/bin/strata-bridge/src/mode/rpc_server/server.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/server.rs
@@ -38,6 +38,7 @@ use tokio::{
     sync::{RwLock, oneshot},
     time::interval,
 };
+use tower::ServiceBuilder;
 use tracing::{debug, info, warn};
 
 use super::monitoring::{
@@ -48,6 +49,7 @@ use super::monitoring::{
 use crate::{
     config::{Config, RpcConfig},
     constants::DEFAULT_RPC_CACHE_REFRESH_INTERVAL,
+    health::{COMPONENT_RPC_CACHE, HealthHttpLayer, HealthRegistry},
     mode::{
         rpc_server::da::{stake_aggregate_signatures_response, stake_data_response},
         services::orchestrator::build_sm_config,
@@ -61,6 +63,7 @@ pub(in crate::mode) async fn init_rpc_server(
     db: Arc<FdbClient>,
     command_handle: CommandHandle,
     executor: &TaskExecutor,
+    health_registry: HealthRegistry,
 ) -> anyhow::Result<()> {
     let rpc_persister = Persister::new(db);
     let sm_config = build_sm_config(config, params);
@@ -76,14 +79,19 @@ pub(in crate::mode) async fn init_rpc_server(
             rpc_params,
             sm_config,
             rpc_config,
+            health_registry.clone(),
         );
-        start_rpc(&rpc_impl, rpc_addr.as_str()).await
+        start_rpc(&rpc_impl, rpc_addr.as_str(), health_registry).await
     });
 
     Ok(())
 }
 
-async fn start_rpc<T>(rpc_impl: &T, rpc_addr: &str) -> anyhow::Result<()>
+async fn start_rpc<T>(
+    rpc_impl: &T,
+    rpc_addr: &str,
+    health_registry: HealthRegistry,
+) -> anyhow::Result<()>
 where
     T: StrataBridgeControlApiServer
         + StrataBridgeMonitoringApiServer
@@ -102,10 +110,12 @@ where
         .context("merge monitoring api")?;
     rpc_module.merge(da_api).context("merge da api")?;
     debug!("starting bridge rpc server at {rpc_addr}");
+    let health_middleware = ServiceBuilder::new().layer(HealthHttpLayer::new(health_registry));
     let rpc_server = jsonrpsee::server::ServerBuilder::new()
+        .set_http_middleware(health_middleware)
         .build(&rpc_addr)
         .await
-        .expect("build bridge rpc server");
+        .context("build bridge rpc server")?;
     let rpc_handle = rpc_server.start(rpc_module);
 
     // Using `_` for `_stop_tx` as the variable causes it to be dropped immediately!
@@ -149,6 +159,9 @@ pub(crate) struct BridgeRpc {
 
     /// RPC server configuration.
     config: RpcConfig,
+
+    /// Shared bridge component health registry.
+    health_registry: HealthRegistry,
 }
 
 impl BridgeRpc {
@@ -159,6 +172,7 @@ impl BridgeRpc {
         params: Params,
         sm_config: SMConfig,
         config: RpcConfig,
+        health_registry: HealthRegistry,
     ) -> Self {
         // Initialize with empty cache
         let cached_contracts = Arc::new(RwLock::new(SMRegistry::new(sm_config)));
@@ -171,6 +185,7 @@ impl BridgeRpc {
             command_handle,
             params,
             config,
+            health_registry,
         };
 
         // Start the cache refresh task
@@ -187,26 +202,47 @@ impl BridgeRpc {
             .refresh_interval
             .unwrap_or(DEFAULT_RPC_CACHE_REFRESH_INTERVAL);
         let db = self.db.clone();
+        let health_registry = self.health_registry.clone();
 
         // Spawn a background task to refresh the cache
         tokio::spawn(async move {
             info!(?period, "initializing rpc server cache refresh task");
 
-            Self::refresh_registry(&db, &cached_registry).await;
-            debug!("rpc server contracts cache initialized");
+            match Self::refresh_registry(&db, &cached_registry).await {
+                Ok(()) => {
+                    health_registry.mark_ok(COMPONENT_RPC_CACHE, "cache_initialized");
+                    debug!("rpc server contracts cache initialized");
+                }
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_RPC_CACHE, "recover_registry_failed");
+                    warn!(%err, "rpc server cache initialization failed");
+                }
+            }
 
             // Periodic refresh in a separate loop outside the closure
             let mut refresh_interval = interval(period);
             loop {
                 refresh_interval.tick().await;
 
-                Self::refresh_registry(&db, &cached_registry).await;
-                debug!("rpc state machine registry cache refreshed");
+                match Self::refresh_registry(&db, &cached_registry).await {
+                    Ok(()) => {
+                        health_registry.mark_ok(COMPONENT_RPC_CACHE, "cache_refreshed");
+                        debug!("rpc state machine registry cache refreshed");
+                    }
+                    Err(err) => {
+                        health_registry
+                            .mark_unhealthy(COMPONENT_RPC_CACHE, "recover_registry_failed");
+                        warn!(%err, "rpc state machine registry cache refresh failed");
+                    }
+                }
             }
         });
     }
 
-    async fn refresh_registry(db: &Persister, cached_registry: &RwLock<SMRegistry>) {
+    async fn refresh_registry(
+        db: &Persister,
+        cached_registry: &RwLock<SMRegistry>,
+    ) -> anyhow::Result<()> {
         let config = {
             let registry_read_lock = cached_registry.read().await;
             registry_read_lock.cfg().clone()
@@ -216,13 +252,14 @@ impl BridgeRpc {
         let sm_registry = db
             .recover_registry(config)
             .await
-            .expect("must recover state machine registry from database");
+            .map_err(|e| anyhow::anyhow!("recover state machine registry from database: {e:?}"))?;
 
         let mut cache_registry_lock = cached_registry.write().await;
         *cache_registry_lock = sm_registry;
 
         let deposit_count = cache_registry_lock.num_deposits();
         info!(%deposit_count, "rpc server state machine registry cache refresh complete");
+        Ok(())
     }
 }
 

--- a/bin/strata-bridge/src/mode/services/btc_client.rs
+++ b/bin/strata-bridge/src/mode/services/btc_client.rs
@@ -7,7 +7,7 @@ use anyhow::anyhow;
 use bitcoin::Block;
 use bitcoind_async_client::{Auth, Client as BitcoinClient, error::ClientError, traits::Reader};
 use btc_tracker::{
-    client::{BlockFetcher, BtcNotifyClient, Connected},
+    client::{BlockFetcher, BtcNotifyClient, BtcNotifyHealthEvent, Connected},
     config::BtcNotifyConfig,
 };
 
@@ -36,11 +36,13 @@ pub(in crate::mode) async fn init_zmq_client(
     config: &Config,
     bury_depth: usize,
     start_height: u64,
+    health_observer: impl Fn(BtcNotifyHealthEvent) + Send + Sync + 'static,
 ) -> anyhow::Result<BtcNotifyClient<Connected>> {
     // We have no awareness of what blocks are unburied at startup, so we start with an empty list.
     let unburied_blocks = VecDeque::new();
     let zmq_cfg = btc_notify_config(config, bury_depth);
-    let zmq_client = BtcNotifyClient::new(&zmq_cfg, unburied_blocks);
+    let zmq_client =
+        BtcNotifyClient::new(&zmq_cfg, unburied_blocks).with_health_observer(health_observer);
 
     let btc_rpc_client = init_btc_rpc_client(config)?;
     zmq_client

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -1,6 +1,6 @@
 //! Periodic bridge component health probes.
 
-use std::{sync::Arc, time::Duration};
+use std::{fmt::Display, future::Future, sync::Arc, time::Duration};
 
 use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
 use btc_tracker::tx_driver::TxDriverHealthHandle;
@@ -41,17 +41,15 @@ pub(in crate::mode) fn spawn_fdb_probe(
 
         loop {
             ticker.tick().await;
-            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, db.health_check()).await {
-                Ok(Ok(())) => health_registry.mark_ok(COMPONENT_FDB, "fdb_reachable"),
-                Ok(Err(err)) => {
-                    health_registry.mark_unhealthy(COMPONENT_FDB, "fdb_unreachable");
-                    error!(%err, "FDB health probe failed");
-                }
-                Err(_) => {
-                    health_registry.mark_unhealthy(COMPONENT_FDB, "probe_timed_out");
-                    error!("FDB health probe timed out");
-                }
-            }
+            run_external_probe(
+                &health_registry,
+                COMPONENT_FDB,
+                "fdb",
+                db.health_check(),
+                "fdb_reachable",
+                "fdb_unreachable",
+            )
+            .await;
         }
     });
 }
@@ -67,17 +65,15 @@ pub(in crate::mode) fn spawn_bitcoin_rpc_probe(
 
         loop {
             ticker.tick().await;
-            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, client.get_block_count()).await {
-                Ok(Ok(_)) => health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "block_count_read"),
-                Ok(Err(err)) => {
-                    health_registry.mark_unhealthy(COMPONENT_BITCOIN_RPC, "block_count_failed");
-                    error!(%err, "Bitcoin RPC health probe failed");
-                }
-                Err(_) => {
-                    health_registry.mark_unhealthy(COMPONENT_BITCOIN_RPC, "probe_timed_out");
-                    error!("Bitcoin RPC health probe timed out");
-                }
-            }
+            run_external_probe(
+                &health_registry,
+                COMPONENT_BITCOIN_RPC,
+                "bitcoin_rpc",
+                client.get_block_count(),
+                "block_count_read",
+                "block_count_failed",
+            )
+            .await;
         }
     });
 }
@@ -93,17 +89,15 @@ pub(in crate::mode) fn spawn_asm_rpc_probe(
 
         loop {
             ticker.tick().await;
-            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, client.get_uptime()).await {
-                Ok(Ok(_)) => health_registry.mark_ok(COMPONENT_ASM_RPC, "asm_rpc_reachable"),
-                Ok(Err(err)) => {
-                    health_registry.mark_unhealthy(COMPONENT_ASM_RPC, "asm_rpc_unreachable");
-                    error!(%err, "ASM RPC health probe failed");
-                }
-                Err(_) => {
-                    health_registry.mark_unhealthy(COMPONENT_ASM_RPC, "probe_timed_out");
-                    error!("ASM RPC health probe timed out");
-                }
-            }
+            run_external_probe(
+                &health_registry,
+                COMPONENT_ASM_RPC,
+                "asm_rpc",
+                client.get_uptime(),
+                "asm_rpc_reachable",
+                "asm_rpc_unreachable",
+            )
+            .await;
         }
     });
 }
@@ -156,17 +150,15 @@ pub(in crate::mode) fn spawn_mosaic_probe(
 
         loop {
             ticker.tick().await;
-            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, client.health_check()).await {
-                Ok(Ok(())) => health_registry.mark_ok(COMPONENT_MOSAIC, "rpc_reachable"),
-                Ok(Err(err)) => {
-                    health_registry.mark_unhealthy(COMPONENT_MOSAIC, "rpc_unreachable");
-                    error!(%err, "Mosaic health probe failed");
-                }
-                Err(_) => {
-                    health_registry.mark_unhealthy(COMPONENT_MOSAIC, "probe_timed_out");
-                    error!("Mosaic health probe timed out");
-                }
-            }
+            run_external_probe(
+                &health_registry,
+                COMPONENT_MOSAIC,
+                "mosaic",
+                client.health_check(),
+                "rpc_reachable",
+                "rpc_unreachable",
+            )
+            .await;
         }
     });
 }
@@ -182,22 +174,15 @@ pub(in crate::mode) fn spawn_s2_probe(
 
         loop {
             ticker.tick().await;
-            match timeout(
-                DEFAULT_HEALTH_PROBE_TIMEOUT,
+            run_external_probe(
+                &health_registry,
+                COMPONENT_S2,
+                "secret_service",
                 client.musig2_signer().pubkey(),
+                "s2_read_succeeded",
+                "s2_read_failed",
             )
-            .await
-            {
-                Ok(Ok(_)) => health_registry.mark_ok(COMPONENT_S2, "s2_read_succeeded"),
-                Ok(Err(err)) => {
-                    health_registry.mark_unhealthy(COMPONENT_S2, "s2_read_failed");
-                    error!(%err, "secret-service health probe failed");
-                }
-                Err(_) => {
-                    health_registry.mark_unhealthy(COMPONENT_S2, "probe_timed_out");
-                    error!("secret-service health probe timed out");
-                }
-            }
+            .await;
         }
     });
 }
@@ -284,5 +269,29 @@ const fn nonzero_interval(interval: Duration) -> Duration {
         Duration::from_secs(1)
     } else {
         interval
+    }
+}
+
+async fn run_external_probe<T, E, F>(
+    health_registry: &HealthRegistry,
+    component: &'static str,
+    probe_name: &'static str,
+    probe: F,
+    ok_reason: &'static str,
+    error_reason: &'static str,
+) where
+    E: Display,
+    F: Future<Output = Result<T, E>>,
+{
+    match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, probe).await {
+        Ok(Ok(_)) => health_registry.mark_ok(component, ok_reason),
+        Ok(Err(err)) => {
+            health_registry.mark_unhealthy(component, error_reason);
+            error!(component, probe_name, %err, "health probe failed");
+        }
+        Err(_) => {
+            health_registry.mark_unhealthy(component, "probe_timed_out");
+            error!(component, probe_name, "health probe timed out");
+        }
     }
 }

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -10,13 +10,16 @@ use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_asm_rpc::traits::AsmControlApiClient;
 use strata_bridge_db::fdb::client::FdbClient;
 use strata_bridge_exec::output_handles::NativeWallet;
-use strata_bridge_orchestrator::{persister::Persister, sm_registry::SMConfig};
 use strata_mosaic_client::MosaicClient;
 use strata_p2p::swarm::handle::CommandHandle;
-use tokio::{sync::RwLock, time::interval};
-use tracing::warn;
+use tokio::{
+    sync::RwLock,
+    time::{interval, timeout},
+};
+use tracing::{error, warn};
 
 use crate::{
+    constants::DEFAULT_HEALTH_PROBE_TIMEOUT,
     health::{
         COMPONENT_ASM_RPC, COMPONENT_BITCOIN_RPC, COMPONENT_FDB, COMPONENT_MOSAIC,
         COMPONENT_ORCHESTRATOR, COMPONENT_P2P, COMPONENT_S2, COMPONENT_TX_DRIVER, COMPONENT_WALLET,
@@ -27,24 +30,26 @@ use crate::{
 
 type BridgeMosaicClient = MosaicClient<HttpClient, BridgeMosaicIdResolver>;
 
-/// Starts a periodic FoundationDB probe by recovering bridge state from disk.
+/// Starts a periodic FoundationDB liveness probe.
 pub(in crate::mode) fn spawn_fdb_probe(
     db: Arc<FdbClient>,
-    sm_config: SMConfig,
     probe_interval: Duration,
     health_registry: HealthRegistry,
 ) {
     tokio::spawn(async move {
-        let persister = Persister::new(db);
         let mut ticker = interval(nonzero_interval(probe_interval));
 
         loop {
             ticker.tick().await;
-            match persister.recover_registry(sm_config.clone()).await {
-                Ok(_) => health_registry.mark_ok(COMPONENT_FDB, "recover_registry_succeeded"),
-                Err(err) => {
-                    health_registry.mark_unhealthy(COMPONENT_FDB, "recover_registry_failed");
-                    warn!(%err, "FDB health probe failed");
+            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, db.health_check()).await {
+                Ok(Ok(())) => health_registry.mark_ok(COMPONENT_FDB, "fdb_reachable"),
+                Ok(Err(err)) => {
+                    health_registry.mark_unhealthy(COMPONENT_FDB, "fdb_unreachable");
+                    error!(%err, "FDB health probe failed");
+                }
+                Err(_) => {
+                    health_registry.mark_unhealthy(COMPONENT_FDB, "probe_timed_out");
+                    error!("FDB health probe timed out");
                 }
             }
         }
@@ -62,11 +67,15 @@ pub(in crate::mode) fn spawn_bitcoin_rpc_probe(
 
         loop {
             ticker.tick().await;
-            match client.get_block_count().await {
-                Ok(_) => health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "block_count_read"),
-                Err(err) => {
+            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, client.get_block_count()).await {
+                Ok(Ok(_)) => health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "block_count_read"),
+                Ok(Err(err)) => {
                     health_registry.mark_unhealthy(COMPONENT_BITCOIN_RPC, "block_count_failed");
-                    warn!(%err, "Bitcoin RPC health probe failed");
+                    error!(%err, "Bitcoin RPC health probe failed");
+                }
+                Err(_) => {
+                    health_registry.mark_unhealthy(COMPONENT_BITCOIN_RPC, "probe_timed_out");
+                    error!("Bitcoin RPC health probe timed out");
                 }
             }
         }
@@ -84,11 +93,15 @@ pub(in crate::mode) fn spawn_asm_rpc_probe(
 
         loop {
             ticker.tick().await;
-            match client.get_uptime().await {
-                Ok(_) => health_registry.mark_ok(COMPONENT_ASM_RPC, "asm_rpc_reachable"),
-                Err(err) => {
+            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, client.get_uptime()).await {
+                Ok(Ok(_)) => health_registry.mark_ok(COMPONENT_ASM_RPC, "asm_rpc_reachable"),
+                Ok(Err(err)) => {
                     health_registry.mark_unhealthy(COMPONENT_ASM_RPC, "asm_rpc_unreachable");
-                    warn!(%err, "ASM RPC health probe failed");
+                    error!(%err, "ASM RPC health probe failed");
+                }
+                Err(_) => {
+                    health_registry.mark_unhealthy(COMPONENT_ASM_RPC, "probe_timed_out");
+                    error!("ASM RPC health probe timed out");
                 }
             }
         }
@@ -107,13 +120,15 @@ pub(in crate::mode) fn spawn_p2p_probe(
 
         loop {
             ticker.tick().await;
+            // `get_connected_peers` is internally bounded: it returns an empty set rather than
+            // hanging if the swarm task is unresponsive, so it cannot leave the probe stuck.
             let connected_peer_count = command_handle.get_connected_peers(None).await.len();
 
             if expected_peer_count == 0 {
                 health_registry.mark_ok(COMPONENT_P2P, "no_peers_configured");
             } else if connected_peer_count == 0 {
                 health_registry.mark_unhealthy(COMPONENT_P2P, "no_connected_peers");
-                warn!(
+                error!(
                     expected_peer_count,
                     "P2P health probe found no connected peers"
                 );
@@ -141,11 +156,15 @@ pub(in crate::mode) fn spawn_mosaic_probe(
 
         loop {
             ticker.tick().await;
-            match client.health_check().await {
-                Ok(()) => health_registry.mark_ok(COMPONENT_MOSAIC, "rpc_reachable"),
-                Err(err) => {
+            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, client.health_check()).await {
+                Ok(Ok(())) => health_registry.mark_ok(COMPONENT_MOSAIC, "rpc_reachable"),
+                Ok(Err(err)) => {
                     health_registry.mark_unhealthy(COMPONENT_MOSAIC, "rpc_unreachable");
-                    warn!(%err, "Mosaic health probe failed");
+                    error!(%err, "Mosaic health probe failed");
+                }
+                Err(_) => {
+                    health_registry.mark_unhealthy(COMPONENT_MOSAIC, "probe_timed_out");
+                    error!("Mosaic health probe timed out");
                 }
             }
         }
@@ -163,18 +182,33 @@ pub(in crate::mode) fn spawn_s2_probe(
 
         loop {
             ticker.tick().await;
-            match client.musig2_signer().pubkey().await {
-                Ok(_) => health_registry.mark_ok(COMPONENT_S2, "s2_read_succeeded"),
-                Err(err) => {
+            match timeout(
+                DEFAULT_HEALTH_PROBE_TIMEOUT,
+                client.musig2_signer().pubkey(),
+            )
+            .await
+            {
+                Ok(Ok(_)) => health_registry.mark_ok(COMPONENT_S2, "s2_read_succeeded"),
+                Ok(Err(err)) => {
                     health_registry.mark_unhealthy(COMPONENT_S2, "s2_read_failed");
-                    warn!(%err, "secret-service health probe failed");
+                    error!(%err, "secret-service health probe failed");
+                }
+                Err(_) => {
+                    health_registry.mark_unhealthy(COMPONENT_S2, "probe_timed_out");
+                    error!("secret-service health probe timed out");
                 }
             }
         }
     });
 }
 
-/// Starts a periodic operator-wallet sync probe.
+/// Starts a periodic operator-wallet liveness probe.
+///
+/// Reads the wallet's local chain tip through a shared read lock — a non-mutating, in-memory
+/// check. It deliberately does not call `sync()`: syncing takes the exclusive write lock and
+/// drives backend I/O, which would let a slow or stuck backend serialize wallet-dependent
+/// duties. The read-lock acquisition is bounded so a stuck writer cannot leave the component
+/// reporting a stale `ok` state.
 pub(in crate::mode) fn spawn_wallet_probe(
     wallet: Arc<RwLock<NativeWallet>>,
     probe_interval: Duration,
@@ -185,11 +219,15 @@ pub(in crate::mode) fn spawn_wallet_probe(
 
         loop {
             ticker.tick().await;
-            match wallet.write().await.sync().await {
-                Ok(()) => health_registry.mark_ok(COMPONENT_WALLET, "sync_succeeded"),
-                Err(err) => {
-                    health_registry.mark_unhealthy(COMPONENT_WALLET, "sync_failed");
-                    warn!(%err, "operator wallet health probe failed");
+            match timeout(DEFAULT_HEALTH_PROBE_TIMEOUT, wallet.read()).await {
+                Ok(guard) => {
+                    let height = guard.local_chain_tip_height();
+                    drop(guard);
+                    health_registry.mark_ok(COMPONENT_WALLET, format!("synced_to_height_{height}"));
+                }
+                Err(_) => {
+                    health_registry.mark_unhealthy(COMPONENT_WALLET, "probe_timed_out");
+                    error!("operator wallet health probe timed out acquiring read lock");
                 }
             }
         }
@@ -211,7 +249,7 @@ pub(in crate::mode) fn spawn_tx_driver_probe(
                 health_registry.mark_ok(COMPONENT_TX_DRIVER, "driver_accepting_jobs");
             } else {
                 health_registry.mark_unhealthy(COMPONENT_TX_DRIVER, "driver_not_accepting_jobs");
-                warn!("transaction driver health probe found driver not accepting jobs");
+                error!("transaction driver health probe found driver not accepting jobs");
             }
         }
     });

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -279,7 +279,7 @@ pub(in crate::mode) fn spawn_orchestrator_stale_monitor(
     });
 }
 
-fn nonzero_interval(interval: Duration) -> Duration {
+const fn nonzero_interval(interval: Duration) -> Duration {
     if interval.is_zero() {
         Duration::from_secs(1)
     } else {

--- a/bin/strata-bridge/src/mode/services/health_probes.rs
+++ b/bin/strata-bridge/src/mode/services/health_probes.rs
@@ -1,0 +1,250 @@
+//! Periodic bridge component health probes.
+
+use std::{sync::Arc, time::Duration};
+
+use bitcoind_async_client::{Client as BitcoinClient, traits::Reader};
+use btc_tracker::tx_driver::TxDriverHealthHandle;
+use jsonrpsee::http_client::HttpClient;
+use secret_service_client::SecretServiceClient;
+use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
+use strata_asm_rpc::traits::AsmControlApiClient;
+use strata_bridge_db::fdb::client::FdbClient;
+use strata_bridge_exec::output_handles::NativeWallet;
+use strata_bridge_orchestrator::{persister::Persister, sm_registry::SMConfig};
+use strata_mosaic_client::MosaicClient;
+use strata_p2p::swarm::handle::CommandHandle;
+use tokio::{sync::RwLock, time::interval};
+use tracing::warn;
+
+use crate::{
+    health::{
+        COMPONENT_ASM_RPC, COMPONENT_BITCOIN_RPC, COMPONENT_FDB, COMPONENT_MOSAIC,
+        COMPONENT_ORCHESTRATOR, COMPONENT_P2P, COMPONENT_S2, COMPONENT_TX_DRIVER, COMPONENT_WALLET,
+        HealthRegistry,
+    },
+    mode::services::mosaic_client::BridgeMosaicIdResolver,
+};
+
+type BridgeMosaicClient = MosaicClient<HttpClient, BridgeMosaicIdResolver>;
+
+/// Starts a periodic FoundationDB probe by recovering bridge state from disk.
+pub(in crate::mode) fn spawn_fdb_probe(
+    db: Arc<FdbClient>,
+    sm_config: SMConfig,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let persister = Persister::new(db);
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            match persister.recover_registry(sm_config.clone()).await {
+                Ok(_) => health_registry.mark_ok(COMPONENT_FDB, "recover_registry_succeeded"),
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_FDB, "recover_registry_failed");
+                    warn!(%err, "FDB health probe failed");
+                }
+            }
+        }
+    });
+}
+
+/// Starts a periodic Bitcoin RPC probe.
+pub(in crate::mode) fn spawn_bitcoin_rpc_probe(
+    client: BitcoinClient,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            match client.get_block_count().await {
+                Ok(_) => health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "block_count_read"),
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_BITCOIN_RPC, "block_count_failed");
+                    warn!(%err, "Bitcoin RPC health probe failed");
+                }
+            }
+        }
+    });
+}
+
+/// Starts a periodic ASM RPC liveness probe.
+pub(in crate::mode) fn spawn_asm_rpc_probe(
+    client: HttpClient,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            match client.get_uptime().await {
+                Ok(_) => health_registry.mark_ok(COMPONENT_ASM_RPC, "asm_rpc_reachable"),
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_ASM_RPC, "asm_rpc_unreachable");
+                    warn!(%err, "ASM RPC health probe failed");
+                }
+            }
+        }
+    });
+}
+
+/// Starts a periodic P2P command/peer connectivity probe.
+pub(in crate::mode) fn spawn_p2p_probe(
+    command_handle: CommandHandle,
+    expected_peer_count: usize,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            let connected_peer_count = command_handle.get_connected_peers(None).await.len();
+
+            if expected_peer_count == 0 {
+                health_registry.mark_ok(COMPONENT_P2P, "no_peers_configured");
+            } else if connected_peer_count == 0 {
+                health_registry.mark_unhealthy(COMPONENT_P2P, "no_connected_peers");
+                warn!(
+                    expected_peer_count,
+                    "P2P health probe found no connected peers"
+                );
+            } else if connected_peer_count < expected_peer_count {
+                health_registry.mark_degraded(COMPONENT_P2P, "partial_peer_connectivity");
+                warn!(
+                    connected_peer_count,
+                    expected_peer_count, "P2P health probe found partial peer connectivity"
+                );
+            } else {
+                health_registry.mark_ok(COMPONENT_P2P, "peers_connected");
+            }
+        }
+    });
+}
+
+/// Starts a periodic Mosaic RPC probe.
+pub(in crate::mode) fn spawn_mosaic_probe(
+    client: Arc<BridgeMosaicClient>,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            match client.health_check().await {
+                Ok(()) => health_registry.mark_ok(COMPONENT_MOSAIC, "rpc_reachable"),
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_MOSAIC, "rpc_unreachable");
+                    warn!(%err, "Mosaic health probe failed");
+                }
+            }
+        }
+    });
+}
+
+/// Starts a periodic secret-service probe.
+pub(in crate::mode) fn spawn_s2_probe(
+    client: SecretServiceClient,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            match client.musig2_signer().pubkey().await {
+                Ok(_) => health_registry.mark_ok(COMPONENT_S2, "s2_read_succeeded"),
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_S2, "s2_read_failed");
+                    warn!(%err, "secret-service health probe failed");
+                }
+            }
+        }
+    });
+}
+
+/// Starts a periodic operator-wallet sync probe.
+pub(in crate::mode) fn spawn_wallet_probe(
+    wallet: Arc<RwLock<NativeWallet>>,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            match wallet.write().await.sync().await {
+                Ok(()) => health_registry.mark_ok(COMPONENT_WALLET, "sync_succeeded"),
+                Err(err) => {
+                    health_registry.mark_unhealthy(COMPONENT_WALLET, "sync_failed");
+                    warn!(%err, "operator wallet health probe failed");
+                }
+            }
+        }
+    });
+}
+
+/// Starts a periodic transaction-driver liveness probe.
+pub(in crate::mode) fn spawn_tx_driver_probe(
+    tx_driver_health: TxDriverHealthHandle,
+    probe_interval: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let mut ticker = interval(nonzero_interval(probe_interval));
+
+        loop {
+            ticker.tick().await;
+            if tx_driver_health.is_accepting_jobs() {
+                health_registry.mark_ok(COMPONENT_TX_DRIVER, "driver_accepting_jobs");
+            } else {
+                health_registry.mark_unhealthy(COMPONENT_TX_DRIVER, "driver_not_accepting_jobs");
+                warn!("transaction driver health probe found driver not accepting jobs");
+            }
+        }
+    });
+}
+
+/// Starts a monitor that marks the orchestrator unhealthy when its heartbeat becomes stale.
+pub(in crate::mode) fn spawn_orchestrator_stale_monitor(
+    stale_after: Duration,
+    health_registry: HealthRegistry,
+) {
+    tokio::spawn(async move {
+        let stale_after = nonzero_interval(stale_after);
+        let probe_interval = stale_after
+            .checked_div(2)
+            .filter(|interval| !interval.is_zero())
+            .unwrap_or(stale_after);
+        let mut ticker = interval(probe_interval);
+
+        loop {
+            ticker.tick().await;
+            health_registry.mark_unhealthy_if_stale(
+                COMPONENT_ORCHESTRATOR,
+                stale_after,
+                "pipeline_stale",
+            );
+        }
+    });
+}
+
+fn nonzero_interval(interval: Duration) -> Duration {
+    if interval.is_zero() {
+        Duration::from_secs(1)
+    } else {
+        interval
+    }
+}

--- a/bin/strata-bridge/src/mode/services/mod.rs
+++ b/bin/strata-bridge/src/mode/services/mod.rs
@@ -2,6 +2,7 @@
 
 pub(in crate::mode) mod asm_rpc;
 pub(in crate::mode) mod btc_client;
+pub(in crate::mode) mod health_probes;
 pub(in crate::mode) mod mosaic_client;
 pub(in crate::mode) mod operator_table;
 pub(in crate::mode) mod operator_wallet;

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -1,15 +1,15 @@
 //! Provides orchestrator initialization.
 
-use std::{num::NonZero, sync::Arc};
+use std::{cmp, num::NonZero, sync::Arc, time::Duration};
 
 use anyhow::anyhow;
 use bitcoin::{FeeRate, relative};
 use bitcoind_async_client::Client as BitcoinClient;
-use btc_tracker::tx_driver::TxDriver;
+use btc_tracker::{client::BtcNotifyHealthEvent, tx_driver::TxDriver};
 use jsonrpsee::http_client::HttpClient;
 use libp2p_identity::ed25519::Keypair;
 use secret_service_client::SecretServiceClient;
-use strata_bridge_asm_events::client::AsmEventFeed;
+use strata_bridge_asm_events::client::{AsmEventFeed, AsmFeedHealthEvent};
 use strata_bridge_common::params::Params;
 use strata_bridge_db::fdb::client::FdbClient;
 use strata_bridge_exec::{
@@ -38,7 +38,18 @@ use tokio::{
 };
 use tracing::{debug, error, info};
 
-use crate::{config::Config, mode::services::btc_client::init_zmq_client};
+use crate::{
+    config::Config,
+    constants::DEFAULT_HEALTH_PROBE_INTERVAL,
+    health::{
+        COMPONENT_ASM_ASSIGNMENT_FEED, COMPONENT_BITCOIN_ZMQ, COMPONENT_ORCHESTRATOR,
+        COMPONENT_TX_DRIVER, HealthRegistry,
+    },
+    mode::services::{
+        btc_client::init_zmq_client,
+        health_probes::{spawn_orchestrator_stale_monitor, spawn_tx_driver_probe},
+    },
+};
 
 #[expect(clippy::too_many_arguments)]
 pub(crate) async fn init_orchestrator<M>(
@@ -56,6 +67,7 @@ pub(crate) async fn init_orchestrator<M>(
     asm_rpc_client: HttpClient,
     fdb_client: Arc<FdbClient>,
     executor: &TaskExecutor,
+    health_registry: HealthRegistry,
 ) -> anyhow::Result<()>
 where
     M: MosaicClientApi + 'static,
@@ -79,7 +91,25 @@ where
         })
         .min()
         .unwrap_or(params.genesis_height);
-    let zmq_client = init_zmq_client(config, params.protocol.bury_depth, start_height).await?;
+    let zmq_health_registry = health_registry.clone();
+    let zmq_client = init_zmq_client(
+        config,
+        params.protocol.bury_depth,
+        start_height,
+        move |event| match event {
+            BtcNotifyHealthEvent::MessageReceived => {
+                zmq_health_registry.mark_ok(COMPONENT_BITCOIN_ZMQ, "message_received")
+            }
+            BtcNotifyHealthEvent::MessageError => {
+                zmq_health_registry.mark_unhealthy(COMPONENT_BITCOIN_ZMQ, "message_error")
+            }
+            BtcNotifyHealthEvent::StreamEnded => {
+                zmq_health_registry.mark_unhealthy(COMPONENT_BITCOIN_ZMQ, "stream_ended")
+            }
+        },
+    )
+    .await?;
+    health_registry.mark_ok(COMPONENT_BITCOIN_ZMQ, "client_connected");
 
     let (ouroboros_msg_sender, ouroboros_msg_receiver) = mpsc::unbounded_channel();
     let message_handler =
@@ -87,10 +117,19 @@ where
 
     debug!("initializing asm assignments feed");
     let asm_block_feed = zmq_client.subscribe_blocks().await;
-    let asm_feed = AsmEventFeed::new(asm_rpc_client.clone(), config.asm_rpc.clone());
+    let feed_health_registry = health_registry.clone();
+    let asm_feed = AsmEventFeed::new(asm_rpc_client.clone(), config.asm_rpc.clone())
+        .with_health_observer(move |event| match event {
+            AsmFeedHealthEvent::AssignmentsFetched => {
+                feed_health_registry.mark_ok(COMPONENT_ASM_ASSIGNMENT_FEED, "assignments_fetched")
+            }
+            AsmFeedHealthEvent::AssignmentsFetchFailed => feed_health_registry
+                .mark_unhealthy(COMPONENT_ASM_ASSIGNMENT_FEED, "assignments_fetch_failed"),
+        });
     let asm_feed = asm_feed.attach_block_stream(asm_block_feed);
     let assignments_sub = asm_feed.subscribe_assignments_state().await;
     info!("asm assignments feed initialized and subscribed to assignment events");
+    health_registry.mark_ok(COMPONENT_ASM_ASSIGNMENT_FEED, "assignments_subscribed");
 
     let orchestrator_block_sub = zmq_client.subscribe_blocks().await;
 
@@ -115,6 +154,13 @@ where
 
     let exec_cfg = build_exec_config(params, config, &sm_config, claim_funding_utxo_value);
     let tx_driver = TxDriver::new(zmq_client, btc_rpc_client.clone()).await;
+    let tx_driver_health = tx_driver.health_handle();
+    health_registry.mark_ok(COMPONENT_TX_DRIVER, "driver_initialized");
+    spawn_tx_driver_probe(
+        tx_driver_health,
+        DEFAULT_HEALTH_PROBE_INTERVAL,
+        health_registry.clone(),
+    );
     let bridge_proof_host = strata_bridge_proof::build_host(&config.bridge_proof).await?;
     let counterproof_host = strata_bridge_counterproof::build_host(&config.counterproof).await?;
     let output_handles = OutputHandles {
@@ -135,6 +181,9 @@ where
     let orchestrator_pipeline = Pipeline::new(events_mux, registry, persister, duty_dispatcher);
 
     debug!("starting orchestrator pipeline");
+    health_registry.mark_ok(COMPONENT_ORCHESTRATOR, "pipeline_spawned");
+    spawn_orchestrator_stale_monitor(orchestrator_stale_after(config), health_registry.clone());
+    let pipeline_health_registry = health_registry.clone();
     executor.spawn_critical_async_with_shutdown("orchestrator", |shutdown_guard| async move {
         let pipeline = orchestrator_pipeline;
 
@@ -151,7 +200,11 @@ where
 
             // Handle pipeline completion (this should indicate an error as this is supposed to run indefinitely)
             pipeline_complete = tokio::task::spawn(async move {
-                pipeline.run(operator_table, start_height).await
+                pipeline
+                    .run_with_observer(operator_table, start_height, move || {
+                        pipeline_health_registry.mark_ok(COMPONENT_ORCHESTRATOR, "event_processed");
+                    })
+                    .await
             }) => {
                 match pipeline_complete {
                     Ok(Ok(())) => {
@@ -159,10 +212,12 @@ where
                         Ok(())
                     }
                     Ok(Err(e)) => {
+                        health_registry.mark_unhealthy(COMPONENT_ORCHESTRATOR, "pipeline_failed");
                         error!(error=?e, "orchestrator pipeline failed");
                         Err(e.into())
                     }
                     Err(e) => {
+                        health_registry.mark_unhealthy(COMPONENT_ORCHESTRATOR, "pipeline_panicked");
                         error!(error=?e, "orchestrator pipeline task panicked");
                         Err(e.into())
                     }
@@ -173,6 +228,11 @@ where
     info!("orchestrator pipeline started");
 
     Ok(())
+}
+
+fn orchestrator_stale_after(config: &Config) -> Duration {
+    let base_interval = cmp::max(config.nag_interval, config.retry_interval);
+    base_interval.checked_mul(2).unwrap_or(base_interval)
 }
 
 pub(in crate::mode) fn build_sm_config(config: &Config, params: &Params) -> SMConfig {

--- a/crates/asm-events/src/client.rs
+++ b/crates/asm-events/src/client.rs
@@ -14,7 +14,7 @@
 // TODO: <https://alpenlabs.atlassian.net/browse/STR-2667>
 // Explicitly detect lag vs. fork divergence and surface a clear health signal.
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 use algebra::retry::{Strategy, retry_with};
 use bitcoin::BlockHash;
@@ -49,7 +49,35 @@ pub struct AsmEventFeed<State = Detached> {
     client: HttpClient,
     subscribers: Arc<Mutex<Vec<mpsc::UnboundedSender<AssignmentsState>>>>,
     thread_handle: Option<Arc<JoinHandle<()>>>,
+    health_observer: Option<HealthObserver>,
     _state: PhantomData<State>,
+}
+
+/// Health events emitted by the ASM assignments feed.
+#[derive(Debug, Clone, Copy)]
+pub enum AsmFeedHealthEvent {
+    /// Assignments were fetched successfully for a buried block.
+    AssignmentsFetched,
+
+    /// Assignment fetching exhausted all retries for a buried block.
+    AssignmentsFetchFailed,
+}
+
+#[derive(Clone)]
+struct HealthObserver(Arc<dyn Fn(AsmFeedHealthEvent) + Send + Sync>);
+
+impl HealthObserver {
+    fn observe(&self, event: AsmFeedHealthEvent) {
+        (self.0)(event);
+    }
+}
+
+impl fmt::Debug for HealthObserver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("HealthObserver")
+            .field(&"<callback>")
+            .finish()
+    }
 }
 
 impl<State> Drop for AsmEventFeed<State> {
@@ -68,6 +96,7 @@ impl AsmEventFeed<Detached> {
             client,
             subscribers: Arc::new(Mutex::new(Vec::new())),
             thread_handle: None,
+            health_observer: None,
             _state: PhantomData,
         }
     }
@@ -89,13 +118,19 @@ impl AsmEventFeed<Detached> {
         // Assignment state is idempotent and queryable by block hash.
         let (request_sender, request_receiver) = watch::channel(None);
         let subscribers_worker = self.subscribers.clone();
+        let health_observer = self.health_observer.clone();
         let cfg = self.cfg.clone();
         let client = self.client.clone();
 
         let thread_handle = Arc::new(task::spawn(async move {
             let forwarder = run_block_ref_forwarder(block_sub, request_sender);
-            let fetcher =
-                run_assignments_state_fetcher(cfg, client, request_receiver, subscribers_worker);
+            let fetcher = run_assignments_state_fetcher(
+                cfg,
+                client,
+                request_receiver,
+                subscribers_worker,
+                health_observer,
+            );
 
             tokio::join!(forwarder, fetcher);
         }));
@@ -105,8 +140,20 @@ impl AsmEventFeed<Detached> {
             client: self.client.clone(),
             subscribers: self.subscribers.clone(),
             thread_handle: Some(thread_handle),
+            health_observer: self.health_observer.clone(),
             _state: PhantomData,
         }
+    }
+}
+
+impl<State> AsmEventFeed<State> {
+    /// Installs a synchronous health observer for assignment fetch success and failure.
+    pub fn with_health_observer(
+        mut self,
+        observer: impl Fn(AsmFeedHealthEvent) + Send + Sync + 'static,
+    ) -> Self {
+        self.health_observer = Some(HealthObserver(Arc::new(observer)));
+        self
     }
 }
 
@@ -162,6 +209,7 @@ async fn run_assignments_state_fetcher(
     client: HttpClient,
     mut request_receiver: watch::Receiver<Option<BlockHash>>,
     subscribers: Arc<Mutex<Vec<mpsc::UnboundedSender<AssignmentsState>>>>,
+    health_observer: Option<HealthObserver>,
 ) {
     let mut last_processed: Option<BlockHash> = None;
 
@@ -199,6 +247,9 @@ async fn run_assignments_state_fetcher(
         match result {
             Ok(assignments) => {
                 last_processed = Some(block_hash);
+                if let Some(observer) = &health_observer {
+                    observer.observe(AsmFeedHealthEvent::AssignmentsFetched);
+                }
                 info!(
                     %block_hash,
                     num_assignments = assignments.len(),
@@ -214,6 +265,9 @@ async fn run_assignments_state_fetcher(
                 subs.retain(|sub| sub.send(event.clone()).is_ok());
             }
             Err(err) => {
+                if let Some(observer) = &health_observer {
+                    observer.observe(AsmFeedHealthEvent::AssignmentsFetchFailed);
+                }
                 error!(
                     ?err,
                     %block_hash,

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -3,7 +3,9 @@
 //! Once the client is initialized, consumers of this API will create [`Subscription`]s with
 //! [`BtcNotifyClient::subscribe_blocks`] or [`BtcNotifyClient::subscribe_transactions`]. These
 //! subscription objects can be primarily worked with via their [`futures::Stream`] trait API.
-use std::{collections::VecDeque, error::Error, marker::PhantomData, sync::Arc, time::Duration};
+use std::{
+    collections::VecDeque, error::Error, fmt, marker::PhantomData, sync::Arc, time::Duration,
+};
 
 use algebra::retry::{retry_with, Strategy};
 use bitcoin::{Block, Transaction};
@@ -37,6 +39,36 @@ struct TxSubscriptionDetails {
     outbox: mpsc::UnboundedSender<TxEvent>,
 }
 
+/// Health events emitted by the Bitcoin ZMQ notification client.
+#[derive(Debug, Clone, Copy)]
+pub enum BtcNotifyHealthEvent {
+    /// The ZMQ stream delivered a message.
+    MessageReceived,
+
+    /// The ZMQ stream delivered an error.
+    MessageError,
+
+    /// The ZMQ stream ended.
+    StreamEnded,
+}
+
+#[derive(Clone)]
+struct HealthObserver(Arc<dyn Fn(BtcNotifyHealthEvent) + Send + Sync>);
+
+impl HealthObserver {
+    fn observe(&self, event: BtcNotifyHealthEvent) {
+        (self.0)(event);
+    }
+}
+
+impl fmt::Debug for HealthObserver {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("HealthObserver")
+            .field(&"<callback>")
+            .finish()
+    }
+}
+
 // Coverage is disabled because when tests pass, most Debug impls will never be invoked.
 #[coverage(off)]
 impl std::fmt::Debug for TxSubscriptionDetails {
@@ -63,6 +95,7 @@ pub struct BtcNotifyClient<State = Disconnected> {
     tx_subs: Arc<Mutex<Vec<TxSubscriptionDetails>>>,
     state_machine: Arc<Mutex<BtcNotifySM>>,
     thread_handle: Option<Arc<JoinHandle<()>>>,
+    health_observer: Option<HealthObserver>,
 
     _state: PhantomData<State>,
 }
@@ -265,6 +298,7 @@ impl BtcNotifyClient<Disconnected> {
             state_machine,
             thread_handle: None,
             start_height: None,
+            health_observer: None,
             _state: PhantomData,
         }
     }
@@ -340,6 +374,7 @@ impl BtcNotifyClient<Disconnected> {
         let tx_subs_thread = self.tx_subs.clone();
         let state_machine_thread = self.state_machine.clone();
         let fetcher = Arc::new(fetcher);
+        let health_observer = self.health_observer.clone();
 
         let mut cursor = start_height;
         let thread_handle = Arc::new(task::spawn(async move {
@@ -352,6 +387,9 @@ impl BtcNotifyClient<Disconnected> {
                     let mut sm = state_machine_thread.lock().await;
                     let diff = match res {
                         Ok(SocketMessage::Message(msg)) => {
+                            if let Some(observer) = &health_observer {
+                                observer.observe(BtcNotifyHealthEvent::MessageReceived);
+                            }
                             let topic = msg.topic_str();
                             match msg {
                                 Message::HashBlock(_, _) => {
@@ -416,10 +454,16 @@ impl BtcNotifyClient<Disconnected> {
                             }
                         }
                         Ok(monitoring_msg) => {
+                            if let Some(observer) = &health_observer {
+                                observer.observe(BtcNotifyHealthEvent::MessageReceived);
+                            }
                             warn!(?monitoring_msg, "ignoring monitoring message");
                             Vec::new()
                         }
                         Err(e) => {
+                            if let Some(observer) = &health_observer {
+                                observer.observe(BtcNotifyHealthEvent::MessageError);
+                            }
                             error!(%e, "Error processing ZMQ message");
                             Vec::new()
                         }
@@ -441,6 +485,11 @@ impl BtcNotifyClient<Disconnected> {
                         true
                     });
                 }
+
+                if let Some(observer) = &health_observer {
+                    observer.observe(BtcNotifyHealthEvent::StreamEnded);
+                }
+                break;
             }
         }));
 
@@ -454,8 +503,20 @@ impl BtcNotifyClient<Disconnected> {
             state_machine: self.state_machine.clone(),
             thread_handle: Some(thread_handle),
             start_height: Some(start_height),
+            health_observer: self.health_observer.clone(),
             _state: PhantomData,
         })
+    }
+}
+
+impl<State> BtcNotifyClient<State> {
+    /// Installs a synchronous health observer for Bitcoin ZMQ stream health.
+    pub fn with_health_observer(
+        mut self,
+        observer: impl Fn(BtcNotifyHealthEvent) + Send + Sync + 'static,
+    ) -> Self {
+        self.health_observer = Some(HealthObserver(Arc::new(observer)));
+        self
     }
 }
 
@@ -478,6 +539,7 @@ impl BtcNotifyClient<Connected> {
             state_machine: self.state_machine.clone(),
             thread_handle: None,
             start_height: None,
+            health_observer: self.health_observer.clone(),
             _state: PhantomData,
         }
     }

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -378,118 +378,114 @@ impl BtcNotifyClient<Disconnected> {
 
         let mut cursor = start_height;
         let thread_handle = Arc::new(task::spawn(async move {
-            loop {
-                // This loop has no break condition. It is only aborted when the BtcNotifyClient is
-                // dropped.
-                info!("listening for ZMQ events");
+            // Drains ZMQ events until the stream ends (only when the BtcNotifyClient is dropped),
+            // then emits `StreamEnded` and lets the task exit.
+            info!("listening for ZMQ events");
 
-                while let Some(res) = stream.next().await {
-                    let mut sm = state_machine_thread.lock().await;
-                    let diff = match res {
-                        Ok(SocketMessage::Message(msg)) => {
-                            if let Some(observer) = &health_observer {
-                                observer.observe(BtcNotifyHealthEvent::MessageReceived);
+            while let Some(res) = stream.next().await {
+                let mut sm = state_machine_thread.lock().await;
+                let diff = match res {
+                    Ok(SocketMessage::Message(msg)) => {
+                        if let Some(observer) = &health_observer {
+                            observer.observe(BtcNotifyHealthEvent::MessageReceived);
+                        }
+                        let topic = msg.topic_str();
+                        match msg {
+                            Message::HashBlock(_, _) => {
+                                trace!(%topic, "received event");
+                                Vec::new()
                             }
-                            let topic = msg.topic_str();
-                            match msg {
-                                Message::HashBlock(_, _) => {
-                                    trace!(%topic, "received event");
-                                    Vec::new()
-                                }
-                                Message::HashTx(_, _) => {
-                                    trace!(%topic, "received event");
-                                    Vec::new()
-                                }
-                                Message::Block(block, _) => {
-                                    trace!(%topic, "received event");
+                            Message::HashTx(_, _) => {
+                                trace!(%topic, "received event");
+                                Vec::new()
+                            }
+                            Message::Block(block, _) => {
+                                trace!(%topic, "received event");
 
-                                    process_block_message(
-                                        block,
-                                        &mut cursor,
-                                        start_height,
-                                        &mut sm,
-                                        &fetcher,
-                                        &block_subs_thread,
-                                    )
-                                    .await
-                                }
-                                Message::Tx(tx, _) => {
-                                    trace!(%topic, "received event");
-                                    info!(txid=%tx.compute_txid(), "processing transaction");
-                                    sm.process_tx(tx)
-                                }
-                                Message::Sequence(seq, _) => {
-                                    trace!(%topic, "received event");
-                                    info!(%seq, "processing sequence");
-                                    let (tx_events, block_event) = sm.process_sequence(seq);
+                                process_block_message(
+                                    block,
+                                    &mut cursor,
+                                    start_height,
+                                    &mut sm,
+                                    &fetcher,
+                                    &block_subs_thread,
+                                )
+                                .await
+                            }
+                            Message::Tx(tx, _) => {
+                                trace!(%topic, "received event");
+                                info!(txid=%tx.compute_txid(), "processing transaction");
+                                sm.process_tx(tx)
+                            }
+                            Message::Sequence(seq, _) => {
+                                trace!(%topic, "received event");
+                                info!(%seq, "processing sequence");
+                                let (tx_events, block_event) = sm.process_sequence(seq);
 
-                                    if let Some(block_event) = block_event {
-                                        if matches!(&block_event.status, BlockStatus::Uncled) {
-                                            let disconnected_height = block_event
-                                                .block
-                                                .bip34_block_height()
-                                                .unwrap_or(start_height);
-                                            let realigned_cursor =
-                                                disconnected_height.max(start_height);
-                                            if realigned_cursor < cursor {
-                                                warn!(
-                                                    cursor = %cursor,
-                                                    %disconnected_height,
-                                                    %start_height,
-                                                    %realigned_cursor,
-                                                    "block disconnect rolled back state machine tip, realigning cursor"
-                                                );
-                                                cursor = realigned_cursor;
-                                            }
+                                if let Some(block_event) = block_event {
+                                    if matches!(&block_event.status, BlockStatus::Uncled) {
+                                        let disconnected_height = block_event
+                                            .block
+                                            .bip34_block_height()
+                                            .unwrap_or(start_height);
+                                        let realigned_cursor = disconnected_height.max(start_height);
+                                        if realigned_cursor < cursor {
+                                            warn!(
+                                                cursor = %cursor,
+                                                %disconnected_height,
+                                                %start_height,
+                                                %realigned_cursor,
+                                                "block disconnect rolled back state machine tip, realigning cursor"
+                                            );
+                                            cursor = realigned_cursor;
                                         }
-
-                                        block_subs_thread
-                                            .lock()
-                                            .await
-                                            .retain(|sub| sub.send(block_event.clone()).is_ok())
                                     }
 
-                                    tx_events
+                                    block_subs_thread
+                                        .lock()
+                                        .await
+                                        .retain(|sub| sub.send(block_event.clone()).is_ok())
                                 }
-                            }
-                        }
-                        Ok(monitoring_msg) => {
-                            if let Some(observer) = &health_observer {
-                                observer.observe(BtcNotifyHealthEvent::MessageReceived);
-                            }
-                            warn!(?monitoring_msg, "ignoring monitoring message");
-                            Vec::new()
-                        }
-                        Err(e) => {
-                            if let Some(observer) = &health_observer {
-                                observer.observe(BtcNotifyHealthEvent::MessageError);
-                            }
-                            error!(%e, "Error processing ZMQ message");
-                            Vec::new()
-                        }
-                    };
 
-                    tx_subs_thread.lock().await.retain(|sub| {
-                        for msg in diff.iter().filter(|event| (sub.predicate)(&event.rawtx)) {
-                            // Now we send the diff to the relevant subscribers.
-                            // If we ever encounter a send error,
-                            // it means the receiver has been dropped.
-                            trace!(?msg, "notifying subscriber");
-
-                            if let Err(e) = sub.outbox.send(msg.clone()) {
-                                debug!(%e, "failed to notify subscriber");
-                                sm.rm_filter(&sub.predicate);
-                                return false;
+                                tx_events
                             }
                         }
-                        true
-                    });
-                }
+                    }
+                    Ok(monitoring_msg) => {
+                        if let Some(observer) = &health_observer {
+                            observer.observe(BtcNotifyHealthEvent::MessageReceived);
+                        }
+                        warn!(?monitoring_msg, "ignoring monitoring message");
+                        Vec::new()
+                    }
+                    Err(e) => {
+                        if let Some(observer) = &health_observer {
+                            observer.observe(BtcNotifyHealthEvent::MessageError);
+                        }
+                        error!(%e, "Error processing ZMQ message");
+                        Vec::new()
+                    }
+                };
 
-                if let Some(observer) = &health_observer {
-                    observer.observe(BtcNotifyHealthEvent::StreamEnded);
-                }
-                break;
+                tx_subs_thread.lock().await.retain(|sub| {
+                    for msg in diff.iter().filter(|event| (sub.predicate)(&event.rawtx)) {
+                        // Now we send the diff to the relevant subscribers.
+                        // If we ever encounter a send error,
+                        // it means the receiver has been dropped.
+                        trace!(?msg, "notifying subscriber");
+
+                        if let Err(e) = sub.outbox.send(msg.clone()) {
+                            debug!(%e, "failed to notify subscriber");
+                            sm.rm_filter(&sub.predicate);
+                            return false;
+                        }
+                    }
+                    true
+                });
+            }
+
+            if let Some(observer) = &health_observer {
+                observer.observe(BtcNotifyHealthEvent::StreamEnded);
             }
         }));
 

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -428,7 +428,8 @@ impl BtcNotifyClient<Disconnected> {
                                             .block
                                             .bip34_block_height()
                                             .unwrap_or(start_height);
-                                        let realigned_cursor = disconnected_height.max(start_height);
+                                        let realigned_cursor =
+                                            disconnected_height.max(start_height);
                                         if realigned_cursor < cursor {
                                             warn!(
                                                 cursor = %cursor,

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -114,6 +114,20 @@ pub struct TxDriver {
     new_jobs_sender: UnboundedSender<TxDriveJob>,
     driver: JoinHandle<()>,
 }
+
+/// Lightweight health handle for the transaction driver background worker.
+#[derive(Clone, Debug)]
+pub struct TxDriverHealthHandle {
+    new_jobs_sender: UnboundedSender<TxDriveJob>,
+}
+
+impl TxDriverHealthHandle {
+    /// Returns true while the transaction driver is still accepting jobs.
+    pub fn is_accepting_jobs(&self) -> bool {
+        !self.new_jobs_sender.is_closed()
+    }
+}
+
 impl TxDriver {
     /// Initializes the TxDriver.
     pub async fn new(zmq_client: BtcNotifyClient<Connected>, rpc_client: BitcoinClient) -> Self {
@@ -287,6 +301,13 @@ impl TxDriver {
             .await
             .map_err(|_| DriveErr::DriverAborted)
             .flatten()
+    }
+
+    /// Returns a cloneable health handle for observing the background worker.
+    pub fn health_handle(&self) -> TxDriverHealthHandle {
+        TxDriverHealthHandle {
+            new_jobs_sender: self.new_jobs_sender.clone(),
+        }
     }
 }
 

--- a/crates/db/src/fdb/client.rs
+++ b/crates/db/src/fdb/client.rs
@@ -130,6 +130,17 @@ impl FdbClient {
         self.db.create_trx()
     }
 
+    /// Performs a lightweight cluster-liveness check.
+    ///
+    /// Fetches a read version, which forces a single round-trip to the FDB cluster without
+    /// reading any user keys. This is intended for health probes: it is far cheaper than a
+    /// range scan and returns an error when the cluster is unreachable. Note that creating a
+    /// transaction alone does not contact the cluster, so the read-version fetch is what
+    /// actually verifies connectivity.
+    pub async fn health_check(&self) -> Result<(), FdbError> {
+        self.db.create_trx()?.get_read_version().await.map(|_| ())
+    }
+
     /// Returns a reference to the client's [`TransactOption`] configuration, which is used for all
     /// transactions initiated via `transact` and the auto-transactional primitives.
     pub const fn transact_options(&self) -> &TransactOption {

--- a/crates/mosaic-client/src/lib.rs
+++ b/crates/mosaic-client/src/lib.rs
@@ -240,6 +240,21 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Ok(completed_sigs)
     }
 
+    /// Performs a read-only Mosaic RPC health check.
+    pub async fn health_check(&self) -> Result<(), MosaicError> {
+        let rpc = self.rpc.clone();
+        retry_with(self.default_retry_strategy(), move || {
+            let rpc = rpc.clone();
+            async move {
+                rpc.list_tableset_ids()
+                    .await
+                    .map(|_| ())
+                    .map_err(MosaicError::rpc_error)
+            }
+        })
+        .await
+    }
+
     /// Polls `get_tableset_status` until the tableset is `Consumed`, checking the game
     /// index at each step. Returns the `success` flag from the `Consumed` variant.
     //

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -118,6 +118,19 @@ impl<G: GeneralWallet> OperatorWallet<G> {
         }
     }
 
+    // ── Sync status ─────────────────────────────────────────────────────────
+
+    /// Returns the block height of the reserved wallet's local chain tip (its most recent sync
+    /// checkpoint).
+    ///
+    /// This is a non-mutating, in-memory read: it neither contacts the backend nor takes any
+    /// internal write path, so health probes can observe sync progress through a shared read
+    /// lock without serializing against wallet-dependent duties. Both the general and reserved
+    /// wallets advance together in [`sync`](Self::sync), so the reserved tip is representative.
+    pub fn local_chain_tip_height(&self) -> u32 {
+        self.reserved.latest_checkpoint().height()
+    }
+
     // ── Reserved-wallet UTXO lookup ─────────────────────────────────────────
 
     /// Returns every reserved-wallet UTXO whose output value matches `value`.

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -61,9 +61,20 @@ impl Pipeline {
     /// preserved; only missing ones are created. The `start_height` is used as the initial block
     /// height for newly created stake SMs (typically the chain tip or the persisted cursor).
     pub async fn run(
+        self,
+        initial_operator_table: OperatorTable,
+        start_height: BitcoinBlockHeight,
+    ) -> Result<(), PipelineError> {
+        self.run_with_observer(initial_operator_table, start_height, || {})
+            .await
+    }
+
+    /// Runs the main event loop and calls `on_event` after each non-shutdown event is received.
+    pub async fn run_with_observer(
         mut self,
         initial_operator_table: OperatorTable,
         start_height: BitcoinBlockHeight,
+        mut on_event: impl FnMut(),
     ) -> Result<(), PipelineError> {
         self.bootstrap_stake_sms(&initial_operator_table, start_height)
             .await?;
@@ -83,6 +94,7 @@ impl Pipeline {
                 // Routable events — pass through to the classification stage
                 routable => routable,
             };
+            on_event();
 
             // Stage 2+3: Classify and process through Applicator
             let mut applicator = Applicator::new(&mut self.registry);


### PR DESCRIPTION
## Summary

Adds a bridge `/healthz` endpoint backed by a component health registry for STR-3591.

## How it's shown

```json
{"status":"unhealthy","checked_at":"2026-06-10T11:40:48Z","components":[{"component":"asm_assignment_feed","status":"unhealthy","reason":"not_initialized","last_success_time":null},{"component":"asm_rpc","status":"degraded","reason":"client_initialized_not_checked","last_success_time":null},{"component":"bitcoin_rpc","status":"ok","reason":"block_count_read","last_success_time":"2026-06-10T11:17:34Z"},{"component":"bitcoin_zmq","status":"unhealthy","reason":"not_initialized","last_success_time":null},{"component":"fdb","status":"ok","reason":"client_initialized","last_success_time":"2026-06-10T11:17:34Z"},{"component":"mosaic","status":"unhealthy","reason":"not_initialized","last_success_time":null},{"component":"orchestrator","status":"unhealthy","reason":"not_initialized","last_success_time":null},{"component":"p2p","status":"ok","reason":"swarm_initialized","last_success_time":"2026-06-10T11:17:34Z"},{"component":"process","status":"ok","reason":"process_started","last_success_time":"2026-06-10T11:17:34Z"},{"component":"rpc_cache","status":"ok","reason":"cache_refreshed","last_success_time":"2026-06-10T11:18:46Z"},{"component":"s2","status":"ok","reason":"operator_table_loaded","last_success_time":"2026-06-10T11:17:34Z"},{"component":"tx_driver","status":"unhealthy","reason":"not_initialized","last_success_time":null},{"component":"wallet","status":"ok","reason":"wallet_initialized","last_success_time":"2026-06-10T11:17:34Z"}]}
```

## Verification

- `cargo fmt --all --check`
- `cargo test -p strata-bridge health::tests`
- `cargo check -p strata-bridge`
- Functional keepalive run on k2: `/healthz` served component JSON on the bridge RPC port.
