### PR TITLE
fix(common): add `unstaking_timelock` to top-level params

### DIFF
--- a/bin/dev-cli/params.toml
+++ b/bin/dev-cli/params.toml
@@ -37,3 +37,4 @@ proof_timelock = 144
 ack_timelock = 144
 nack_timelock = 144
 contested_payout_timelock = 1_008
+unstaking_timelock = 2_016

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -286,15 +286,11 @@ pub(in crate::mode) fn build_sm_config(config: &Config, params: &Params) -> SMCo
         counterproof_predicate: params.protocol.counterproof_predicate.clone(),
     };
 
-    // FIXME: <https://alpenlabs.atlassian.net/browse/STR-2924>
-    // Promote `unstaking_timelock` to a protocol parameter on `ProtocolParams` once the
-    // params schema is updated. For now, use a sensible default (approximately 21 days).
-    const DEFAULT_UNSTAKING_TIMELOCK_BLOCKS: u16 = 3024;
     let stake_config = StakeSMCfg {
         protocol_params: StakeGraphProtocolParams {
             network,
             magic_bytes,
-            unstaking_timelock: relative::Height::from_height(DEFAULT_UNSTAKING_TIMELOCK_BLOCKS),
+            unstaking_timelock: relative::Height::from_height(params.protocol.unstaking_timelock),
             stake_amount: params.protocol.stake_amount,
         },
     };

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -95,6 +95,10 @@ pub struct ProtocolParams {
     /// becomes viable.
     pub contested_payout_timelock: u16,
 
+    /// The number of blocks after the unstaking intent transaction until which the operator cannot
+    /// post the unstaking transaction.
+    pub unstaking_timelock: u16,
+
     /// Predicate key used to verify bridge proof.
     #[serde(default = "PredicateKey::always_accept")]
     pub bridge_proof_predicate: PredicateKey,
@@ -481,6 +485,7 @@ mod tests {
             ack_timelock = 144
             nack_timelock = 144
             contested_payout_timelock = 1_008
+            unstaking_timelock = 2_016
     "#
         )
     }

--- a/docker/vol/strata-bridge-1/params.toml
+++ b/docker/vol/strata-bridge-1/params.toml
@@ -38,3 +38,4 @@ proof_timelock = 144
 ack_timelock = 144
 nack_timelock = 144
 contested_payout_timelock = 1_008
+unstaking_timelock = 2_016

--- a/docker/vol/strata-bridge-2/params.toml
+++ b/docker/vol/strata-bridge-2/params.toml
@@ -38,3 +38,4 @@ proof_timelock = 144
 ack_timelock = 144
 nack_timelock = 144
 contested_payout_timelock = 1_008
+unstaking_timelock = 2_016

--- a/docker/vol/strata-bridge-3/params.toml
+++ b/docker/vol/strata-bridge-3/params.toml
@@ -38,3 +38,4 @@ proof_timelock = 144
 ack_timelock = 144
 nack_timelock = 144
 contested_payout_timelock = 1_008
+unstaking_timelock = 2_016

--- a/functional-tests/factory/bridge_operator/params_cfg.py
+++ b/functional-tests/factory/bridge_operator/params_cfg.py
@@ -43,6 +43,7 @@ class BridgeProtocolParams:
     ack_timelock: int = 35
     nack_timelock: int = 30
     contested_payout_timelock: int = 60
+    unstaking_timelock: int = 75
     bridge_proof_predicate: str | None = None
     counterproof_predicate: str | None = None
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR adds `unstaking_timelock` as a first-class parameter in the top-level params for the bridge, instead of a default value.

AI was not used for this PR.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
This is needed for release.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->