### PR TITLE
chore(fntests): disable unreliable fn tests

### DIFF
--- a/functional-tests/tests/concurrency/fn_batched_deposit_test.py
+++ b/functional-tests/tests/concurrency/fn_batched_deposit_test.py
@@ -19,8 +19,12 @@ GRAPH_NAG_INTERVAL_MS = 900  # set this to a lower value on more powerful machin
 GRAPH_BLOCK_GENERATION_INTERVAL_SECS = 3
 
 
+# FIXME: <https://alpenlabs.atlassian.net/browse/STR-3867>
+# rethink how this test can be re-written to test the desired property
+# without being so sensitive to timing and resource constraints.
+# The current implementation is too brittle and fails often in CI. And so this has been disabled.
 @flexitest.register
-class BatchedDepositTest(StrataTestBase):
+class BatchedDepositTestDisabled(StrataTestBase):
     """Batched deposits must complete when graph nags duplicate initial duties."""
 
     def __init__(self, ctx: flexitest.InitContext):


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR disables the functional test that tests for consistent funding UTXO allocation of a given deposit index as it is being tested by bombarding the node with nags, making sure concurrent duties are created and things still remain consistent. What ends up happening is that the nodes just silent the nagging peers at the p2p/network layer and so the protocol progresses forward _extremely_ slowly such that the deposits take more than 15 minutes. As such, this test does not pull its weight and the resulting flakiness degrades developer experience.

AI was not used.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->