### PR TITLE
fix(bridge-exec): skip counterproof generation when mosaic setup is unavailable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11474,6 +11474,7 @@ dependencies = [
  "foundationdb",
  "futures",
  "jsonrpsee",
+ "metrics",
  "musig2",
  "operator-wallet",
  "secret-service-client",

--- a/bin/strata-bridge/src/main.rs
+++ b/bin/strata-bridge/src/main.rs
@@ -60,7 +60,11 @@ fn main() {
         .build()
         .expect("must be able to create runtime");
 
-    observability::init(&config, &mode_label, &network_label, runtime.handle());
+    let runtime_handle = runtime.handle().clone();
+    {
+        let _runtime_guard = runtime_handle.enter();
+        observability::init(&config, &mode_label, &network_label, &runtime_handle);
+    }
 
     info!(mode = %mode_label, network = %network_label, "starting bridge node");
 
@@ -77,7 +81,7 @@ fn main() {
     let fdb_client = Arc::new(fdb_client);
     debug!("FoundationDB client initialized");
 
-    let task_manager = TaskManager::new(runtime.handle().clone());
+    let task_manager = TaskManager::new(runtime_handle);
     task_manager.start_signal_listeners();
 
     let executor = task_manager.create_executor();

--- a/crates/bridge-exec/Cargo.toml
+++ b/crates/bridge-exec/Cargo.toml
@@ -42,6 +42,7 @@ borsh.workspace = true
 foundationdb.workspace = true
 futures.workspace = true
 jsonrpsee = { workspace = true, features = ["client"] }
+metrics.workspace = true
 musig2.workspace = true
 ssz.workspace = true
 terrors.workspace = true

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -5,6 +5,7 @@ use std::num::NonZero;
 use bitcoin::{Amount, Network, ScriptBuf, Transaction, consensus, relative};
 use bitcoind_async_client::{error::ClientError, traits::Reader};
 use btc_tracker::event::TxStatus;
+use metrics::counter;
 use musig2::secp256k1::schnorr::Signature;
 use strata_bridge_connectors::prelude::{ContestCounterproofWitness, ContestProofConnector};
 use strata_bridge_counterproof::{
@@ -96,6 +97,8 @@ async fn generate_counterproof(
     game_index: NonZero<u32>,
     bridge_proof_tx: Transaction,
 ) -> Result<G16ProofRaw, ExecutorError> {
+    counter!("strata_bridge_counterproof_generation_attempts").increment(1);
+
     let proof_input = fetch_counterproof_input(
         cfg,
         output_handles,

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -14,7 +14,7 @@ use strata_bridge_counterproof::{
 use strata_bridge_primitives::types::{DepositIdx, OperatorIdx};
 use strata_bridge_proof_common::prove;
 use strata_bridge_tx_graph::transactions::counterproof::CounterproofTx;
-use strata_mosaic_client_api::types::{G16ProofRaw, N_WITHDRAWAL_INPUT_WIRES};
+use strata_mosaic_client_api::types::{G16ProofRaw, N_WITHDRAWAL_INPUT_WIRES, Role};
 use tracing::{info, warn};
 #[cfg(feature = "sp1")]
 use zkaleido_sp1_groth16_verifier::Sp1Groth16Proof;
@@ -39,6 +39,25 @@ pub(super) async fn generate_and_publish_counterproof(
     bridge_proof_tx: Transaction,
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %operator_idx, %game_index, "generating and publishing counterproof for graph");
+
+    let setup_available = output_handles
+        .mosaic_client
+        .is_setup_available(operator_idx, Role::Garbler, game_index.into())
+        .await
+        .map_err(|e| {
+            warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to check mosaic setup availability");
+            ExecutorError::MosaicErr(format!("is_setup_available: {e:?}"))
+        })?;
+
+    if !setup_available {
+        warn!(
+            %deposit_idx,
+            %game_index,
+            %operator_idx,
+            "skipping counterproof generation because mosaic setup is unavailable",
+        );
+        return Ok(());
+    }
 
     let counterproof_data = generate_counterproof(
         cfg,

--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -24,9 +24,9 @@ use crate::{
     output_handles::OutputHandles,
 };
 
-/// Generates the counterproof, completes adaptor signatures via mosaic,
-/// assembles the witness with the pre-computed N-of-N signature, and publishes
-/// the counterproof transaction to Bitcoin.
+/// Generates the counterproof or reuses already-completed adaptor signatures, assembles the
+/// witness with the pre-computed N-of-N signature, and publishes the counterproof transaction to
+/// Bitcoin.
 #[expect(clippy::too_many_arguments)]
 pub(super) async fn generate_and_publish_counterproof(
     cfg: &ExecutionConfig,
@@ -40,45 +40,63 @@ pub(super) async fn generate_and_publish_counterproof(
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %operator_idx, %game_index, "generating and publishing counterproof for graph");
 
-    let setup_available = output_handles
+    let completed_sigs = if let Some(completed_sigs) = output_handles
         .mosaic_client
-        .is_setup_available(operator_idx, Role::Garbler, game_index.into())
+        .get_completed_adaptor_sigs(operator_idx, game_index.into())
         .await
         .map_err(|e| {
-            warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to check mosaic setup availability");
-            ExecutorError::MosaicErr(format!("is_setup_available: {e:?}"))
-        })?;
-
-    if !setup_available {
-        warn!(
+            warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to get completed adaptor sigs for counterproof");
+            ExecutorError::MosaicErr(format!("get_completed_adaptor_sigs: {e:?}"))
+        })?
+    {
+        info!(
             %deposit_idx,
             %game_index,
             %operator_idx,
-            "skipping counterproof generation because mosaic setup is unavailable",
+            "reusing completed adaptor signatures for counterproof",
         );
-        return Ok(());
-    }
+        completed_sigs
+    } else {
+        let setup_available = output_handles
+            .mosaic_client
+            .is_setup_available(operator_idx, Role::Garbler, game_index.into())
+            .await
+            .map_err(|e| {
+                warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to check mosaic setup availability");
+                ExecutorError::MosaicErr(format!("is_setup_available: {e:?}"))
+            })?;
 
-    let counterproof_data = generate_counterproof(
-        cfg,
-        output_handles,
-        deposit_idx,
-        operator_idx,
-        game_index,
-        bridge_proof_tx,
-    )
-    .await?;
+        if !setup_available {
+            warn!(
+                %deposit_idx,
+                %game_index,
+                %operator_idx,
+                "skipping counterproof generation because mosaic setup is unavailable",
+            );
+            return Ok(());
+        }
 
-    // Complete adaptor signatures via mosaic (we are the garbler/watchtower).
-    info!(%deposit_idx, %game_index, %operator_idx, "completing adaptor signatures via mosaic for graph");
-    let completed_sigs = output_handles
-        .mosaic_client
-        .complete_adaptor_sigs(operator_idx, game_index.into(), counterproof_data)
-        .await
-        .map_err(|e| {
-            warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to complete adaptor sigs for counterproof");
-            ExecutorError::MosaicErr(format!("complete_adaptor_sigs: {e:?}"))
-        })?;
+        let counterproof_data = generate_counterproof(
+            cfg,
+            output_handles,
+            deposit_idx,
+            operator_idx,
+            game_index,
+            bridge_proof_tx,
+        )
+        .await?;
+
+        // Complete adaptor signatures via mosaic (we are the garbler/watchtower).
+        info!(%deposit_idx, %game_index, %operator_idx, "completing adaptor signatures via mosaic for graph");
+        output_handles
+            .mosaic_client
+            .complete_adaptor_sigs(operator_idx, game_index.into(), counterproof_data)
+            .await
+            .map_err(|e| {
+                warn!(%deposit_idx, %game_index, %operator_idx, ?e, "failed to complete adaptor sigs for counterproof");
+                ExecutorError::MosaicErr(format!("complete_adaptor_sigs: {e:?}"))
+            })?
+    };
 
     // The counterproof leaf script expects one operator signature per byte of counterproof
     // data (n_data = N_DEPOSIT + N_WITHDRAWAL wires), so we need ALL completed adaptor sigs.

--- a/crates/mosaic-client-api/src/api.rs
+++ b/crates/mosaic-client-api/src/api.rs
@@ -114,6 +114,18 @@ pub trait MosaicClientApi: Send + Sync + 'static {
         game_index: GameIndex,
     ) -> Result<(), MosaicError>;
 
+    /// Returns whether the setup for the given operator and role can still enter contested
+    /// withdrawal processing for this game.
+    ///
+    /// `false` means mosaic reports the setup is already in contest processing or consumed, so
+    /// callers must not start work that depends on completing adaptor signatures with this setup.
+    async fn is_setup_available(
+        &self,
+        operator_idx: OperatorIdx,
+        role: Role,
+        game_index: GameIndex,
+    ) -> Result<bool, MosaicError>;
+
     /// Garbler side: completes adaptor signatures for a contested withdrawal.
     ///
     /// `operator_idx`: the remote operator in this setup.

--- a/crates/mosaic-client-api/src/api.rs
+++ b/crates/mosaic-client-api/src/api.rs
@@ -114,11 +114,13 @@ pub trait MosaicClientApi: Send + Sync + 'static {
         game_index: GameIndex,
     ) -> Result<(), MosaicError>;
 
-    /// Returns whether the setup for the given operator and role can still enter contested
+    /// Returns whether the setup for the given operator and role can be used for contested
     /// withdrawal processing for this game.
     ///
-    /// `false` means mosaic reports the setup is already in contest processing or consumed, so
-    /// callers must not start work that depends on completing adaptor signatures with this setup.
+    /// `true` means the setup is either fresh enough to enter contested withdrawal processing or
+    /// was already consumed for this same game and its consumed result can be reused. `false`
+    /// means mosaic reports the setup is in contest processing, or consumed by another game, so
+    /// callers must not start fresh counterproof generation with this setup.
     async fn is_setup_available(
         &self,
         operator_idx: OperatorIdx,
@@ -139,6 +141,24 @@ pub trait MosaicClientApi: Send + Sync + 'static {
         game_index: GameIndex,
         counterproof: G16ProofRaw,
     ) -> Result<CompletedSignatures, MosaicError>;
+
+    /// Returns completed adaptor signatures from a garbler tableset that was already consumed
+    /// for this game.
+    ///
+    /// `operator_idx`: the remote operator in this setup.
+    ///
+    /// Returns `Some` only when mosaic reports the garbler tableset as `Consumed` for the same
+    /// `game_index`. This lets callers retry counterproof publication after a crash that happened
+    /// after signature completion but before the counterproof transaction was broadcast, without
+    /// recomputing the counterproof.
+    ///
+    /// Returns `None` when the setup is not yet consumed, or when it was consumed by a different
+    /// game.
+    async fn get_completed_adaptor_sigs(
+        &self,
+        operator_idx: OperatorIdx,
+        game_index: GameIndex,
+    ) -> Result<Option<CompletedSignatures>, MosaicError>;
 
     /// Evaluator side: evaluates the tableset to extract the fault secret
     /// and signs the given digest.

--- a/crates/mosaic-client/src/client.rs
+++ b/crates/mosaic-client/src/client.rs
@@ -362,19 +362,9 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
     ) -> Result<bool, MosaicError> {
         let tableset_id = self.get_tableset_id(role, operator_idx).await?;
 
-        let rpc = self.rpc.clone();
-        let status = retry_with(self.default_retry_strategy(), move || {
-            let rpc = rpc.clone();
-            async move {
-                rpc.get_tableset_status(tableset_id)
-                    .await
-                    .map_err(MosaicError::rpc_error)
-                    .and_then(|maybe_status| {
-                        maybe_status.ok_or_else(|| MosaicError::SetupMissing(operator_idx, role))
-                    })
-            }
-        })
-        .await?;
+        let status = self
+            .read_tableset_status(tableset_id, operator_idx, role)
+            .await?;
 
         match status {
             RpcTablesetStatus::SetupComplete => Ok(true),
@@ -389,12 +379,20 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
             }
             RpcTablesetStatus::Consumed { deposit, .. } => {
                 let actual_game_index = deposit.into_game_index();
-                warn!(
-                    expected_game_index = %game_index,
-                    actual_game_index = %actual_game_index,
-                    "mosaic setup is already consumed"
-                );
-                Ok(false)
+                if actual_game_index == game_index {
+                    info!(
+                        %game_index,
+                        "mosaic setup is already consumed for this game; completed signatures can be reused"
+                    );
+                    Ok(true)
+                } else {
+                    warn!(
+                        expected_game_index = %game_index,
+                        actual_game_index = %actual_game_index,
+                        "mosaic setup is already consumed by another game"
+                    );
+                    Ok(false)
+                }
             }
             RpcTablesetStatus::Incomplete { details } => Err(MosaicError::UnexpectedDepositState(
                 format!("mosaic setup incomplete: {details}"),
@@ -415,34 +413,106 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         let rpc_game_id = game_id.into();
         let withdrawal_inputs: WithdrawalInputs = counterproof.0;
 
-        let rpc = self.rpc.clone();
-        let rpc_withdrawal_inputs = withdrawal_inputs.into();
-        retry_with(self.default_retry_strategy(), move || {
-            let rpc = rpc.clone();
-            async move {
-                rpc.complete_adaptor_sigs(tableset_id, rpc_game_id, rpc_withdrawal_inputs)
-                    .await
-                    .map_err(MosaicError::rpc_error)
+        let status = self
+            .read_tableset_status(tableset_id, operator_idx, Role::Garbler)
+            .await?;
+
+        match status {
+            RpcTablesetStatus::SetupComplete => {
+                let rpc = self.rpc.clone();
+                let rpc_withdrawal_inputs = withdrawal_inputs.into();
+                retry_with(self.default_retry_strategy(), move || {
+                    let rpc = rpc.clone();
+                    async move {
+                        rpc.complete_adaptor_sigs(tableset_id, rpc_game_id, rpc_withdrawal_inputs)
+                            .await
+                            .map_err(MosaicError::rpc_error)
+                    }
+                })
+                .await?;
             }
-        })
-        .await?;
+            RpcTablesetStatus::Contest { deposit } => {
+                let actual_game_index = deposit.into_game_index();
+                if actual_game_index != game_index {
+                    return Err(MosaicError::UnexpectedDepositContest {
+                        expected: game_index.to_string(),
+                        actual: actual_game_index.to_string(),
+                    });
+                }
+
+                info!(
+                    %game_index,
+                    %operator_idx,
+                    "mosaic is already completing adaptor signatures for this game"
+                );
+            }
+            RpcTablesetStatus::Consumed { deposit, .. } => {
+                let actual_game_index = deposit.into_game_index();
+                if actual_game_index != game_index {
+                    return Err(MosaicError::UnexpectedDepositContest {
+                        expected: game_index.to_string(),
+                        actual: actual_game_index.to_string(),
+                    });
+                }
+
+                info!(
+                    %game_index,
+                    %operator_idx,
+                    "reusing completed adaptor signatures from consumed mosaic setup"
+                );
+                return self.read_completed_adaptor_sigs(tableset_id).await;
+            }
+            RpcTablesetStatus::Incomplete { details } => {
+                return Err(MosaicError::UnexpectedDepositState(format!(
+                    "mosaic setup incomplete: {details}"
+                )));
+            }
+            RpcTablesetStatus::Aborted { reason } => return Err(MosaicError::Aborted(reason)),
+        }
 
         self.poll_until_consumed(tableset_id, game_index, operator_idx, Role::Garbler)
             .await?;
 
-        let rpc = self.rpc.clone();
-        let completed_sigs = retry_with(self.default_retry_strategy(), move || {
-            let rpc = rpc.clone();
-            async move {
-                rpc.get_completed_adaptor_sigs(tableset_id)
-                    .await
-                    .map_err(MosaicError::rpc_error)
-            }
-        })
-        .await?
-        .into();
+        self.read_completed_adaptor_sigs(tableset_id).await
+    }
 
-        Ok(completed_sigs)
+    #[instrument(skip_all, fields(%operator_idx, %game_index))]
+    async fn get_completed_adaptor_sigs(
+        &self,
+        operator_idx: OperatorIdx,
+        game_index: GameIndex,
+    ) -> Result<Option<CompletedSignatures>, MosaicError> {
+        let tableset_id = self.get_tableset_id(Role::Garbler, operator_idx).await?;
+        let status = self
+            .read_tableset_status(tableset_id, operator_idx, Role::Garbler)
+            .await?;
+
+        match status {
+            RpcTablesetStatus::Consumed { deposit, .. } => {
+                let actual_game_index = deposit.into_game_index();
+                if actual_game_index == game_index {
+                    info!(
+                        %game_index,
+                        %operator_idx,
+                        "reusing completed adaptor signatures from consumed mosaic setup"
+                    );
+                    self.read_completed_adaptor_sigs(tableset_id)
+                        .await
+                        .map(Some)
+                } else {
+                    warn!(
+                        expected_game_index = %game_index,
+                        actual_game_index = %actual_game_index,
+                        "mosaic setup is already consumed by another game"
+                    );
+                    Ok(None)
+                }
+            }
+            RpcTablesetStatus::Aborted { reason } => Err(MosaicError::Aborted(reason)),
+            RpcTablesetStatus::Incomplete { .. }
+            | RpcTablesetStatus::SetupComplete
+            | RpcTablesetStatus::Contest { .. } => Ok(None),
+        }
     }
 
     #[instrument(skip_all, fields(%operator_idx, %game_index))]

--- a/crates/mosaic-client/src/client.rs
+++ b/crates/mosaic-client/src/client.rs
@@ -9,9 +9,9 @@ use strata_mosaic_client_api::{
     MosaicClientApi, MosaicError, MosaicEvent, MosaicSetupError, types::*,
 };
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
-use crate::{MosaicClient, MosaicIdResolver, util::make_setup_config};
+use crate::{MosaicClient, MosaicIdResolver, RpcDepositIdExt, util::make_setup_config};
 
 #[async_trait::async_trait]
 impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClientApi
@@ -351,6 +351,56 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         .await?;
 
         Ok(())
+    }
+
+    #[instrument(skip_all, fields(%operator_idx, %role, %game_index))]
+    async fn is_setup_available(
+        &self,
+        operator_idx: OperatorIdx,
+        role: Role,
+        game_index: GameIndex,
+    ) -> Result<bool, MosaicError> {
+        let tableset_id = self.get_tableset_id(role, operator_idx).await?;
+
+        let rpc = self.rpc.clone();
+        let status = retry_with(self.default_retry_strategy(), move || {
+            let rpc = rpc.clone();
+            async move {
+                rpc.get_tableset_status(tableset_id)
+                    .await
+                    .map_err(MosaicError::rpc_error)
+                    .and_then(|maybe_status| {
+                        maybe_status.ok_or_else(|| MosaicError::SetupMissing(operator_idx, role))
+                    })
+            }
+        })
+        .await?;
+
+        match status {
+            RpcTablesetStatus::SetupComplete => Ok(true),
+            RpcTablesetStatus::Contest { deposit } => {
+                let actual_game_index = deposit.into_game_index();
+                warn!(
+                    expected_game_index = %game_index,
+                    actual_game_index = %actual_game_index,
+                    "mosaic setup is already in contest processing"
+                );
+                Ok(false)
+            }
+            RpcTablesetStatus::Consumed { deposit, .. } => {
+                let actual_game_index = deposit.into_game_index();
+                warn!(
+                    expected_game_index = %game_index,
+                    actual_game_index = %actual_game_index,
+                    "mosaic setup is already consumed"
+                );
+                Ok(false)
+            }
+            RpcTablesetStatus::Incomplete { details } => Err(MosaicError::UnexpectedDepositState(
+                format!("mosaic setup incomplete: {details}"),
+            )),
+            RpcTablesetStatus::Aborted { reason } => Err(MosaicError::Aborted(reason)),
+        }
     }
 
     #[instrument(skip_all, fields(%operator_idx, %game_index))]

--- a/crates/mosaic-client/src/lib.rs
+++ b/crates/mosaic-client/src/lib.rs
@@ -200,6 +200,46 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         Strategy::fixed_delay(self.retry_delay).with_max_retries(self.max_retries)
     }
 
+    async fn read_tableset_status(
+        &self,
+        tableset_id: RpcTablesetId,
+        operator_idx: OperatorIdx,
+        role: Role,
+    ) -> Result<RpcTablesetStatus, MosaicError> {
+        let rpc = self.rpc.clone();
+        retry_with(self.default_retry_strategy(), move || {
+            let rpc = rpc.clone();
+            async move {
+                rpc.get_tableset_status(tableset_id)
+                    .await
+                    .map_err(MosaicError::rpc_error)
+                    .and_then(|maybe_status| {
+                        maybe_status.ok_or_else(|| MosaicError::SetupMissing(operator_idx, role))
+                    })
+            }
+        })
+        .await
+    }
+
+    async fn read_completed_adaptor_sigs(
+        &self,
+        tableset_id: RpcTablesetId,
+    ) -> Result<CompletedSignatures, MosaicError> {
+        let rpc = self.rpc.clone();
+        let completed_sigs = retry_with(self.default_retry_strategy(), move || {
+            let rpc = rpc.clone();
+            async move {
+                rpc.get_completed_adaptor_sigs(tableset_id)
+                    .await
+                    .map_err(MosaicError::rpc_error)
+            }
+        })
+        .await?
+        .into();
+
+        Ok(completed_sigs)
+    }
+
     /// Polls `get_tableset_status` until the tableset is `Consumed`, checking the game
     /// index at each step. Returns the `success` flag from the `Consumed` variant.
     //
@@ -213,20 +253,9 @@ impl<R: MosaicRpcClient + Send + Sync + 'static, P: MosaicIdResolver> MosaicClie
         role: Role,
     ) -> Result<bool, MosaicError> {
         loop {
-            let rpc = self.rpc.clone();
-            let status = retry_with(self.default_retry_strategy(), move || {
-                let rpc = rpc.clone();
-                async move {
-                    rpc.get_tableset_status(tableset_id)
-                        .await
-                        .map_err(MosaicError::rpc_error)
-                        .and_then(|maybe_status| {
-                            maybe_status
-                                .ok_or_else(|| MosaicError::SetupMissing(operator_idx, role))
-                        })
-                }
-            })
-            .await?;
+            let status = self
+                .read_tableset_status(tableset_id, operator_idx, role)
+                .await?;
 
             match status {
                 RpcTablesetStatus::Incomplete { details } => {

--- a/functional-tests/factory/bridge_operator/__init__.py
+++ b/functional-tests/factory/bridge_operator/__init__.py
@@ -105,6 +105,8 @@ class BridgeOperatorFactory(flexitest.Factory):
 
         # write bridge operator config
         config_toml_path = str((envdd_path / bridge_operator_name / "config.toml").resolve())
+        metrics_port = self.next_port() if bridge_config_params.prometheus_metrics else None
+        metrics_listener_addr = f"127.0.0.1:{metrics_port}" if metrics_port is not None else None
         # heartbeat delay decreases with operator index
         # so that first node tries to establish connections the last_cred_path
         # NOTE: (@Rajil1213) This assumes that the nodes are started in the order of their indices
@@ -123,6 +125,7 @@ class BridgeOperatorFactory(flexitest.Factory):
             mosaic_peers,
             mosaic_rpc,
             heartbeat_delay_factor,
+            metrics_listener_addr,
         )
 
         # write bridge operator params
@@ -149,6 +152,8 @@ class BridgeOperatorFactory(flexitest.Factory):
             "reserved_wallet_address": current_operator_key.RESERVED_WALLET,
             "general_wallet_address": current_operator_key.GENERAL_WALLET,
         }
+        if metrics_port is not None:
+            props["metrics_url"] = f"http://127.0.0.1:{metrics_port}"
 
         # env vars exported to the bridge binary process
         env = {

--- a/functional-tests/factory/bridge_operator/config_cfg.py
+++ b/functional-tests/factory/bridge_operator/config_cfg.py
@@ -95,12 +95,19 @@ class MosaicConfig:
 
 
 @dataclass
+class MetricsConfig:
+    otlp_url: str | None = None
+    prometheus_listener_addr: str | None = None
+
+
+@dataclass
 class BridgeConfigParams:
     min_withdrawal_fulfillment_window: int = 144
     cooperative_payout_timeout: int = 144
     max_fee_rate: int = 10
     nag_interval_secs: int = 10
     retry_interval_secs: int = 10
+    prometheus_metrics: bool = False
 
 
 @dataclass
@@ -131,3 +138,4 @@ class BridgeOperatorConfig:
     mosaic: MosaicConfig
     bridge_proof: ProofBackendConfig
     counterproof: ProofBackendConfig
+    metrics: MetricsConfig | None

--- a/functional-tests/factory/bridge_operator/utils.py
+++ b/functional-tests/factory/bridge_operator/utils.py
@@ -21,6 +21,7 @@ from .config_cfg import (
     DbConfig,
     Duration,
     FdbRetryConfig,
+    MetricsConfig,
     MosaicConfig,
     OperatorWalletConfig,
     P2pConfig,
@@ -51,6 +52,7 @@ def generate_config_toml(
     mosaic_peers: list[str],
     mosaic_rpc: str,
     heartbeat_delay_factor: int = 1,  # no delay by default
+    metrics_listener_addr: str | None = None,
 ):
     mtls_dir = Path(tls_dir)
     total_peers = len(other_p2p_addrs) + 1  # +1 for self
@@ -145,6 +147,11 @@ def generate_config_toml(
         ),
         bridge_proof=_build_bridge_proof_config(),
         counterproof=_build_counterproof_config(),
+        metrics=(
+            MetricsConfig(prometheus_listener_addr=metrics_listener_addr)
+            if metrics_listener_addr
+            else None
+        ),
     )
 
     with open(output_path, "w") as f:

--- a/functional-tests/tests/contest/fn_skip_counterproof_after_gc_consumed.py
+++ b/functional-tests/tests/contest/fn_skip_counterproof_after_gc_consumed.py
@@ -1,0 +1,288 @@
+from typing import Any, cast
+
+import flexitest
+
+from constants import CONTEST_WATCHTOWER_0_VOUT, DT_DEPOSIT_VOUT
+from envs import BridgeNetworkEnv
+from envs.base_test import StrataTestBase
+from factory.bridge_operator.config_cfg import BridgeConfigParams
+from factory.bridge_operator.params_cfg import BridgeProtocolParams
+from rpc.types import RpcDepositStatusComplete
+from utils.bridge import get_bridge_nodes_and_rpcs
+from utils.deposit import (
+    wait_until_deposit_status,
+    wait_until_drts_recognized,
+    wait_until_utxo_spent,
+)
+from utils.dev_cli import DevCli
+from utils.metrics import read_prometheus_metric_sum
+from utils.utils import (
+    find_utxo_spender_txid,
+    read_operator_key,
+    wait_for_tx_confirmation,
+    wait_until,
+)
+
+ACK_TIMELOCK_BLOCKS = 15
+COUNTERPROOF_GENERATION_METRIC = "strata_bridge_counterproof_generation_attempts"
+PAYOUT_TIMEOUT_SECS = 600
+
+
+@flexitest.register
+class CounterproofSkippedAfterGcConsumedTest(StrataTestBase):
+    """
+    Test that a watchtower does not publish a second counterproof after its GC setup
+    for the same operator has already been consumed.
+
+    Steps:
+    1. Complete two deposits.
+    2. Post, contest, and refute an invalid claim from operator-0 for deposit 0.
+    3. Wait for every watchtower counterproof output on the first contest to be spent.
+    4. Post, contest, and refute another invalid claim from operator-0 for deposit 1.
+    5. Wait for the second deposit to pay out after the ack timelock while asserting
+       the counterproof generation-attempt metric does not increase and no watchtower
+       counterproof output on the second contest is spent.
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        self.bridge_protocol_params = BridgeProtocolParams(
+            contest_timelock=5,
+            ack_timelock=ACK_TIMELOCK_BLOCKS,
+        )
+        ctx.set_env(
+            BridgeNetworkEnv(
+                bridge_protocol_params=self.bridge_protocol_params,
+                bridge_config_params=BridgeConfigParams(
+                    cooperative_payout_timeout=0,
+                    retry_interval_secs=1,
+                    prometheus_metrics=True,
+                ),
+            )
+        )
+
+    def main(self, ctx: flexitest.RunContext):
+        bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        bridge_rpc = bridge_rpcs[0]
+
+        bitcoind_service = ctx.get_service("bitcoin")
+        bitcoin_rpc = bitcoind_service.create_rpc()
+
+        num_operators = len(bridge_nodes)
+        operator_key_infos = [read_operator_key(i) for i in range(num_operators)]
+
+        dev_cli = DevCli(
+            bitcoind_service.props,
+            operator_key_infos,
+            bridge_protocol_params=self.bridge_protocol_params,
+        )
+
+        drt_txids = [dev_cli.send_deposit_request() for _ in range(2)]
+        for idx, drt_txid in enumerate(drt_txids):
+            self.logger.info(f"Broadcasted DRT[{idx}]: {drt_txid}")
+
+        deposit_ids = wait_until_drts_recognized(bridge_rpc, drt_txids)
+        assert set(deposit_ids) >= {0, 1}, f"expected deposits 0 and 1, got {deposit_ids}"
+
+        deposit_txids = {}
+        for deposit_id in sorted(deposit_ids):
+            deposit_info = wait_until_deposit_status(
+                bridge_rpc,
+                deposit_id,
+                RpcDepositStatusComplete,
+            )
+            assert deposit_info is not None, f"Deposit {deposit_id} did not complete"
+            deposit_data = cast("dict[str, Any]", deposit_info)
+            deposit_txids[deposit_id] = str(deposit_data["status"]["deposit_txid"])
+        self.logger.info("Both deposits completed")
+
+        dishonest_idx = 0
+        dishonest_rpc_url = f"http://127.0.0.1:{bridge_nodes[dishonest_idx].props['rpc_port']}"
+        dishonest_seed = read_operator_key(dishonest_idx).SEED
+
+        first_contest_txid, _ = self.post_faulty_claim_contest_and_proof(
+            bitcoin_rpc,
+            dev_cli,
+            deposit_idx=0,
+            operator_idx=dishonest_idx,
+            bridge_node_url=dishonest_rpc_url,
+            seed=dishonest_seed,
+        )
+
+        num_watchtowers = num_operators - 1
+        self.wait_for_all_counterproofs(bitcoin_rpc, first_contest_txid, num_watchtowers)
+        counterproof_attempts = self.counterproof_generation_attempts_by_node(bridge_nodes)
+        assert sum(counterproof_attempts.values()) >= num_watchtowers, (
+            "first invalid proof should have generated counterproofs; "
+            f"attempts by node: {counterproof_attempts}"
+        )
+        self.logger.info("First invalid proof consumed every watchtower GC setup")
+
+        second_contest_txid, second_contest_block_height = self.post_faulty_claim_contest_and_proof(
+            bitcoin_rpc,
+            dev_cli,
+            deposit_idx=1,
+            operator_idx=dishonest_idx,
+            bridge_node_url=dishonest_rpc_url,
+            seed=dishonest_seed,
+        )
+
+        self.wait_for_contested_payout_after_ack_timelock_without_counterproof(
+            bitcoin_rpc,
+            bridge_nodes,
+            deposit_txid=deposit_txids[1],
+            contest_txid=second_contest_txid,
+            contest_block_height=second_contest_block_height,
+            num_watchtowers=num_watchtowers,
+            counterproof_attempts=counterproof_attempts,
+        )
+        self.logger.info("Second invalid proof paid out without counterproof generation")
+
+        return True
+
+    def post_faulty_claim_contest_and_proof(
+        self,
+        bitcoin_rpc,
+        dev_cli: DevCli,
+        deposit_idx: int,
+        operator_idx: int,
+        bridge_node_url: str,
+        seed: str,
+    ) -> tuple[str, int]:
+        claim_txid = dev_cli.send_claim(
+            deposit_idx=deposit_idx,
+            operator_idx=operator_idx,
+            bridge_node_url=bridge_node_url,
+            seed=seed,
+        )
+        self.logger.info(
+            f"Broadcasted faulty claim tx from op-{operator_idx} "
+            f"for deposit {deposit_idx}: {claim_txid}"
+        )
+
+        claim_block_hash = wait_for_tx_confirmation(bitcoin_rpc, claim_txid, timeout=300)
+        self.logger.info(f"Faulty claim tx {claim_txid} confirmed in block {claim_block_hash}")
+
+        wait_until_utxo_spent(bitcoin_rpc, claim_txid, vout=0, timeout=300)
+        contest_txid = find_utxo_spender_txid(bitcoin_rpc, claim_txid, 0)
+        contest_block_hash = wait_for_tx_confirmation(bitcoin_rpc, contest_txid, timeout=300)
+        contest_block_height = self.block_height(bitcoin_rpc, contest_block_hash)
+        self.logger.info(
+            f"Claim {claim_txid} contested by tx {contest_txid} "
+            f"confirmed in block {contest_block_hash} at height {contest_block_height}"
+        )
+
+        bridge_proof_txid = dev_cli.send_bridge_proof(
+            deposit_idx=deposit_idx,
+            operator_idx=operator_idx,
+            bridge_node_url=bridge_node_url,
+            seed=seed,
+        )
+        self.logger.info(
+            f"Broadcasted faulty bridge proof tx from op-{operator_idx} "
+            f"for deposit {deposit_idx}: {bridge_proof_txid}"
+        )
+
+        bridge_proof_block_hash = wait_for_tx_confirmation(
+            bitcoin_rpc,
+            bridge_proof_txid,
+            timeout=300,
+        )
+        self.logger.info(
+            f"Faulty bridge proof tx {bridge_proof_txid} "
+            f"confirmed in block {bridge_proof_block_hash}"
+        )
+
+        return contest_txid, contest_block_height
+
+    def block_height(self, bitcoin_rpc, block_hash: str) -> int:
+        return int(bitcoin_rpc.proxy.getblock(block_hash)["height"])
+
+    def wait_for_all_counterproofs(self, bitcoin_rpc, contest_txid: str, num_watchtowers: int):
+        for slot in range(num_watchtowers):
+            watchtower_vout = CONTEST_WATCHTOWER_0_VOUT + slot
+            wait_until_utxo_spent(bitcoin_rpc, contest_txid, watchtower_vout, timeout=300)
+            self.logger.info(
+                f"Counterproof posted by watchtower slot {slot} (contest:{watchtower_vout} spent)"
+            )
+
+    def wait_for_contested_payout_after_ack_timelock_without_counterproof(
+        self,
+        bitcoin_rpc,
+        bridge_nodes,
+        deposit_txid: str,
+        contest_txid: str,
+        contest_block_height: int,
+        num_watchtowers: int,
+        counterproof_attempts: dict[int, int],
+    ):
+        payout_height_floor = contest_block_height + ACK_TIMELOCK_BLOCKS
+        payout: dict[str, str | int | None] = {"txid": None, "height": None}
+        invariant_error: dict[str, AssertionError | None] = {"error": None}
+
+        def check_payout_after_ack_timelock():
+            current_attempts = self.counterproof_generation_attempts_by_node(bridge_nodes)
+            if current_attempts != counterproof_attempts:
+                invariant_error["error"] = AssertionError(
+                    "unexpected counterproof generation attempt after GC setup was consumed: "
+                    f"before={counterproof_attempts}, after={current_attempts}"
+                )
+                return True
+
+            for slot in range(num_watchtowers):
+                watchtower_vout = CONTEST_WATCHTOWER_0_VOUT + slot
+                if bitcoin_rpc.proxy.gettxout(contest_txid, watchtower_vout) is None:
+                    spender = find_utxo_spender_txid(bitcoin_rpc, contest_txid, watchtower_vout)
+                    invariant_error["error"] = AssertionError(
+                        f"unexpected counterproof from watchtower slot {slot}: "
+                        f"contest {contest_txid}:{watchtower_vout} spent by {spender}"
+                    )
+                    return True
+
+            if bitcoin_rpc.proxy.gettxout(deposit_txid, DT_DEPOSIT_VOUT) is not None:
+                return False
+
+            payout_txid = find_utxo_spender_txid(bitcoin_rpc, deposit_txid, DT_DEPOSIT_VOUT)
+            payout_tx = bitcoin_rpc.proxy.getrawtransaction(payout_txid, True)
+            payout_block_hash = payout_tx.get("blockhash")
+            if payout_block_hash is None:
+                return False
+
+            payout_height = self.block_height(bitcoin_rpc, payout_block_hash)
+            if payout_height <= payout_height_floor:
+                invariant_error["error"] = AssertionError(
+                    f"contest payout {payout_txid} confirmed at height {payout_height}, "
+                    f"expected after ack timelock height {payout_height_floor}"
+                )
+                return True
+
+            payout["txid"] = payout_txid
+            payout["height"] = payout_height
+            return True
+
+        wait_until(
+            check_payout_after_ack_timelock,
+            timeout=PAYOUT_TIMEOUT_SECS,
+            step=1,
+            error_msg=(
+                f"deposit {deposit_txid} did not pay out after ack timelock "
+                f"for contest {contest_txid}"
+            ),
+        )
+
+        if invariant_error["error"] is not None:
+            raise invariant_error["error"]
+
+        self.logger.info(
+            f"Contest payout {payout['txid']} confirmed at height {payout['height']} "
+            f"after ack timelock height {payout_height_floor}"
+        )
+
+    def counterproof_generation_attempts_by_node(self, bridge_nodes) -> dict[int, int]:
+        return {
+            idx: int(
+                read_prometheus_metric_sum(
+                    node.props["metrics_url"], COUNTERPROOF_GENERATION_METRIC
+                )
+            )
+            for idx, node in enumerate(bridge_nodes)
+        }

--- a/functional-tests/utils/metrics.py
+++ b/functional-tests/utils/metrics.py
@@ -1,0 +1,87 @@
+from urllib.request import urlopen
+
+DEFAULT_METRICS_SCRAPE_TIMEOUT_SECS = 2
+
+
+def scrape_prometheus_metrics(
+    metrics_url: str,
+    timeout: int = DEFAULT_METRICS_SCRAPE_TIMEOUT_SECS,
+) -> str:
+    """
+    Read Prometheus text exposition from ``{metrics_url}/metrics``.
+
+    Input:
+        ``metrics_url`` is the service metrics base URL, for example
+        ``http://127.0.0.1:12501``.
+
+    Output:
+        Raw Prometheus text exposition, with lines such as
+        ``metric_name{label="value"} 3``.
+    """
+    with urlopen(f"{metrics_url}/metrics", timeout=timeout) as response:
+        return response.read().decode()
+
+
+def sum_prometheus_metric_samples(
+    metrics_text: str,
+    metric_name: str,
+    *,
+    include_counter_total: bool = True,
+) -> float:
+    """
+    Sum all samples matching a metric name in Prometheus text exposition.
+
+    Input:
+        ``metrics_text`` is Prometheus text exposition. Matching sample lines may
+        be unlabeled, like ``metric_name 1``, or labeled, like
+        ``metric_name{operator="0"} 2``. Comment and metadata lines beginning
+        with ``#`` are ignored.
+
+    Output:
+        Floating-point sum of every matching sample value, ignoring labels. When
+        ``include_counter_total`` is true, ``metric_name_total`` is also matched.
+    """
+    metric_names = {metric_name}
+    if include_counter_total:
+        metric_names.add(f"{metric_name}_total")
+
+    total = 0.0
+    for line in metrics_text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+
+        sample_name = parts[0].split("{", 1)[0]
+        if sample_name in metric_names:
+            total += float(parts[1])
+
+    return total
+
+
+def read_prometheus_metric_sum(
+    metrics_url: str,
+    metric_name: str,
+    *,
+    timeout: int = DEFAULT_METRICS_SCRAPE_TIMEOUT_SECS,
+    include_counter_total: bool = True,
+) -> float:
+    """
+    Scrape a service metrics endpoint and sum samples for one metric.
+
+    Input:
+        ``metrics_url`` is the service metrics base URL, and ``metric_name`` is
+        the Prometheus metric name without labels, for example
+        ``strata_bridge_counterproof_generation_attempts``.
+
+    Output:
+        Floating-point sum of all matching samples from ``{metrics_url}/metrics``.
+    """
+    return sum_prometheus_metric_samples(
+        scrape_prometheus_metrics(metrics_url, timeout=timeout),
+        metric_name,
+        include_counter_total=include_counter_total,
+    )


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR adds a guard in the counterproof generation executor so that the node does not start generating the counterproof if the associated mosaic setup has already been consumed (by some other counterproof). The functional test for this relies on the prometheus metrics for number of counterproof generations. There was a bug in how the metrics harness had been setup resulting in it being outside the tokio runtime. This has also been fixed as part of this PR.

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3748