### PR TITLE
fix(btc-tracker): realign block cursor after reorg

### DIFF
--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -112,6 +112,22 @@ where
         return Vec::new();
     }
 
+    if let Some(next_expected_height) = sm.next_expected_block_height() {
+        if next_expected_height != *cursor {
+            warn!(
+                cursor = %*cursor,
+                %next_expected_height,
+                "block cursor diverged from state machine tip, realigning cursor"
+            );
+            *cursor = next_expected_height;
+        }
+    }
+
+    if received_height < *cursor {
+        warn!(%received_height, cursor = %*cursor, "received block is behind cursor, skipping block");
+        return Vec::new();
+    }
+
     debug!("received block at height {received_height}, expected {cursor}");
 
     // Backfill any skipped blocks in the range:
@@ -161,6 +177,19 @@ async fn process_connected_block(
     sm: &mut BtcNotifySM,
     block_subs: &Arc<Mutex<Vec<mpsc::UnboundedSender<BlockEvent>>>>,
 ) -> Vec<TxEvent> {
+    let height = block.bip34_block_height().unwrap_or(0);
+    let block_hash = block.block_hash();
+
+    if !sm.can_connect_block(&block) {
+        warn!(
+            %height,
+            %block_hash,
+            cursor = %*cursor,
+            "block does not connect to state machine tip, leaving cursor unchanged"
+        );
+        return Vec::new();
+    }
+
     // First send the block to the block subscribers.
     // if the receiver has been dropped, we remove it from the
     // subscription list.
@@ -188,8 +217,7 @@ async fn process_connected_block(
             .retain(|sub| sub.send(block_event.clone()).is_ok())
     }
 
-    // increment the cursor with every block that is processed
-    *cursor += 1;
+    *cursor = height.saturating_add(1);
 
     tx_events
 }

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -502,9 +502,154 @@ impl<State> BtcNotifyClient<State> {
 }
 
 #[cfg(test)]
