### PR TITLE
chore: pin asm and mosaic to v0.3.0-rc.1

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -195,19 +195,24 @@ jobs:
       - name: Resolve external binary versions
         id: bin-versions
         run: |
-          MOSAIC_REV=$(grep 'mosaic-rpc-api.*rev' Cargo.toml | sed 's/.*rev = "\([^"]*\)".*/\1/')
-          if [ -z "$MOSAIC_REV" ]; then
-            echo "ERROR: failed to extract mosaic rev from Cargo.toml" >&2
+          extract_cargo_git_ref() {
+            local crate="$1"
+            local dep_line
+            dep_line=$(grep -E "^[[:space:]]*${crate}[[:space:]]*=" Cargo.toml | head -n 1)
+            if [[ "$dep_line" =~ (rev|tag)[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+              echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+              return
+            fi
+            echo "ERROR: failed to extract ${crate} git ref from Cargo.toml" >&2
             exit 1
-          fi
-          ASM_REV=$(grep 'strata-asm-worker.*rev' Cargo.toml | sed 's/.*rev = "\([^"]*\)".*/\1/')
-          if [ -z "$ASM_REV" ]; then
-            echo "ERROR: failed to extract asm rev from Cargo.toml" >&2
-            exit 1
-          fi
+          }
+          read -r MOSAIC_REF_TYPE MOSAIC_REF < <(extract_cargo_git_ref mosaic-rpc-api)
+          read -r ASM_REF_TYPE ASM_REF < <(extract_cargo_git_ref strata-asm-worker)
           {
-            echo "mosaic-rev=$MOSAIC_REV"
-            echo "asm-rev=$ASM_REV"
+            echo "mosaic-ref-type=$MOSAIC_REF_TYPE"
+            echo "mosaic-ref=$MOSAIC_REF"
+            echo "asm-ref-type=$ASM_REF_TYPE"
+            echo "asm-ref=$ASM_REF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Restore cached mosaic binary
@@ -215,14 +220,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/target/mosaic
-          key: ${{ runner.os }}-mosaic-${{ steps.bin-versions.outputs.mosaic-rev }}-${{ needs.extract-rust-version.outputs.nightly-version }}
+          key: ${{ runner.os }}-mosaic-${{ steps.bin-versions.outputs.mosaic-ref-type }}-${{ steps.bin-versions.outputs.mosaic-ref }}-${{ needs.extract-rust-version.outputs.nightly-version }}
 
       - name: Install mosaic binary
         if: steps.cache-mosaic.outputs.cache-hit != 'true'
         env:
-          MOSAIC_REV: ${{ steps.bin-versions.outputs.mosaic-rev }}
+          MOSAIC_REF_TYPE: ${{ steps.bin-versions.outputs.mosaic-ref-type }}
+          MOSAIC_REF: ${{ steps.bin-versions.outputs.mosaic-ref }}
         run: |
-          cargo install --locked --git https://github.com/alpenlabs/mosaic --rev "$MOSAIC_REV" --features=reduced-circuits --root "$GITHUB_WORKSPACE/target/mosaic" mosaic
+          cargo install --locked --git https://github.com/alpenlabs/mosaic "--$MOSAIC_REF_TYPE" "$MOSAIC_REF" --features=reduced-circuits --root "$GITHUB_WORKSPACE/target/mosaic" mosaic
 
       - name: Add mosaic binary to PATH
         run: |
@@ -233,14 +239,15 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/target/asm
-          key: ${{ runner.os }}-asm-runner-${{ steps.bin-versions.outputs.asm-rev }}-${{ needs.extract-rust-version.outputs.nightly-version }}
+          key: ${{ runner.os }}-asm-runner-${{ steps.bin-versions.outputs.asm-ref-type }}-${{ steps.bin-versions.outputs.asm-ref }}-${{ needs.extract-rust-version.outputs.nightly-version }}
 
       - name: Install asm binary
         if: steps.cache-asm.outputs.cache-hit != 'true'
         env:
-          ASM_REV: ${{ steps.bin-versions.outputs.asm-rev }}
+          ASM_REF_TYPE: ${{ steps.bin-versions.outputs.asm-ref-type }}
+          ASM_REF: ${{ steps.bin-versions.outputs.asm-ref }}
         run: |
-          cargo install --locked --git https://github.com/alpenlabs/asm --rev "$ASM_REV" --root "$GITHUB_WORKSPACE/target/asm" strata-asm-runner
+          cargo install --locked --git https://github.com/alpenlabs/asm "--$ASM_REF_TYPE" "$ASM_REF" --root "$GITHUB_WORKSPACE/target/asm" strata-asm-runner
 
       - name: Add asm binary to PATH
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10966,7 +10966,7 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 [[package]]
 name = "strata-asm-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "borsh",
@@ -10993,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-logs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-proto-checkpoint-types",
@@ -11007,7 +11007,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-manifest-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -11028,14 +11028,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-params"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-btc-types",
  "strata-btc-verification",
  "strata-crypto",
@@ -11047,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-impl"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "moho-runtime-impl",
@@ -11069,7 +11069,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proof-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -11080,7 +11080,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "ssz",
@@ -11090,7 +11090,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-admin-txs",
  "strata-asm-proto-bridge-v1-msgs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-msgs",
  "strata-crypto",
  "strata-identifiers",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-admin-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11110,7 +11110,7 @@ dependencies = [
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-params",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-crypto",
  "strata-identifiers",
  "strata-l1-envelope-fmt",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11135,7 +11135,7 @@ dependencies = [
  "strata-asm-params",
  "strata-asm-proto-bridge-v1-msgs",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-msgs",
  "strata-btc-types",
  "strata-codec",
@@ -11147,26 +11147,26 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-bridge-v1-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "ssz",
  "ssz_derive",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-crypto",
 ]
 
 [[package]]
 name = "strata-asm-proto-bridge-v1-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
  "bitcoin-bosd 0.11.0",
  "strata-asm-common",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-btc-types",
  "strata-codec",
  "strata-crypto",
@@ -11178,23 +11178,6 @@ dependencies = [
 name = "strata-asm-proto-bridge-v1-types"
 version = "0.1.0"
 source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
-dependencies = [
- "arbitrary",
- "bitcoin-bosd 0.11.0",
- "bitvec",
- "borsh",
- "serde",
- "ssz",
- "ssz_derive",
- "strata-btc-types",
- "strata-identifiers",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "strata-asm-proto-bridge-v1-types"
-version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11212,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-logs",
@@ -11228,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-msgs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "ssz",
  "ssz_derive",
@@ -11241,7 +11224,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-txs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "strata-asm-common",
@@ -11256,7 +11239,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-proto-checkpoint-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "borsh",
  "serde",
@@ -11276,14 +11259,14 @@ dependencies = [
 [[package]]
 name = "strata-asm-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
  "strata-asm-common",
  "strata-asm-proof-types",
  "strata-asm-proto-bridge-v1",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-types",
  "strata-asm-worker",
 ]
@@ -11291,7 +11274,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-spec"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "strata-asm-common",
  "strata-asm-params",
@@ -11304,7 +11287,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-stf"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin",
  "ssz_types",
@@ -11317,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "strata-asm-worker"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -11807,7 +11790,7 @@ dependencies = [
 [[package]]
 name = "strata-btc-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "bitcoin",
@@ -11824,7 +11807,7 @@ dependencies = [
 [[package]]
 name = "strata-checkpoint-verification"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "bitcoin-bosd 0.11.0",
  "ssz",
@@ -11834,7 +11817,7 @@ dependencies = [
  "ssz_types",
  "strata-asm-manifest-types",
  "strata-asm-params",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-asm-proto-checkpoint-types",
  "strata-btc-types",
  "strata-crypto",
@@ -12037,7 +12020,7 @@ dependencies = [
  "serde",
  "ssz",
  "ssz_derive",
- "strata-asm-proto-bridge-v1-types 0.1.0 (git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1)",
+ "strata-asm-proto-bridge-v1-types",
  "strata-codec",
  "strata-identifiers",
  "strata-primitives",
@@ -12147,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "strata-test-utils-arb"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/asm.git?rev=d35687b2bded925d7562057ff9cd6b49bf91cd95#d35687b2bded925d7562057ff9cd6b49bf91cd95"
+source = "git+https://github.com/alpenlabs/asm?tag=v0.3.0-rc.1#d35687b2bded925d7562057ff9cd6b49bf91cd95"
 dependencies = [
  "arbitrary",
  "rand_core 0.6.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "mosaic-adaptor-sigs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6790,7 +6790,7 @@ dependencies = [
 [[package]]
 name = "mosaic-cac-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6811,7 +6811,7 @@ dependencies = [
 [[package]]
 name = "mosaic-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6820,7 +6820,7 @@ dependencies = [
 [[package]]
 name = "mosaic-heap-array"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6829,7 +6829,7 @@ dependencies = [
 [[package]]
 name = "mosaic-net-svc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "ark-serialize 0.6.0",
  "ed25519-dalek",
@@ -6841,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "bitcoin",
  "ckt-fmtv5-types",
@@ -6868,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "mosaic-vs3"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?rev=6a85547cc8d4d408eaa7e1aa121a285e7813430f#6a85547cc8d4d408eaa7e1aa121a285e7813430f"
+source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.1#5d88561f2dfd10e9857be11f6640fab62497cd41"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,10 +107,10 @@ strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b
 strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
 strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
 
-# Dependencies from alpenlabs/mosaic pinned to commit 6a85547c (main @ 2026-06-22)
-mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "6a85547cc8d4d408eaa7e1aa121a285e7813430f" }
-mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "6a85547cc8d4d408eaa7e1aa121a285e7813430f" }
-mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "6a85547cc8d4d408eaa7e1aa121a285e7813430f" }
+# Dependencies from alpenlabs/mosaic
+mosaic-common = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.1" }
+mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.1" }
+mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.1" }
 
 # Dependencies from alpenlabs/strata-common
 strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,20 +92,20 @@ strata-mosaic-client-api = { path = "crates/mosaic-client-api" }
 # single strata_identifiers / strata_codec version.
 strata-ol-bridge-types = { git = "https://github.com/alpenlabs/alpen.git", rev = "e63783002c12b5e61891cf1b04c341cbf0f31bd3" }
 
-# Dependencies from alpenlabs/asm pinned to tag v0.3.0-rc.1 (commit d35687b, main @ 2026-06-22)
-asm-storage = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-common = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-params = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-rpc = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-spec = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-asm-worker = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
-strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm.git", rev = "d35687b2bded925d7562057ff9cd6b49bf91cd95" }
+# Dependencies from alpenlabs/asm
+asm-storage = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-common = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-params = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-proof-impl = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-proto-bridge-v1 = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-proto-bridge-v1-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-proto-checkpoint = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-proto-checkpoint-txs = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-proto-checkpoint-types = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-rpc = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-spec = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-asm-worker = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
+strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm", tag = "v0.3.0-rc.1" }
 
 # Dependencies from alpenlabs/mosaic
 mosaic-common = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.1" }

--- a/docker/asm-runner/Dockerfile
+++ b/docker/asm-runner/Dockerfile
@@ -8,11 +8,13 @@ COPY Cargo.toml /tmp/Cargo.toml
 
 RUN --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cargo/registry \
-    ASM_REV=$(grep 'strata-asm-worker.*rev' /tmp/Cargo.toml | sed 's/.*rev = "\([^"]*\)".*/\1/') && \
-    if [ -z "$ASM_REV" ]; then \
-        echo "ERROR: failed to extract asm rev from Cargo.toml" >&2; exit 1; \
+    ASM_DEP=$(grep -E '^[[:space:]]*strata-asm-worker[[:space:]]*=' /tmp/Cargo.toml) && \
+    ASM_REF_TYPE=$(printf '%s\n' "$ASM_DEP" | sed -n 's/.*tag[[:space:]]*=[[:space:]]*"[^"]*".*/tag/p; s/.*rev[[:space:]]*=[[:space:]]*"[^"]*".*/rev/p') && \
+    ASM_REF=$(printf '%s\n' "$ASM_DEP" | sed -n 's/.*tag[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p; s/.*rev[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p') && \
+    if [ -z "$ASM_REF_TYPE" ] || [ -z "$ASM_REF" ]; then \
+        echo "ERROR: failed to extract asm git ref from Cargo.toml" >&2; exit 1; \
     fi && \
-    cargo install --locked --git https://github.com/alpenlabs/asm --rev "$ASM_REV" --root /app strata-asm-runner ${ASM_FEATURES}
+    cargo install --locked --git https://github.com/alpenlabs/asm "--$ASM_REF_TYPE" "$ASM_REF" --root /app strata-asm-runner ${ASM_FEATURES}
 
 FROM --platform=linux/amd64 bridge-rt:latest AS runtime
 

--- a/functional-tests/run_test.sh
+++ b/functional-tests/run_test.sh
@@ -16,20 +16,21 @@ ulimit -n 10240
 # Move to project root for cargo builds
 pushd .. > /dev/null
 
-# Resolve a dependency's git rev pinned in Cargo.toml.
-extract_cargo_rev() {
+# Resolve a dependency's git ref pinned in Cargo.toml.
+extract_cargo_git_ref() {
     local crate="$1"
-    local rev
-    rev=$(grep "${crate}.*rev" Cargo.toml | sed 's/.*rev = "\([^"]*\)".*/\1/')
-    if [ -z "$rev" ]; then
-        echo "ERROR: failed to extract ${crate} rev from Cargo.toml" >&2
-        exit 1
+    local dep_line
+    dep_line=$(grep -E "^[[:space:]]*${crate}[[:space:]]*=" Cargo.toml | head -n 1)
+    if [[ "$dep_line" =~ (rev|tag)[[:space:]]*=[[:space:]]*\"([^\"]+)\" ]]; then
+        echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+        return
     fi
-    echo "$rev"
+    echo "ERROR: failed to extract ${crate} git ref from Cargo.toml" >&2
+    exit 1
 }
 
-# Pin the asm rev once; sp1-setup.bash and the asm-runner install both consume it.
-ASM_REV=$(extract_cargo_rev strata-asm-worker)
+# Pin the asm ref once; sp1-setup.bash and the asm-runner install both consume it.
+read -r ASM_REF_TYPE ASM_REF < <(extract_cargo_git_ref strata-asm-worker)
 
 # Configure build parameters based on environment
 if [ $CI_COVERAGE ]; then
@@ -71,14 +72,14 @@ RUSTFLAGS="$RUSTFLAGS" cargo build --bin strata-bridge $CARGO_ARGS $BRIDGE_FEATU
 RUSTFLAGS="$RUSTFLAGS" cargo build -p secret-service --bin secret-service $CARGO_ARGS
 cargo build --bin dev-cli $CARGO_ARGS
 
-MOSAIC_REV=$(extract_cargo_rev mosaic-rpc-api)
-echo "installing mosaic (rev $MOSAIC_REV)"
+read -r MOSAIC_REF_TYPE MOSAIC_REF < <(extract_cargo_git_ref mosaic-rpc-api)
+echo "installing mosaic ($MOSAIC_REF_TYPE $MOSAIC_REF)"
 mkdir -p functional-tests/_dd/.bin
 CARGO_LOCAL_BIN=$(realpath "functional-tests/_dd/.bin")
 export PATH="$CARGO_LOCAL_BIN/bin:$PATH"
 RUSTFLAGS="" cargo install \
     --git https://github.com/alpenlabs/mosaic \
-    --rev "$MOSAIC_REV" \
+    "--$MOSAIC_REF_TYPE" "$MOSAIC_REF" \
     --features=reduced-circuits \
     --root "$CARGO_LOCAL_BIN" \
     mosaic
@@ -88,11 +89,11 @@ ASM_RUNNER_FEATURES=""
 if [ "$BRIDGE_PROOF_SP1_ASM" = "1" ]; then
     ASM_RUNNER_FEATURES="--features sp1"
 fi
-echo "installing strata-asm-runner (rev $ASM_REV) $ASM_RUNNER_FEATURES"
+echo "installing strata-asm-runner ($ASM_REF_TYPE $ASM_REF) $ASM_RUNNER_FEATURES"
 RUSTFLAGS="" cargo install \
     --locked \
     --git https://github.com/alpenlabs/asm \
-    --rev "$ASM_REV" \
+    "--$ASM_REF_TYPE" "$ASM_REF" \
     $ASM_RUNNER_FEATURES \
     --root "$CARGO_LOCAL_BIN" \
     strata-asm-runner

--- a/functional-tests/sp1-setup.bash
+++ b/functional-tests/sp1-setup.bash
@@ -8,8 +8,7 @@
 # and bake them into the ELF so proofs verify against the actual chain; otherwise build
 # with bundled stub params.
 #
-# Sourced from run_test.sh after `pushd ..`: expects CWD = repo root and consumes the
-# parent shell's `extract_cargo_rev` helper plus `$ASM_REV`.
+# Sourced from run_test.sh after `pushd ..`: expects CWD = repo root and consumes `$ASM_REF`.
 BRIDGE_FEATURES=""
 if [ "$BRIDGE_PROOF_SP1" = "1" ]; then
     export SP1_PROVER="${SP1_PROVER:-mock}"
@@ -19,17 +18,19 @@ if [ "$BRIDGE_PROOF_SP1" = "1" ]; then
         export BRIDGE_PROOF_NUM_OPERATORS="${BRIDGE_PROOF_NUM_OPERATORS:-2}"
 
         # Opt-in: real SP1 Groth16 ASM+Moho proving. Build the asm/moho guest ELFs at the
-        # pinned asm rev, derive their Sp1Groth16 predicates, and (later) point the
+        # pinned asm ref, derive their Sp1Groth16 predicates, and (later) point the
         # asm-runner at the ELFs. Without this, the asm-runner signs native Schnorr
         # attestations and the vk files stay Bip340Schnorr.
         if [ "$BRIDGE_PROOF_SP1_ASM" = "1" ]; then
             ASM_SRC="$(realpath functional-tests)/.asm-src"
-            if [ "$(git -C "$ASM_SRC" rev-parse HEAD 2>/dev/null)" != "$ASM_REV" ]; then
+            CURRENT_ASM_COMMIT="$(git -C "$ASM_SRC" rev-parse HEAD 2>/dev/null || true)"
+            TARGET_ASM_COMMIT="$(git -C "$ASM_SRC" rev-parse "$ASM_REF^{commit}" 2>/dev/null || true)"
+            if [ -z "$TARGET_ASM_COMMIT" ] || [ "$CURRENT_ASM_COMMIT" != "$TARGET_ASM_COMMIT" ]; then
                 rm -rf "$ASM_SRC"
                 git clone https://github.com/alpenlabs/asm "$ASM_SRC"
-                git -C "$ASM_SRC" checkout "$ASM_REV"
+                git -C "$ASM_SRC" checkout "$ASM_REF"
             fi
-            echo "Building ASM/Moho SP1 guest ELFs (asm rev $ASM_REV); this is slow"
+            echo "Building ASM/Moho SP1 guest ELFs (asm ref $ASM_REF); this is slow"
             # The asm guest-builder compiles C deps for the riscv guest target; point AR at
             # the succinct toolchain's llvm-ar so cross-compilation finds a compatible archiver.
             SP1_AR="$(rustc +succinct --print sysroot)/lib/rustlib/$(rustc +succinct -vV | sed -n 's/^host: //p')/bin/llvm-ar"


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR pins the mosaic and asm deps to the `0.3.0-rc.1` tag. The functional tests and CI scripts have been updated so that `asm-runner` and `mosaic` binaries are installed by `ref` (`tag` or `rev`).

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->