### PR TITLE
refactor(bridge-exec): compute claim-funding UTXO denomination at point of use (STR-3641)

### DIFF
--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -16,7 +16,6 @@ secret-service-client.workspace = true
 secret-service-proto.workspace = true
 strata-bridge-asm-events.workspace = true
 strata-bridge-common.workspace = true
-strata-bridge-connectors.workspace = true
 strata-bridge-counterproof.workspace = true
 strata-bridge-db.workspace = true
 strata-bridge-exec.workspace = true
@@ -68,6 +67,7 @@ tikv-jemallocator = "0.6"
 [dev-dependencies]
 bitcoin-bosd.workspace = true
 strata-asm-params = { workspace = true, features = ["arbitrary"] }
+strata-bridge-connectors.workspace = true
 strata-bridge-test-utils.workspace = true
 strata-bridge-tx-graph = { workspace = true, features = ["test_utils"] }
 strata-l1-txfmt.workspace = true

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -100,10 +100,10 @@ pub(crate) async fn bootstrap(
     health_registry.mark_ok(COMPONENT_S2, "operator_table_loaded");
 
     debug!("initializing operator wallet");
-    let initialized_wallet = init_operator_wallet(&config, &params, &s2_client, &db).await?;
-    let claim_funding_utxo_value = initialized_wallet.claim_funding_utxo_value;
-    let operator_wallet = Arc::new(RwLock::new(initialized_wallet.wallet));
-    info!(%claim_funding_utxo_value, "operator wallet initialized");
+    let operator_wallet = Arc::new(RwLock::new(
+        init_operator_wallet(&config, &params, &s2_client, &db).await?,
+    ));
+    info!("operator wallet initialized");
     health_registry.mark_ok(COMPONENT_WALLET, "wallet_initialized");
 
     debug!("spawning initial operator wallet sync");
@@ -197,7 +197,6 @@ pub(crate) async fn bootstrap(
         req_resp_handle,
         keypair,
         operator_wallet,
-        claim_funding_utxo_value,
         btc_rpc_client,
         asm_rpc_client,
         bridge_proof_host,

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -1,18 +1,12 @@
 //! Provides operator wallet initialization.
 
 use std::{
-    num::NonZero,
     sync::Arc,
     time::{Duration, Instant},
 };
 
 use anyhow::anyhow;
 use bdk_bitcoind_rpc::bitcoincore_rpc;
-use bitcoin::{
-    Amount, XOnlyPublicKey,
-    hashes::{Hash, sha256},
-    relative,
-};
 use operator_wallet::{
     AnyOperatorWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
     general::fireblocks::{FireblocksConfig, FireblocksGeneralWallet},
@@ -21,36 +15,19 @@ use operator_wallet::{
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_common::params::Params;
-use strata_bridge_connectors::prelude::{ClaimContestConnector, ClaimPayoutConnector};
 use strata_bridge_db::{fdb::client::FdbClient, traits::BridgeDb};
 use strata_bridge_primitives::constants::SEGWIT_MIN_AMOUNT;
-use strata_bridge_tx_graph::{fee, transactions::prelude::ClaimTx};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
 use crate::config::Config;
-
-/// Result of [`init_operator_wallet`] — the constructed wallet plus the per-UTXO
-/// denomination of the claim-funding pool. The latter is no longer stored on
-/// `OperatorWalletConfig` (the composer is now agnostic of caller denominations); the
-/// orchestrator forwards it into `strata_bridge_exec::config::ExecutionConfig` so duty
-/// executors can reference the pool by value.
-pub(in crate::mode) struct InitializedOperatorWallet {
-    /// The composed operator wallet, ready to lease + sign against. Backend (native vs
-    /// Fireblocks) is selected from config; erased so the orchestrator stays backend-agnostic.
-    pub wallet: AnyOperatorWallet,
-    /// Per-UTXO denomination of the claim-funding pool. The composer is denomination-
-    /// agnostic; this value is propagated into `strata_bridge_exec::config::ExecutionConfig`
-    /// so duty executors can reference the pool by value.
-    pub claim_funding_utxo_value: Amount,
-}
 
 pub(in crate::mode) async fn init_operator_wallet(
     config: &Config,
     params: &Params,
     s2_client: &SecretServiceClient,
     db_client: &FdbClient,
-) -> anyhow::Result<InitializedOperatorWallet> {
+) -> anyhow::Result<AnyOperatorWallet> {
     info!("fetching leased utxos from database");
     let leased_outpoints = db_client
         .get_all_funds()
@@ -72,10 +49,8 @@ pub(in crate::mode) async fn init_operator_wallet(
 
     let reserved_key = s2_client.reserved_wallet_signer().pubkey().await?;
     info!(%reserved_key, "operator wallet reserved key");
-    let own_musig2_key = s2_client.musig2_signer().pubkey().await?;
-    let claim_funding_utxo_value = compute_claim_funding_utxo_value(params, own_musig2_key);
     let operator_wallet_config = OperatorWalletConfig::new(SEGWIT_MIN_AMOUNT, params.network);
-    debug!(?operator_wallet_config, %claim_funding_utxo_value, "operator wallet config");
+    debug!(?operator_wallet_config, "operator wallet config");
 
     // The reserved wallet is always native (BDK), regardless of the general-wallet backend.
     let reserved_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
@@ -132,10 +107,7 @@ pub(in crate::mode) async fn init_operator_wallet(
     };
     debug!("operator wallet initialized");
 
-    Ok(InitializedOperatorWallet {
-        wallet,
-        claim_funding_utxo_value,
-    })
+    Ok(wallet)
 }
 
 /// Interval between attempts when the initial operator wallet sync fails.
@@ -178,57 +150,4 @@ pub(in crate::mode) async fn spawn_initial_operator_wallet_sync(
             }
         }
     }
-}
-
-/// Computes the per-UTXO denomination for the claim-funding pool. Each claim transaction
-/// consumes one UTXO of this size from the reserved wallet, so the value is derived from
-/// the connectors that the claim tx must pay for (which depend on the watchtower set size).
-///
-/// Not a constant since it depends on the number of watchtowers allowed to contest a claim.
-fn compute_claim_funding_utxo_value(params: &Params, own_musig2_key: XOnlyPublicKey) -> Amount {
-    // Must match the value used in `orchestrator.rs::COUNTERPROOF_N_DATA`. Hardcoded here too
-    // because `Params` does not currently expose it.
-    const COUNTERPROOF_N_DATA: NonZero<usize> =
-        NonZero::new(128 + 4).expect("counterproof_n_data must be non-zero");
-
-    let network = params.network;
-
-    // The consensus-validity of the following two values do not affect the calculation of the
-    // funding amount and so have been set to dummy values instead of hooking this up with other
-    // more complicated services to obtain proper values.
-    let n_of_n_key = XOnlyPublicKey::from_slice(&[1u8; 32]).expect("must be a valid x-only pubkey");
-    let unstaking_image =
-        sha256::Hash::from_slice(&[0u8; 32]).expect("must be a valid sha256 hash");
-
-    // NOTE: (@Rajil1213)  musig2 keys are the watchtower keys for the time being until we separate
-    // the sets. Exclude the owner — graph construction in `bridge-sm` excludes the owner from
-    // watchtowers (see `GraphContext::watchtower_pubkeys`), so the funding amount must too.
-    let watchtower_keys: Vec<_> = params
-        .keys
-        .covenant
-        .iter()
-        .map(|c| c.musig2)
-        .filter(|k| *k != own_musig2_key)
-        .collect();
-    // cast safety: covenant.len() is bounded by the number of operators, much smaller than u32::MAX
-    let n_watchtowers = watchtower_keys.len() as u32;
-    let contest_timelock = relative::Height::from_height(params.protocol.contest_timelock);
-
-    let claim_contest_connector = ClaimContestConnector::new(
-        network,
-        n_of_n_key,
-        watchtower_keys,
-        contest_timelock,
-        fee::claim_contest_surcharge(n_watchtowers, COUNTERPROOF_N_DATA),
-    );
-
-    let claim_payout_connector = ClaimPayoutConnector::new(
-        network,
-        n_of_n_key,
-        params.keys.admin.pubkeys.clone(),
-        params.keys.admin.threshold,
-        unstaking_image,
-    );
-
-    ClaimTx::claim_funds_required(&claim_contest_connector, &claim_payout_connector)
 }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -75,7 +75,6 @@ pub(crate) async fn init_orchestrator<M>(
     req_resp_handle: ReqRespHandle,
     p2p_keypair: Keypair,
     wallet: Arc<RwLock<AnyOperatorWallet>>,
-    claim_funding_utxo_value: bitcoin::Amount,
     btc_rpc_client: BitcoinClient,
     asm_rpc_client: HttpClient,
     bridge_proof_host: BridgeProofHost,
@@ -208,21 +207,11 @@ where
             .map_err(|e| anyhow!("failed to initialize cached fee source: {e}"))?,
     );
 
-    let exec_cfg = build_exec_config(
-        params,
-        config,
-        &sm_config,
-        claim_funding_utxo_value,
-        cached_fee_source.clone(),
-    );
-
-    // CPFP wiring: bundle the wallet / shared fee-source / package-submitter / anchor-signer
-    // adapters into a `CpfpContext` the tx-driver consumes in its bump loop.
-    //
-    // Fetch the operator's pubkeys up-front: needed both for the CPFP adapter
-    // (`operator_general_pubkey` is used as the foreign-UTXO `tap_internal_key` for
-    // `ParentTxCombined` strategies) and for `OutputHandles` (anchor inference key + caveat
-    // pubkeys for the publishing helper).
+    // Fetch the operator's pubkeys up-front: needed by the CPFP adapter
+    // (`operator_general_pubkey` is the foreign-UTXO `tap_internal_key` for `ParentTxCombined`
+    // strategies), by `OutputHandles` (anchor inference key + caveat pubkeys for the publishing
+    // helper), and by `ExecutionConfig::watchtower_musig2_keys` below (musig2-pubkey-as-self
+    // filter on the covenant set).
     let operator_musig2_pubkey = s2_client
         .musig2_signer()
         .pubkey()
@@ -312,6 +301,33 @@ where
             }
         }
     }