-mod e2e_tests {
-    use std::{path::PathBuf, task::Poll};
+mod tests {
+    use std::{
+        collections::{BTreeMap, VecDeque},
+        sync::{Arc, Mutex as StdMutex},
+    };
 
+    use bitcoin::{
+        absolute::LockTime, block, hashes::Hash, script::Builder, transaction, Amount, BlockHash,
+        CompactTarget, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    };
+    use bitcoincore_zmq::SequenceMessage;
+
+    use super::*;
+    use crate::{constants::DEFAULT_BURY_DEPTH, event::BlockStatus};
+
+    #[derive(Clone)]
+    struct StaticFetcher {
+        blocks: Arc<BTreeMap<u64, Block>>,
+        fetched_heights: Arc<StdMutex<Vec<u64>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl BlockFetcher for StaticFetcher {
+        type Error = String;
+
+        async fn fetch_block(&self, height: u64) -> Result<Block, Self::Error> {
+            self.fetched_heights.lock().unwrap().push(height);
+            self.blocks
+                .get(&height)
+                .cloned()
+                .ok_or_else(|| format!("missing block at height {height}"))
+        }
+    }
+
+    fn test_block(height: u64, prev_blockhash: BlockHash, nonce: u32) -> Block {
+        let coinbase = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::null(),
+                script_sig: Builder::new().push_int(height as i64).into_script(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::ZERO,
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+
+        let header = block::Header {
+            version: block::Version::TWO,
+            prev_blockhash,
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: height as u32,
+            bits: CompactTarget::from_consensus(u32::MAX),
+            nonce,
+        };
+        let mut block = Block {
+            header,
+            txdata: vec![coinbase],
+        };
+        block.header.merkle_root = block.compute_merkle_root().unwrap();
+        block
+    }
+
+    #[tokio::test]
+    async fn backfills_missing_block_after_reorg_disconnect_rolls_back_state_tip() {
+        const BASE_HEIGHT: u64 = 18;
+        let base = test_block(BASE_HEIGHT, BlockHash::all_zeros(), 1);
+        let stale_child = test_block(BASE_HEIGHT + 1, base.block_hash(), 2);
+        let canonical_child = test_block(BASE_HEIGHT + 1, base.block_hash(), 3);
+        let canonical_grandchild = test_block(BASE_HEIGHT + 2, canonical_child.block_hash(), 4);
+
+        let mut fetchable_blocks = BTreeMap::new();
+        fetchable_blocks.insert(BASE_HEIGHT + 1, canonical_child.clone());
+        let fetched_heights = Arc::new(StdMutex::new(Vec::new()));
+        let fetcher = Arc::new(StaticFetcher {
+            blocks: Arc::new(fetchable_blocks),
+            fetched_heights: fetched_heights.clone(),
+        });
+
+        let mut sm = BtcNotifySM::init(DEFAULT_BURY_DEPTH, VecDeque::new());
+        let block_subs = Arc::new(Mutex::new(Vec::new()));
+        let mut cursor = BASE_HEIGHT;
+
+        process_block_message(
+            base,
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+        assert_eq!(cursor, BASE_HEIGHT + 1);
+
+        process_block_message(
+            stale_child.clone(),
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+        assert_eq!(cursor, BASE_HEIGHT + 2);
+
+        let (_tx_events, disconnected) = sm.process_sequence(SequenceMessage::BlockDisconnect {
+            blockhash: stale_child.block_hash(),
+        });
+        assert_eq!(
+            disconnected.map(|event| event.status),
+            Some(BlockStatus::Uncled)
+        );
+        assert_eq!(cursor, BASE_HEIGHT + 2);
+
+        sm.process_sequence(SequenceMessage::BlockConnect {
+            blockhash: canonical_child.block_hash(),
+        });
+        sm.process_sequence(SequenceMessage::BlockConnect {
+            blockhash: canonical_grandchild.block_hash(),
+        });
+
+        process_block_message(
+            canonical_grandchild,
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+
+        assert_eq!(
+            *fetched_heights.lock().unwrap(),
+            vec![BASE_HEIGHT + 1],
+            "canonical child must be backfilled after the disconnect rolled back the state tip"
+        );
+        assert_eq!(cursor, BASE_HEIGHT + 3);
+    }
+}
+
+#[cfg(test)]
+mod e2e_tests {
+    use std::{path::PathBuf, sync::Mutex as StdMutex, task::Poll};
+
+    use bitcoincore_zmq::SequenceMessage;
     use corepc_node::{client::client_sync::Auth, serde_json::json};
     use proptest::prelude::*;
     use serial_test::serial;
@@ -639,6 +784,145 @@ mod e2e_tests {
             .await?;
 
         Ok((client_1, client_2, bitcoind))
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn chain_reorg_backfills_replacement_parent_before_later_child(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        logging::init_from_env("btc-tracker");
+
+        struct RecordingFetcher {
+            client: corepc_node::Client,
+            fetched_heights: Arc<StdMutex<Vec<u64>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl BlockFetcher for RecordingFetcher {
+            type Error = String;
+
+            async fn fetch_block(&self, height: u64) -> Result<Block, Self::Error> {
+                self.fetched_heights.lock().unwrap().push(height);
+
+                let hash = self
+                    .client
+                    .get_block_hash(height)
+                    .map_err(|e| e.to_string())?
+                    .block_hash()
+                    .expect("must be valid hash");
+
+                self.client.get_block(hash).map_err(|e| e.to_string())
+            }
+        }
+
+        let (cfg, bitcoind) = setup_node().await?;
+        let base_height = bitcoind.client.get_block_count()?.0;
+        let base_hash = bitcoind
+            .client
+            .get_block_hash(base_height)?
+            .block_hash()
+            .expect("must be valid hash");
+        let base = bitcoind.client.get_block(base_hash)?;
+
+        let fetched_heights = Arc::new(StdMutex::new(Vec::new()));
+        let fetcher = Arc::new(RecordingFetcher {
+            client: corepc_node::Client::new_with_auth(
+                &bitcoind.rpc_url(),
+                Auth::CookieFile(bitcoind.params.cookie_file.clone()),
+            )?,
+            fetched_heights: fetched_heights.clone(),
+        });
+        let block_subs = Arc::new(Mutex::new(Vec::new()));
+        let mut sm = BtcNotifySM::init(cfg.bury_depth, VecDeque::new());
+        let mut cursor = base_height;
+
+        process_block_message(
+            base,
+            &mut cursor,
+            base_height,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+        assert_eq!(cursor, base_height + 1);
+
+        let stale_hash = bitcoind
+            .client
+            .generate_to_address(1, &bitcoind.client.new_address()?)?
+            .into_model()?
+            .0
+            .remove(0);
+        let stale = bitcoind.client.get_block(stale_hash)?;
+
+        process_block_message(
+            stale,
+            &mut cursor,
+            base_height,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+        assert_eq!(cursor, base_height + 2);
+
+        let backfilled_block_height = base_height + 1;
+        bitcoind
+            .client
+            .call::<()>("invalidateblock", &[json!(stale_hash.to_string())])?;
+        assert_eq!(
+            bitcoind.client.get_block_count()?.0,
+            base_height,
+            "chain must be back to base height"
+        );
+
+        let (_tx_events, disconnected) = sm.process_sequence(SequenceMessage::BlockDisconnect {
+            blockhash: stale_hash,
+        });
+        assert_eq!(
+            disconnected.map(|event| event.status),
+            Some(BlockStatus::Uncled)
+        );
+        assert_eq!(
+            cursor,
+            base_height + 2,
+            "cursor must not move on disconnect"
+        );
+
+        let mut canonical_hashes = bitcoind
+            .client
+            .generate_to_address(2, &bitcoind.client.new_address()?)?
+            .into_model()?
+            .0;
+        let canonical_child_hash = canonical_hashes.remove(0);
+        let canonical_grandchild_hash = canonical_hashes.remove(0);
+        let canonical_grandchild = bitcoind.client.get_block(canonical_grandchild_hash)?;
+
+        sm.process_sequence(SequenceMessage::BlockConnect {
+            blockhash: canonical_child_hash,
+        });
+        sm.process_sequence(SequenceMessage::BlockConnect {
+            blockhash: canonical_grandchild_hash,
+        });
+
+        process_block_message(
+            canonical_grandchild,
+            &mut cursor,
+            base_height,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+
+        assert_eq!(
+            *fetched_heights.lock().unwrap(),
+            vec![backfilled_block_height],
+            "the replacement parent must be backfilled before the later child is processed"
+        );
+        assert_eq!(cursor, base_height + 3);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -89,6 +89,111 @@ pub trait BlockFetcher {
     async fn fetch_block(&self, height: u64) -> Result<Block, Self::Error>;
 }
 
+/// Handles a `rawblock` ZMQ message and returns transaction events produced by it.
+///
+/// The handler enforces the configured start height, backfills any height gap before the received
+/// block, and then processes the resulting contiguous block list in order. `cursor` is advanced by
+/// the lower-level block processor for each block that is accepted.
+async fn process_block_message<F>(
+    block: Block,
+    cursor: &mut u64,
+    start_height: u64,
+    sm: &mut BtcNotifySM,
+    fetcher: &Arc<F>,
+    block_subs: &Arc<Mutex<Vec<mpsc::UnboundedSender<BlockEvent>>>>,
+) -> Vec<TxEvent>
+where
+    F: BlockFetcher + Send + Sync + 'static,
+    <F as BlockFetcher>::Error: std::fmt::Debug + Send,
+{
+    let received_height = block.bip34_block_height().unwrap_or(0);
+    if start_height > received_height {
+        warn!(%received_height, %start_height, "start height is in the future, skipping block");
+        return Vec::new();
+    }
+
+    debug!("received block at height {received_height}, expected {cursor}");
+
+    // Backfill any skipped blocks in the range:
+    // [cursor, received_height).
+    // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2680>
+    // Process massive backlogs in bounded batches instead of all
+    // at once to avoid excessive memory use after prolonged
+    // downtime.
+    let mut blocks = match join_all((*cursor..received_height).map(|height| {
+        debug!(%height, "fetching lagged block");
+        let fetcher = fetcher.clone();
+        async move { fetcher.fetch_block(height).await }
+    }))
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(skipped_blocks) => skipped_blocks,
+        Err(e) => {
+            error!(?e, "failed to backfill lagged blocks");
+            // if we can't fetch any of the skipped blocks,
+            // then we wait for the next ZMQ event and try
+            // again since returning intermediate/broken stream
+            // of blocks may introduce unpredictable weirdness.
+            return Vec::new();
+        }
+    };
+
+    blocks.push(block); // add the one from ZMQ
+
+    let mut all_tx_events = Vec::new();
+    for block in blocks {
+        all_tx_events.extend(process_connected_block(block, cursor, sm, block_subs).await);
+    }
+
+    all_tx_events
+}
+
+/// Applies one block to subscribers and the state machine.
+///
+/// The block is announced as mined, processed for transaction state transitions, and any resulting
+/// block event is forwarded to block subscribers. On success the cursor is moved past the processed
+/// block and the transaction diff is returned to the caller.
+async fn process_connected_block(
+    block: Block,
+    cursor: &mut u64,
+    sm: &mut BtcNotifySM,
+    block_subs: &Arc<Mutex<Vec<mpsc::UnboundedSender<BlockEvent>>>>,
+) -> Vec<TxEvent> {
+    // First send the block to the block subscribers.
+    // if the receiver has been dropped, we remove it from the
+    // subscription list.
+    block_subs.lock().await.retain(|sub| {
+        sub.send(BlockEvent {
+            block: block.clone(),
+            status: BlockStatus::Mined,
+        })
+        .is_ok()
+    });
+
+    // Now we process the block to understand what the relevant
+    // transaction diff is.
+    trace!(?block, "processing block");
+    let height_string = block
+        .bip34_block_height()
+        .map_or_else(|_| "UNKNOWN".to_string(), |h| h.to_string());
+    info!(block_height=%height_string, block_hash=%block.block_hash(), "processing block");
+    let (tx_events, block_event) = sm.process_block(block);
+
+    if let Some(block_event) = block_event {
+        block_subs
+            .lock()
+            .await
+            .retain(|sub| sub.send(block_event.clone()).is_ok())
+    }
+
+    // increment the cursor with every block that is processed
+    *cursor += 1;
+
+    tx_events
+}
+
 // Implementation for Disconnected state
 impl BtcNotifyClient<Disconnected> {
     /// Creates a new disconnected client.
@@ -221,80 +326,15 @@ impl BtcNotifyClient<Disconnected> {
                                 Message::Block(block, _) => {
                                     trace!(%topic, "received event");
 
-                                    let received_height = block.bip34_block_height().unwrap_or(0);
-                                    if start_height > received_height {
-                                        warn!(%received_height, %start_height, "start height is in the future, skipping block");
-                                        continue;
-                                    }
-
-                                    debug!("received block at height {received_height}, expected {cursor}");
-
-                                    // Backfill any skipped blocks in the range:
-                                    // [cursor, received_height).
-                                    // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2680>
-                                    // Process massive backlogs in bounded batches instead of all
-                                    // at once to avoid excessive memory use after prolonged
-                                    // downtime.
-                                    let mut blocks =
-                                        match join_all((cursor..received_height).map(|height| {
-                                            debug!(%height, "fetching lagged block");
-                                            let fetcher = fetcher.clone();
-                                            async move { fetcher.fetch_block(height).await }
-                                        }))
-                                        .await
-                                        .into_iter()
-                                        .collect::<Result<Vec<_>, _>>()
-                                        {
-                                            Ok(skipped_blocks) => skipped_blocks,
-                                            Err(e) => {
-                                                error!(?e, "failed to backfill lagged blocks");
-                                                // if we can't fetch any of the skipped blocks,
-                                                // then we wait for the next ZMQ event and try
-                                                // again since returning intermediate/broken stream
-                                                // of blocks may introduce unpredictable weirdness.
-                                                continue;
-                                            }
-                                        };
-
-                                    blocks.push(block); // add the one from ZMQ
-
-                                    let mut all_tx_events = Vec::new();
-                                    for block in blocks {
-                                        // First send the block to the block subscribers.
-                                        // if the receiver has been dropped, we remove it from the
-                                        // subscription list.
-                                        block_subs_thread.lock().await.retain(|sub| {
-                                            sub.send(BlockEvent {
-                                                block: block.clone(),
-                                                status: BlockStatus::Mined,
-                                            })
-                                            .is_ok()
-                                        });
-
-                                        // Now we process the block to understand what the relevant
-                                        // transaction diff is.
-                                        trace!(?block, "processing block");
-                                        let height_string = block.bip34_block_height().map_or_else(
-                                            |_| "UNKNOWN".to_string(),
-                                            |h| h.to_string(),
-                                        );
-                                        info!(block_height=%height_string, block_hash=%block.block_hash(), "processing block");
-                                        let (tx_events, block_event) = sm.process_block(block);
-
-                                        if let Some(block_event) = block_event {
-                                            block_subs_thread
-                                                .lock()
-                                                .await
-                                                .retain(|sub| sub.send(block_event.clone()).is_ok())
-                                        }
-
-                                        all_tx_events.extend(tx_events);
-
-                                        // increment the cursor with every block that is processed
-                                        cursor += 1;
-                                    }
-
-                                    all_tx_events
+                                    process_block_message(
+                                        block,
+                                        &mut cursor,
+                                        start_height,
+                                        &mut sm,
+                                        &fetcher,
+                                        &block_subs_thread,
+                                    )
+                                    .await
                                 }
                                 Message::Tx(tx, _) => {
                                     trace!(%topic, "received event");

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -106,7 +106,15 @@ where
     F: BlockFetcher + Send + Sync + 'static,
     <F as BlockFetcher>::Error: std::fmt::Debug + Send,
 {
-    let received_height = block.bip34_block_height().unwrap_or(0);
+    let received_height = match block.bip34_block_height() {
+        Ok(block_height) => block_height,
+        Err(e) => {
+            error!(?e, block_hash = %block.block_hash(),
+                "could not determine block height, skipping block");
+            return Vec::new();
+        }
+    };
+
     if start_height > received_height {
         warn!(%received_height, %start_height, "start height is in the future, skipping block");
         return Vec::new();

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -113,13 +113,16 @@ where
     }
 
     if let Some(next_expected_height) = sm.next_expected_block_height() {
-        if next_expected_height != *cursor {
+        let realigned_cursor = next_expected_height.max(start_height);
+        if realigned_cursor != *cursor {
             warn!(
                 cursor = %*cursor,
                 %next_expected_height,
+                %start_height,
+                %realigned_cursor,
                 "block cursor diverged from state machine tip, realigning cursor"
             );
-            *cursor = next_expected_height;
+            *cursor = realigned_cursor;
         }
     }
 
@@ -815,6 +818,40 @@ mod tests {
         );
         assert_eq!(cursor, BASE_HEIGHT + 2);
         assert_eq!(sm.next_expected_block_height(), Some(BASE_HEIGHT + 2));
+    }
+
+    #[tokio::test]
+    async fn state_tip_realignment_does_not_backfill_before_start_height() {
+        const START_HEIGHT: u64 = 20;
+        let old_tip = test_block(START_HEIGHT - 2, BlockHash::all_zeros(), 1);
+        let first_allowed = test_block(START_HEIGHT, old_tip.block_hash(), 2);
+
+        let fetched_heights = Arc::new(StdMutex::new(Vec::new()));
+        let fetcher = Arc::new(StaticFetcher {
+            blocks: Arc::new(BTreeMap::new()),
+            fetched_heights: fetched_heights.clone(),
+        });
+
+        let mut sm = BtcNotifySM::init(DEFAULT_BURY_DEPTH, VecDeque::from([old_tip]));
+        let block_subs = Arc::new(Mutex::new(Vec::new()));
+        let mut cursor = START_HEIGHT;
+
+        process_block_message(
+            first_allowed,
+            &mut cursor,
+            START_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+
+        assert!(
+            fetched_heights.lock().unwrap().is_empty(),
+            "realignment must not backfill blocks before the configured start height"
+        );
+        assert_eq!(cursor, START_HEIGHT + 1);
+        assert_eq!(sm.next_expected_block_height(), Some(START_HEIGHT + 1));
     }
 }
 

--- a/crates/btc-tracker/src/client.rs
+++ b/crates/btc-tracker/src/client.rs
@@ -375,6 +375,25 @@ impl BtcNotifyClient<Disconnected> {
                                     let (tx_events, block_event) = sm.process_sequence(seq);
 
                                     if let Some(block_event) = block_event {
+                                        if matches!(&block_event.status, BlockStatus::Uncled) {
+                                            let disconnected_height = block_event
+                                                .block
+                                                .bip34_block_height()
+                                                .unwrap_or(start_height);
+                                            let realigned_cursor =
+                                                disconnected_height.max(start_height);
+                                            if realigned_cursor < cursor {
+                                                warn!(
+                                                    cursor = %cursor,
+                                                    %disconnected_height,
+                                                    %start_height,
+                                                    %realigned_cursor,
+                                                    "block disconnect rolled back state machine tip, realigning cursor"
+                                                );
+                                                cursor = realigned_cursor;
+                                            }
+                                        }
+
                                         block_subs_thread
                                             .lock()
                                             .await
@@ -641,11 +660,17 @@ mod tests {
         let (_tx_events, disconnected) = sm.process_sequence(SequenceMessage::BlockDisconnect {
             blockhash: stale_child.block_hash(),
         });
-        assert_eq!(
-            disconnected.map(|event| event.status),
-            Some(BlockStatus::Uncled)
-        );
-        assert_eq!(cursor, BASE_HEIGHT + 2);
+        let disconnected = disconnected.expect("disconnect should emit block event");
+        assert_eq!(disconnected.status, BlockStatus::Uncled);
+        let disconnected_height = disconnected
+            .block
+            .bip34_block_height()
+            .unwrap_or(BASE_HEIGHT);
+        let realigned_cursor = disconnected_height.max(BASE_HEIGHT);
+        if realigned_cursor < cursor {
+            cursor = realigned_cursor;
+        }
+        assert_eq!(cursor, BASE_HEIGHT + 1);
 
         sm.process_sequence(SequenceMessage::BlockConnect {
             blockhash: canonical_child.block_hash(),
@@ -670,6 +695,126 @@ mod tests {
             "canonical child must be backfilled after the disconnect rolled back the state tip"
         );
         assert_eq!(cursor, BASE_HEIGHT + 3);
+    }
+
+    #[tokio::test]
+    async fn disconnecting_only_tracked_block_rewinds_cursor_for_replacement_block() {
+        const BASE_HEIGHT: u64 = 18;
+        let stale_base = test_block(BASE_HEIGHT, BlockHash::all_zeros(), 1);
+        let canonical_base = test_block(BASE_HEIGHT, BlockHash::all_zeros(), 2);
+
+        let fetched_heights = Arc::new(StdMutex::new(Vec::new()));
+        let fetcher = Arc::new(StaticFetcher {
+            blocks: Arc::new(BTreeMap::new()),
+            fetched_heights,
+        });
+
+        let mut sm = BtcNotifySM::init(DEFAULT_BURY_DEPTH, VecDeque::new());
+        let block_subs = Arc::new(Mutex::new(Vec::new()));
+        let mut cursor = BASE_HEIGHT;
+
+        process_block_message(
+            stale_base.clone(),
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+        assert_eq!(cursor, BASE_HEIGHT + 1);
+
+        let (_tx_events, disconnected) = sm.process_sequence(SequenceMessage::BlockDisconnect {
+            blockhash: stale_base.block_hash(),
+        });
+        let disconnected = disconnected.expect("disconnect should emit block event");
+        assert_eq!(disconnected.status, BlockStatus::Uncled);
+        let disconnected_height = disconnected
+            .block
+            .bip34_block_height()
+            .unwrap_or(BASE_HEIGHT);
+        let realigned_cursor = disconnected_height.max(BASE_HEIGHT);
+        if realigned_cursor < cursor {
+            cursor = realigned_cursor;
+        }
+        assert_eq!(cursor, BASE_HEIGHT);
+
+        process_block_message(
+            canonical_base,
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+
+        assert_eq!(cursor, BASE_HEIGHT + 1);
+        assert_eq!(sm.next_expected_block_height(), Some(BASE_HEIGHT + 1));
+    }
+
+    #[tokio::test]
+    async fn disconnecting_only_tracked_block_backfills_replacement_before_child() {
+        const BASE_HEIGHT: u64 = 18;
+        let stale_base = test_block(BASE_HEIGHT, BlockHash::all_zeros(), 1);
+        let canonical_base = test_block(BASE_HEIGHT, BlockHash::all_zeros(), 2);
+        let canonical_child = test_block(BASE_HEIGHT + 1, canonical_base.block_hash(), 3);
+
+        let mut fetchable_blocks = BTreeMap::new();
+        fetchable_blocks.insert(BASE_HEIGHT, canonical_base);
+        let fetched_heights = Arc::new(StdMutex::new(Vec::new()));
+        let fetcher = Arc::new(StaticFetcher {
+            blocks: Arc::new(fetchable_blocks),
+            fetched_heights: fetched_heights.clone(),
+        });
+
+        let mut sm = BtcNotifySM::init(DEFAULT_BURY_DEPTH, VecDeque::new());
+        let block_subs = Arc::new(Mutex::new(Vec::new()));
+        let mut cursor = BASE_HEIGHT;
+
+        process_block_message(
+            stale_base.clone(),
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+        assert_eq!(cursor, BASE_HEIGHT + 1);
+
+        let (_tx_events, disconnected) = sm.process_sequence(SequenceMessage::BlockDisconnect {
+            blockhash: stale_base.block_hash(),
+        });
+        let disconnected = disconnected.expect("disconnect should emit block event");
+        assert_eq!(disconnected.status, BlockStatus::Uncled);
+        let disconnected_height = disconnected
+            .block
+            .bip34_block_height()
+            .unwrap_or(BASE_HEIGHT);
+        let realigned_cursor = disconnected_height.max(BASE_HEIGHT);
+        if realigned_cursor < cursor {
+            cursor = realigned_cursor;
+        }
+        assert_eq!(cursor, BASE_HEIGHT);
+
+        process_block_message(
+            canonical_child,
+            &mut cursor,
+            BASE_HEIGHT,
+            &mut sm,
+            &fetcher,
+            &block_subs,
+        )
+        .await;
+
+        assert_eq!(
+            *fetched_heights.lock().unwrap(),
+            vec![BASE_HEIGHT],
+            "replacement parent must be backfilled before the child is processed"
+        );
+        assert_eq!(cursor, BASE_HEIGHT + 2);
+        assert_eq!(sm.next_expected_block_height(), Some(BASE_HEIGHT + 2));
     }
 }
 
@@ -907,15 +1052,17 @@ mod e2e_tests {
         let (_tx_events, disconnected) = sm.process_sequence(SequenceMessage::BlockDisconnect {
             blockhash: stale_hash,
         });
-        assert_eq!(
-            disconnected.map(|event| event.status),
-            Some(BlockStatus::Uncled)
-        );
-        assert_eq!(
-            cursor,
-            base_height + 2,
-            "cursor must not move on disconnect"
-        );
+        let disconnected = disconnected.expect("disconnect should emit block event");
+        assert_eq!(disconnected.status, BlockStatus::Uncled);
+        let disconnected_height = disconnected
+            .block
+            .bip34_block_height()
+            .unwrap_or(base_height);
+        let realigned_cursor = disconnected_height.max(base_height);
+        if realigned_cursor < cursor {
+            cursor = realigned_cursor;
+        }
+        assert_eq!(cursor, base_height + 1, "cursor must rewind on disconnect");
 
         let mut canonical_hashes = bitcoind
             .client

--- a/crates/btc-tracker/src/state_machine.rs
+++ b/crates/btc-tracker/src/state_machine.rs
@@ -134,7 +134,7 @@ impl BtcNotifySM {
         self.unburied_blocks
             .front()
             .and_then(|block| block.bip34_block_height().ok())
-            .map(|height| height + 1)
+            .map(|height| height.saturating_add(1))
     }
 
     /// Returns true when `block` can be appended to the current in-memory tip.

--- a/crates/btc-tracker/src/state_machine.rs
+++ b/crates/btc-tracker/src/state_machine.rs
@@ -129,6 +129,21 @@ impl BtcNotifySM {
         }
     }
 
+    /// Returns the height of the next block expected by the current in-memory tip.
+    pub(crate) fn next_expected_block_height(&self) -> Option<u64> {
+        self.unburied_blocks
+            .front()
+            .and_then(|block| block.bip34_block_height().ok())
+            .map(|height| height + 1)
+    }
+
+    /// Returns true when `block` can be appended to the current in-memory tip.
+    pub(crate) fn can_connect_block(&self, block: &Block) -> bool {
+        self.unburied_blocks
+            .front()
+            .is_none_or(|tip| block.header.prev_blockhash == tip.block_hash())
+    }
+
     /// One of the three primary state transition functions of the [`BtcNotifySM`], updating
     /// internal state to reflect the the `rawblock` event.
     pub(crate) fn process_block(&mut self, block: Block) -> (Vec<TxEvent>, Option<BlockEvent>) {
@@ -151,6 +166,7 @@ impl BtcNotifySM {
                     trace!(?block, prev_block=?tip, "block's previous block hash does not match the tip");
                     warn!(block_hash=%block.block_hash(), prev_block_hash=%tip.block_hash(), "block's previous block hash does not match the tip, possible reorg detected");
                     debug_assert!(false, "block's previous block hash does not match the tip");
+                    return (Vec::new(), None);
                 }
             }
             // TODO: <https://alpenlabs.atlassian.net/browse/STR-2685>


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Currently, the `btc-tracker` crate maintains two views of the tip -- one derived from the actual chain by tracing the block hashes, and the other using a `cursor` that is used to backfill missed blocks. It recognizes reorgs using the `Block::Disconnect` message from the bitcoin full node. This pops the disconnected block from the actual chain tracker (the state machine in the `btc-tracker`) but does not reset the cursor causing reorgs to halt the processing of further blocks (as the chain is broken). This PR fixes this issue by reconciling the cursor with whatever tip is recorded by the state machine.

Codex was used to troubleshoot the bug and fix the issue.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->