### PR TITLE
chore(deps): bump asm to v0.3.0-rc.1 and mosaic to cc7bb0a9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -808,7 +808,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.4",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1048,7 +1048,7 @@ checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc 2.0.4",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.2",
  "serde_json",
  "tower 0.5.2",
@@ -1756,6 +1756,17 @@ dependencies = [
  "http 1.3.1",
  "log",
  "url",
+]
+
+[[package]]
+name = "auto-const-array"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd73835ad7deb4bd2b389e6f10333b143f025d607c55ca04c66a0bcc6bb2fc6d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3010,13 +3021,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckt-fmtv5-types"
+version = "0.1.0"
+source = "git+https://github.com/alpenlabs/ckt#a3683426d73af89e136725b0f8957f073f67cc1b"
+dependencies = [
+ "blake3",
+ "cynosure 0.4.0",
+ "kanal",
+ "libc",
+ "monoio",
+]
+
+[[package]]
 name = "ckt-gobble"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#fde2f125947e411140a38c15ce420e1e0dc3750d"
+source = "git+https://github.com/alpenlabs/ckt#a3683426d73af89e136725b0f8957f073f67cc1b"
 dependencies = [
  "bitvec",
  "blake3",
- "rand_chacha 0.9.0",
+ "rand_chacha 0.10.0",
  "thiserror 2.0.18",
 ]
 
