### PR TITLE
ci(circuit-gen): upload g16 circuit to central alpen-mosaic-artifacts bucket

### DIFF
--- a/.github/workflows/circuit-gen.yml
+++ b/.github/workflows/circuit-gen.yml
@@ -19,7 +19,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
-  S3_BUCKET: alpen-shared-mosaic-circuits
+  S3_BUCKET: alpen-mosaic-artifacts
   S3_PREFIX: mosaic-circuits
   G16_DEFAULT_REF: v0.3.0-rc.2
 


### PR DESCRIPTION
## What

Repoint the `circuit-gen` reusable workflow's S3 upload target from `alpen-shared-mosaic-circuits` to the shared-services **central artifact bucket `alpen-mosaic-artifacts`** (STR-3866). **Bucket-only change — the `mosaic-circuits` prefix is kept as-is.**

```diff
-  S3_BUCKET: alpen-shared-mosaic-circuits
+  S3_BUCKET: alpen-mosaic-artifacts
   S3_PREFIX: mosaic-circuits
```

New object key: `s3://alpen-mosaic-artifacts/mosaic-circuits/<version>/g16.v5c`, where `<version> = <genesis_l1_height>-<bridge_sha8>`.

## Why

Consolidate to **one bucket + one read credential** across all environments (circuits / ELFs / dev-cli), replacing the current split where CI uploads to `alpen-shared-mosaic-circuits` and mosaic pods read from per-env `alpen-<env>-mosaic-shared` buckets via a manual copy step.

- `<version>` already encodes the environment (each env has a distinct `genesis_l1_height`), so the flat `mosaic-circuits/` prefix stays globally unique.
- The OIDC upload role `github-actions-strata-bridge-circuit-s3` is repointed to `alpen-mosaic-artifacts` in companion alpen-infra#134. **Apply that first** so the role can write to the new bucket.
- Reads use the in-account `mosaic-artifacts-reader` IAM user (already provisioned), which sidesteps the cross-account `aws/s3` KMS-decrypt wall.

## Rollout

1. alpen-infra#134: apply the repointed upload role.
2. Merge this PR.
3. `workflow_dispatch` a run; confirm the object lands under `alpen-mosaic-artifacts/mosaic-circuits/…`.
4. Follow-up (deployments repo): repoint each `clusters/<env>/values/mosaic/base.yaml` `artifact.bucket`/`prefix` to the central bucket, promoting dev → staging → prod.

## Test plan

- [ ] Companion alpen-infra#134 role change applied
- [ ] Dispatch `Publish Guests + g16 Circuit`; verify upload to new bucket + traceability summary S3 URI