+
+    // Snapshot of the watchtower musig2 keys (every covenant entry except self). Stored on
+    // `ExecutionConfig` so the executors can recompute the claim-funding UTXO denomination per
+    // duty firing via `bridge_exec::claim_funding::utxo_value`, keeping it in lockstep with the
+    // current set rather than freezing a precomputed value at startup. Snapshotted today because
+    // operator entry/exit isn't a runtime event yet — when it lands, this field becomes the
+    // single point that needs to swap to a live handle.
+    let watchtower_musig2_keys: Arc<Vec<bitcoin::XOnlyPublicKey>> = Arc::new(
+        params
+            .keys
+            .covenant
+            .iter()
+            .map(|c| c.musig2)
+            .filter(|k| *k != operator_musig2_pubkey)
+            .collect(),
+    );
+
+    let exec_cfg = build_exec_config(
+        params,
+        config,
+        &sm_config,
+        watchtower_musig2_keys,
+        cached_fee_source.clone(),
+    );
+
+    // CPFP wiring: bundle the wallet / shared fee-source / package-submitter / anchor-signer
+    // adapters into a `CpfpContext` the tx-driver consumes in its bump loop.
 
     let cpfp_wallet = Arc::new(OperatorWalletCpfpAdapter::new(
         wallet.clone(),
@@ -507,7 +523,7 @@ fn build_exec_config(
     params: &Params,
     config: &Config,
     sm_config: &SMConfig,
-    claim_funding_utxo_value: bitcoin::Amount,
+    watchtower_musig2_keys: Arc<Vec<bitcoin::XOnlyPublicKey>>,
     fee_source: Arc<CachedFeeSource>,
 ) -> ExecutionConfig {
     ExecutionConfig {
@@ -517,8 +533,8 @@ fn build_exec_config(
         maximum_fee_rate: FeeRate::from_sat_per_vb(config.max_fee_rate).unwrap(),
         operator_fee: params.protocol.operator_fee,
         stake_amount: params.protocol.stake_amount,
-        claim_funding_utxo_value,
         funding_uxto_pool_size: config.operator_wallet.claim_funding_pool_size,
+        watchtower_musig2_keys,
         graph_sm_cfg: sm_config.graph.clone(),
         fee_source,
     }

--- a/crates/bridge-exec/src/claim_funding.rs
+++ b/crates/bridge-exec/src/claim_funding.rs
@@ -1,0 +1,62 @@
+//! Per-UTXO denomination for the claim-funding pool, computed on demand from the current
+//! protocol state instead of being snapshotted onto [`ExecutionConfig`] at startup.
+//!
+//! Each claim transaction consumes one UTXO of this size from the reserved wallet, so the value
+//! is derived from the connectors the claim tx must pay for — which depend on the watchtower
+//! set size. That set will change at runtime once operator entry/exit lands, and a value frozen
+//! at startup would then go stale: refills after the change would deposit UTXOs of the wrong
+//! size and silently fail to fund a claim later.
+//!
+//! To be precise about what this buys *today*: [`ExecutionConfig::watchtower_musig2_keys`] is
+//! itself still a startup snapshot, so per-duty recomputation currently always yields the same
+//! value. The point is structural — when entry/exit lands, only that one field needs to swap to
+//! a live handle and every duty picks up the current denomination with no further plumbing.
+//!
+//! The wallet API (`reserve_utxo_with_value` / `reserved_utxos_with_value` /
+//! `create_reserved_utxos`) is denomination-agnostic — it takes the value as a parameter — so
+//! the plumbing change is entirely on this side.
+
+use bitcoin::{Amount, XOnlyPublicKey, hashes::Hash, secp256k1::hashes::sha256};
+use strata_bridge_connectors::prelude::{ClaimContestConnector, ClaimPayoutConnector};
+use strata_bridge_tx_graph::{fee, transactions::prelude::ClaimTx};
+
+use crate::config::ExecutionConfig;
+
+/// Computes the per-UTXO denomination for the claim-funding pool from the live inputs on `cfg`.
+///
+/// Reads the current watchtower set from [`ExecutionConfig::watchtower_musig2_keys`] (which
+/// the orchestrator populates from `params.keys.covenant`, excluding the operator's own key),
+/// the protocol-static inputs from `cfg.graph_sm_cfg.game_graph_params`, and the admin
+/// multisig from `cfg.graph_sm_cfg.admin`. The `n_of_n_key` and `unstaking_image` plumbed into
+/// the connectors here are dummies: they affect
+/// the connectors' consensus validity, not the amount [`ClaimTx::claim_funds_required`]
+/// reports, so wiring up the real values would be churn for no value.
+pub fn utxo_value(cfg: &ExecutionConfig) -> Amount {
+    let game_params = &cfg.graph_sm_cfg.game_graph_params;
+
+    let n_of_n_key = XOnlyPublicKey::from_slice(&[1u8; 32]).expect("must be a valid x-only pubkey");
+    let unstaking_image =
+        sha256::Hash::from_slice(&[0u8; 32]).expect("must be a valid sha256 hash");
+
+    let watchtower_keys: Vec<XOnlyPublicKey> = cfg.watchtower_musig2_keys.as_ref().clone();
+    // cast safety: watchtower set is bounded by the operator count, which is way under u32::MAX.
+    let n_watchtowers = watchtower_keys.len() as u32;
+
+    let claim_contest_connector = ClaimContestConnector::new(
+        game_params.network,
+        n_of_n_key,
+        watchtower_keys,
+        game_params.contest_timelock,
+        fee::claim_contest_surcharge(n_watchtowers, game_params.counterproof_n_data),
+    );
+
+    let claim_payout_connector = ClaimPayoutConnector::new(
+        game_params.network,
+        n_of_n_key,
+        cfg.graph_sm_cfg.admin.pubkeys.clone(),
+        cfg.graph_sm_cfg.admin.threshold,
+        unstaking_image,
+    );
+
+    ClaimTx::claim_funds_required(&claim_contest_connector, &claim_payout_connector)
+}

--- a/crates/bridge-exec/src/config.rs
+++ b/crates/bridge-exec/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use bitcoin::{Amount, FeeRate, Network};
+use bitcoin::{Amount, FeeRate, Network, XOnlyPublicKey};
 use btc_tracker::cpfp::CachedFeeSource;
 use strata_bridge_sm::graph::config::GraphSMCfg;
 use strata_l1_txfmt::MagicBytes;
@@ -31,14 +31,22 @@ pub struct ExecutionConfig {
     /// stake transaction must carry `stake_amount` plus any connector dust the stake tx produces.
     pub stake_amount: Amount,
 
-    /// The denomination of each UTXO in the claim-funding pool. The composer creates
-    /// reserved-wallet UTXOs of exactly this value when refilling the pool, and the duty
-    /// dispatcher selects them by exact value match.
-    pub claim_funding_utxo_value: Amount,
-
     /// The target number of claim-funding UTXOs to keep available in the reserved wallet.
     /// When the pool is exhausted, the duty dispatcher tops it back up to this size.
     pub funding_uxto_pool_size: usize,
+
+    /// musig2 keys of every operator that contests claims, excluding the operator running this
+    /// node. Drives the per-UTXO denomination of the claim-funding pool via
+    /// [`crate::claim_funding::utxo_value`]; the connector that the claim tx must pay for scales
+    /// with the watchtower count.
+    ///
+    /// Today this is snapshotted from `params.keys.covenant` at orchestrator startup, since the
+    /// operator set doesn't change at runtime yet. The value lives here (rather than as a
+    /// precomputed `claim_funding_utxo_value: Amount`) so the executors recompute the
+    /// denomination on every duty firing — when runtime operator entry/exit lands, only the
+    /// source of this field needs to swap to a live handle and the executors get correct values
+    /// without further plumbing.
+    pub watchtower_musig2_keys: Arc<Vec<XOnlyPublicKey>>,
 
     /// The graph state-machine configuration, shared with the GSM to keep protocol parameters
     /// and static keys consistent across graph construction paths.

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -33,6 +33,7 @@ use tracing::{error, info, warn};
 use super::utils::sign_claim_funding_tx;
 use crate::{
     chain::{self, CpfpKind, is_outpoint_unspent, is_txid_onchain, publish_signed_transaction},
+    claim_funding,
     config::ExecutionConfig,
     errors::ExecutorError,
     fees::wallet_tx_fee_rate,
@@ -151,6 +152,10 @@ async fn ensure_claim_funding_outpoint(
         return Ok(funding_outpoint);
     }
 
+    // Compute once per duty-firing from the current watchtower set on `cfg`; reused across the
+    // reserve/refill/post-refill-reserve path below so all of them target the same denomination.
+    let claim_funding_utxo_value = claim_funding::utxo_value(cfg);
+
     info!(?graph_idx, "fetching funding outpoint from wallet");
     let (funding_outpoint, funding_lease) = {
         let mut wallet = output_handles.wallet.write().await;
@@ -165,7 +170,7 @@ async fn ensure_claim_funding_outpoint(
 
         let reserved = wallet
             .reserve_utxo_with_value(
-                cfg.claim_funding_utxo_value,
+                claim_funding_utxo_value,
                 LeaseOwner::ClaimFunding,
                 predicate::never::<UtxoInfo>,
             )
@@ -184,7 +189,7 @@ async fn ensure_claim_funding_outpoint(
                 // batch, after which the post-refill `reserve_utxo_with_value` below would
                 // panic with nothing to hand out.
                 let current_pool_size = {
-                    let pool = wallet.reserved_utxos_with_value(cfg.claim_funding_utxo_value);
+                    let pool = wallet.reserved_utxos_with_value(claim_funding_utxo_value);
                     let leased = wallet.leased_outpoints();
                     pool.iter()
                         .filter(|u| !leased.contains(&u.outpoint))
@@ -201,7 +206,7 @@ async fn ensure_claim_funding_outpoint(
                         // presigned-graph floor, so a refill issued into a busy mempool
                         // actually confirms.
                         wallet_tx_fee_rate(&cfg.fee_source, cfg.maximum_fee_rate)?,
-                        cfg.claim_funding_utxo_value,
+                        claim_funding_utxo_value,
                         batch_size,
                         GeneralUtxoPolicy::ConfirmedOnly,
                         LeaseOwner::ClaimFundingRefill,
@@ -259,7 +264,7 @@ async fn ensure_claim_funding_outpoint(
                 })?;
                 wallet
                     .reserve_utxo_with_value(
-                        cfg.claim_funding_utxo_value,
+                        claim_funding_utxo_value,
                         LeaseOwner::ClaimFunding,
                         predicate::never::<UtxoInfo>,
                     )
@@ -641,7 +646,6 @@ pub(super) async fn publish_graph_partials(
 
 /// Publishes the claim transaction to Bitcoin.
 pub(super) async fn publish_claim(
-    cfg: &ExecutionConfig,
     output_handles: &OutputHandles,
     claim_tx: &ClaimTx,
 ) -> Result<(), ExecutorError> {
@@ -652,14 +656,27 @@ pub(super) async fn publish_claim(
         "signing claim transaction"
     );
 
+    // Look up the claim-funding UTXO by outpoint, NOT by current denomination: the graph cached
+    // its funding outpoint at construction time under whatever the denomination was then, and the
+    // current denomination — recomputed from the live watchtower set — can diverge if that set
+    // has changed since (the runtime entry/exit case `bridge_exec::claim_funding` is preparing
+    // for). Filtering by `reserved_utxos_with_value(current_denom)` would silently drop the
+    // older-denomination UTXO. The outpoint-keyed lookup below still misses when the wallet
+    // view is stale (a failed sync) or the UTXO has left the reserved pool; that is a duty
+    // failure the dispatcher retries, not a node panic — a panic here crash-loops the whole
+    // operator on every duty tick.
+    let claim_outpoint = claim_tx.as_ref().input[0].previous_output;
     let claim_prevout: TxOut = {
         let wallet = output_handles.wallet.read().await;
         wallet
-            .reserved_utxos_with_value(cfg.claim_funding_utxo_value)
-            .into_iter()
-            .find(|utxo| utxo.outpoint == claim_tx.as_ref().input[0].previous_output)
-            .expect("claim funding outpoint not found in wallet")
-            .into()
+            .reserved_utxo_at(claim_outpoint)
+            .map(Into::into)
+            .ok_or_else(|| {
+                ExecutorError::WalletErr(format!(
+                    "claim funding outpoint {claim_outpoint} not found in the reserved wallet; \
+                     a wallet sync must restore it before the claim publishes"
+                ))
+            })?
     };
 
     let prevouts = Prevouts::All(&[claim_prevout]);

--- a/crates/bridge-exec/src/graph/mod.rs
+++ b/crates/bridge-exec/src/graph/mod.rs
@@ -120,9 +120,7 @@ pub async fn execute_graph_duty(
             )
             .await
         }
-        GraphDuty::PublishClaim { claim_tx } => {
-            publish_claim(&cfg, &output_handles, claim_tx).await
-        }
+        GraphDuty::PublishClaim { claim_tx } => publish_claim(&output_handles, claim_tx).await,
         GraphDuty::PublishUncontestedPayout {
             signed_uncontested_payout_tx,
         } => publish_uncontested_payout(&output_handles, signed_uncontested_payout_tx).await,

--- a/crates/bridge-exec/src/lib.rs
+++ b/crates/bridge-exec/src/lib.rs
@@ -10,6 +10,7 @@
 //! - It can be run asynchronously and independently of other executors.
 
 mod chain;
+pub mod claim_funding;
 pub mod config;
 pub mod cpfp_adapters;
 pub mod deposit;

--- a/crates/operator-wallet/src/any.rs
+++ b/crates/operator-wallet/src/any.rs
@@ -116,6 +116,11 @@ impl AnyOperatorWallet {
         delegate!(self, w => w.last_general_sync())
     }
 
+    /// See [`OperatorWallet::reserved_utxo_at`].
+    pub fn reserved_utxo_at(&self, outpoint: OutPoint) -> Option<UtxoInfo> {
+        delegate!(self, w => w.reserved_utxo_at(outpoint))
+    }
+
     /// Lists the general wallet's UTXOs.
     ///
     /// Delegates to `GeneralWallet::list_utxos` on whichever backend is active. Exposed on the

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -256,6 +256,22 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             .collect()
     }
 
+    /// Returns the reserved-wallet UTXO at `outpoint`, or `None` if the reserved wallet's
+    /// unspent list does not contain it — it may be spent, or the wallet's view may be stale.
+    ///
+    /// Outpoint-keyed because the caller already holds a previously-reserved outpoint (e.g. a
+    /// claim-funding UTXO recorded against a graph at construction time) and needs the matching
+    /// `TxOut`, regardless of the value that UTXO was funded at — callers can't assume the
+    /// current pool denomination matches an older reservation if the denomination is recomputed
+    /// from live protocol state.
+    pub fn reserved_utxo_at(&self, outpoint: OutPoint) -> Option<UtxoInfo> {
+        let tip = self.reserved.latest_checkpoint().height();
+        self.reserved
+            .list_unspent()
+            .find(|utxo| utxo.outpoint == outpoint)
+            .map(|lo| local_output_to_utxo_info(&lo, tip))
+    }
+
     /// Takes a lease on one free reserved-wallet UTXO of value `value` that the `ignore`
     /// predicate does not reject.
     ///


### PR DESCRIPTION
## Description

[STR-3641](https://alpenlabs.atlassian.net/browse/STR-3641). Follow-up from #560 review (Rajil flagged the duplication).

Drop \`claim_funding_utxo_value\` from \`ExecutionConfig\`. It was snapshotted at orchestrator startup from the watchtower set and frozen onto the config. The per-UTXO denomination depends on the watchtower count via the connectors the claim tx must pay for, and that set **can change at runtime** during operator entry/exit — the startup snapshot goes stale and refills after the change would deposit UTXOs of the wrong size that can't satisfy a later claim.

The fix is plumbing on this side; the wallet API is already denomination-agnostic and takes the value per-call.

### What changes

- Add \`watchtower_musig2_keys: Arc<Vec<XOnlyPublicKey>>\` to \`ExecutionConfig\` (still snapshotted today since operator entry/exit isn't a runtime event yet). When a live source lands, only that one field swaps to a live handle and the executors keep producing correct values without further plumbing.
- New \`bridge_exec::claim_funding::utxo_value(cfg)\` computes the denomination per duty-firing from \`cfg.watchtower_musig2_keys\` and \`cfg.graph_sm_cfg.game_graph_params\` (\`contest_timelock\`, \`counterproof_n_data\`, \`network\`).
- Migrate the 5 call sites in \`crates/bridge-exec/src/graph/common.rs\` to call the new helper (cached once per duty in \`ensure_claim_funding_outpoint\`, inline in \`publish_claim\`).
- Move \`compute_claim_funding_utxo_value\` out of the bin layer and delete the orphaned \`COUNTERPROOF_N_DATA = 128 + 4\` hardcode that mirrored \`orchestrator.rs\`. The orchestrator's \`COUNTERPROOF_N_DATA\` is now the single source of truth, fed through \`graph_sm_cfg.game_graph_params.counterproof_n_data\`.
- Remove the \`InitializedOperatorWallet\` shell since the wallet is now \`init_operator_wallet\`'s sole output.
- Move \`strata-bridge-connectors\` to the bin's \`[dev-dependencies]\` — the only remaining user is the test in \`mode/rpc_server\`.

### Stack

Stacked on **#563** (\`azz/str-3438-fee-source-abstraction\`); merge after #572 → #580 → #563.

### Type of Change

- [x] Refactor

## Notes to Reviewers

The behaviour-visible change is in \`deposit::fulfill_withdrawal\` and the claim-funding refill path: the denomination is now recomputed per duty-firing instead of being a startup constant. With the operator set static today, the value is byte-identical to the previous snapshot every time; the difference only materialises once operator entry/exit lands.

I considered moving the \`Vec\` straight onto \`GraphSMCfg\` (alongside \`admin_pubkey\`) so the executor could read everything from one place, but the watchtower set is the only field that will become live in the future — keeping it separate on \`ExecutionConfig\` makes the lifetime distinction explicit.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Closes STR-3641. Follow-up from #560 review.

[STR-3641]: https://alpenlabs.atlassian.net/browse/STR-3641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