@@ -3101,7 +3124,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3472,6 +3495,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cynosure"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b87575c1637454fd3c7de54730c5780c9605c87c30f174e03ec3d94e634a36b"
+dependencies = [
+ "futures",
+ "monoio",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,7 +3654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4295,6 +4328,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,6 +4585,15 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "gcd"
@@ -5396,6 +5450,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,7 +5885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6411,6 +6475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memory_pprof"
 version = "0.1.0"
 dependencies = [
@@ -6556,6 +6629,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -6654,9 +6739,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "monoio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd0f8bcde87b1949f95338b547543fcab187bc7e7a5024247e359a5e828ba6a"
+dependencies = [
+ "auto-const-array",
+ "bytes",
+ "flume",
+ "fxhash",
+ "io-uring",
+ "libc",
+ "memchr",
+ "mio 0.8.11",
+ "monoio-macros",
+ "nix",
+ "once_cell",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "threadpool",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "monoio-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176a5f5e69613d9e88337cf2a65e11135332b4efbcc628404a7c555e4452084c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "mosaic-adaptor-sigs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6671,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "mosaic-cac-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6692,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "mosaic-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6701,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "mosaic-heap-array"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6710,8 +6829,9 @@ dependencies = [
 [[package]]
 name = "mosaic-net-svc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
+ "ark-serialize 0.6.0",
  "ed25519-dalek",
  "hex",
  "kanal",
@@ -6721,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
@@ -6731,9 +6851,10 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "bitcoin",
+ "ckt-fmtv5-types",
  "hex",
  "jsonrpsee-types",
  "mosaic-cac-types",
@@ -6747,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "mosaic-vs3"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=713324eea6d930713586dd37b0a63ae8cc98c9ed#713324eea6d930713586dd37b0a63ae8cc98c9ed"
+source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6869,6 +6990,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6961,6 +7091,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.4",
  "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -8375,6 +8507,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8392,6 +8534,12 @@ dependencies = [
  "getrandom 0.3.3",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -11919,7 +12067,7 @@ name = "strata-p2p"
 version = "0.3.7"
 source = "git+https://github.com/alpenlabs/strata-p2p.git?tag=v0.3.7#6182180f7f5cc74134af0caab090854033e144cf"
 dependencies = [
- "cynosure",
+ "cynosure 0.2.3",
  "flexbuffers",
  "futures",
  "libp2p",
@@ -13381,7 +13529,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "moho-recursive-proof"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "moho-types",
  "ssz",
@@ -6681,7 +6681,7 @@ dependencies = [
 [[package]]
 name = "moho-runtime-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "moho-runtime-interface",
  "moho-types",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "moho-runtime-interface"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "moho-types",
  "ssz",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "moho-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "hex",
  "sha2 0.11.0",
@@ -7292,7 +7292,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10967,7 +10966,7 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -10994,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -11008,7 +11007,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -11029,14 +11028,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-btc-types",
  "strata-btc-verification",
  "strata-crypto",
@@ -11048,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
@@ -11070,7 +11069,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -11081,7 +11080,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -11091,7 +11090,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-admin-txs",
  "strata-asm-proto-bridge-v1-msgs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-asm-proto-checkpoint-msgs",
  "strata-crypto",
  "strata-identifiers",
@@ -11102,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11111,7 +11110,7 @@ dependencies = [
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-params",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-crypto",
  "strata-identifiers",
  "strata-l1-envelope-fmt",
@@ -11123,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11136,7 +11135,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-msgs",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-asm-proto-checkpoint-msgs",
  "strata-btc-types",
  "strata-codec",
@@ -11148,26 +11147,26 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "ssz",
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-crypto",
 ]
 
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.11.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-btc-types",
  "strata-codec",
  "strata-crypto",
@@ -11178,7 +11177,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.14#6177f51e1cace33e676e699a30903b11f7723e85"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin-bosd 0.11.0",
@@ -11195,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11213,7 +11212,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -11229,7 +11228,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -11242,7 +11241,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -11257,7 +11256,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -11277,14 +11276,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
  "strata-asm-common",
  "strata-asm-proof-types",
  "strata-asm-proto-bridge-v1",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-asm-proto-checkpoint-types",
  "strata-asm-worker",
 ]
@@ -11292,7 +11291,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -11305,7 +11304,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -11318,7 +11317,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -11783,13 +11782,12 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.9.0",
  "borsh",
- "num_enum 0.7.4",
  "serde",
  "ssz",
  "ssz_codegen",
@@ -11798,7 +11796,6 @@ dependencies = [
  "ssz_types",
  "strata-codec",
  "strata-identifiers",
- "strata-l1-txfmt",
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
@@ -11807,7 +11804,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11824,7 +11821,7 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "ssz",
@@ -11834,7 +11831,7 @@ dependencies = [
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-asm-params",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
  "strata-asm-proto-checkpoint-types",
  "strata-btc-types",
  "strata-crypto",
@@ -11849,7 +11846,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "strata-codec-derive",
  "thiserror 2.0.18",
@@ -11858,7 +11855,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -11867,7 +11864,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "borsh",
  "ssz",
@@ -11878,7 +11875,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11903,7 +11900,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11924,7 +11921,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "bitcoin",
  "thiserror 2.0.18",
@@ -11933,7 +11930,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11945,7 +11942,7 @@ dependencies = [
 [[package]]
 name = "strata-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry-otlp",
@@ -11959,7 +11956,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -11979,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "strata-metrics"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "metrics",
  "metrics-exporter-otel",
@@ -12022,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -12030,14 +12027,14 @@ dependencies = [
 [[package]]
 name = "strata-ol-bridge-types"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=8589f8e8bc58e07183d5683b2a10b0c6748cb533#8589f8e8bc58e07183d5683b2a10b0c6748cb533"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=e63783002c12b5e61891cf1b04c341cbf0f31bd3#e63783002c12b5e61891cf1b04c341cbf0f31bd3"
 dependencies = [
  "arbitrary",
  "borsh",
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.1-alpha.14)",
+ "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1)",
  "strata-codec",
  "strata-identifiers",
  "strata-primitives",
@@ -12047,7 +12044,7 @@ dependencies = [
 [[package]]
 name = "strata-ol-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -12081,7 +12078,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -12103,7 +12100,7 @@ dependencies = [
 [[package]]
 name = "strata-primitives"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/alpen.git?rev=8589f8e8bc58e07183d5683b2a10b0c6748cb533#8589f8e8bc58e07183d5683b2a10b0c6748cb533"
+source = "git+https://github.com/alpenlabs/alpen.git?rev=e63783002c12b5e61891cf1b04c341cbf0f31bd3#e63783002c12b5e61891cf1b04c341cbf0f31bd3"
 dependencies = [
  "bitcoin",
  "bitcoin-bosd 0.11.0",
@@ -12119,7 +12116,7 @@ dependencies = [
 [[package]]
 name = "strata-service"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "anyhow",
  "futures",
@@ -12135,7 +12132,7 @@ dependencies = [
 [[package]]
 name = "strata-tasks"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -12147,7 +12144,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-arb"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",
@@ -14220,7 +14217,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "async-trait",
  "bincode",
@@ -14233,7 +14230,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "tracing",
 ]
@@ -14241,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "async-trait",
  "bincode",
@@ -14255,7 +14252,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "blake3",
  "borsh",
@@ -14270,7 +14267,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-host"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,10 +108,10 @@ strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4
 strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
 strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
 
-# Dependencies from alpenlabs/mosaic pinned to commit 0fc9ba8d (main @ 2026-06-05)
-mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "713324eea6d930713586dd37b0a63ae8cc98c9ed" }
-mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "713324eea6d930713586dd37b0a63ae8cc98c9ed" }
-mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "713324eea6d930713586dd37b0a63ae8cc98c9ed" }
+# Dependencies from alpenlabs/mosaic pinned to commit cc7bb0a9 (main @ 2026-06-22)
+mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
+mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
+mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
 
 # Dependencies from alpenlabs/strata-common
 strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,27 +86,26 @@ strata-bridge-tx-graph = { path = "crates/tx-graph" }
 strata-mosaic-client = { path = "crates/mosaic-client" }
 strata-mosaic-client-api = { path = "crates/mosaic-client-api" }
 
-# Dependencies from alpenlabs/alpen pinned to commit 8589f8e (main @ 2026-06-18)
-# alpen #1965 — the coordinated rc26 / asm v0.1-alpha.14 / zkaleido beta.5 bump;
+# Dependencies from alpenlabs/alpen pinned to commit e63783002 (main @ 2026-06-22)
+# alpen #2001 — the coordinated strata-common / asm / zkaleido v0.3.0-rc.1 bump;
 # keeps strata-common in sync with asm so dev-cli's deposit path resolves a
 # single strata_identifiers / strata_codec version.
-strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "8589f8e8bc58e07183d5683b2a10b0c6748cb533" }
+strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "e63783002c12b5e61891cf1b04c341cbf0f31bd3" }
 
-# Dependencies from alpenlabs/asm pinned to commit 31d88a4 (main — asm PR #155 squash-merged on top
-# of v0.1-alpha.14 / 6177f51e) — picks up the phantom-reorg / MohoState desync fix.
-asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
-strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "31d88a4f49c87c26f4db3859810de10775234339" }
+# Dependencies from alpenlabs/asm pinned to tag v0.3.0-rc.1 (commit d35687b, main @ 2026-06-22)
+asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
 
 # Dependencies from alpenlabs/mosaic pinned to commit cc7bb0a9 (main @ 2026-06-22)
 mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
@@ -114,23 +113,23 @@ mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b
 mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
 
 # Dependencies from alpenlabs/strata-common
-strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-codec = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-merkle = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
-strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26", features = [
+strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-codec = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-crypto = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-identifiers = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-l1-envelope-fmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-l1-txfmt = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-logging = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-merkle = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-metrics = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
+strata-predicate = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1", features = [
   # strata-common renamed `all` -> `all-verifiers` and dropped serde/borsh from
   # its default set; list them explicitly to preserve the pre-bump feature set.
   "all-verifiers",
   "serde",
   "borsh",
 ] }
-strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.1.0-alpha-rc26" }
+strata-tasks = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }
 
 strata-p2p = { git = "https://github.com/alpenlabs/strata-p2p.git", tag = "v0.3.7", features = [
   "quic",
@@ -143,15 +142,15 @@ ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 ssz_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 
 # Dependencies from alpenlabs/moho
-moho-recursive-proof = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.9" }
-moho-runtime-interface = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.9" }
-moho-types = { git = "https://github.com/alpenlabs/moho", tag = "v0.1-alpha.9" }
+moho-recursive-proof = { git = "https://github.com/alpenlabs/moho", tag = "v0.3.0-rc.1" }
+moho-runtime-interface = { git = "https://github.com/alpenlabs/moho", tag = "v0.3.0-rc.1" }
+moho-types = { git = "https://github.com/alpenlabs/moho", tag = "v0.3.0-rc.1" }
 
 # Dependencies from alpenlabs/zkaleido
-zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
-zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
-zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
+zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
+zkaleido-native-adapter = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
+zkaleido-sp1-host = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
 
 # external deps
 alloy = { version = "2.0.4", features = ["full", "node-bindings"] }

--- a/guest-builder/sp1/guest-bridge-proof/Cargo.lock
+++ b/guest-builder/sp1/guest-bridge-proof/Cargo.lock
@@ -912,7 +912,7 @@ dependencies = [
 [[package]]
 name = "moho-recursive-proof"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "moho-types",
  "ssz",
@@ -928,7 +928,7 @@ dependencies = [
 [[package]]
 name = "moho-runtime-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "moho-runtime-interface",
  "moho-types",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "moho-runtime-interface"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "moho-types",
  "ssz",
@@ -949,7 +949,7 @@ dependencies = [
 [[package]]
 name = "moho-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/moho?tag=v0.1-alpha.9#58e13bf221fd47ee4d8c8f8f2086c1383268bf2b"
+source = "git+https://github.com/alpenlabs/moho?tag=v0.3.0-rc.1#8e8f70f6ac865d9dbaf01f34635d5712e632f6be"
 dependencies = [
  "hex",
  "sha2 0.11.0",
@@ -1019,28 +1019,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -1879,7 +1857,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -1906,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -1920,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -1941,7 +1919,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -1960,7 +1938,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
@@ -1982,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -2003,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2024,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2049,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -2062,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2079,7 +2057,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2097,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -2113,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -2126,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -2141,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -2161,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -2174,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -2226,13 +2204,12 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.9.0",
  "borsh",
- "num_enum",
  "serde",
  "ssz",
  "ssz_codegen",
@@ -2241,7 +2218,6 @@ dependencies = [
  "ssz_types",
  "strata-codec",
  "strata-identifiers",
- "strata-l1-txfmt",
  "thiserror",
  "tree_hash",
  "tree_hash_derive",
@@ -2250,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2267,7 +2243,7 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=31d88a4f49c87c26f4db3859810de10775234339#31d88a4f49c87c26f4db3859810de10775234339"
+source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "ssz",
@@ -2292,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "strata-codec-derive",
  "thiserror",
@@ -2301,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2310,7 +2286,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "borsh",
  "ssz",
@@ -2321,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2346,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2367,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "bitcoin",
  "thiserror",
@@ -2376,7 +2352,7 @@ dependencies = [
 [[package]]
 name = "strata-l1-txfmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2388,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "strata-merkle"
 version = "0.2.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "borsh",
  "digest 0.10.7",
@@ -2408,7 +2384,7 @@ dependencies = [
 [[package]]
 name = "strata-msg-fmt"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "thiserror",
 ]
@@ -2416,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "strata-ol-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "ssz",
  "ssz_codegen",
@@ -2434,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2808,7 +2784,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2821,7 +2797,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-logging"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "tracing",
 ]
@@ -2829,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2843,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "blake3",
  "borsh",
@@ -2858,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "bincode",
  "cfg-if",

--- a/guest-builder/sp1/guest-bridge-proof/Cargo.toml
+++ b/guest-builder/sp1/guest-bridge-proof/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [dependencies]
 ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 strata-bridge-proof = { path = "../../../crates/proofs/bridge-proof", default-features = false }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
 
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-6.2.0" }

--- a/guest-builder/sp1/guest-counterproof/Cargo.lock
+++ b/guest-builder/sp1/guest-counterproof/Cargo.lock
@@ -1085,28 +1085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,13 +2126,12 @@ dependencies = [
 [[package]]
 name = "strata-btc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.9.0",
  "borsh",
- "num_enum",
  "serde",
  "ssz",
  "ssz_codegen",
@@ -2163,7 +2140,6 @@ dependencies = [
  "ssz_types",
  "strata-codec",
  "strata-identifiers",
- "strata-l1-txfmt",
  "thiserror",
  "tree_hash",
  "tree_hash_derive",
@@ -2172,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "strata-codec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "strata-codec-derive",
  "thiserror",
@@ -2181,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "strata-codec-derive"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2190,7 +2166,7 @@ dependencies = [
 [[package]]
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -2215,7 +2191,7 @@ dependencies = [
 [[package]]
 name = "strata-identifiers"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2234,21 +2210,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "strata-l1-txfmt"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
-dependencies = [
- "arbitrary",
- "bitcoin",
- "borsh",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "strata-predicate"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/strata-common?tag=v0.1.0-alpha-rc26#f2c6703b2a641838e0058730bb076fdf9a9dbdff"
+source = "git+https://github.com/alpenlabs/strata-common?tag=v0.3.0-rc.1#861ef15a7a2e0335ca84d21d35c2326c85638904"
 dependencies = [
  "borsh",
  "hex",
@@ -2691,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "bincode",
  "borsh",
@@ -2703,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-native-adapter"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "bincode",
  "k256",
@@ -2715,7 +2679,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "blake3",
  "borsh",
@@ -2730,7 +2694,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-guest-env"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "bincode",
  "cfg-if",

--- a/guest-builder/sp1/guest-counterproof/Cargo.toml
+++ b/guest-builder/sp1/guest-counterproof/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [dependencies]
 ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.16.0" }
 strata-bridge-counterproof = { path = "../../../crates/proofs/bridge-counterproof" }
-zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5", features = [
+zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1", features = [
   "blake3",
 ] }
 


### PR DESCRIPTION
## Description
Bumps asm to tag `v0.3.0-rc.1` (`d35687b2`) and mosaic to `cc7bb0a9`, keeping the bridge / asm-runner in sync with the latest asm generation.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update