### PR TITLE
fix: bump mosaic to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "ckt-fmtv5-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#a3683426d73af89e136725b0f8957f073f67cc1b"
+source = "git+https://github.com/alpenlabs/ckt?rev=432cdd11eb5780bbf7edcaad698850deb5b49675#432cdd11eb5780bbf7edcaad698850deb5b49675"
 dependencies = [
  "blake3",
  "cynosure 0.4.0",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "ckt-gobble"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/ckt#a3683426d73af89e136725b0f8957f073f67cc1b"
+source = "git+https://github.com/alpenlabs/ckt?rev=432cdd11eb5780bbf7edcaad698850deb5b49675#432cdd11eb5780bbf7edcaad698850deb5b49675"
 dependencies = [
  "bitvec",
  "blake3",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "mosaic-adaptor-sigs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6790,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "mosaic-cac-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "mosaic-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6820,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "mosaic-heap-array"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6829,7 +6829,7 @@ dependencies = [
 [[package]]
 name = "mosaic-net-svc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "ark-serialize 0.6.0",
  "ed25519-dalek",
@@ -6841,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "bitcoin",
  "ckt-fmtv5-types",
@@ -6868,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "mosaic-vs3"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c#cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c"
+source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,10 +107,10 @@ strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b
 strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
 strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
 
-# Dependencies from alpenlabs/mosaic pinned to commit cc7bb0a9 (main @ 2026-06-22)
-mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
-mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
-mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "cc7bb0a9b4af7f37d4173583c0c051b3c70c2a5c" }
+# Dependencies from alpenlabs/mosaic pinned to commit 6a85547c (main @ 2026-06-22)
+mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "6a85547cc8d4d408eaa7e1aa121a285e7813430f" }
+mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "6a85547cc8d4d408eaa7e1aa121a285e7813430f" }
+mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "6a85547cc8d4d408eaa7e1aa121a285e7813430f" }
 
 # Dependencies from alpenlabs/strata-common
 strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }


### PR DESCRIPTION
## Description

Mosaic had not pinned its `ckt` dependencies and was incompatible with latest ckt main. This was causing CI failures here as well. 

The PR in mosaic has been made to pin `ckt` to last compatible version. This PR bumps mosaic to use this commit. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
