### PR TITLE
ci: switch g16 circuit gen to v0.3.0-rc.2 and drop --mock dry-run path

### DIFF
--- a/.github/workflows/circuit-gen.yml
+++ b/.github/workflows/circuit-gen.yml
@@ -21,10 +21,7 @@ env:
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
   S3_BUCKET: alpen-shared-mosaic-circuits
   S3_PREFIX: mosaic-circuits
-  # TEMP: hardcoded to g16-lite (c76ab7e), which provides the --mock flag used for
-  # dry runs. Revert to g16 main (93173abe1770b373f718187e3db3bb901fb7ebda) and drop
-  # --mock from the gen step in the follow-up PR.
-  G16_DEFAULT_REF: c76ab7e7538b6fd91c51aada4445bdd56dfe55af
+  G16_DEFAULT_REF: v0.3.0-rc.2
 
 concurrency:
   # The pipeline forbids parallel runs sharing a runs-dir; serialize globally.
@@ -97,10 +94,9 @@ jobs:
 
       - name: Build g16-pipeline
         working-directory: g16
-        # --mock skips the g16gen/prealloc stages, so only the pipeline binary is
-        # needed. When --mock is dropped, the pipeline spawns g16gen via `cargo run`
-        # at runtime — add `-p g16gen` here to pre-build it and keep gen pure execution.
-        run: cargo build --release -p g16-pipeline
+        # Pre-build g16gen too: the pipeline spawns it via `cargo run` at runtime,
+        # so building it here keeps the gen step pure execution.
+        run: cargo build --release -p g16-pipeline -p g16gen
 
       - name: Generate v5c circuit
         working-directory: g16
@@ -108,9 +104,7 @@ jobs:
           VKEY_PATH: ${{ steps.version.outputs.vkey_path }}
         run: |
           set -euo pipefail
-          # TEMP: --mock is for dry-running on main and needs the g16 ref set to
-          # c76ab7e (g16-lite). Remove --mock in the follow-up PR (main rev lacks it).
-          ./target/release/g16-pipeline gen --vkey "$VKEY_PATH" --runs-dir "$RUNS_DIR" --mock
+          ./target/release/g16-pipeline gen --vkey "$VKEY_PATH" --runs-dir "$RUNS_DIR"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1


### PR DESCRIPTION
## Description
Promotes the g16 circuit-generation workflow from its temporary dry-run setup to a real run against a pinned g16 release. This is the follow-up PR the`TEMP:` comments in `circuit-gen.yml` pointed to.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update