### PR TITLE
fix(gsm): do not publish slash from AllNackd state

### DIFF
--- a/crates/bridge-sm/src/graph/tests/notify_new_block.rs
+++ b/crates/bridge-sm/src/graph/tests/notify_new_block.rs
@@ -1267,9 +1267,9 @@ mod tests {
         );
     }
 
-    /// Non-owner publishes slash after payout timelock expires in AllNackd state.
+    /// Non-owner does not publish slash even after payout timelock expires in AllNackd state.
     #[test]
-    fn all_nackd_nonpov_slash() {
+    fn all_nackd_nonpov_no_slash() {
         let cfg = test_graph_sm_cfg();
         let ctx = test_graph_sm_ctx();
         let contest_height = LATER_BLOCK_HEIGHT;
@@ -1278,10 +1278,6 @@ mod tests {
 
         let game_graph = generate_game_graph(&cfg, &ctx, &test_deposit_params());
         let signatures = mock_game_signatures(&game_graph);
-        let slash_sigs = GameFunctor::unpack(signatures.clone(), ctx.watchtower_pubkeys().len())
-            .expect("Failed to unpack signatures")
-            .slash;
-        let signed_slash_tx = game_graph.slash.finalize(slash_sigs);
 
         test_transition::<GraphSM, _, _, _, _, _, _, _>(
             create_nonpov_sm,
@@ -1297,7 +1293,7 @@ mod tests {
                     block_height: new_height,
                 }),
                 expected_state: all_nackd_state_with(new_height, contest_height, signatures),
-                expected_duties: vec![GraphDuty::PublishSlash { signed_slash_tx }],
+                expected_duties: vec![],
                 expected_signals: vec![],
             },
         );

--- a/crates/bridge-sm/src/graph/transitions/common.rs
+++ b/crates/bridge-sm/src/graph/transitions/common.rs
@@ -334,17 +334,6 @@ impl GraphSM {
             } => {
                 *last_block_height = new_block_event.block_height;
 
-                if let Some(slash_duty) = check_slash_timeout(
-                    &cfg,
-                    &graph_ctx,
-                    new_block_event.block_height,
-                    *contest_block_height,
-                    graph_data.clone(),
-                    signatures,
-                ) {
-                    return Ok(GSMOutput::with_duties(vec![slash_duty]));
-                }
-
                 if let Some(contested_payout_duty) = check_contested_payout_timeout(
                     &cfg,
                     &graph_ctx,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
In the canonical implementation of the `strata-bridge`, we do not want to slash whenever possible regardless of operator fault. This means we must not have this implementation publish a slash transaciton if the payout timelock has expired in the `AllNackd` state as this state is only reached if the operator is _not_ at fault.

AI was not used in this PR.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3565