### PR TITLE
feat: support op-return burn broadcasts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,14 +2595,14 @@ dependencies = [
 
 [[package]]
 name = "bitcoind-async-client"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d84118d9e2075d111dc90b1f1ffefced50beb6c37a32fcde4b55521fc881f"
+checksum = "fbfef338cdb79b56b6ef8133a8b18058d8b64e057164674a0ff41199b5cd44de"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
  "bitreq 0.3.5",
- "corepc-types",
+ "corepc-types 0.13.0",
  "hex-conservative 0.2.2",
  "secp256k1 0.29.1",
  "serde",
@@ -3252,7 +3252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0d0096927a820ea80d4a43a2355209d9a69ef5b420861bf413c7e667cbff0b"
 dependencies = [
  "bitcoin",
- "corepc-types",
+ "corepc-types 0.12.0",
  "jsonrpc 0.19.0",
  "log",
  "serde",
@@ -3278,6 +3278,17 @@ name = "corepc-types"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583872320eb2ac629c36753023fd072f1ca1b3b74b20cc62bab055b54278789"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96c7869aa8234d10a41cbe3a1697bcb3a2482c48d9eb3541b3a4014a81afdad"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,13 +169,13 @@ bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", tag = "v0.11
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoincore-rpc = "0.19.0"
 bitcoind-async-client = { version = "0.14.0", default-features = false, features = [
-  "29_0",
+  "30_2",
 ] }
 borsh = { version = "1.6.1", features = ["derive"] }
 cfg-if = "1.0"
 chrono = "0.4.44"
 clap = { version = "4.6.1", features = ["cargo", "derive", "env"] }
-corepc-node = { version = "0.12.0", features = ["29_0"] }
+corepc-node = { version = "0.12.0", features = ["30_2"] }
 ed25519-dalek = { version = "2.2.0", features = ["zeroize"] }
 esplora-client = { git = "https://github.com/BitVM/rust-esplora-client", default-features = false, features = [
   "blocking-https-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,9 @@ bitcoin-bosd = { git = "https://github.com/alpenlabs/bitcoin-bosd", tag = "v0.11
 ] }
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoincore-rpc = "0.19.0"
-bitcoind-async-client = { version = "0.11.0", features = ["29_0"] }
+bitcoind-async-client = { version = "0.14.0", default-features = false, features = [
+  "29_0",
+] }
 borsh = { version = "1.6.1", features = ["derive"] }
 cfg-if = "1.0"
 chrono = "0.4.44"

--- a/bin/strata-bridge/src/mode/services/btc_client.rs
+++ b/bin/strata-bridge/src/mode/services/btc_client.rs
@@ -23,7 +23,7 @@ pub(in crate::mode) fn init_btc_rpc_client(config: &Config) -> anyhow::Result<Bi
     BitcoinClient::new(
         config.btc_client.url.to_string(),
         auth,
-        config.btc_client.retry_count,
+        config.btc_client.retry_count.map(u16::from),
         config.btc_client.retry_interval,
         None,
     )

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bitcoin::{
-    Amount, FeeRate, OutPoint, TapSighashType, Transaction, Txid,
+    Amount, OutPoint, TapSighashType, Transaction, Txid,
     secp256k1::{Message, PublicKey, XOnlyPublicKey, schnorr},
     sighash::{Prevouts, SighashCache},
 };
@@ -413,14 +413,15 @@ async fn fulfill_withdrawal(
     // Get fee rate estimate from bitcoind, bounded from below by `fee::FEE_RATE` so the
     // withdrawal-fulfillment v3 transaction always meets the bridge's hardcoded minimum even
     // on networks where `estimatesmartfee` returns a value below `minrelaytxfee`.
-    let fee_rate = output_handles
+    let smart_fee = output_handles
         .bitcoind_rpc_client
         .estimate_smart_fee(1)
         .await
         .map_err(|e| ExecutorError::WalletErr(format!("failed to estimate fee: {e}")))?;
-    info!(%fee_rate, "estimated fee rate for withdrawal fulfillment");
+    info!(?smart_fee, "estimated fee rate for withdrawal fulfillment");
 
-    let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
+    let fee_rate = smart_fee
+        .fee_rate
         .unwrap_or(fee::FEE_RATE)
         .max(fee::FEE_RATE);
 

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -143,7 +143,7 @@ pub(super) async fn publish_unstaking_burn(
 /// The executor asks Bitcoin Core for a one-block estimate and floors missing or low estimates at
 /// the network broadcast minimum so the constructed transaction remains relayable.
 async fn burn_fee_rate(output_handles: &OutputHandles) -> Result<FeeRate, ExecutorError> {
-    let fee_rate = output_handles
+    let smart_fee = output_handles
         .bitcoind_rpc_client
         .estimate_smart_fee(1)
         .await
@@ -155,7 +155,8 @@ async fn burn_fee_rate(output_handles: &OutputHandles) -> Result<FeeRate, Execut
             ExecutorError::WalletErr(format!("failed to estimate fee: {e}"))
         })?;
 
-    let fee_rate = FeeRate::from_sat_per_vb(fee_rate)
+    let fee_rate = smart_fee
+        .fee_rate
         .unwrap_or(FeeRate::BROADCAST_MIN)
         .max(FeeRate::BROADCAST_MIN);
 

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -168,16 +168,17 @@ async fn estimate_funding_fee_rate(
     output_handles: &OutputHandles,
 ) -> Result<FeeRate, ExecutorError> {
     info!("fetching fee rate from bitcoind");
-    let raw_fee_rate = output_handles
+    let smart_fee = output_handles
         .bitcoind_rpc_client
         .estimate_smart_fee(1)
         .await?;
-    info!(%raw_fee_rate, "fetched fee rate from bitcoind");
+    info!(?smart_fee, "fetched fee rate from bitcoind");
 
     // Bound the rate from below by `fee::FEE_RATE` so this v3 (TRUC) funding transaction
     // always meets the bridge's hardcoded minimum, even on networks like signet where
     // `estimatesmartfee` may return a value below `minrelaytxfee`.
-    let fee_rate = FeeRate::from_sat_per_vb(raw_fee_rate)
+    let fee_rate = smart_fee
+        .fee_rate
         .unwrap_or(fee::FEE_RATE)
         .max(fee::FEE_RATE);
 

--- a/crates/bridge-sm/src/deposit/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/deposit/tests/tx_classifier.rs
@@ -8,9 +8,14 @@
 mod tests {
     use std::collections::BTreeMap;
 
+    use bitcoin_bosd::Descriptor;
+
     use crate::{
         deposit::tests::*,
-        testing::fixtures::{test_payout_tx, test_takeback_tx},
+        testing::fixtures::{
+            test_fulfillment_tx_for_recipient, test_op_return_recipient_desc, test_payout_tx,
+            test_takeback_tx,
+        },
         tx_classifier::TxClassifier,
     };
 
@@ -82,13 +87,17 @@ mod tests {
         ]
     }
 
-    fn assigned_state() -> DepositState {
+    fn assigned_state_with_recipient(recipient_desc: Descriptor) -> DepositState {
         DepositState::Assigned {
             last_block_height: LATER_BLOCK_HEIGHT,
             assignee: TEST_ASSIGNEE,
             deadline: LATER_BLOCK_HEIGHT + 15,
-            recipient_desc: test_recipient_desc(1),
+            recipient_desc,
         }
+    }
+
+    fn assigned_state() -> DepositState {
+        assigned_state_with_recipient(test_recipient_desc(1))
     }
 
     /// States that expect a payout (deposit spend).
@@ -190,6 +199,19 @@ mod tests {
         let cfg = test_deposit_sm_cfg();
         let sm = create_sm(assigned_state());
         let result = sm.classify_tx(&cfg, &test_fulfillment_tx(), LATER_BLOCK_HEIGHT);
+        assert!(
+            matches!(result, Some(DepositEvent::FulfillmentConfirmed(_))),
+            "expected Some(FulfillmentConfirmed) but got {result:?}"
+        );
+    }
+
+    #[test]
+    fn classify_tx_recognizes_op_return_fulfillment() {
+        let cfg = test_deposit_sm_cfg();
+        let recipient_desc = test_op_return_recipient_desc();
+        let fulfillment_tx = test_fulfillment_tx_for_recipient(recipient_desc.clone());
+        let sm = create_sm(assigned_state_with_recipient(recipient_desc));
+        let result = sm.classify_tx(&cfg, &fulfillment_tx, LATER_BLOCK_HEIGHT);
         assert!(
             matches!(result, Some(DepositEvent::FulfillmentConfirmed(_))),
             "expected Some(FulfillmentConfirmed) but got {result:?}"

--- a/crates/bridge-sm/src/graph/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/graph/tests/tx_classifier.rs
@@ -24,7 +24,10 @@ mod tests {
             state::GraphState,
             tests::{mock_states::*, *},
         },
-        testing::fixtures::{TEST_DEPOSIT_IDX, test_operator_table},
+        testing::fixtures::{
+            TEST_DEPOSIT_IDX, test_fulfillment_tx_for_recipient, test_op_return_recipient_desc,
+            test_operator_table,
+        },
         tx_classifier::TxClassifier,
     };
 
@@ -211,6 +214,23 @@ mod tests {
             test_recipient_desc(1),
         ));
         let result = sm.classify_tx(&cfg, &test_fulfillment_tx(), LATER_BLOCK_HEIGHT);
+        assert!(
+            matches!(result, Some(GraphEvent::FulfillmentConfirmed(_))),
+            "expected Some(FulfillmentConfirmed) but got {result:?}"
+        );
+    }
+
+    #[test]
+    fn classify_tx_recognizes_op_return_fulfillment_in_assigned() {
+        let cfg = test_graph_sm_cfg();
+        let recipient_desc = test_op_return_recipient_desc();
+        let fulfillment_tx = test_fulfillment_tx_for_recipient(recipient_desc.clone());
+        let sm = create_sm(assigned_state(
+            TEST_ASSIGNEE,
+            LATER_BLOCK_HEIGHT + 15,
+            recipient_desc,
+        ));
+        let result = sm.classify_tx(&cfg, &fulfillment_tx, LATER_BLOCK_HEIGHT);
         assert!(
             matches!(result, Some(GraphEvent::FulfillmentConfirmed(_))),
             "expected Some(FulfillmentConfirmed) but got {result:?}"

--- a/crates/bridge-sm/src/testing/fixtures.rs
+++ b/crates/bridge-sm/src/testing/fixtures.rs
@@ -28,25 +28,36 @@ pub const TEST_ASSIGNEE: OperatorIdx = 2;
 
 /// Returns a deterministic P2TR descriptor for use in fulfillment tests.
 ///
-/// Both [`test_fulfillment_tx`] and the `Assigned` state in TxClassifier tests must use the same
-/// recipient descriptor so that [`is_fulfillment`](crate::tx_classifier::is_fulfillment) can match
-/// the transaction against the state.
+/// Both [`test_fulfillment_tx_for_recipient`] and the `Assigned` state in TxClassifier tests must
+/// use the same recipient descriptor so that
+/// [`is_fulfillment`](crate::tx_classifier::is_fulfillment) can match the transaction against the
+/// state.
 pub fn test_recipient_desc(key_byte: u8) -> Descriptor {
     let sk = SecretKey::from_slice(&[key_byte; 32]).unwrap();
     let pk = sk.public_key(SECP256K1).x_only_public_key().0;
     Descriptor::new_p2tr(&pk.serialize()).expect("valid descriptor")
 }
 
+/// Returns a deterministic OP_RETURN descriptor for fulfillment classifier tests.
+pub fn test_op_return_recipient_desc() -> Descriptor {
+    Descriptor::new_op_return(&[1u8; 32]).expect("valid descriptor")
+}
+
 /// Creates a test withdrawal fulfillment transaction with the test deposit index and magic bytes.
 ///
 /// This constructs a properly formatted SPS-50 transaction that the classifier can parse.
-pub fn test_fulfillment_tx() -> Transaction {
+pub fn test_fulfillment_tx_for_recipient(recipient_desc: Descriptor) -> Transaction {
     let data = WithdrawalFulfillmentData {
         deposit_idx: TEST_DEPOSIT_IDX,
         user_amount: TEST_DEPOSIT_AMOUNT - TEST_OPERATOR_FEE,
         magic_bytes: TEST_MAGIC_BYTES.into(),
     };
-    WithdrawalFulfillmentTx::new(data, test_recipient_desc(1)).into_unsigned_tx()
+    WithdrawalFulfillmentTx::new(data, recipient_desc).into_unsigned_tx()
+}
+
+/// Creates a test withdrawal fulfillment transaction for [`test_recipient_desc`].
+pub fn test_fulfillment_tx() -> Transaction {
+    test_fulfillment_tx_for_recipient(test_recipient_desc(1))
 }
 
 // ===== Transaction Fixtures =====

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -6,10 +6,11 @@ use algebra::{
     monoid::{self, Monoid},
     semigroup::Semigroup,
 };
-use bitcoin::{Transaction, Txid};
+use bitcoin::{Amount, Transaction, Txid};
 use bitcoind_async_client::{
     error::ClientError,
     traits::{Broadcaster, Reader},
+    types::BroadcastOptions,
     Client as BitcoinClient,
 };
 use futures::{channel::oneshot, stream::SelectAll, FutureExt, StreamExt};
@@ -108,6 +109,20 @@ impl From<TxDriveJob> for TxJobHeap {
     }
 }
 
+fn broadcast_options(tx: &Transaction) -> Option<BroadcastOptions> {
+    let max_burn_amount = tx
+        .output
+        .iter()
+        .filter(|output| output.value > Amount::ZERO && output.script_pubkey.is_op_return())
+        .map(|output| output.value)
+        .max()?;
+
+    Some(BroadcastOptions {
+        max_burn_amount: Some(max_burn_amount),
+        ..Default::default()
+    })
+}
+
 /// System for driving a signed transaction to confirmation.
 #[derive(Debug)]
 pub struct TxDriver {
@@ -177,7 +192,8 @@ impl TxDriver {
                             continue;
                         }
 
-                        match rpc_client.send_raw_transaction(&rawtx_rpc_client, None).await {
+                        let options = broadcast_options(&rawtx_rpc_client);
+                        match rpc_client.send_raw_transaction(&rawtx_rpc_client, options).await {
                             Ok(txid) => {
                                 info!(%txid, "broadcasted transaction successfully");
                                 // only add subscriptions and jobs if the transaction was
@@ -210,7 +226,8 @@ impl TxDriver {
                         match event.status {
                             TxStatus::Unknown => {
                                 // Transaction has been evicted, resubmit and see what happens
-                                match rpc_client.send_raw_transaction(&event.rawtx, None).await {
+                                let options = broadcast_options(&event.rawtx);
+                                match rpc_client.send_raw_transaction(&event.rawtx, options).await {
                                     Ok(txid) => {
                                         /* NOOP, we good fam */
                                         info!(%txid, "resubmitted transaction successfully");
@@ -297,11 +314,52 @@ impl Drop for TxDriver {
 }
 
 #[cfg(test)]
+mod tests {
+    use bitcoin::{absolute, transaction, Amount, ScriptBuf, Transaction, TxOut};
+
+    use super::broadcast_options;
+
+    fn tx_with_outputs(output: Vec<TxOut>) -> Transaction {
+        Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![],
+            output,
+        }
+    }
+
+    #[test]
+    fn broadcast_options_use_largest_op_return_burn() {
+        let tx = tx_with_outputs(vec![
+            TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new_op_return([1u8; 32]),
+            },
+            TxOut {
+                value: Amount::from_sat(2_000),
+                script_pubkey: ScriptBuf::new_op_return([2u8; 32]),
+            },
+            TxOut {
+                value: Amount::from_sat(3_000),
+                script_pubkey: ScriptBuf::new(),
+            },
+        ]);
+
+        let options = broadcast_options(&tx).expect("OP_RETURN burn must require options");
+
+        assert_eq!(options.max_burn_amount, Some(Amount::from_sat(2_000)));
+    }
+}
+
+#[cfg(test)]
 mod e2e_tests {
     use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 
     use algebra::predicate;
-    use bitcoin::{Amount, Block};
+    use bitcoin::{
+        absolute, transaction, Amount, Block, OutPoint, ScriptBuf, Sequence, Transaction, TxIn,
+        TxOut, Witness,
+    };
     use bitcoind_async_client::Client as BitcoinClient;
     use corepc_node::{client::client_sync::Auth, vtype::FundRawTransaction, CookieValues, Output};
     use futures::join;
@@ -522,9 +580,85 @@ mod e2e_tests {
 
         info!("driving to mempool");
         driver
-            .drive(signed.clone(), predicate::eq(TxStatus::Mempool))
+            .drive(signed, predicate::eq(TxStatus::Mempool))
             .await?;
         info!("transaction appeared in mempool");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn tx_drive_op_return_burn() -> Result<(), Box<dyn std::error::Error>> {
+        logging::init_from_env("tx_drive_op_return_burn");
+
+        let (driver, bitcoind) = setup().await?;
+
+        let new_address = bitcoind.client.new_address()?;
+        let blocks = bitcoind
+            .client
+            .generate_to_address(101, &new_address)?
+            .into_model()?;
+        debug!("waiting for test funds to mature");
+        wait_for_height(&bitcoind, 101).await?;
+        debug!("test funds matured");
+
+        let spendable_block = bitcoind.client.get_block(
+            *blocks
+                .0
+                .first()
+                .expect("generate_to_address must return mined block hashes"),
+        )?;
+        let coinbase_tx = spendable_block
+            .coinbase()
+            .expect("mined block must contain a coinbase transaction");
+
+        let burn_amount = Amount::from_sat(1_000);
+        let fee = Amount::from_sat(10_000);
+        let change_amount = coinbase_tx.output[0].value - burn_amount - fee;
+        let change_address = bitcoind.client.new_address()?;
+        let unsigned = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(coinbase_tx.compute_txid(), 0),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::default(),
+            }],
+            output: vec![
+                TxOut {
+                    value: burn_amount,
+                    script_pubkey: ScriptBuf::new_op_return([1u8; 32]),
+                },
+                TxOut {
+                    value: change_amount,
+                    script_pubkey: change_address.script_pubkey(),
+                },
+            ],
+        };
+
+        let signed = bitcoind
+            .client
+            .sign_raw_transaction_with_wallet(&unsigned)?
+            .into_model()?
+            .tx;
+
+        let err = bitcoind
+            .client
+            .send_raw_transaction(&signed)
+            .expect_err("default maxburnamount must reject OP_RETURN burns");
+        let err = err.to_string();
+        assert!(
+            err.contains("maxburnamount") || err.contains("max-burn-amount"),
+            "unexpected sendrawtransaction error: {err}"
+        );
+
+        info!("driving OP_RETURN burn to mempool");
+        driver
+            .drive(signed.clone(), predicate::eq(TxStatus::Mempool))
+            .await?;
+        info!("OP_RETURN burn transaction appeared in mempool");
 
         Ok(())
     }

--- a/crates/btc-tracker/src/tx_driver.rs
+++ b/crates/btc-tracker/src/tx_driver.rs
@@ -177,7 +177,7 @@ impl TxDriver {
                             continue;
                         }
 
-                        match rpc_client.send_raw_transaction(&rawtx_rpc_client).await {
+                        match rpc_client.send_raw_transaction(&rawtx_rpc_client, None).await {
                             Ok(txid) => {
                                 info!(%txid, "broadcasted transaction successfully");
                                 // only add subscriptions and jobs if the transaction was
@@ -210,7 +210,7 @@ impl TxDriver {
                         match event.status {
                             TxStatus::Unknown => {
                                 // Transaction has been evicted, resubmit and see what happens
-                                match rpc_client.send_raw_transaction(&event.rawtx).await {
+                                match rpc_client.send_raw_transaction(&event.rawtx, None).await {
                                     Ok(txid) => {
                                         /* NOOP, we good fam */
                                         info!(%txid, "resubmitted transaction successfully");

--- a/crates/connectors/Cargo.toml
+++ b/crates/connectors/Cargo.toml
@@ -19,14 +19,14 @@ strata-crypto.workspace = true
 
 # Optional dependencies for test_utils feature
 bitcoind-async-client = { workspace = true, features = [
-  "29_0",
+  "30_2",
 ], optional = true }
-corepc-node = { workspace = true, features = ["29_0"], optional = true }
+corepc-node = { workspace = true, features = ["30_2"], optional = true }
 
 [dev-dependencies]
 strata-bridge-test-utils.workspace = true
 
 strata-bridge-common.workspace = true
-bitcoind-async-client = { workspace = true, features = ["29_0"] }
-corepc-node = { workspace = true, features = ["29_0"] }
+bitcoind-async-client = { workspace = true, features = ["30_2"] }
+corepc-node = { workspace = true, features = ["30_2"] }
 tracing.workspace = true

--- a/crates/connectors/src/test_utils.rs
+++ b/crates/connectors/src/test_utils.rs
@@ -7,7 +7,7 @@ use bitcoin::{
     sighash::{Prevouts, SighashCache},
     transaction, Address, Amount, BlockHash, OutPoint, Psbt, Transaction, TxIn, TxOut, Txid,
 };
-use bitcoind_async_client::corepc_types::v29::SignRawTransactionWithWallet;
+use bitcoind_async_client::corepc_types::v30::SignRawTransactionWithWallet;
 use corepc_node::{
     serde_json::{self, json},
     Client, Conf, Node,

--- a/crates/test-utils/src/bitcoin.rs
+++ b/crates/test-utils/src/bitcoin.rs
@@ -15,7 +15,7 @@ use bitcoin::{
     Transaction, TxIn, TxMerkleNode, TxOut, Txid, Witness,
 };
 use bitcoind_async_client::{
-    corepc_types::v29::{ListUnspent, SignRawTransactionWithWallet},
+    corepc_types::v30::{ListUnspent, SignRawTransactionWithWallet},
     Auth, Client as BitcoinClient,
 };
 use corepc_node::{serde_json::json, Client, Node};

--- a/crates/test-utils/src/bitcoin_rpc.rs
+++ b/crates/test-utils/src/bitcoin_rpc.rs
@@ -3,7 +3,7 @@
 //!
 //! Based on <https://github.com/rust-bitcoin/rust-bitcoincore-rpc/tree/master>.
 use bitcoin::{consensus, Address, Amount, Transaction, Txid};
-use bitcoind_async_client::corepc_types::v29::{GetRawTransaction, SignRawTransactionWithWallet};
+use bitcoind_async_client::corepc_types::v30::{GetRawTransaction, SignRawTransactionWithWallet};
 use corepc_node::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/crates/test-utils/src/tx.rs
+++ b/crates/test-utils/src/tx.rs
@@ -1,7 +1,7 @@
 //! Module to generate transactions for testing.
 
 use bitcoin::{consensus, Address, Amount, OutPoint, Transaction, TxOut};
-use bitcoind_async_client::corepc_types::v29::{ListUnspent, SignRawTransactionWithWallet};
+use bitcoind_async_client::corepc_types::v30::{ListUnspent, SignRawTransactionWithWallet};
 use corepc_node::{serde_json, Client};
 use strata_bridge_primitives::scripts::prelude::{create_tx, create_tx_ins, create_tx_outs};
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This adds support for fulfillment transactions addressed to an OP_RETURN output. This has been implemented by first bumping `bitcoind-async-client` to 0.14.0 which adds support for configurable `maxburnamount` and then, having the `tx-driver` dynamically attach the `maxburnamount` value based on the amount being burned. So, these changes solve the issue in a more general sense as _any_ transaction that burns sat can now be broadcasted via the `tx-driver`. This is in-line with the ethos of `tx-driver` which is that it drives a transaction to confirmation by whatever means necessary and available to it. Unit tests have been added to the `tx-classifier` as well to make sure that a fulfillment addressed to an `OP_RETURN` output are correctly identified.

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3070