### PR TITLE
add a _deposit confirmed_ log for all nodes

### DIFF
--- a/crates/bridge-sm/src/deposit/transitions/deposit.rs
+++ b/crates/bridge-sm/src/deposit/transitions/deposit.rs
@@ -455,11 +455,10 @@ impl DepositSM {
                 ..
             } => {
                 let expected_txid = deposit_transaction.as_ref().compute_txid();
-                
+
                 // Ensure that the deposit transaction confirmed on-chain is the one we were
                 // expecting.
-                if confirmed.deposit_transaction.compute_txid() != expected_txid
-                {
+                if confirmed.deposit_transaction.compute_txid() != expected_txid {
                     return Err(DSMError::rejected(
                         self.state().clone(),
                         confirmed.into(),

--- a/crates/bridge-sm/src/deposit/transitions/deposit.rs
+++ b/crates/bridge-sm/src/deposit/transitions/deposit.rs
@@ -454,10 +454,11 @@ impl DepositSM {
                 deposit_transaction,
                 ..
             } => {
+                let expected_txid = deposit_transaction.as_ref().compute_txid();
+                
                 // Ensure that the deposit transaction confirmed on-chain is the one we were
                 // expecting.
-                if confirmed.deposit_transaction.compute_txid()
-                    != deposit_transaction.as_ref().compute_txid()
+                if confirmed.deposit_transaction.compute_txid() != expected_txid
                 {
                     return Err(DSMError::rejected(
                         self.state().clone(),
@@ -465,6 +466,11 @@ impl DepositSM {
                         "Transaction confirmed on chain does not match expected deposit transaction",
                     ));
                 }
+
+                info!(
+                    txid=%expected_txid,
+                    "Deposit transaction confirmed on chain",
+                );
                 // Transition to the Deposited State
                 self.state = DepositState::Deposited {
                     last_block_height: *last_block_height,


### PR DESCRIPTION
## Description

Adding verbosity in `DepositState::DepositNoncesCollected` to reflect that the node is aware that the deposit tx is confirmed on chain.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
