### PR TITLE
fix(bridge-exec): use tweaked key for all payouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7473,6 +7473,7 @@ version = "0.1.0"
 dependencies = [
  "bdk_bitcoind_rpc",
  "bdk_wallet",
+ "bitcoin-bosd 0.11.0",
  "corepc-node",
  "serial_test",
  "thiserror 2.0.18",

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -612,17 +612,11 @@ async fn request_payout_nonces(
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, "creating descriptor to request payout nonces");
 
-    // TODO: <https://alpenlabs.atlassian.net/browse/STR-2668>
-    // Have the s2 client provide the descriptor directly instead of only the public key.
-    // Get the general wallet public key for the payout descriptor
-    let pubkey = output_handles
-        .s2_client
-        .general_wallet_signer()
-        .pubkey()
-        .await?;
-
-    // Create a P2TR descriptor for the payout address.
-    let descriptor = Descriptor::new_p2tr(&pubkey.serialize())
+    let descriptor = output_handles
+        .wallet
+        .read()
+        .await
+        .descriptor()
         .map_err(|e| ExecutorError::WalletErr(format!("failed to create descriptor: {e}")))?;
 
     // Convert to PayoutDescriptor for P2P transmission

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -4,13 +4,11 @@
 //! the stake transaction.
 
 use bitcoin::{
-    Address, Amount, FeeRate, Network, OutPoint, Psbt, TapSighashType, Transaction, TxOut,
+    Amount, FeeRate, Network, OutPoint, Psbt, TapSighashType, Transaction, TxOut,
     hashes::{Hash, sha256},
-    key::TapTweak,
     secp256k1::{Message, XOnlyPublicKey},
     sighash::{Prevouts, SighashCache},
 };
-use bitcoin_bosd::Descriptor;
 use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
@@ -65,18 +63,15 @@ pub(crate) async fn publish_stake_data(
     info!(%unstaking_image, "fetched unstaking intent preimage and computed the unstaking image");
 
     info!("constructing the unstaking output descriptor");
-    let general_wallet_key = output_handles
-        .s2_client
-        .general_wallet_signer()
-        .pubkey()
-        .await?;
-    // Safety: the general wallet uses the operator's pubkey directly as the taproot output key
-    // (no additional tweak), so the pubkey returned by secret-service is already tweaked.
-    let address = Address::p2tr_tweaked(general_wallet_key.dangerous_assume_tweaked(), cfg.network);
-    info!(%address, "constructed the unstaking output address");
-
-    let output_desc = Descriptor::try_from(address)
-        .expect("must be able to create descriptor from a valid address");
+    let output_desc = output_handles
+        .wallet
+        .read()
+        .await
+        .descriptor()
+        .map_err(|e| {
+            ExecutorError::WalletErr(format!("failed to create unstaking descriptor: {e}"))
+        })?;
+    info!(%output_desc, "constructed the unstaking output descriptor");
 
     let unstaking_input = UnstakingInput {
         stake_funds,

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 [dependencies]
 bdk_bitcoind_rpc.workspace = true
 bdk_wallet.workspace = true
+bitcoin-bosd.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -40,6 +40,12 @@ pub enum Error {
     /// The general wallet backend reported an error.
     #[error("general wallet: {0}")]
     General(Box<dyn std::error::Error + Send + Sync>),
+    /// The wallet receive script cannot be represented as a Bitcoin address.
+    #[error("wallet receive script is not addressable: {0}")]
+    Address(#[from] bdk_wallet::bitcoin::address::FromScriptError),
+    /// The wallet address cannot be represented as a BOSD descriptor.
+    #[error("wallet address cannot be converted into a descriptor: {0}")]
+    Descriptor(#[from] bitcoin_bosd::DescriptorError),
     /// BDK reported an error building a transaction on the reserved wallet.
     #[error("reserved wallet create-tx: {0}")]
     Reserved(#[from] bdk_wallet::error::CreateTxError),

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -15,9 +15,10 @@
 use std::collections::BTreeSet;
 
 use bdk_wallet::{
-    bitcoin::{Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    bitcoin::{Address, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
     descriptor, KeychainKind, Wallet,
 };
+use bitcoin_bosd::Descriptor;
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
@@ -88,6 +89,12 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// Returns the reserved wallet's receive script.
     pub fn reserved_script_pubkey(&self) -> ScriptBuf {
         self.reserved_script_pubkey.clone()
+    }
+
+    /// Returns a BOSD descriptor for the general wallet's current receive script.
+    pub fn descriptor(&self) -> Result<Descriptor, Error> {
+        let address = Address::from_script(&self.general_script_pubkey(), self.config.network)?;
+        Descriptor::try_from(address).map_err(Error::Descriptor)
     }
 
     // ── Lease bookkeeping ───────────────────────────────────────────────────


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR udpdates the executors for generating stake and cooperative payout data such that the operator's receive address corresponds to the tweaked general wallet key. This is the same address that the general wallet uses when looking up existing funds. 

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-3851