### PR TITLE
ci: add g16 circuit generation and S3 upload workflow (2)

### DIFF
--- a/.github/scripts/circuit_gen.py
+++ b/.github/scripts/circuit_gen.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """circuit_gen.py — Helpers for the "Generate g16 Circuit" workflow.
 
-Drives the g16 boolean-circuit generation that runs *after* a "Publish SP1
-Bridge Guests" run: it resolves which publish run to consume, validates disk
-and tooling, derives the S3 version string from that run's artifact, uploads
+Drives the g16 boolean-circuit generation that runs *after* the "Publish SP1
+Bridge Guests" guest build in the same pipeline run: it validates disk and
+tooling, derives the S3 version string from the guest-build artifact, uploads
 the (~142 GB) `v5c.ckt` to S3, and writes a traceability summary.
 
 Pure-stdlib so it runs on any runner without an install step, mirroring
@@ -11,7 +11,6 @@ Pure-stdlib so it runs on any runner without an install step, mirroring
 documented on the per-command function.
 
 Subcommands:
-    resolve     Pick the source publish run id from the triggering event.
     preflight   Check free disk on the runs-dir mount and required CLIs.
     version     Validate the vkey and derive `<genesis_l1_height>-<bridge_sha8>`.
     upload      Copy `v5c.ckt` to s3://<bucket>/<prefix>/<version>/g16.v5c.
@@ -49,44 +48,6 @@ VKEY_NAME = "counterproof-vkey.bin"
 MANIFEST_NAME = "manifest.json"
 ASM_PARAMS_NAME = "asm-params.json"
 VKEY_LEN = 32
-
-
-# ---- resolve ---------------------------------------------------------------
-
-
-def cmd_resolve() -> None:
-    """Env: GITHUB_EVENT_NAME, GITHUB_EVENT_PATH, INPUT_PUBLISH_RUN_ID,
-    GITHUB_OUTPUT.
-
-    On a `workflow_run` event, consume the triggering publish run (and require
-    it succeeded). Otherwise (manual dispatch) use the `publish_run_id` input.
-    """
-    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
-    run_id = ""
-
-    if event_name == "workflow_run":
-        event_path = os.environ.get("GITHUB_EVENT_PATH")
-        if not event_path or not Path(event_path).is_file():
-            fail("workflow_run event but GITHUB_EVENT_PATH is missing")
-        payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
-        wr = payload.get("workflow_run") or {}
-        conclusion = wr.get("conclusion")
-        if conclusion != "success":
-            fail(
-                "triggering publish run did not succeed "
-                f"(conclusion={conclusion!r}); skipping circuit generation"
-            )
-        run_id = str(wr.get("id") or "")
-        if not run_id:
-            fail("workflow_run payload has no run id")
-    else:
-        run_id = os.environ.get("INPUT_PUBLISH_RUN_ID", "").strip()
-        if not run_id:
-            fail("no publish run id: pass the `publish_run_id` dispatch input")
-
-    if not run_id.isdigit():
-        fail(f"resolved publish_run_id is not numeric: {run_id!r}")
-    set_outputs(publish_run_id=run_id)
 
 
 # ---- preflight -------------------------------------------------------------
@@ -159,10 +120,7 @@ def cmd_version() -> None:
     vkey_path = _find_one(artifact_dir, VKEY_NAME)
     vkey_bytes = vkey_path.read_bytes()
     if len(vkey_bytes) != VKEY_LEN:
-        fail(
-            f"{VKEY_NAME} must be exactly {VKEY_LEN} bytes "
-            f"(got {len(vkey_bytes)} at {vkey_path})"
-        )
+        fail(f"{VKEY_NAME} must be exactly {VKEY_LEN} bytes (got {len(vkey_bytes)} at {vkey_path})")
 
     manifest = json.loads(_find_one(artifact_dir, MANIFEST_NAME).read_text())
     bridge_sha_full = (manifest.get("strata_bridge") or {}).get("sha", "")
@@ -248,9 +206,7 @@ def cmd_summarize() -> None:
     genesis = os.environ.get("GENESIS_L1_HEIGHT", "")
     bridge_sha = os.environ.get("BRIDGE_SHA", "")
     size_bytes = os.environ.get("CIRCUIT_SIZE_BYTES", "")
-    size_gib = (
-        f"{int(size_bytes) / (1024**3):.1f} GiB" if size_bytes.isdigit() else "n/a"
-    )
+    size_gib = f"{int(size_bytes) / (1024**3):.1f} GiB" if size_bytes.isdigit() else "n/a"
 
     lines = [
         "## g16 circuit generation",
@@ -277,7 +233,6 @@ def cmd_summarize() -> None:
 # ---- entry point -----------------------------------------------------------
 
 COMMANDS = {
-    "resolve": cmd_resolve,
     "preflight": cmd_preflight,
     "version": cmd_version,
     "upload": cmd_upload,

--- a/.github/workflows/circuit-gen.yml
+++ b/.github/workflows/circuit-gen.yml
@@ -1,27 +1,15 @@
 name: Generate g16 Circuit
 
-# Generates the g16 Groth16 boolean circuit (v5c.ckt, ~142 GB) from the
-# counterproof verification key produced by "Publish SP1 Bridge Guests", and
-# uploads it to S3. Auto-chains off a successful publish run; can also be run
-# manually. See .github/scripts/circuit_gen.py for the per-step logic.
-#
-# zizmor dangerous-triggers: workflow_run is intentional and safe here — the
-# upstream "Publish SP1 Bridge Guests" is workflow_dispatch-only (no fork/PR can
-# initiate the chain), and this job checks out trusted `main` (not the triggering
-# run's code) and only parses JSON / reads a 32-byte vkey from the artifact.
-on: # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    workflows: ["Publish SP1 Bridge Guests"]
-    types: [completed]
-  workflow_dispatch:
+# Reusable workflow: generates the g16 Groth16 boolean circuit (v5c.ckt, ~142 GB)
+# from the counterproof verification key produced by "Publish SP1 Bridge Guests"
+# in the SAME run, and uploads it to S3. Called by publish-guests-and-circuit.yml
+# after the guest-build job. See .github/scripts/circuit_gen.py for step logic.
+on:
+  workflow_call:
     inputs:
-      publish_run_id:
-        description: Run id of a completed "Publish SP1 Bridge Guests" run to consume.
-        required: true
-        type: string
       g16_ref:
         description: alpenlabs/g16 git ref (commit SHA or branch) to build g16-pipeline from.
-        required: true
+        required: false
         type: string
       runs_dir:
         description: Parent dir for pipeline run output (must sit on a >=300 GB mount). Defaults to runner temp.
@@ -53,7 +41,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # assume the circuit S3 role via OIDC
-      actions: read # download the publish run's artifact
+      actions: read # download the guest-build artifact from this run
     steps:
       - name: Checkout strata-bridge
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -73,23 +61,15 @@ jobs:
             echo "G16_REF=${INPUT_G16_REF:-$G16_DEFAULT_REF}"
           } >> "$GITHUB_ENV"
 
-      - name: Resolve source publish run
-        id: resolve
-        env:
-          INPUT_PUBLISH_RUN_ID: ${{ inputs.publish_run_id }}
-        run: python3 .github/scripts/circuit_gen.py resolve
-
       - name: Preflight (disk + tooling)
         run: python3 .github/scripts/circuit_gen.py preflight
 
-      - name: Download publish artifact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PUBLISH_RUN_ID: ${{ steps.resolve.outputs.publish_run_id }}
-        run: |
-          set -euo pipefail
-          rm -rf "$ART"
-          gh run download "$PUBLISH_RUN_ID" --repo "$GITHUB_REPOSITORY" --dir "$ART"
+      - name: Download guest-build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: sp1-bridge-guests-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/guest-artifact
 
       - name: Derive version and validate vkey
         id: version
@@ -109,6 +89,19 @@ jobs:
         working-directory: g16
         run: rustup show # installs the channel pinned by g16/rust-toolchain.toml
 
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          workspaces: g16
+          cache-on-failure: true
+
+      - name: Build g16-pipeline
+        working-directory: g16
+        # --mock skips the g16gen/prealloc stages, so only the pipeline binary is
+        # needed. When --mock is dropped, the pipeline spawns g16gen via `cargo run`
+        # at runtime — add `-p g16gen` here to pre-build it and keep gen pure execution.
+        run: cargo build --release -p g16-pipeline
+
       - name: Generate v5c circuit
         working-directory: g16
         env:
@@ -117,7 +110,7 @@ jobs:
           set -euo pipefail
           # TEMP: --mock is for dry-running on main and needs the g16 ref set to
           # c76ab7e (g16-lite). Remove --mock in the follow-up PR (main rev lacks it).
-          cargo run -p g16-pipeline --release -- gen --vkey "$VKEY_PATH" --runs-dir "$RUNS_DIR" --mock
+          ./target/release/g16-pipeline gen --vkey "$VKEY_PATH" --runs-dir "$RUNS_DIR" --mock
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
@@ -136,7 +129,7 @@ jobs:
         env:
           S3_URI: ${{ steps.upload.outputs.s3_uri }}
           VERSION: ${{ steps.version.outputs.version }}
-          PUBLISH_RUN_ID: ${{ steps.resolve.outputs.publish_run_id }}
+          PUBLISH_RUN_ID: ${{ github.run_id }}
           G16_REF: ${{ env.G16_REF }}
           VKEY_SHA256: ${{ steps.version.outputs.vkey_sha256 }}
           GENESIS_L1_HEIGHT: ${{ steps.version.outputs.genesis_l1_height }}

--- a/.github/workflows/publish-guests-and-circuit.yml
+++ b/.github/workflows/publish-guests-and-circuit.yml
@@ -1,0 +1,53 @@
+name: Publish Guests + g16 Circuit
+
+# Single entry point for the two-stage pipeline, shown as one navigable run:
+#   guest-build (ELF + counterproof vkey)  ->  circuit-gen (g16 v5c -> S3)
+# Both stages are reusable workflows (uses:), chained with needs:, so the Actions
+# UI nests them under this run — the same pattern as test-coverage.yml.
+on:
+  workflow_dispatch:
+    inputs:
+      asm_tag:
+        description: Tag in alpenlabs/asm whose release ships asm-vk.json and moho-vk.json (e.g. v0.1-alpha.11).
+        required: true
+        type: string
+      asm_params_url:
+        description: HTTPS URL to fetch asm-params.json from (raw URL, not a github.com /blob/ view URL).
+        required: true
+        type: string
+      ref:
+        description: strata-bridge git ref to build. Defaults to the branch selected in the UI.
+        required: false
+        type: string
+      g16_ref:
+        description: alpenlabs/g16 git ref to build g16-pipeline from. Defaults to the pinned rev.
+        required: false
+        type: string
+
+concurrency:
+  group: publish-guests-and-circuit-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  guest-build:
+    name: Guest build
+    uses: ./.github/workflows/publish-sp1-bridge-guests.yml
+    permissions:
+      contents: read
+    with:
+      asm_tag: ${{ inputs.asm_tag }}
+      asm_params_url: ${{ inputs.asm_params_url }}
+      ref: ${{ inputs.ref }}
+
+  circuit-gen:
+    name: Circuit gen
+    needs: guest-build
+    uses: ./.github/workflows/circuit-gen.yml
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    with:
+      g16_ref: ${{ inputs.g16_ref }}

--- a/.github/workflows/publish-guests-and-circuit.yml
+++ b/.github/workflows/publish-guests-and-circuit.yml
@@ -23,6 +23,10 @@ on:
         description: alpenlabs/g16 git ref to build g16-pipeline from. Defaults to the pinned rev.
         required: false
         type: string
+      runs_dir:
+        description: Parent dir for circuit output (must sit on a >=300 GB mount). Defaults to runner temp.
+        required: false
+        type: string
 
 concurrency:
   group: publish-guests-and-circuit-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
@@ -51,3 +55,4 @@ jobs:
       actions: read
     with:
       g16_ref: ${{ inputs.g16_ref }}
+      runs_dir: ${{ inputs.runs_dir }}

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -15,6 +15,20 @@ on:
         description: strata-bridge git ref to build. Defaults to the branch selected in the UI.
         required: false
         type: string
+  workflow_call:
+    inputs:
+      asm_tag:
+        description: Tag in alpenlabs/asm whose release ships asm-vk.json and moho-vk.json.
+        required: true
+        type: string
+      asm_params_url:
+        description: HTTPS URL to fetch asm-params.json from (raw URL, not a /blob/ view URL).
+        required: true
+        type: string
+      ref:
+        description: strata-bridge git ref to build. Defaults to the caller's ref.
+        required: false
+        type: string
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Description
Updates the bridge-side g16 circuit publishing pipeline. A new parent workflow chains two stages in one navigable run.
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
