### PR TITLE
feat(connectors): use threshold multisig for admin block payouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,7 +3124,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5885,7 +5885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8386,9 +8386,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -13526,7 +13526,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/bin/dev-cli/params.toml
+++ b/bin/dev-cli/params.toml
@@ -2,7 +2,14 @@ network = "regtest"
 genesis_height = 101
 
 [keys]
-admin = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"
+
+[keys.admin]
+pubkeys = [
+  "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d",
+  "1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4",
+  "a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba",
+]
+threshold = 2
 
 [[keys.covenant]]
 musig2 = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"

--- a/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
@@ -38,7 +38,7 @@ use strata_bridge_test_utils::{
     prelude::generate_txid,
 };
 use strata_bridge_tx_graph::{
-    game_graph::{DepositParams, GameGraphSummary, ProtocolParams},
+    game_graph::{AdminMultisig, DepositParams, GameGraphSummary, ProtocolParams},
     stake_graph::ProtocolParams as StakeProtocolParams,
     transactions::{
         cooperative_payout::{CooperativePayoutData, CooperativePayoutTx},
@@ -99,7 +99,10 @@ fn test_graph_cfg() -> GraphSMCfg {
             stake_amount: Amount::from_sat(20_000),
         },
         operator_fee: TEST_OPERATOR_FEE,
-        admin_pubkey: generate_xonly_pubkey(),
+        admin: AdminMultisig {
+            pubkeys: vec![generate_xonly_pubkey()],
+            threshold: 1,
+        },
         payout_descs: (0..3).map(|_| random_p2tr_desc()).collect(),
         bridge_proof_predicate: PredicateKey::always_accept(),
         counterproof_predicate: PredicateKey::always_accept(),

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -149,9 +149,13 @@ fn compute_claim_funding_utxo_value(params: &Params, own_musig2_key: XOnlyPublic
         fee::claim_contest_surcharge(n_watchtowers, COUNTERPROOF_N_DATA),
     );
 
-    let admin_key = params.keys.admin;
-    let claim_payout_connector =
-        ClaimPayoutConnector::new(network, n_of_n_key, admin_key, unstaking_image);
+    let claim_payout_connector = ClaimPayoutConnector::new(
+        network,
+        n_of_n_key,
+        params.keys.admin.pubkeys.clone(),
+        params.keys.admin.threshold,
+        unstaking_image,
+    );
 
     ClaimTx::claim_funds_required(&claim_contest_connector, &claim_payout_connector)
 }

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -26,7 +26,7 @@ use strata_bridge_sm::{
     self, deposit::config::DepositSMCfg, graph::config::GraphSMCfg, stake::config::StakeSMCfg,
 };
 use strata_bridge_tx_graph::{
-    game_graph::ProtocolParams as TxGraphProtocolParams,
+    game_graph::{AdminMultisig, ProtocolParams as TxGraphProtocolParams},
     stake_graph::ProtocolParams as StakeGraphProtocolParams,
 };
 use strata_mosaic_client_api::MosaicClientApi;
@@ -212,7 +212,10 @@ pub(in crate::mode) fn build_sm_config(config: &Config, params: &Params) -> SMCo
     let graph_config = GraphSMCfg {
         game_graph_params,
         operator_fee,
-        admin_pubkey: params.keys.admin,
+        admin: AdminMultisig {
+            pubkeys: params.keys.admin.pubkeys.clone(),
+            threshold: params.keys.admin.threshold,
+        },
         payout_descs: params
             .keys
             .covenant

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -596,7 +596,8 @@ mod tests {
         let connector = ClaimPayoutConnector::new(
             Network::Regtest,
             xonly_pubkey(3),
-            xonly_pubkey(4),
+            vec![xonly_pubkey(4)],
+            1,
             sha256::Hash::hash(&unstaking_preimage),
         );
         let data = UnstakingBurnData {

--- a/crates/bridge-sm/src/graph/config.rs
+++ b/crates/bridge-sm/src/graph/config.rs
@@ -1,8 +1,8 @@
 //! Configuration shared across all graph state machines.
 
-use bitcoin::{Amount, XOnlyPublicKey};
+use bitcoin::Amount;
 use bitcoin_bosd::Descriptor;
-use strata_bridge_tx_graph::game_graph::ProtocolParams;
+use strata_bridge_tx_graph::game_graph::{AdminMultisig, ProtocolParams};
 use strata_predicate::PredicateKey;
 
 /// Bridge-wide configuration shared across all graph state machines.
@@ -17,10 +17,10 @@ pub struct GraphSMCfg {
     /// Fees paid to the operator for fronting a user.
     pub operator_fee: Amount,
 
-    /// Key that locks the payout connector output.
+    /// Admin multisig that locks the payout connector output.
     ///
-    /// Signature corresponding to this key can be used to block payouts to the operator.
-    pub admin_pubkey: XOnlyPublicKey,
+    /// Signatures satisfying this threshold can be used to block payouts to the operator.
+    pub admin: AdminMultisig,
 
     /// Descriptor to which payouts are to be sent in case of a successful peg out.
     pub payout_descs: Vec<Descriptor>,

--- a/crates/bridge-sm/src/graph/context.rs
+++ b/crates/bridge-sm/src/graph/context.rs
@@ -102,7 +102,7 @@ impl GraphSMCtx {
         let owner_idx = self.operator_idx() as usize;
         let watchtower_pubkeys = self.watchtower_pubkeys();
 
-        let admin_pubkey = cfg.admin_pubkey;
+        let admin = cfg.admin.clone();
         let unstaking_image = self.unstaking_image();
 
         let owner_desc = cfg.payout_descs[owner_idx].clone();
@@ -125,7 +125,7 @@ impl GraphSMCtx {
             operator_pubkey,
             operator_adaptor_pubkeys: deposit_params.adaptor_pubkeys.clone(),
             watchtower_pubkeys,
-            admin_pubkey,
+            admin,
             unstaking_image,
             wt_fault_pubkeys: deposit_params.fault_pubkeys.clone(),
             operator_descriptor: owner_desc,

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -34,7 +34,8 @@ use strata_bridge_test_utils::{
 };
 use strata_bridge_tx_graph::{
     game_graph::{
-        CounterproofGraphSummary, DepositParams, GameGraph, GameGraphSummary, ProtocolParams,
+        AdminMultisig, CounterproofGraphSummary, DepositParams, GameGraph, GameGraphSummary,
+        ProtocolParams,
     },
     transactions::prelude::{ClaimTx, ContestTx, CounterproofTx},
 };
@@ -120,7 +121,10 @@ pub(super) fn test_graph_sm_cfg() -> Arc<GraphSMCfg> {
             deposit_amount: TEST_DEPOSIT_AMOUNT,
             stake_amount: STAKE_AMOUNT,
         },
-        admin_pubkey: generate_xonly_pubkey(),
+        admin: AdminMultisig {
+            pubkeys: vec![generate_xonly_pubkey()],
+            threshold: 1,
+        },
         operator_fee: TEST_OPERATOR_FEE,
         payout_descs,
         bridge_proof_predicate: PredicateKey::always_accept(),

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -230,6 +230,15 @@ where
             "admin multisig threshold must not exceed pubkey count",
         ));
     }
+    if let Some(duplicate_index) = admin_pubkeys
+        .iter()
+        .enumerate()
+        .find_map(|(i, pubkey)| admin_pubkeys[..i].contains(pubkey).then_some(i))
+    {
+        return Err(serde::de::Error::custom(format!(
+            "duplicate admin pubkey at index {duplicate_index}"
+        )));
+    }
     let admin = AdminParams {
         pubkeys: admin_pubkeys,
         threshold: encoded_keys.admin.threshold,
@@ -303,11 +312,142 @@ mod tests {
 
     #[test]
     fn test_params_serde_toml() {
+        let params = params_toml(&valid_admin_section());
+
+        let deserialized = toml::from_str::<Params>(&params);
+
+        assert!(
+            deserialized.is_ok(),
+            "must be able to deserialize params from toml but got: {}",
+            deserialized.unwrap_err()
+        );
+
+        let deserialized = deserialized.unwrap();
+        let serialized = toml::to_string(&deserialized).unwrap();
+        let params = toml::from_str::<Params>(&serialized).unwrap();
+
+        assert_eq!(
+            Amount::from_int_btc(1),
+            params.protocol.deposit_amount,
+            "deposit amounts must match across serialization"
+        );
+
+        assert_eq!(
+            params.keys.covenant.len(),
+            2,
+            "must have 2 covenant key entries"
+        );
+
+        assert_eq!(params.protocol.bury_depth, 6, "bury depth must round-trip");
+
+        assert_eq!(
+            params.keys.admin.threshold, 2,
+            "admin threshold must round-trip"
+        );
+        assert_eq!(
+            params.keys.admin.pubkeys.len(),
+            2,
+            "admin pubkeys must round-trip"
+        );
+    }
+
+    #[test]
+    fn params_reject_empty_admin_pubkeys() {
+        assert_admin_section_deserialize_error(
+            r#"
+            pubkeys = []
+            threshold = 1
+            "#,
+            "admin multisig must include at least one pubkey",
+        );
+    }
+
+    #[test]
+    fn params_reject_zero_admin_threshold() {
+        assert_admin_section_deserialize_error(
+            &format!(
+                r#"
+                pubkeys = ["{XONLY_KEY_1}"]
+                threshold = 0
+                "#
+            ),
+            "admin multisig threshold must be greater than zero",
+        );
+    }
+
+    #[test]
+    fn params_reject_admin_threshold_above_pubkey_count() {
+        assert_admin_section_deserialize_error(
+            &format!(
+                r#"
+                pubkeys = ["{XONLY_KEY_1}", "{XONLY_KEY_2}"]
+                threshold = 3
+                "#
+            ),
+            "admin multisig threshold must not exceed pubkey count",
+        );
+    }
+
+    #[test]
+    fn params_reject_duplicate_admin_pubkey() {
+        assert_admin_section_deserialize_error(
+            &format!(
+                r#"
+                pubkeys = ["{XONLY_KEY_1}", "{XONLY_KEY_1}"]
+                threshold = 2
+                "#
+            ),
+            "duplicate admin pubkey at index 1",
+        );
+    }
+
+    #[test]
+    fn params_reject_malformed_admin_pubkey() {
+        assert_admin_section_deserialize_error(
+            r#"
+            pubkeys = ["not-hex"]
+            threshold = 1
+            "#,
+            "failed to decode hex admin pubkey at index 0",
+        );
+    }
+
+    #[test]
+    fn params_reject_invalid_admin_pubkey() {
+        assert_admin_section_deserialize_error(
+            r#"
+            pubkeys = ["deadbeef"]
+            threshold = 1
+            "#,
+            "failed to create admin xonly pk at index 0",
+        );
+    }
+
+    fn valid_admin_section() -> String {
+        format!(
+            r#"
+            pubkeys = ["{XONLY_KEY_1}", "{XONLY_KEY_2}"]
+            threshold = 2
+            "#
+        )
+    }
+
+    fn assert_admin_section_deserialize_error(admin_section: &str, expected_error: &str) {
+        let err = toml::from_str::<Params>(&params_toml(admin_section)).unwrap_err();
+        let err = err.to_string();
+
+        assert!(
+            err.contains(expected_error),
+            "expected deserialize error to contain {expected_error:?}, got {err:?}"
+        );
+    }
+
+    fn params_toml(admin_section: &str) -> String {
         let deposit_amount = Amount::from_int_btc(1).to_sat();
         let desc_1 = p2tr_descriptor(XONLY_KEY_1);
         let desc_2 = p2tr_descriptor(XONLY_KEY_2);
 
-        let params = format!(
+        format!(
             r#"
             network = "signet"
             genesis_height = 101
@@ -315,8 +455,7 @@ mod tests {
             [keys]
 
             [keys.admin]
-            pubkeys = ["{XONLY_KEY_1}", "{XONLY_KEY_2}"]
-            threshold = 2
+            {admin_section}
 
             [[keys.covenant]]
             musig2 = "{XONLY_KEY_1}"
@@ -343,43 +482,7 @@ mod tests {
             nack_timelock = 144
             contested_payout_timelock = 1_008
     "#
-        );
-
-        let deserialized = toml::from_str::<Params>(&params);
-
-        assert!(
-            deserialized.is_ok(),
-            "must be able to deserialize params from toml but got: {}",
-            deserialized.unwrap_err()
-        );
-
-        let deserialized = deserialized.unwrap();
-        let serialized = toml::to_string(&deserialized).unwrap();
-        let params = toml::from_str::<Params>(&serialized).unwrap();
-
-        assert_eq!(
-            Amount::from_sat(deposit_amount),
-            params.protocol.deposit_amount,
-            "deposit amounts must match across serialization"
-        );
-
-        assert_eq!(
-            params.keys.covenant.len(),
-            2,
-            "must have 2 covenant key entries"
-        );
-
-        assert_eq!(params.protocol.bury_depth, 6, "bury depth must round-trip");
-
-        assert_eq!(
-            params.keys.admin.threshold, 2,
-            "admin threshold must round-trip"
-        );
-        assert_eq!(
-            params.keys.admin.pubkeys.len(),
-            2,
-            "admin pubkeys must round-trip"
-        );
+        )
     }
 
     /// Construct a P2TR BOSD descriptor string from an x-only public key hex string.

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -107,12 +107,22 @@ pub struct ProtocolParams {
 /// The keys used by the operators.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyParams {
-    /// The admin key used to block payouts in case of a malicious operator flooding the network
-    /// with invalid claims and overwhelming the watchtowers.
-    pub admin: XOnlyPublicKey,
+    /// The admin multisig used to block payouts in case of a malicious operator flooding the
+    /// network with invalid claims and overwhelming the watchtowers.
+    pub admin: AdminParams,
 
     /// The per-operator keys that form the N-of-N covenant.
     pub covenant: Vec<CovenantKeys>,
+}
+
+/// The admin threshold multisig configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdminParams {
+    /// Public keys participating in the admin multisig.
+    pub pubkeys: Vec<XOnlyPublicKey>,
+
+    /// Number of signatures required to spend the admin path.
+    pub threshold: usize,
 }
 
 /// The per-entity keys that form the N-of-N covenant.
@@ -140,8 +150,14 @@ struct EncodedCovenantKeys {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct EncodedAdminParams {
+    pubkeys: Vec<String>,
+    threshold: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct EncodedKeyParams {
-    admin: String,
+    admin: EncodedAdminParams,
     covenant: Vec<EncodedCovenantKeys>,
 }
 
@@ -151,7 +167,15 @@ where
     S: serde::Serializer,
 {
     let encoded_keys = EncodedKeyParams {
-        admin: keys.admin.serialize().to_lower_hex_string(),
+        admin: EncodedAdminParams {
+            pubkeys: keys
+                .admin
+                .pubkeys
+                .iter()
+                .map(|key| key.serialize().to_lower_hex_string())
+                .collect(),
+            threshold: keys.admin.threshold,
+        },
         covenant: keys
             .covenant
             .iter()
@@ -173,9 +197,43 @@ where
 {
     let encoded_keys = EncodedKeyParams::deserialize(deserializer)?;
 
-    let admin = hex::decode(&encoded_keys.admin).expect("Failed to decode hex admin key");
-    let admin =
-        XOnlyPublicKey::from_slice(&admin).expect("Failed to create admin xonly pk from slice");
+    let admin_pubkeys = encoded_keys
+        .admin
+        .pubkeys
+        .into_iter()
+        .enumerate()
+        .map(|(i, key)| -> Result<XOnlyPublicKey, D::Error> {
+            let key = hex::decode(&key).map_err(|e| {
+                serde::de::Error::custom(format!(
+                    "failed to decode hex admin pubkey at index {i}: {e}"
+                ))
+            })?;
+            XOnlyPublicKey::from_slice(&key).map_err(|e| {
+                serde::de::Error::custom(format!(
+                    "failed to create admin xonly pk at index {i}: {e}"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if admin_pubkeys.is_empty() {
+        return Err(serde::de::Error::custom(
+            "admin multisig must include at least one pubkey",
+        ));
+    }
+    if encoded_keys.admin.threshold == 0 {
+        return Err(serde::de::Error::custom(
+            "admin multisig threshold must be greater than zero",
+        ));
+    }
+    if encoded_keys.admin.threshold > admin_pubkeys.len() {
+        return Err(serde::de::Error::custom(
+            "admin multisig threshold must not exceed pubkey count",
+        ));
+    }
+    let admin = AdminParams {
+        pubkeys: admin_pubkeys,
+        threshold: encoded_keys.admin.threshold,
+    };
 
     let covenant = encoded_keys
         .covenant
@@ -255,7 +313,10 @@ mod tests {
             genesis_height = 101
 
             [keys]
-            admin = "{XONLY_KEY_1}"
+
+            [keys.admin]
+            pubkeys = ["{XONLY_KEY_1}", "{XONLY_KEY_2}"]
+            threshold = 2
 
             [[keys.covenant]]
             musig2 = "{XONLY_KEY_1}"
@@ -309,6 +370,16 @@ mod tests {
         );
 
         assert_eq!(params.protocol.bury_depth, 6, "bury depth must round-trip");
+
+        assert_eq!(
+            params.keys.admin.threshold, 2,
+            "admin threshold must round-trip"
+        );
+        assert_eq!(
+            params.keys.admin.pubkeys.len(),
+            2,
+            "admin pubkeys must round-trip"
+        );
     }
 
     /// Construct a P2TR BOSD descriptor string from an x-only public key hex string.

--- a/crates/connectors/src/claim_payout.rs
+++ b/crates/connectors/src/claim_payout.rs
@@ -5,17 +5,19 @@ use bitcoin::{
     opcodes, Amount, Network, ScriptBuf,
 };
 use secp256k1::{schnorr, XOnlyPublicKey};
+use strata_bridge_primitives::scripts::prelude::threshold_multisig_script;
 
 use crate::{Connector, TaprootWitness};
 
 /// Connector output between `Claim` and:
 /// 1. `Bridge Proof Timeout`
 /// 2. `Uncontested Payout` / `Contested Payout`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClaimPayoutConnector {
     network: Network,
     n_of_n_pubkey: XOnlyPublicKey,
-    admin_pubkey: XOnlyPublicKey,
+    admin_pubkeys: Vec<XOnlyPublicKey>,
+    admin_threshold: usize,
     unstaking_image: sha256::Hash,
 }
 
@@ -23,16 +25,43 @@ impl ClaimPayoutConnector {
     /// Creates a new connector.
     ///
     /// The preimage of `unstaking_image` must be 32 bytes long.
-    pub const fn new(
+    ///
+    /// # Panics
+    ///
+    /// Panics if `admin_pubkeys` is empty, if `admin_pubkeys` contains duplicate keys, if
+    /// `admin_threshold` is zero, or if `admin_threshold` exceeds the number of admin pubkeys.
+    pub fn new(
         network: Network,
         n_of_n_pubkey: XOnlyPublicKey,
-        admin_pubkey: XOnlyPublicKey,
+        admin_pubkeys: Vec<XOnlyPublicKey>,
+        admin_threshold: usize,
         unstaking_image: sha256::Hash,
     ) -> Self {
+        assert!(
+            !admin_pubkeys.is_empty(),
+            "admin multisig requires at least one pubkey"
+        );
+        assert!(
+            admin_threshold > 0,
+            "admin multisig threshold must be greater than zero"
+        );
+        assert!(
+            admin_threshold <= admin_pubkeys.len(),
+            "admin multisig threshold must not exceed pubkey count"
+        );
+        assert!(
+            admin_pubkeys
+                .iter()
+                .enumerate()
+                .all(|(i, pubkey)| !admin_pubkeys[..i].contains(pubkey)),
+            "admin multisig pubkeys must be unique"
+        );
+
         Self {
             network,
             n_of_n_pubkey,
-            admin_pubkey,
+            admin_pubkeys,
+            admin_threshold,
             unstaking_image,
         }
     }
@@ -53,10 +82,8 @@ impl Connector for ClaimPayoutConnector {
     fn leaf_scripts(&self) -> Vec<ScriptBuf> {
         let mut scripts = Vec::new();
 
-        let admin_burn_script = ScriptBuf::builder()
-            .push_slice(self.admin_pubkey.serialize())
-            .push_opcode(opcodes::all::OP_CHECKSIG)
-            .into_script();
+        let admin_burn_script =
+            threshold_multisig_script(&self.admin_pubkeys, self.admin_threshold);
         scripts.push(admin_burn_script);
 
         let unstaking_burn_script = ScriptBuf::builder()
@@ -91,16 +118,57 @@ impl Connector for ClaimPayoutConnector {
             } => TaprootWitness::Key {
                 output_key_signature: *output_key_signature,
             },
-            ClaimPayoutWitness::AdminBurn { admin_signature } => TaprootWitness::Script {
-                leaf_index: 0,
-                script_inputs: vec![admin_signature.serialize().to_vec()],
-            },
+            ClaimPayoutWitness::AdminBurn { admin_signatures } => {
+                let mut accepted_signatures = admin_signatures
+                    .iter()
+                    .copied()
+                    .filter(|admin_signature| {
+                        admin_signature.pubkey_index < self.admin_pubkeys.len()
+                    })
+                    .collect::<Vec<_>>();
+
+                // sort first so that the subsequent call to `dedup_by_key` can remove consecutive
+                // duplicates
+                accepted_signatures.sort_by_key(|sig| sig.pubkey_index);
+                accepted_signatures.dedup_by_key(|admin_signature| admin_signature.pubkey_index);
+
+                assert!(
+                    accepted_signatures.len() >= self.admin_threshold,
+                    "admin burn requires at least threshold signatures for distinct known admin pubkeys"
+                );
+                accepted_signatures.truncate(self.admin_threshold);
+
+                let script_inputs = (0..self.admin_pubkeys.len())
+                    .rev()
+                    .map(|pubkey_index| {
+                        accepted_signatures
+                            .iter()
+                            .find(|admin_signature| admin_signature.pubkey_index == pubkey_index)
+                            .map(|admin_signature| admin_signature.signature.serialize().to_vec())
+                            .unwrap_or_default()
+                    })
+                    .collect();
+
+                TaprootWitness::Script {
+                    leaf_index: 0,
+                    script_inputs,
+                }
+            }
             ClaimPayoutWitness::UnstakingBurn { unstaking_preimage } => TaprootWitness::Script {
                 leaf_index: 1,
                 script_inputs: vec![unstaking_preimage.to_vec()],
             },
         }
     }
+}
+
+/// Signature for a specific admin pubkey position.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct AdminSignature {
+    /// Index of the admin pubkey this signature validates against.
+    pub pubkey_index: usize,
+    /// Signature produced by the admin key at `pubkey_index`.
+    pub signature: schnorr::Signature,
 }
 
 /// Available spending paths for a [`ClaimPayoutConnector`].
@@ -116,7 +184,7 @@ pub enum ClaimPayoutSpendPath {
 }
 
 /// Witness data to spend a [`ClaimPayoutConnector`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ClaimPayoutWitness {
     /// The connector is spent in the `Uncontested Payout`
     /// or in the `Contested Payout` transaction.
@@ -128,8 +196,12 @@ pub enum ClaimPayoutWitness {
     },
     /// The connector is spent in the `Admin Burn` transaction.
     AdminBurn {
-        /// Admin signature.
-        admin_signature: schnorr::Signature,
+        /// Admin signatures paired with the pubkey indices they validate against.
+        ///
+        /// The witness builder ignores unknown or repeated pubkey indices, keeps threshold
+        /// signatures in descending pubkey-index order, and emits empty placeholders for known
+        /// admin pubkeys that are not selected.
+        admin_signatures: Vec<AdminSignature>,
     },
     /// The connector is spent in the `Unstaking Burn` transaction.
     UnstakingBurn {
@@ -140,25 +212,33 @@ pub enum ClaimPayoutWitness {
 
 #[cfg(test)]
 mod tests {
-    use secp256k1::{rand::random, Keypair};
+    use std::array;
+
+    use secp256k1::{rand::random, schnorr, Keypair};
     use strata_bridge_test_utils::prelude::generate_keypair;
 
     use super::*;
     use crate::{test_utils::Signer, SigningInfo};
 
-    struct ClaimPayoutSigner {
+    struct ClaimPayoutSigner<const THRESHOLD: usize, const N_ADMINS: usize> {
         n_of_n_keypair: Keypair,
-        admin_keypair: Keypair,
+        admin_keypairs: [Keypair; N_ADMINS],
         unstaking_preimage: [u8; 32],
     }
 
-    impl Signer for ClaimPayoutSigner {
+    impl<const THRESHOLD: usize, const N_ADMINS: usize> Signer
+        for ClaimPayoutSigner<THRESHOLD, N_ADMINS>
+    {
         type Connector = ClaimPayoutConnector;
 
         fn generate() -> Self {
+            assert!(N_ADMINS > 0);
+            assert!(THRESHOLD > 0);
+            assert!(THRESHOLD <= N_ADMINS);
+
             Self {
                 n_of_n_keypair: generate_keypair(),
-                admin_keypair: generate_keypair(),
+                admin_keypairs: array::from_fn(|_| generate_keypair()),
                 unstaking_preimage: random::<[u8; 32]>(),
             }
         }
@@ -167,7 +247,11 @@ mod tests {
             ClaimPayoutConnector::new(
                 Network::Regtest,
                 self.n_of_n_keypair.x_only_public_key().0,
-                self.admin_keypair.x_only_public_key().0,
+                self.admin_keypairs
+                    .iter()
+                    .map(|keypair| keypair.x_only_public_key().0)
+                    .collect(),
+                THRESHOLD,
                 sha256::Hash::hash(&self.unstaking_preimage),
             )
         }
@@ -186,7 +270,16 @@ mod tests {
                     output_key_signature: signing_info.sign(&self.n_of_n_keypair),
                 },
                 ClaimPayoutSpendPath::AdminBurn => ClaimPayoutWitness::AdminBurn {
-                    admin_signature: signing_info.sign(&self.admin_keypair),
+                    admin_signatures: self
+                        .admin_keypairs
+                        .iter()
+                        .enumerate()
+                        .take(THRESHOLD)
+                        .map(|(pubkey_index, keypair)| AdminSignature {
+                            pubkey_index,
+                            signature: signing_info.sign(keypair),
+                        })
+                        .collect(),
                 },
                 ClaimPayoutSpendPath::UnstakingBurn => ClaimPayoutWitness::UnstakingBurn {
                     unstaking_preimage: self.unstaking_preimage,
@@ -197,16 +290,208 @@ mod tests {
 
     #[test]
     fn payout_spend() {
-        ClaimPayoutSigner::assert_connector_is_spendable(ClaimPayoutSpendPath::Payout);
+        ClaimPayoutSigner::<2, 4>::assert_connector_is_spendable(ClaimPayoutSpendPath::Payout);
     }
 
     #[test]
-    fn admin_burn_spend() {
-        ClaimPayoutSigner::assert_connector_is_spendable(ClaimPayoutSpendPath::AdminBurn);
+    fn admin_burn_spend_1_of_1() {
+        ClaimPayoutSigner::<1, 1>::assert_connector_is_spendable(ClaimPayoutSpendPath::AdminBurn);
+    }
+
+    #[test]
+    fn admin_burn_spend_1_of_3() {
+        ClaimPayoutSigner::<1, 3>::assert_connector_is_spendable(ClaimPayoutSpendPath::AdminBurn);
+    }
+
+    #[test]
+    fn admin_burn_spend_2_of_3() {
+        ClaimPayoutSigner::<2, 3>::assert_connector_is_spendable(ClaimPayoutSpendPath::AdminBurn);
+    }
+
+    #[test]
+    fn admin_burn_spend_3_of_3() {
+        ClaimPayoutSigner::<3, 3>::assert_connector_is_spendable(ClaimPayoutSpendPath::AdminBurn);
+    }
+
+    #[test]
+    fn admin_burn_witness_truncates_surplus_indexed_signatures() {
+        let signer = ClaimPayoutSigner::<2, 3>::generate();
+        let connector = signer.get_connector();
+        let signature_0 =
+            schnorr::Signature::from_slice(&[0xAA; 64]).expect("signature length is valid");
+        let signature_1 =
+            schnorr::Signature::from_slice(&[0xBB; 64]).expect("signature length is valid");
+        let signature_2 =
+            schnorr::Signature::from_slice(&[0xCC; 64]).expect("signature length is valid");
+        let witness = ClaimPayoutWitness::AdminBurn {
+            admin_signatures: vec![
+                AdminSignature {
+                    pubkey_index: 0,
+                    signature: signature_0,
+                },
+                AdminSignature {
+                    pubkey_index: 2,
+                    signature: signature_2,
+                },
+                AdminSignature {
+                    pubkey_index: 1,
+                    signature: signature_1,
+                },
+            ],
+        };
+
+        let TaprootWitness::Script { script_inputs, .. } = connector.get_taproot_witness(&witness)
+        else {
+            panic!("admin burn is a script-path spend");
+        };
+
+        assert_eq!(
+            script_inputs,
+            vec![
+                Vec::new(),
+                signature_1.serialize().to_vec(),
+                signature_0.serialize().to_vec(),
+            ]
+        );
+    }
+
+    #[test]
+    fn admin_burn_witness_ignores_duplicate_indices() {
+        let signer = ClaimPayoutSigner::<2, 3>::generate();
+        let connector = signer.get_connector();
+        let signature_0 =
+            schnorr::Signature::from_slice(&[0xAA; 64]).expect("signature length is valid");
+        let duplicate_signature =
+            schnorr::Signature::from_slice(&[0xBB; 64]).expect("signature length is valid");
+        let signature_2 =
+            schnorr::Signature::from_slice(&[0xCC; 64]).expect("signature length is valid");
+        let witness = ClaimPayoutWitness::AdminBurn {
+            admin_signatures: vec![
+                AdminSignature {
+                    pubkey_index: 0,
+                    signature: signature_0,
+                },
+                AdminSignature {
+                    pubkey_index: 0,
+                    signature: duplicate_signature,
+                },
+                AdminSignature {
+                    pubkey_index: 2,
+                    signature: signature_2,
+                },
+            ],
+        };
+
+        let TaprootWitness::Script { script_inputs, .. } = connector.get_taproot_witness(&witness)
+        else {
+            panic!("admin burn is a script-path spend");
+        };
+
+        assert_eq!(
+            script_inputs,
+            vec![
+                signature_2.serialize().to_vec(),
+                Vec::new(),
+                signature_0.serialize().to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    fn admin_burn_witness_ignores_out_of_bounds_indices() {
+        let signer = ClaimPayoutSigner::<2, 3>::generate();
+        let connector = signer.get_connector();
+        let signature_0 =
+            schnorr::Signature::from_slice(&[0xAA; 64]).expect("signature length is valid");
+        let out_of_bounds_signature =
+            schnorr::Signature::from_slice(&[0xBB; 64]).expect("signature length is valid");
+        let signature_2 =
+            schnorr::Signature::from_slice(&[0xCC; 64]).expect("signature length is valid");
+        let witness = ClaimPayoutWitness::AdminBurn {
+            admin_signatures: vec![
+                AdminSignature {
+                    pubkey_index: 0,
+                    signature: signature_0,
+                },
+                AdminSignature {
+                    pubkey_index: 3,
+                    signature: out_of_bounds_signature,
+                },
+                AdminSignature {
+                    pubkey_index: 2,
+                    signature: signature_2,
+                },
+            ],
+        };
+
+        let TaprootWitness::Script { script_inputs, .. } = connector.get_taproot_witness(&witness)
+        else {
+            panic!("admin burn is a script-path spend");
+        };
+
+        assert_eq!(
+            script_inputs,
+            vec![
+                signature_2.serialize().to_vec(),
+                Vec::new(),
+                signature_0.serialize().to_vec()
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "admin burn requires at least threshold signatures for distinct known admin pubkeys"
+    )]
+    fn admin_burn_witness_rejects_below_threshold_signatures() {
+        let signer = ClaimPayoutSigner::<2, 3>::generate();
+        let connector = signer.get_connector();
+        let signature =
+            schnorr::Signature::from_slice(&[0xAA; 64]).expect("signature length is valid");
+        let duplicate_signature =
+            schnorr::Signature::from_slice(&[0xBB; 64]).expect("signature length is valid");
+        let out_of_bounds_signature =
+            schnorr::Signature::from_slice(&[0xCC; 64]).expect("signature length is valid");
+        let witness = ClaimPayoutWitness::AdminBurn {
+            admin_signatures: vec![
+                AdminSignature {
+                    pubkey_index: 0,
+                    signature,
+                },
+                AdminSignature {
+                    pubkey_index: 0,
+                    signature: duplicate_signature,
+                },
+                AdminSignature {
+                    pubkey_index: 3,
+                    signature: out_of_bounds_signature,
+                },
+            ],
+        };
+
+        connector.get_taproot_witness(&witness);
+    }
+
+    #[test]
+    #[should_panic(expected = "admin multisig pubkeys must be unique")]
+    fn connector_rejects_duplicate_admin_pubkeys() {
+        let n_of_n_keypair = generate_keypair();
+        let admin_keypair = generate_keypair();
+        let admin_pubkey = admin_keypair.x_only_public_key().0;
+
+        ClaimPayoutConnector::new(
+            Network::Regtest,
+            n_of_n_keypair.x_only_public_key().0,
+            vec![admin_pubkey, admin_pubkey],
+            2,
+            sha256::Hash::hash(&random::<[u8; 32]>()),
+        );
     }
 
     #[test]
     fn unstaking_burn_spend() {
-        ClaimPayoutSigner::assert_connector_is_spendable(ClaimPayoutSpendPath::UnstakingBurn);
+        ClaimPayoutSigner::<2, 4>::assert_connector_is_spendable(
+            ClaimPayoutSpendPath::UnstakingBurn,
+        );
     }
 }

--- a/crates/orchestrator/src/testing.rs
+++ b/crates/orchestrator/src/testing.rs
@@ -40,7 +40,7 @@ use strata_bridge_test_utils::{
     bitcoin::generate_xonly_pubkey, bridge_fixtures::TEST_RECOVERY_DELAY, prelude::generate_txid,
 };
 use strata_bridge_tx_graph::{
-    game_graph::ProtocolParams as GameProtocolParams,
+    game_graph::{AdminMultisig, ProtocolParams as GameProtocolParams},
     stake_graph::{ProtocolParams as StakeProtocolParams, StakeGraphSummary},
     transactions::{deposit::DepositTx, prelude::DepositData},
 };
@@ -89,7 +89,10 @@ pub(crate) fn test_graph_sm_cfg() -> Arc<GraphSMCfg> {
             deposit_amount: TEST_DEPOSIT_AMOUNT,
             stake_amount: Amount::from_sat(100_000_000),
         },
-        admin_pubkey: generate_xonly_pubkey(),
+        admin: AdminMultisig {
+            pubkeys: vec![generate_xonly_pubkey()],
+            threshold: 1,
+        },
         operator_fee: TEST_OPERATOR_FEE,
         payout_descs,
         bridge_proof_predicate: PredicateKey::always_accept(),

--- a/crates/primitives/src/scripts/general.rs
+++ b/crates/primitives/src/scripts/general.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use bitcoin::{
     absolute::LockTime,
-    opcodes::all::OP_RETURN,
+    opcodes::all::{OP_CHECKSIG, OP_CHECKSIGADD, OP_EQUAL, OP_RETURN},
     script::{Builder, PushBytesBuf},
     transaction, Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Witness,
 };
@@ -23,6 +23,42 @@ pub fn n_of_n_script(aggregated_pubkey: &XOnlyPublicKey) -> Script {
         { *aggregated_pubkey }
         OP_CHECKSIG
     }
+}
+
+/// Creates a script requiring exactly `threshold` successful signature checks from `pubkeys`.
+///
+/// # Panics
+///
+/// Panics if `pubkeys` is empty, if `threshold` is zero, or if `threshold` exceeds the number of
+/// pubkeys.
+pub fn threshold_multisig_script(pubkeys: &[XOnlyPublicKey], threshold: usize) -> ScriptBuf {
+    assert!(
+        !pubkeys.is_empty(),
+        "threshold multisig requires at least one pubkey"
+    );
+    assert!(
+        threshold > 0,
+        "threshold multisig threshold must be greater than zero"
+    );
+    assert!(
+        threshold <= pubkeys.len(),
+        "threshold multisig threshold must not exceed pubkey count"
+    );
+
+    let mut builder = Builder::new()
+        .push_slice(pubkeys[0].serialize())
+        .push_opcode(OP_CHECKSIG);
+
+    for pubkey in &pubkeys[1..] {
+        builder = builder
+            .push_slice(pubkey.serialize())
+            .push_opcode(OP_CHECKSIGADD);
+    }
+
+    builder
+        .push_int(threshold.try_into().expect("threshold must fit in i64"))
+        .push_opcode(OP_EQUAL)
+        .into_script()
 }
 
 /// Creates a "take back" script that is used to validate a deposit request transaction (DRT) given
@@ -143,6 +179,26 @@ mod tests {
     use secp256k1::{generate_keypair, rand::rngs::OsRng, Message, SECP256K1};
 
     use super::*;
+
+    #[test]
+    fn threshold_multisig_script_matches_spec_shape() {
+        let pubkeys = (0..3)
+            .map(|_| generate_keypair(&mut OsRng).1.x_only_public_key().0)
+            .collect::<Vec<_>>();
+
+        let expected = Builder::new()
+            .push_slice(pubkeys[0].serialize())
+            .push_opcode(OP_CHECKSIG)
+            .push_slice(pubkeys[1].serialize())
+            .push_opcode(OP_CHECKSIGADD)
+            .push_slice(pubkeys[2].serialize())
+            .push_opcode(OP_CHECKSIGADD)
+            .push_int(2)
+            .push_opcode(OP_EQUAL)
+            .into_script();
+
+        assert_eq!(threshold_multisig_script(&pubkeys, 2), expected);
+    }
 
     #[test]
     fn test_agg_pubkey_single() {

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -428,7 +428,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        game_graph::{DepositParams, GameData, GameGraph, KeyData, ProtocolParams, SetupParams},
+        game_graph::{
+            AdminMultisig, DepositParams, GameData, GameGraph, KeyData, ProtocolParams, SetupParams,
+        },
         stake_graph::{
             ProtocolParams as StakeProtocolParams, SetupParams as StakeSetupParams, StakeData,
             StakeGraph,
@@ -515,7 +517,10 @@ mod tests {
                 .take(n_wt)
                 .map(|k| k.x_only_public_key().0)
                 .collect(),
-            admin_pubkey: signer.admin.x_only_public_key().0,
+            admin: AdminMultisig {
+                pubkeys: vec![signer.admin.x_only_public_key().0],
+                threshold: 1,
+            },
             unstaking_image: sha256::Hash::hash(&signer.unstaking_preimage),
             wt_fault_pubkeys: signer
                 .wt_faults

--- a/crates/tx-graph/src/game_graph.rs
+++ b/crates/tx-graph/src/game_graph.rs
@@ -97,8 +97,8 @@ pub struct KeyData {
     pub operator_adaptor_pubkeys: Vec<XOnlyPublicKey>,
     /// For each watchtower, a key to authorize the contest.
     pub watchtower_pubkeys: Vec<XOnlyPublicKey>,
-    /// Admin key.
-    pub admin_pubkey: XOnlyPublicKey,
+    /// Admin multisig used to block payouts.
+    pub admin: AdminMultisig,
     /// Unstaking hash image.
     pub unstaking_image: sha256::Hash,
     /// For each watchtower, a fault key from Mosaic.
@@ -107,6 +107,15 @@ pub struct KeyData {
     pub operator_descriptor: Descriptor,
     /// For each watchtower, a descriptor where to receive the slashed stake.
     pub slash_watchtower_descriptors: Vec<Descriptor>,
+}
+
+/// Admin threshold multisig that can block payouts.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AdminMultisig {
+    /// Public keys participating in the admin multisig.
+    pub pubkeys: Vec<XOnlyPublicKey>,
+    /// Number of signatures required to spend the admin path.
+    pub threshold: usize,
 }
 
 /// Parameters that are inherent from the protocol.
@@ -232,6 +241,9 @@ impl GameGraph {
     /// - The number of watchtower slash descriptors.
     ///
     /// This method panics if the number of watchtowers is greater than [`u32::MAX`].
+    ///
+    /// This method panics if the configured admin multisig has no pubkeys, a zero threshold, or a
+    /// threshold greater than the number of admin pubkeys.
     pub fn new(data: GameData) -> (Self, GameConnectors) {
         let protocol = data.protocol;
         let setup = data.setup;
@@ -262,7 +274,7 @@ impl GameGraph {
         let claim = ClaimTx::new(
             claim_data,
             connectors.claim_contest.clone(),
-            connectors.claim_payout,
+            connectors.claim_payout.clone(),
             keys.operator_pubkey,
         );
 
@@ -274,7 +286,7 @@ impl GameGraph {
             uncontested_payout_data,
             connectors.deposit,
             connectors.claim_contest.clone(),
-            connectors.claim_payout,
+            connectors.claim_payout.clone(),
             &keys.operator_descriptor,
         );
 
@@ -353,7 +365,7 @@ impl GameGraph {
         let contested_payout = ContestedPayoutTx::new(
             contested_payout_data,
             connectors.deposit,
-            connectors.claim_payout,
+            connectors.claim_payout.clone(),
             connectors.contest_payout,
             connectors.contest_slash,
             &keys.operator_descriptor,
@@ -511,6 +523,9 @@ impl GameConnectors {
     /// - The number of watchtower slash descriptors.
     ///
     /// This method also panics if the number of watchtowers is greater than [`u32::MAX`].
+    ///
+    /// This method panics if the configured admin multisig has no pubkeys, a zero threshold, or a
+    /// threshold greater than the number of admin pubkeys.
     pub fn new(game_index: NonZero<u32>, protocol: &ProtocolParams, setup: &SetupParams) -> Self {
         let keys = &setup.keys;
 
@@ -544,7 +559,8 @@ impl GameConnectors {
         let claim_payout = ClaimPayoutConnector::new(
             protocol.network,
             keys.n_of_n_pubkey,
-            keys.admin_pubkey,
+            keys.admin.pubkeys.clone(),
+            keys.admin.threshold,
             keys.unstaking_image,
         );
         let deposit = NOfNConnector::new(
@@ -624,7 +640,9 @@ mod tests {
     use bitcoin::{hashes::Hash, transaction::Version, TxOut};
     use secp256k1::{rand::random, Keypair, SECP256K1};
     use strata_bridge_connectors::{
-        prelude::ContestCounterproofWitness, test_utils::BitcoinNode, Connector,
+        prelude::{AdminSignature, ContestCounterproofWitness},
+        test_utils::BitcoinNode,
+        Connector,
     };
     use strata_bridge_primitives::scripts::prelude::{create_tx, create_tx_ins};
     use strata_bridge_test_utils::prelude::generate_keypair;
@@ -648,13 +666,15 @@ mod tests {
     const DEPOSIT_AMOUNT: Amount = Amount::from_sat(100_000_000);
     const STAKE_AMOUNT: Amount = Amount::from_sat(100_000_000);
     const FEE: Amount = Amount::from_sat(1_000);
+    const N_ADMINS: usize = 4;
+    const ADMIN_THRESHOLD: usize = 2;
 
     #[derive(Debug)]
     struct Signer {
         pub n_of_n_keypair: Keypair,
         pub operator_keypair: Keypair,
         pub watchtower_keypairs: Vec<Keypair>,
-        pub admin_keypair: Keypair,
+        pub admin_keypairs: Vec<Keypair>,
         pub unstaking_preimage: [u8; 32],
         pub wt_fault_keypairs: Vec<Keypair>,
     }
@@ -665,7 +685,7 @@ mod tests {
                 n_of_n_keypair: generate_keypair(),
                 operator_keypair: generate_keypair(),
                 watchtower_keypairs: (0..N_WATCHTOWERS).map(|_| generate_keypair()).collect(),
-                admin_keypair: generate_keypair(),
+                admin_keypairs: (0..N_ADMINS).map(|_| generate_keypair()).collect(),
                 unstaking_preimage: random(),
                 wt_fault_keypairs: (0..N_WATCHTOWERS).map(|_| generate_keypair()).collect(),
             }
@@ -696,7 +716,14 @@ mod tests {
                 .iter()
                 .map(|k| k.x_only_public_key().0)
                 .collect(),
-            admin_pubkey: signer.admin_keypair.x_only_public_key().0,
+            admin: AdminMultisig {
+                pubkeys: signer
+                    .admin_keypairs
+                    .iter()
+                    .map(|k| k.x_only_public_key().0)
+                    .collect(),
+                threshold: ADMIN_THRESHOLD,
+            },
             unstaking_image: sha256::Hash::hash(&signer.unstaking_preimage),
             wt_fault_pubkeys: signer
                 .wt_fault_keypairs
@@ -725,7 +752,8 @@ mod tests {
         let claim_payout_connector = ClaimPayoutConnector::new(
             protocol.network,
             keys.n_of_n_pubkey,
-            keys.admin_pubkey,
+            keys.admin.pubkeys.clone(),
+            keys.admin.threshold,
             keys.unstaking_image,
         );
         let claim_funds_amount =
@@ -886,10 +914,18 @@ mod tests {
                 script_pubkey: node.wallet_address().script_pubkey(),
             });
 
-            let admin_signature = admin_burn
-                .signing_info_partial()
-                .sign(&signer.admin_keypair);
-            let admin_burn = admin_burn.finalize_partial(admin_signature);
+            let signing_info = admin_burn.signing_info_partial();
+            let admin_signatures = signer
+                .admin_keypairs
+                .iter()
+                .enumerate()
+                .take(ADMIN_THRESHOLD)
+                .map(|(pubkey_index, keypair)| AdminSignature {
+                    pubkey_index,
+                    signature: signing_info.sign(keypair),
+                })
+                .collect();
+            let admin_burn = admin_burn.finalize_partial(admin_signatures);
             assert_eq!(admin_burn.version, Version(3));
 
             node.sign_and_broadcast(&admin_burn);

--- a/crates/tx-graph/src/transactions/not_presigned.rs
+++ b/crates/tx-graph/src/transactions/not_presigned.rs
@@ -16,8 +16,8 @@ use bitcoin::{
 use secp256k1::schnorr;
 use strata_bridge_connectors::{
     prelude::{
-        ClaimPayoutConnector, ClaimPayoutSpendPath, ClaimPayoutWitness, CounterproofConnector,
-        TimelockedSpendPath, TimelockedWitness,
+        AdminSignature, ClaimPayoutConnector, ClaimPayoutSpendPath, ClaimPayoutWitness,
+        CounterproofConnector, TimelockedSpendPath, TimelockedWitness,
     },
     Connector, SigningInfo,
 };
@@ -169,13 +169,19 @@ impl AdminBurnTx {
     /// Finalizes the first transaction input and returns the resulting bitcoin transaction.
     ///
     /// The remaining inputs must be manually signed.
-    pub fn finalize_partial(self, admin_signature: schnorr::Signature) -> Transaction {
+    ///
+    /// # Panics
+    ///
+    /// Panics if fewer than the admin threshold signatures for distinct known admin pubkeys remain
+    /// after unknown or repeated pubkey indices are ignored, or if the underlying PSBT cannot be
+    /// built or extracted.
+    pub fn finalize_partial(self, admin_signatures: Vec<AdminSignature>) -> Transaction {
         let mut psbt = Psbt::from_unsigned_tx(self.tx).expect("witness should be empty");
         for (input, utxo) in psbt.inputs.iter_mut().zip(self.prevouts) {
             input.witness_utxo = Some(utxo);
         }
 
-        let witness = ClaimPayoutWitness::AdminBurn { admin_signature };
+        let witness = ClaimPayoutWitness::AdminBurn { admin_signatures };
         self.connector.finalize_input(&mut psbt.inputs[0], &witness);
 
         psbt.extract_tx().expect("should be able to extract tx")

--- a/docker/vol/strata-bridge-1/params.toml
+++ b/docker/vol/strata-bridge-1/params.toml
@@ -2,7 +2,14 @@ network = "regtest"
 genesis_height = 101
 
 [keys]
-admin = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"
+
+[keys.admin]
+pubkeys = [
+  "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d",
+  "1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4",
+  "a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba",
+]
+threshold = 2
 
 [[keys.covenant]]
 musig2 = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"

--- a/docker/vol/strata-bridge-2/params.toml
+++ b/docker/vol/strata-bridge-2/params.toml
@@ -2,7 +2,14 @@ network = "regtest"
 genesis_height = 101
 
 [keys]
-admin = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"
+
+[keys.admin]
+pubkeys = [
+  "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d",
+  "1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4",
+  "a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba",
+]
+threshold = 2
 
 [[keys.covenant]]
 musig2 = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"

--- a/docker/vol/strata-bridge-3/params.toml
+++ b/docker/vol/strata-bridge-3/params.toml
@@ -2,7 +2,14 @@ network = "regtest"
 genesis_height = 101
 
 [keys]
-admin = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"
+
+[keys.admin]
+pubkeys = [
+  "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d",
+  "1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4",
+  "a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba",
+]
+threshold = 2
 
 [[keys.covenant]]
 musig2 = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"

--- a/functional-tests/factory/bridge_operator/params_cfg.py
+++ b/functional-tests/factory/bridge_operator/params_cfg.py
@@ -19,8 +19,14 @@ class CovenantKeys:
 
 
 @dataclass
+class Admin:
+    pubkeys: list[str]
+    threshold: int
+
+
+@dataclass
 class Keys:
-    admin: str
+    admin: Admin
     covenant: list[CovenantKeys]
 
 

--- a/functional-tests/factory/bridge_operator/utils.py
+++ b/functional-tests/factory/bridge_operator/utils.py
@@ -29,7 +29,7 @@ from .config_cfg import (
     RpcConfig,
     SecretServiceClientConfig,
 )
-from .params_cfg import BridgeOperatorParams, BridgeProtocolParams, CovenantKeys, Keys
+from .params_cfg import Admin, BridgeOperatorParams, BridgeProtocolParams, CovenantKeys, Keys
 
 DEFAULT_INITIAL_HEARBEAT_DELAY_SECS = 10
 
@@ -225,6 +225,7 @@ def generate_params_toml(
         )
         for key in operator_key_infos
     ]
+    admin_pubkeys = [key.MUSIG2_KEY for key in operator_key_infos]
 
     # Resolve the predicate from the active backend unless the test pinned one explicitly.
     protocol = bridge_protocol_params
@@ -236,7 +237,10 @@ def generate_params_toml(
     params = BridgeOperatorParams(
         network="regtest",
         genesis_height=genesis_height,
-        keys=Keys(admin=operator_key_infos[0].MUSIG2_KEY, covenant=covenant),
+        keys=Keys(
+            admin=Admin(pubkeys=admin_pubkeys, threshold=min(2, len(admin_pubkeys))),
+            covenant=covenant,
+        ),
         protocol=protocol,
     )
 

--- a/functional-tests/utils/dev_cli.py
+++ b/functional-tests/utils/dev_cli.py
@@ -6,6 +6,7 @@ from dataclasses import asdict
 import toml
 
 from factory.bridge_operator.params_cfg import (
+    Admin,
     BridgeOperatorParams,
     BridgeProtocolParams,
     CovenantKeys,
@@ -45,12 +46,14 @@ class DevCli:
             )
             for key in self.operator_key_infos
         ]
+        # use the operator keys as the admin keys for simplicity
+        admin_pubkeys = [key.MUSIG2_KEY for key in self.operator_key_infos]
 
         params = BridgeOperatorParams(
             network="regtest",
             genesis_height=DEFAULT_GENESIS_HEIGHT,
             keys=Keys(
-                admin=self.operator_key_infos[0].MUSIG2_KEY,
+                admin=Admin(pubkeys=admin_pubkeys, threshold=min(2, len(admin_pubkeys))),
                 covenant=covenant,
             ),
             protocol=p,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR updates the locking script for the `Admin` path in the `ClaimPayoutConnector` to use a threshold multisig instead of a taproot key. The params have been updated to expect a list of (schnorr) pubkeys and a threshold value.

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

The [spec](https://app.notion.com/p/Transaction-Graph-v1-2b5901ba000f8039911ced4295ae9248?source=copy_link#2bd901ba000f8065aafdfbd1a22f8216).

The API is designed to panic if the threshold value exists the total size of the set or is set to zero. This should be fine as these values are all set once at setup time.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3805