### PR TITLE
fix(bridge-sm): bind bridge proof to the graph's expected claim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11633,10 +11633,8 @@ dependencies = [
  "serde_json",
  "strata-crypto",
  "strata-identifiers",
- "strata-predicate",
  "thiserror 2.0.18",
  "tokio",
- "zkaleido",
 ]
 
 [[package]]
@@ -11710,13 +11708,16 @@ dependencies = [
  "secp256k1 0.29.1",
  "serde",
  "serde-big-array",
+ "ssz",
  "strata-asm-common",
  "strata-asm-proto-bridge-v1-txs",
  "strata-bridge-connectors",
  "strata-bridge-p2p-types",
  "strata-bridge-primitives",
+ "strata-bridge-proof",
  "strata-bridge-test-utils",
  "strata-bridge-tx-graph",
+ "strata-codec",
  "strata-l1-txfmt",
  "strata-mosaic-client-api",
  "strata-predicate",

--- a/crates/bridge-sm/Cargo.toml
+++ b/crates/bridge-sm/Cargo.toml
@@ -11,11 +11,13 @@ workspace = true
 strata-bridge-connectors.workspace = true
 strata-bridge-p2p-types.workspace = true
 strata-bridge-primitives.workspace = true
+strata-bridge-proof.workspace = true
 strata-bridge-tx-graph.workspace = true
 strata-mosaic-client-api.workspace = true
 
 strata-asm-common.workspace = true
 strata-asm-proto-bridge-v1-txs.workspace = true
+strata-codec.workspace = true
 strata-l1-txfmt.workspace = true
 strata-predicate.workspace = true
 
@@ -24,6 +26,7 @@ bitcoin-bosd.workspace = true
 musig2.workspace = true
 serde.workspace = true
 serde-big-array.workspace = true
+ssz.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 zkaleido.workspace = true

--- a/crates/bridge-sm/src/graph/handlers/retry.rs
+++ b/crates/bridge-sm/src/graph/handlers/retry.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use bitcoin::Transaction;
 use musig2::secp256k1::schnorr::Signature;
-use strata_bridge_primitives::proof::verify_bridge_proof;
 use strata_bridge_tx_graph::{
     game_graph::{DepositParams, GameConnectors},
     musig_functor::GameFunctor,
@@ -16,6 +15,7 @@ use crate::graph::{
     errors::{GSMError, GSMResult},
     events::RetryTickEvent,
     machine::{GSMOutput, GraphSM, generate_game_graph},
+    proof::verify_bridge_proof,
     state::GraphState,
     watchtower::watchtower_slot_for_operator,
 };
@@ -125,7 +125,11 @@ impl GraphSM {
                 bridge_proof_tx,
                 ..
             } if self.context().operator_idx() != self.context().operator_table().pov_idx()
-                && !verify_bridge_proof(&cfg.bridge_proof_predicate, proof) =>
+                && !verify_bridge_proof(
+                    self.context().graph_idx(),
+                    &cfg.bridge_proof_predicate,
+                    proof,
+                ) =>
             {
                 vec![self.generate_counterproof_duty(
                     &cfg,
@@ -200,7 +204,11 @@ impl GraphSM {
                     // invalid bridge proof exists and PoV operator's counterproof has not
                     // appeared on chain yet.
                     if let Some((bridge_proof_tx, proof)) = refuted_bridge_proof
-                        && !verify_bridge_proof(&cfg.bridge_proof_predicate, proof)
+                        && !verify_bridge_proof(
+                            self.context().graph_idx(),
+                            &cfg.bridge_proof_predicate,
+                            proof,
+                        )
                         && !counterproofs_and_confs.contains_key(&pov_idx)
                     {
                         vec![self.generate_counterproof_duty(

--- a/crates/bridge-sm/src/graph/mod.rs
+++ b/crates/bridge-sm/src/graph/mod.rs
@@ -7,6 +7,7 @@ pub mod events;
 mod handlers;
 pub mod machine;
 mod post_processor;
+pub(crate) mod proof;
 pub mod state;
 pub mod transitions;
 mod tx_classifier;

--- a/crates/bridge-sm/src/graph/proof.rs
+++ b/crates/bridge-sm/src/graph/proof.rs
@@ -34,8 +34,9 @@ pub(crate) fn verify_bridge_proof(
         return false;
     };
 
-    // TODO(STR-3863): bind `output.total_pow` to a trusted chain-work threshold once "heavier
-    // chain mode" lands. We have no threshold to compare against yet, so PoW stays unchecked.
+    // TODO: <https://alpenlabs.atlassian.net/browse/STR-3863>
+    // Bind `output.total_pow` to a trusted chain-work threshold once "heavier chain mode" lands.
+    // We have no threshold to compare against yet, so PoW stays unchecked.
     let _ = output.total_pow;
 
     // Bind the committed claim to the one this graph defends.

--- a/crates/bridge-sm/src/graph/proof.rs
+++ b/crates/bridge-sm/src/graph/proof.rs
@@ -1,0 +1,164 @@
+//! Verification of bridge proofs against the graph the watchtower defends.
+
+use ssz::Decode;
+use strata_bridge_primitives::types::GraphIdx;
+use strata_bridge_proof::{BridgeProofOutput, OperatorClaimUnlock};
+use strata_codec::decode_buf_exact;
+use strata_predicate::PredicateKey;
+use zkaleido::ProofReceipt;
+
+/// Returns `true` if `proof` verifies under `predicate_key` and commits to the claim expected for
+/// the graph identified by `graph_idx`.
+pub(crate) fn verify_bridge_proof(
+    graph_idx: GraphIdx,
+    predicate_key: &PredicateKey,
+    proof: &ProofReceipt,
+) -> bool {
+    // The SNARK must verify against the public values the prover committed.
+    if predicate_key
+        .verify_claim_witness(proof.public_values().as_bytes(), proof.proof().as_bytes())
+        .is_err()
+    {
+        tracing::warn!(
+            reason = "snark verification failed",
+            "bridge proof rejected"
+        );
+        return false;
+    }
+
+    let Ok(output) = BridgeProofOutput::from_ssz_bytes(proof.public_values().as_bytes()) else {
+        tracing::warn!(
+            reason = "could not decode public values as BridgeProofOutput",
+            "bridge proof rejected"
+        );
+        return false;
+    };
+
+    // TODO(STR-3863): bind `output.total_pow` to a trusted chain-work threshold once "heavier
+    // chain mode" lands. We have no threshold to compare against yet, so PoW stays unchecked.
+    let _ = output.total_pow;
+
+    // Bind the committed claim to the one this graph defends.
+    let Ok(actual_claim) = decode_buf_exact::<OperatorClaimUnlock>(&output.claim_unlock) else {
+        tracing::warn!(
+            reason = "could not decode claim_unlock as OperatorClaimUnlock",
+            "bridge proof rejected"
+        );
+        return false;
+    };
+
+    let expected_claim = OperatorClaimUnlock::new(graph_idx.deposit, graph_idx.operator);
+    if actual_claim != expected_claim {
+        tracing::warn!(
+            ?expected_claim,
+            ?actual_claim,
+            reason = "claim does not match the defended graph",
+            "bridge proof rejected"
+        );
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_codec::encode_to_vec;
+    use strata_predicate::PredicateKey;
+    use zkaleido::{Proof, ProofReceipt, PublicValues};
+
+    use super::*;
+
+    const DEPOSIT_IDX: u32 = 7;
+    const OPERATOR_IDX: u32 = 3;
+
+    fn receipt_for(deposit_idx: u32, operator_idx: u32) -> ProofReceipt {
+        let claim_unlock =
+            encode_to_vec(&OperatorClaimUnlock::new(deposit_idx, operator_idx)).unwrap();
+        let output = BridgeProofOutput {
+            total_pow: [0u8; 32],
+            claim_unlock,
+            mmr_idx: 0,
+        };
+        ProofReceipt::new(
+            Proof::new(vec![]),
+            PublicValues::new(ssz::Encode::as_ssz_bytes(&output)),
+        )
+    }
+
+    fn graph_idx() -> GraphIdx {
+        GraphIdx {
+            deposit: DEPOSIT_IDX,
+            operator: OPERATOR_IDX,
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_snark() {
+        let receipt = receipt_for(DEPOSIT_IDX, OPERATOR_IDX);
+        assert!(!verify_bridge_proof(
+            graph_idx(),
+            &PredicateKey::never_accept(),
+            &receipt
+        ));
+    }
+
+    #[test]
+    fn rejects_undecodable_public_values() {
+        // Empty public values cannot decode into a `BridgeProofOutput`.
+        let receipt = ProofReceipt::new(Proof::new(vec![]), PublicValues::new(vec![]));
+        assert!(!verify_bridge_proof(
+            graph_idx(),
+            &PredicateKey::always_accept(),
+            &receipt
+        ));
+    }
+
+    #[test]
+    fn accepts_valid_matching_claim() {
+        let receipt = receipt_for(DEPOSIT_IDX, OPERATOR_IDX);
+        assert!(verify_bridge_proof(
+            graph_idx(),
+            &PredicateKey::always_accept(),
+            &receipt
+        ));
+    }
+
+    #[test]
+    fn rejects_valid_snark_with_wrong_operator() {
+        let receipt = receipt_for(DEPOSIT_IDX, OPERATOR_IDX + 1);
+        assert!(!verify_bridge_proof(
+            graph_idx(),
+            &PredicateKey::always_accept(),
+            &receipt
+        ));
+    }
+
+    #[test]
+    fn rejects_valid_snark_with_wrong_deposit() {
+        let receipt = receipt_for(DEPOSIT_IDX + 1, OPERATOR_IDX);
+        assert!(!verify_bridge_proof(
+            graph_idx(),
+            &PredicateKey::always_accept(),
+            &receipt
+        ));
+    }
+
+    #[test]
+    fn rejects_garbage_claim_bytes() {
+        let output = BridgeProofOutput {
+            total_pow: [0u8; 32],
+            claim_unlock: vec![0xff; 3],
+            mmr_idx: 0,
+        };
+        let receipt = ProofReceipt::new(
+            Proof::new(vec![]),
+            PublicValues::new(ssz::Encode::as_ssz_bytes(&output)),
+        );
+        assert!(!verify_bridge_proof(
+            graph_idx(),
+            &PredicateKey::always_accept(),
+            &receipt
+        ));
+    }
+}

--- a/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_bridge_proof.rs
@@ -16,7 +16,8 @@ use crate::{
         state::{CounterproofData, GraphState},
         tests::{
             GraphInvalidTransition, GraphTransition, LATER_BLOCK_HEIGHT, TEST_NONPOV_IDX,
-            create_nonpov_sm, create_sm, dummy_proof_receipt, get_state, mock_game_signatures,
+            create_nonpov_sm, create_sm, dummy_proof_receipt, get_state, matching_proof_receipt,
+            mismatching_proof_receipt, mock_game_signatures,
             mock_states::{
                 TEST_FULFILLMENT_TXID, TEST_GRAPH_SUMMARY, all_state_variants,
                 bridge_proof_posted_state, contested_state, contested_state_with,
@@ -38,6 +39,25 @@ fn bridge_proof_event() -> BridgeProofConfirmedEvent {
         bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
         tx: test_bridge_proof_tx(),
         proof: dummy_proof_receipt(),
+    }
+}
+
+/// A bridge proof event carrying a valid proof bound to the graph under test.
+fn matching_bridge_proof_event() -> BridgeProofConfirmedEvent {
+    BridgeProofConfirmedEvent {
+        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx: test_bridge_proof_tx(),
+        proof: matching_proof_receipt(),
+    }
+}
+
+/// A bridge proof event carrying a valid SNARK whose committed claim is for a *different* operator,
+/// so a watchtower must counterproof it even under an accepting predicate.
+fn mismatching_bridge_proof_event() -> BridgeProofConfirmedEvent {
+    BridgeProofConfirmedEvent {
+        bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+        tx: test_bridge_proof_tx(),
+        proof: mismatching_proof_receipt(),
     }
 }
 
@@ -76,7 +96,7 @@ fn event_accepted_pov_no_duties() {
 #[test]
 fn watchtower_skips_counterproof_when_proof_valid() {
     let cfg = test_graph_sm_cfg();
-    let event = bridge_proof_event();
+    let event = matching_bridge_proof_event();
 
     test_transition::<crate::graph::machine::GraphSM, _, _, _, _, _, _, _>(
         create_nonpov_sm,
@@ -94,7 +114,7 @@ fn watchtower_skips_counterproof_when_proof_valid() {
                 contest_block_height: LATER_BLOCK_HEIGHT,
                 bridge_proof_tx: event.tx.clone(),
                 bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
-                proof: dummy_proof_receipt(),
+                proof: matching_proof_receipt(),
                 stake_spent: None,
                 payout_connector_spent: None,
             },
@@ -160,8 +180,66 @@ fn watchtower_emits_counterproof_when_proof_invalid() {
 }
 
 #[test]
+fn watchtower_emits_counterproof_when_proof_claim_mismatched() {
+    // Soundness: the predicate accepts the SNARK, but the proof commits a claim for a *different*
+    // operator than the one this graph defends. The watchtower must still counterproof it.
+    // Before the claim-binding fix this proof was treated as valid and no counterproof was raised.
+    let cfg = test_graph_sm_cfg();
+    let event = mismatching_bridge_proof_event();
+    let sm = create_nonpov_sm(contested_state());
+
+    let game_graph = generate_game_graph(&cfg, sm.context(), &test_deposit_params());
+    let signatures = mock_game_signatures(&game_graph);
+    let watchtower_idx = watchtower_slot_for_operator(
+        sm.context().operator_idx(),
+        sm.context().operator_table().pov_idx(),
+    )
+    .expect("graph owner has no watchtower index");
+    let expected_counterproof_tx = game_graph.counterproofs[watchtower_idx]
+        .counterproof
+        .clone();
+    let expected_n_of_n_sig =
+        GameFunctor::unpack(signatures.clone(), sm.context().watchtower_pubkeys().len())
+            .expect("unpack must succeed")
+            .watchtowers[watchtower_idx]
+            .counterproof[0];
+
+    test_transition::<crate::graph::machine::GraphSM, _, _, _, _, _, _, _>(
+        create_nonpov_sm,
+        get_state,
+        cfg,
+        GraphTransition {
+            from_state: contested_state_with(LATER_BLOCK_HEIGHT, signatures.clone()),
+            event: GraphEvent::BridgeProofConfirmed(event.clone()),
+            expected_state: GraphState::BridgeProofPosted {
+                last_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+                graph_data: test_deposit_params(),
+                graph_summary: TEST_GRAPH_SUMMARY.clone(),
+                signatures,
+                fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+                contest_block_height: LATER_BLOCK_HEIGHT,
+                bridge_proof_tx: event.tx.clone(),
+                bridge_proof_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+                proof: mismatching_proof_receipt(),
+                stake_spent: None,
+                payout_connector_spent: None,
+            },
+            expected_duties: vec![GraphDuty::GenerateAndPublishCounterProof {
+                graph_idx: sm.context().graph_idx(),
+                game_index: test_deposit_params().game_index,
+                counterproof_tx: expected_counterproof_tx,
+                n_of_n_signature: expected_n_of_n_sig,
+                proof: mismatching_proof_receipt(),
+                bridge_proof_tx: event.tx.clone(),
+            }],
+            expected_signals: vec![],
+        },
+    );
+}
+
+#[test]
 fn accepts_bridge_proof_posted_after_counterproof() {
-    let event = bridge_proof_event();
+    let event = matching_bridge_proof_event();
     let event_tx = event.tx.clone();
 
     test_transition::<crate::graph::machine::GraphSM, _, _, _, _, _, _, _>(
@@ -178,7 +256,7 @@ fn accepts_bridge_proof_posted_after_counterproof() {
                 signatures: vec![],
                 fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
                 contest_block_height: LATER_BLOCK_HEIGHT,
-                refuted_bridge_proof: Some((event_tx, dummy_proof_receipt())),
+                refuted_bridge_proof: Some((event_tx, matching_proof_receipt())),
                 counterproofs_and_confs: Default::default(),
                 counterproof_nacks: Default::default(),
                 stake_spent: None,
@@ -252,6 +330,76 @@ fn watchtower_emits_counterproof_when_late_proof_invalid() {
                 counterproof_tx: expected_counterproof_tx,
                 n_of_n_signature: expected_n_of_n_sig,
                 proof: dummy_proof_receipt(),
+                bridge_proof_tx: event.tx.clone(),
+            }],
+            expected_signals: vec![],
+        },
+    );
+}
+
+#[test]
+fn watchtower_emits_counterproof_when_late_proof_claim_mismatched() {
+    // Soundness, late path: accepting predicate, but the proof binds a different operator's claim.
+    let cfg = test_graph_sm_cfg();
+    let event = mismatching_bridge_proof_event();
+    let sm = create_nonpov_sm(counter_proof_posted_without_refuted_proof_state());
+
+    let game_graph = generate_game_graph(&cfg, sm.context(), &test_deposit_params());
+    let signatures = mock_game_signatures(&game_graph);
+    let watchtower_idx = watchtower_slot_for_operator(
+        sm.context().operator_idx(),
+        sm.context().operator_table().pov_idx(),
+    )
+    .expect("graph owner has no watchtower index");
+    let expected_counterproof_tx = game_graph.counterproofs[watchtower_idx]
+        .counterproof
+        .clone();
+    let expected_n_of_n_sig =
+        GameFunctor::unpack(signatures.clone(), sm.context().watchtower_pubkeys().len())
+            .expect("unpack must succeed")
+            .watchtowers[watchtower_idx]
+            .counterproof[0];
+
+    let from_state = GraphState::CounterProofPosted {
+        last_block_height: LATER_BLOCK_HEIGHT,
+        graph_data: test_deposit_params(),
+        graph_summary: TEST_GRAPH_SUMMARY.clone(),
+        signatures: signatures.clone(),
+        fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+        contest_block_height: LATER_BLOCK_HEIGHT,
+        refuted_bridge_proof: None,
+        counterproofs_and_confs: Default::default(),
+        counterproof_nacks: Default::default(),
+        stake_spent: None,
+        payout_connector_spent: None,
+    };
+
+    test_transition::<crate::graph::machine::GraphSM, _, _, _, _, _, _, _>(
+        create_nonpov_sm,
+        get_state,
+        cfg,
+        GraphTransition {
+            from_state,
+            event: GraphEvent::BridgeProofConfirmed(event.clone()),
+            expected_state: GraphState::CounterProofPosted {
+                last_block_height: BRIDGE_PROOF_BLOCK_HEIGHT,
+                graph_data: test_deposit_params(),
+                graph_summary: TEST_GRAPH_SUMMARY.clone(),
+                signatures,
+                fulfillment_txid: Some(*TEST_FULFILLMENT_TXID),
+                contest_block_height: LATER_BLOCK_HEIGHT,
+                refuted_bridge_proof: Some((event.tx.clone(), mismatching_proof_receipt())),
+                counterproofs_and_confs: Default::default(),
+                counterproof_nacks: Default::default(),
+                stake_spent: None,
+                payout_connector_spent: None,
+            },
+            expected_duties: vec![GraphDuty::GenerateAndPublishCounterProof {
+                graph_idx: sm.context().graph_idx(),
+                game_index: test_deposit_params().game_index,
+                counterproof_tx: expected_counterproof_tx,
+                n_of_n_signature: expected_n_of_n_sig,
+                proof: mismatching_proof_receipt(),
                 bridge_proof_tx: event.tx.clone(),
             }],
             expected_signals: vec![],

--- a/crates/bridge-sm/src/graph/tests/handlers/process_retry_tick.rs
+++ b/crates/bridge-sm/src/graph/tests/handlers/process_retry_tick.rs
@@ -20,7 +20,8 @@ mod tests {
         tests::{
             FULFILLMENT_BLOCK_HEIGHT, GraphHandlerOutput, INITIAL_BLOCK_HEIGHT, LATER_BLOCK_HEIGHT,
             TEST_ASSIGNEE, TEST_NONPOV_IDX, TEST_POV_IDX, create_nonpov_sm, create_sm,
-            dummy_proof_receipt, mock_game_signatures,
+            dummy_proof_receipt, matching_proof_receipt, mismatching_proof_receipt,
+            mock_game_signatures,
             mock_states::{
                 assigned_state, bridge_proof_posted_state, bridge_proof_posted_state_with,
                 claimed_state, contested_state, counter_proof_posted_state,
@@ -332,10 +333,15 @@ mod tests {
     // (graph owner: non-PoV, proof valid?: valid)     -> []
     #[test]
     fn test_retry_tick_noop_in_bridge_proof_posted_when_proof_valid() {
+        let mut state = bridge_proof_posted_state();
+        if let GraphState::BridgeProofPosted { proof, .. } = &mut state {
+            *proof = matching_proof_receipt();
+        }
+
         test_nonpov_owned_handler_output(
             test_graph_sm_cfg(),
             GraphHandlerOutput {
-                state: bridge_proof_posted_state(),
+                state,
                 event: GraphEvent::RetryTick(RetryTickEvent),
                 expected_duties: vec![],
             },
@@ -354,6 +360,33 @@ mod tests {
         let game_graph = generate_game_graph(&cfg, sm.context(), &test_deposit_params());
         let signatures = mock_game_signatures(&game_graph);
         let state = bridge_proof_posted_state_with(LATER_BLOCK_HEIGHT, signatures);
+        let expected_duty = expected_counterproof_duty(&cfg, &sm, &state);
+
+        test_nonpov_owned_handler_output(
+            cfg,
+            GraphHandlerOutput {
+                state,
+                event: GraphEvent::RetryTick(RetryTickEvent),
+                expected_duties: vec![expected_duty],
+            },
+        );
+    }
+
+    // (graph owner: non-PoV, proof valid SNARK but claim mismatched)  -> [counterproof]
+    //
+    // Soundness: an accepting predicate must not let a proof bound to a *different* operator's
+    // claim pass. The retry handler must still emit a counterproof.
+    #[test]
+    fn test_retry_tick_emits_counterproof_in_bridge_proof_posted_when_claim_mismatched() {
+        let cfg = test_graph_sm_cfg();
+
+        let sm = create_nonpov_sm(bridge_proof_posted_state());
+        let game_graph = generate_game_graph(&cfg, sm.context(), &test_deposit_params());
+        let signatures = mock_game_signatures(&game_graph);
+        let mut state = bridge_proof_posted_state_with(LATER_BLOCK_HEIGHT, signatures);
+        if let GraphState::BridgeProofPosted { proof, .. } = &mut state {
+            *proof = mismatching_proof_receipt();
+        }
         let expected_duty = expected_counterproof_duty(&cfg, &sm, &state);
 
         test_nonpov_owned_handler_output(
@@ -702,10 +735,19 @@ mod tests {
     // (refuted_proof: Some, proof_valid?: valid, , PoV cp confirmed: no)     -> []
     #[test]
     fn test_retry_tick_noop_in_counter_proof_posted_for_nonpov_graph_when_proof_valid() {
+        let mut state = counter_proof_posted_state();
+        if let GraphState::CounterProofPosted {
+            refuted_bridge_proof: Some((_, proof)),
+            ..
+        } = &mut state
+        {
+            *proof = matching_proof_receipt();
+        }
+
         test_nonpov_owned_handler_output(
             test_graph_sm_cfg(),
             GraphHandlerOutput {
-                state: counter_proof_posted_state(),
+                state,
                 event: GraphEvent::RetryTick(RetryTickEvent),
                 expected_duties: vec![],
             },
@@ -720,7 +762,7 @@ mod tests {
             test_graph_sm_cfg(),
             GraphHandlerOutput {
                 state: counter_proof_posted_state_with(
-                    Some(dummy_proof_receipt()),
+                    Some(matching_proof_receipt()),
                     &[TEST_NONPOV_IDX],
                     &[],
                 ),
@@ -743,6 +785,37 @@ mod tests {
         let signatures = mock_game_signatures(&game_graph);
         let state = counter_proof_posted_state_with_signatures(
             Some(dummy_proof_receipt()),
+            &[],
+            &[],
+            signatures,
+        );
+        let expected_duty = expected_counterproof_duty(&cfg, &sm, &state);
+
+        test_nonpov_owned_handler_output(
+            cfg,
+            GraphHandlerOutput {
+                state,
+                event: GraphEvent::RetryTick(RetryTickEvent),
+                expected_duties: vec![expected_duty],
+            },
+        );
+    }
+
+    // (refuted_proof: Some, valid SNARK but claim mismatched, PoV cp confirmed: no) ->
+    // [counterproof]
+    //
+    // Soundness, refuted-proof retry path: accepting predicate, proof bound to a different
+    // operator.
+    #[test]
+    fn test_retry_tick_emits_counterproof_in_counter_proof_posted_when_refuted_proof_claim_mismatched()
+     {
+        let cfg = test_graph_sm_cfg();
+
+        let sm = create_nonpov_sm(counter_proof_posted_state());
+        let game_graph = generate_game_graph(&cfg, sm.context(), &test_deposit_params());
+        let signatures = mock_game_signatures(&game_graph);
+        let state = counter_proof_posted_state_with_signatures(
+            Some(mismatching_proof_receipt()),
             &[],
             &[],
             signatures,

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -28,6 +28,7 @@ use strata_bridge_primitives::{
     secp::EvenSecretKey,
     types::{GraphIdx, OperatorIdx},
 };
+use strata_bridge_proof::{BridgeProofOutput, OperatorClaimUnlock};
 use strata_bridge_test_utils::{
     bitcoin::{generate_spending_tx, generate_xonly_pubkey},
     prelude::generate_signature,
@@ -39,6 +40,7 @@ use strata_bridge_tx_graph::{
     },
     transactions::prelude::{ClaimTx, ContestTx, CounterproofTx},
 };
+use strata_codec::encode_to_vec;
 use strata_mosaic_client_api::types::CompletedSignatures;
 use strata_predicate::PredicateKey;
 use zkaleido::{Proof, ProofReceipt, PublicValues};
@@ -69,8 +71,41 @@ use crate::{
 
 // ===== Dummy Values =====
 
+/// A proof receipt with **empty** public values. Models an *undecodable / invalid* bridge proof:
+/// verification fails at the public-values decode step regardless of the predicate. Use it where
+/// the proof content is irrelevant or where an invalid proof is intended.
 pub(super) fn dummy_proof_receipt() -> ProofReceipt {
     ProofReceipt::new(Proof::new(vec![]), PublicValues::new(vec![]))
+}
+
+/// Builds a [`ProofReceipt`] whose public values commit a [`BridgeProofOutput`] binding the given
+/// `(deposit_idx, operator_idx)` claim. The PoW/MMR fields are placeholders — they are not checked
+/// by verification yet (see STR-3863).
+pub(super) fn proof_receipt_for_claim(deposit_idx: u32, operator_idx: OperatorIdx) -> ProofReceipt {
+    let claim_unlock = encode_to_vec(&OperatorClaimUnlock::new(deposit_idx, operator_idx)).unwrap();
+    let output = BridgeProofOutput {
+        total_pow: [0u8; 32],
+        claim_unlock,
+        mmr_idx: 0,
+    };
+    ProofReceipt::new(
+        Proof::new(vec![]),
+        PublicValues::new(ssz::Encode::as_ssz_bytes(&output)),
+    )
+}
+
+/// A proof receipt whose committed claim matches the graph under test (`TEST_DEPOSIT_IDX`,
+/// `TEST_POV_IDX`) — the graph owner in both [`create_sm`] and [`create_nonpov_sm`]. Combined with
+/// `PredicateKey::always_accept`, this is a fully valid, correctly-bound proof.
+pub(super) fn matching_proof_receipt() -> ProofReceipt {
+    proof_receipt_for_claim(TEST_DEPOSIT_IDX, TEST_POV_IDX)
+}
+
+/// A proof receipt that is a valid SNARK (under `always_accept`) but commits a claim for a
+/// *different* operator. A watchtower must reject it as a defense of this graph — this is the
+/// soundness case the verifier's claim-binding closes.
+pub(super) fn mismatching_proof_receipt() -> ProofReceipt {
+    proof_receipt_for_claim(TEST_DEPOSIT_IDX, TEST_NONPOV_IDX)
 }
 
 // ===== Test Constants =====

--- a/crates/bridge-sm/src/graph/transitions/contested.rs
+++ b/crates/bridge-sm/src/graph/transitions/contested.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bitcoin::Transaction;
-use strata_bridge_primitives::{proof::verify_bridge_proof, types::OperatorIdx};
+use strata_bridge_primitives::types::OperatorIdx;
 use strata_bridge_tx_graph::{
     game_graph::{GameConnectors, GameGraphSummary},
     musig_functor::GameFunctor,
@@ -17,6 +17,7 @@ use crate::{
             CounterProofAckConfirmedEvent, CounterProofNackConfirmedEvent, StakeSpentEvent,
         },
         machine::{GSMOutput, GraphSM, generate_game_graph},
+        proof::verify_bridge_proof,
         state::{AbortReason, GraphState},
         watchtower::watchtower_slot_for_operator,
     },
@@ -131,8 +132,11 @@ impl GraphSM {
 
                 let is_watchtower =
                     self.context().operator_idx() != self.context().operator_table().pov_idx();
-                let is_proof_valid =
-                    verify_bridge_proof(&cfg.bridge_proof_predicate, &bridge_proof);
+                let is_proof_valid = verify_bridge_proof(
+                    self.context().graph_idx(),
+                    &cfg.bridge_proof_predicate,
+                    &bridge_proof,
+                );
 
                 let mut duties = Vec::new();
 
@@ -221,8 +225,11 @@ impl GraphSM {
                 let bridge_proof = event.proof.clone();
                 let pov_idx = self.context().operator_table().pov_idx();
                 let is_watchtower = self.context().operator_idx() != pov_idx;
-                let is_proof_valid =
-                    verify_bridge_proof(&cfg.bridge_proof_predicate, &bridge_proof);
+                let is_proof_valid = verify_bridge_proof(
+                    self.context().graph_idx(),
+                    &cfg.bridge_proof_predicate,
+                    &bridge_proof,
+                );
                 let counterproof_exists = counterproofs_and_confs.contains_key(&pov_idx);
 
                 let mut duties = Vec::new();

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -10,9 +10,6 @@ workspace = true
 strata-crypto.workspace = true
 strata-identifiers.workspace = true
 
-strata-predicate.workspace = true
-zkaleido.workspace = true
-
 algebra = { path = "../algebra", default-features = false }
 anyhow.workspace = true
 arbitrary.workspace = true

--- a/crates/primitives/src/proof.rs
+++ b/crates/primitives/src/proof.rs
@@ -1,15 +1,6 @@
 //! Proof-related types used across the bridge.
 
 use strata_identifiers::L1BlockCommitment;
-use strata_predicate::PredicateKey;
-use zkaleido::ProofReceipt;
-
-/// Returns `true` if the proof is valid according to the given predicate key.
-pub fn verify_bridge_proof(predicate_key: &PredicateKey, proof: &ProofReceipt) -> bool {
-    predicate_key
-        .verify_claim_witness(proof.public_values().as_bytes(), proof.proof().as_bytes())
-        .is_ok()
-}
 
 /// An opaque ASM step proof for a range of L1 blocks.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Description

The bridge proof verifier only checked that the SNARK was valid for the public values the **prover** supplied — it never checked *what* those values were. The proof's public output is `OperatorClaimUnlock { deposit_idx, operator_idx }` (plus `total_pow`), all chosen by the prover.

This binds the proof to the graph being defended: `verify_bridge_proof` now decodes the committed `BridgeProofOutput`, decodes its `claim_unlock`, and rejects the proof unless it equals the `OperatorClaimUnlock` reconstructed from the graph's own `graph_idx = (deposit, operator)`.

The verifier moved from `strata-bridge-primitives` (its only consumer was `bridge-sm`) into `strata-bridge-sm`, which owns the `(deposit, operator)` context.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New or updated tests

## Notes to Reviewers

- **PoW binding is intentionally out of scope.** `total_pow` is also prover-chosen, but the watchtower has no trusted chain-work threshold to compare against yet, so it's left unchecked with a `// TODO(STR-3863)` at the decode site (deferred to "heavier chain mode in counterproof", STR-3863).
  
## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues
Fixes #680