### PR TITLE
ci(publish-guests): publish bridge & asm-runner ELFs to S3

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -36,4 +36,21 @@ ignore = [
   # Tracked upstream: https://github.com/libp2p/rust-libp2p/issues/6412.
   "RUSTSEC-2026-0118",
   "RUSTSEC-2026-0119",
+
+  # quick-xml 0.37.5 pulled transitively by inferno 0.12.2 (its flamegraph SVG
+  # writer) via jemalloc_pprof -> memory_pprof, behind the optional
+  # `memory_profiling` feature of strata-bridge / secret-service.
+  #
+  # Both advisories are denial-of-service bugs in quick-xml's XML *parsing*
+  # path: RUSTSEC-2026-0194 (O(n²) duplicate-attribute check on a start tag)
+  # and RUSTSEC-2026-0195 (unbounded NsReader namespace-declaration
+  # allocation). inferno only uses quick-xml to *write* SVG flamegraphs from
+  # local profiling data and never parses untrusted XML, so neither is
+  # reachable here.
+  #
+  # Fix requires quick-xml >= 0.41, but every published inferno (through the
+  # latest 0.12.6) still pins quick-xml ^0.37, so the bump is unreachable via
+  # semver until inferno upstream updates.
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
 ]

--- a/.github/scripts/ci_common.py
+++ b/.github/scripts/ci_common.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""ci_common.py — Shared helpers for the .github/scripts publish/circuit scripts.
+
+Imported as a sibling module by guest_publish.py and circuit_gen.py: both are
+invoked as `python3 .github/scripts/<name>.py`, so the script's directory is on
+sys.path and a plain `import ci_common` resolves. Pure-stdlib, no install step.
+"""
+
+import os
+import re
+import sys
+
+
+def fail(message: str) -> None:
+    """Print a GHA `::error::` annotation and exit non-zero."""
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def set_outputs(**outputs: str) -> None:
+    """Append `name=value` step outputs to the $GITHUB_OUTPUT file."""
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
+        for name, value in outputs.items():
+            f.write(f"{name}={value}\n")
+
+
+# `<genesis>-<sha8>` / `<tag>-<sha8>` — the components are numeric/hex/tag chars,
+# so this is the full legal set for an S3 key segment. Reject anything else.
+VERSION_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def genesis_l1_height(asm_params: dict) -> int:
+    """asm-params.json shape: subprotocols is a list of single-key objects; the
+    Checkpoint subprotocol carries `genesis_l1_height`. Keeps the ELF and circuit
+    version strings derived from the same source in lockstep."""
+    for entry in asm_params.get("subprotocols", []):
+        if isinstance(entry, dict) and "Checkpoint" in entry:
+            height = entry["Checkpoint"].get("genesis_l1_height")
+            if height is None:
+                fail("Checkpoint subprotocol has no genesis_l1_height")
+            return int(height)
+    fail("no Checkpoint subprotocol in asm-params.json")

--- a/.github/scripts/circuit_gen.py
+++ b/.github/scripts/circuit_gen.py
@@ -7,8 +7,8 @@ tooling, derives the S3 version string from the guest-build artifact, uploads
 the (~142 GB) `v5c.ckt` to S3, and writes a traceability summary.
 
 Pure-stdlib so it runs on any runner without an install step, mirroring
-`guest_publish.py`. Each subcommand reads its inputs from environment variables
-documented on the per-command function.
+`guest_publish.py`; shared helpers live in ci_common.py. Each subcommand reads
+its inputs from environment variables documented on the per-command function.
 
 Subcommands:
     preflight   Check free disk on the runs-dir mount and required CLIs.
@@ -21,29 +21,12 @@ import argparse
 import hashlib
 import json
 import os
-import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
+from ci_common import VERSION_RE, fail, genesis_l1_height, set_outputs
 
-def fail(message: str) -> None:
-    """Print a GHA `::error::` annotation and exit non-zero."""
-    print(f"::error::{message}", file=sys.stderr)
-    sys.exit(1)
-
-
-def set_outputs(**outputs: str) -> None:
-    """Append `name=value` step outputs to the $GITHUB_OUTPUT file."""
-    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
-        for name, value in outputs.items():
-            f.write(f"{name}={value}\n")
-
-
-# `<genesis>-<sha8>` — both components are numeric/hex, so this is the full
-# legal set. Reject anything else before it becomes an S3 key segment.
-VERSION_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 VKEY_NAME = "counterproof-vkey.bin"
 MANIFEST_NAME = "manifest.json"
 ASM_PARAMS_NAME = "asm-params.json"
@@ -95,18 +78,6 @@ def _find_one(root: Path, name: str) -> Path:
     return matches[0]
 
 
-def _genesis_l1_height(asm_params: dict) -> int:
-    """asm-params.json shape: subprotocols is a list of single-key objects;
-    the Checkpoint subprotocol carries `genesis_l1_height`."""
-    for entry in asm_params.get("subprotocols", []):
-        if isinstance(entry, dict) and "Checkpoint" in entry:
-            height = entry["Checkpoint"].get("genesis_l1_height")
-            if height is None:
-                fail("Checkpoint subprotocol has no genesis_l1_height")
-            return int(height)
-    fail("no Checkpoint subprotocol in asm-params.json")
-
-
 def cmd_version() -> None:
     """Env: ARTIFACT_DIR, GITHUB_OUTPUT.
 
@@ -120,7 +91,9 @@ def cmd_version() -> None:
     vkey_path = _find_one(artifact_dir, VKEY_NAME)
     vkey_bytes = vkey_path.read_bytes()
     if len(vkey_bytes) != VKEY_LEN:
-        fail(f"{VKEY_NAME} must be exactly {VKEY_LEN} bytes (got {len(vkey_bytes)} at {vkey_path})")
+        fail(
+            f"{VKEY_NAME} must be exactly {VKEY_LEN} bytes (got {len(vkey_bytes)} at {vkey_path})"
+        )
 
     manifest = json.loads(_find_one(artifact_dir, MANIFEST_NAME).read_text())
     bridge_sha_full = (manifest.get("strata_bridge") or {}).get("sha", "")
@@ -129,7 +102,7 @@ def cmd_version() -> None:
         fail("manifest.json missing strata_bridge.sha")
 
     asm_params = json.loads(_find_one(artifact_dir, ASM_PARAMS_NAME).read_text())
-    genesis = _genesis_l1_height(asm_params)
+    genesis = genesis_l1_height(asm_params)
 
     version = f"{genesis}-{bridge_sha}"
     if not VERSION_RE.fullmatch(version):
@@ -206,7 +179,9 @@ def cmd_summarize() -> None:
     genesis = os.environ.get("GENESIS_L1_HEIGHT", "")
     bridge_sha = os.environ.get("BRIDGE_SHA", "")
     size_bytes = os.environ.get("CIRCUIT_SIZE_BYTES", "")
-    size_gib = f"{int(size_bytes) / (1024**3):.1f} GiB" if size_bytes.isdigit() else "n/a"
+    size_gib = (
+        f"{int(size_bytes) / (1024**3):.1f} GiB" if size_bytes.isdigit() else "n/a"
+    )
 
     lines = [
         "## g16 circuit generation",

--- a/.github/scripts/guest_publish.py
+++ b/.github/scripts/guest_publish.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
 """guest_publish.py — Helpers for the "Publish SP1 Bridge Guests" workflow.
 
-Bundles three concerns that the workflow chains together so each workflow step
+Bundles the concerns that the workflow chains together so each workflow step
 is one line. Pure-stdlib so it runs on every GitHub-hosted runner without an
 install step.
 
 Subcommands:
     validate    Verify workflow_dispatch inputs before any network/build work.
-    fetch       Download asm-vk.json, moho-vk.json, asm-params.json into $OUTPUT_DIR.
-    summarize   Verify built artifacts and append a traceability block to
-                $GITHUB_STEP_SUMMARY.
+    fetch       Download asm-vk.json, moho-vk.json, asm.elf, moho.elf, asm-params.json
+                into $OUTPUT_DIR and resolve the asm tag's commit (asm_rev).
+    summarize   Verify built artifacts, write the bridge + asm-runner manifests, and
+                append a traceability block to $GITHUB_STEP_SUMMARY.
+    upload      Copy the bridge guests (+vkeys) and the asm-runner ELFs to
+                s3://<bucket>/<prefix>/{bridge,asm-runner}/<version>/.
 
 Each subcommand reads its inputs from environment variables documented on the
-per-command function.
+per-command function. Shared helpers live in ci_common.py.
 """
 
 import argparse
@@ -22,16 +25,11 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
-
-def fail(message: str) -> None:
-    """Print a GHA `::error::` annotation and exit non-zero."""
-    print(f"::error::{message}", file=sys.stderr)
-    sys.exit(1)
+from ci_common import VERSION_RE, fail, genesis_l1_height, set_outputs
 
 
 # ---- validate --------------------------------------------------------------
@@ -85,23 +83,49 @@ def cmd_validate() -> None:
 
 ASM_REPO = "alpenlabs/asm"
 VK_FILES = ("asm-vk.json", "moho-vk.json")
+# asm.elf / moho.elf ship as release assets next to the vk JSONs; we republish
+# them verbatim under elfs/asm-runner/ so consumers get a stable durable URL.
+ELF_FILES = ("asm.elf", "moho.elf")
+RELEASE_FILES = VK_FILES + ELF_FILES
+SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
-def fetch_vks(asm_tag: str, output_dir: Path) -> None:
-    """Pull the two `*-vk.json` files from the alpenlabs/asm release via `gh`.
+def fetch_release_assets(asm_tag: str, output_dir: Path) -> None:
+    """Pull the vk JSONs and guest ELFs from the alpenlabs/asm release via `gh`.
 
     Assumes alpenlabs/asm is public. If this 404s on a tag known to exist, the
     repo is likely private — provision a PAT/App installation token with
     `Contents: read` on alpenlabs/asm and route it via GH_TOKEN.
     """
     cmd = ["gh", "release", "download", asm_tag, "--repo", ASM_REPO]
-    for name in VK_FILES:
+    for name in RELEASE_FILES:
         cmd += ["--pattern", name]
     cmd += ["--dir", str(output_dir)]
     subprocess.run(cmd, check=True)
-    for name in VK_FILES:
-        if not (output_dir / name).is_file():
-            fail(f"missing {name} in {ASM_REPO} release {asm_tag}")
+    for name in RELEASE_FILES:
+        p = output_dir / name
+        if not p.is_file() or p.stat().st_size == 0:
+            fail(f"missing or empty {name} in {ASM_REPO} release {asm_tag}")
+
+
+def resolve_asm_rev(asm_tag: str) -> str:
+    """Resolve the alpenlabs/asm tag to its full commit SHA via the GitHub API.
+
+    The commits endpoint dereferences both lightweight and annotated tags, so it
+    returns the underlying commit regardless of tag kind.
+    """
+    result = subprocess.run(
+        ["gh", "api", f"repos/{ASM_REPO}/commits/{asm_tag}", "--jq", ".sha"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sha = result.stdout.strip()
+    if not SHA1_RE.fullmatch(sha):
+        fail(
+            f"could not resolve {ASM_REPO} tag {asm_tag} to a commit sha (got {sha!r})"
+        )
+    return sha
 
 
 def fetch_asm_params(asm_params_url: str, output_path: Path) -> None:
@@ -134,7 +158,7 @@ def fetch_asm_params(asm_params_url: str, output_path: Path) -> None:
 
 
 def cmd_fetch() -> None:
-    """Env: ASM_TAG, ASM_PARAMS_URL, OUTPUT_DIR, GH_TOKEN."""
+    """Env: ASM_TAG, ASM_PARAMS_URL, OUTPUT_DIR, GH_TOKEN, GITHUB_OUTPUT."""
     asm_tag = os.environ["ASM_TAG"]
     asm_params_url = os.environ["ASM_PARAMS_URL"]
     output_dir = Path(os.environ["OUTPUT_DIR"])
@@ -144,8 +168,10 @@ def cmd_fetch() -> None:
         fail("GH_TOKEN must be set")
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    fetch_vks(asm_tag, output_dir)
+    fetch_release_assets(asm_tag, output_dir)
     fetch_asm_params(asm_params_url, output_dir / "asm-params.json")
+    # Emit the asm commit so summarize/upload can key the asm-runner tree by it.
+    set_outputs(asm_rev=resolve_asm_rev(asm_tag))
 
 
 # ---- summarize -------------------------------------------------------------
@@ -173,10 +199,12 @@ def sha256_hex(path: Path) -> str:
 
 
 def cmd_summarize() -> None:
-    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_PARAMS_URL, BRIDGE_REF, BRIDGE_SHA, GITHUB_STEP_SUMMARY."""
+    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_REV, ASM_PARAMS_URL, BRIDGE_REF, BRIDGE_SHA,
+    GITHUB_STEP_SUMMARY."""
     elf_dir = Path(os.environ["ELF_DIR"])
     inputs_dir = Path(os.environ["INPUTS_DIR"])
     asm_tag = os.environ["ASM_TAG"]
+    asm_rev = os.environ["ASM_REV"]
     asm_params_url = os.environ["ASM_PARAMS_URL"]
     # Caller resolves these from `inputs.ref || github.ref` + `git rev-parse HEAD`
     # post-checkout. We can't fall back to GITHUB_REF/GITHUB_SHA because those
@@ -192,7 +220,17 @@ def cmd_summarize() -> None:
 
     bridge_predicate = (elf_dir / "bridge-proof.predicate").read_text().strip()
     counter_predicate = (elf_dir / "counterproof.predicate").read_text().strip()
+    # The `-vkey.bin` files are the raw 32-byte SP1 program vkey hashes. Log them
+    # as hex so consumers can grab the vkey without parsing the predicate blob.
+    bridge_vkey_hex = (elf_dir / "bridge-proof-vkey.bin").read_bytes().hex()
+    counter_vkey_hex = (elf_dir / "counterproof-vkey.bin").read_bytes().hex()
     digests = dict((name, sha256_hex(elf_dir / name)) for name in EXPECTED_ARTIFACTS)
+
+    # asm genesis L1 height + run id go into the manifest so `upload` can derive the
+    # S3 version (`<genesis>-<bridge_sha8>`) from a single source of truth.
+    asm_params = json.loads((inputs_dir / "asm-params.json").read_text())
+    genesis = genesis_l1_height(asm_params)
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
 
     # Copy the exact input bytes alongside the ELFs so the bundle is
     # self-describing — a consumer can rebuild from these to verify.
@@ -204,18 +242,42 @@ def cmd_summarize() -> None:
     input_digests = {name: sha256_hex(elf_dir / name) for name in BUNDLED_INPUTS}
 
     manifest = {
-        "schema": 1,
+        "schema": 2,
         "asm_tag": asm_tag,
         "asm_params_url": asm_params_url,
+        "asm_genesis_l1_height": genesis,
+        "run_id": run_id,
         "strata_bridge": {"ref": bridge_ref, "sha": bridge_sha},
         "predicates": {
             "bridge_proof": bridge_predicate,
             "counterproof": counter_predicate,
         },
+        "vkeys": {
+            "bridge_proof": bridge_vkey_hex,
+            "counterproof": counter_vkey_hex,
+        },
         "sha256": {**digests, **input_digests},
     }
     (elf_dir / "manifest.json").write_text(
         json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+    # asm-runner manifest — provenance for the asm ELFs fetched from the release.
+    # Written into INPUTS_DIR; `upload` copies it to the asm-runner tree as
+    # manifest.json (keyed by <asm_tag>-<asm_sha8>, independent of the bridge version).
+    for name in ELF_FILES:
+        p = inputs_dir / name
+        if not p.is_file() or p.stat().st_size == 0:
+            fail(f"expected asm artifact missing or empty: {p}")
+    asm_manifest = {
+        "schema": 1,
+        "asm_tag": asm_tag,
+        "asm_rev": asm_rev,
+        "run_id": run_id,
+        "sha256": {name: sha256_hex(inputs_dir / name) for name in ELF_FILES},
+    }
+    (inputs_dir / "asm-runner-manifest.json").write_text(
+        json.dumps(asm_manifest, indent=2) + "\n", encoding="utf-8"
     )
 
     lines: list[str] = [
@@ -234,6 +296,11 @@ def cmd_summarize() -> None:
         f"- bridge-proof: `{bridge_predicate}`",
         f"- counterproof: `{counter_predicate}`",
         "",
+        "### Verifying keys (vkey hash, hex)",
+        "",
+        f"- bridge-proof: `{bridge_vkey_hex}`",
+        f"- counterproof: `{counter_vkey_hex}`",
+        "",
         "### SHA-256",
         "",
         "```",
@@ -247,12 +314,101 @@ def cmd_summarize() -> None:
         f.write("\n".join(lines))
 
 
+# ---- upload ----------------------------------------------------------------
+
+BRIDGE_UPLOAD_FILES = (
+    "bridge-proof.elf",
+    "counterproof.elf",
+    "bridge-proof-vkey.bin",
+    "counterproof-vkey.bin",
+    "manifest.json",
+)
+
+
+def s3_cp(src: Path, dst: str) -> None:
+    """Copy a single non-empty file to S3, failing fast if it's missing/empty."""
+    if not src.is_file() or src.stat().st_size == 0:
+        fail(f"expected upload artifact missing or empty: {src}")
+    print(f"uploading {src} -> {dst}")
+    subprocess.run(["aws", "s3", "cp", str(src), dst], check=True)
+
+
+def cmd_upload() -> None:
+    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_REV, S3_BUCKET, S3_PREFIX (default elfs),
+    GITHUB_OUTPUT, GITHUB_STEP_SUMMARY.
+
+    Uploads two independently-versioned trees:
+      <prefix>/bridge/<genesis>-<bridge_sha8>/   built guests + vkeys + manifest
+      <prefix>/asm-runner/<asm_tag>-<asm_sha8>/  asm.elf, moho.elf + manifest
+    """
+    elf_dir = Path(os.environ["ELF_DIR"])
+    inputs_dir = Path(os.environ["INPUTS_DIR"])
+    asm_tag = os.environ["ASM_TAG"]
+    asm_rev = os.environ["ASM_REV"]
+    bucket = os.environ["S3_BUCKET"]
+    prefix = os.environ.get("S3_PREFIX", "elfs")
+
+    # bridge tree — version from the manifest summarize wrote (single source of truth).
+    manifest = json.loads((elf_dir / "manifest.json").read_text())
+    genesis = manifest.get("asm_genesis_l1_height")
+    bridge_sha = (manifest.get("strata_bridge") or {}).get("sha", "")[:8]
+    if genesis is None or not bridge_sha:
+        fail("manifest.json missing asm_genesis_l1_height or strata_bridge.sha")
+    bridge_version = f"{genesis}-{bridge_sha}"
+    if not VERSION_RE.fullmatch(bridge_version):
+        fail(f"bridge version is not S3-key-safe: {bridge_version!r}")
+
+    # asm-runner tree — version pins the asm release the ELFs came from.
+    asm_version = f"{asm_tag}-{asm_rev[:8]}"
+    if not VERSION_RE.fullmatch(asm_version):
+        fail(f"asm-runner version is not S3-key-safe: {asm_version!r}")
+
+    bridge_base = f"s3://{bucket}/{prefix}/bridge/{bridge_version}"
+    asm_base = f"s3://{bucket}/{prefix}/asm-runner/{asm_version}"
+
+    uris: list[str] = []
+    for name in BRIDGE_UPLOAD_FILES:
+        dst = f"{bridge_base}/{name}"
+        s3_cp(elf_dir / name, dst)
+        uris.append(dst)
+    for name in ELF_FILES:
+        dst = f"{asm_base}/{name}"
+        s3_cp(inputs_dir / name, dst)
+        uris.append(dst)
+    # The asm-runner manifest is staged under a distinct local name to avoid
+    # colliding with the bridge manifest; it lands in S3 as manifest.json.
+    asm_manifest_dst = f"{asm_base}/manifest.json"
+    s3_cp(inputs_dir / "asm-runner-manifest.json", asm_manifest_dst)
+    uris.append(asm_manifest_dst)
+
+    set_outputs(
+        bridge_version=bridge_version,
+        asm_version=asm_version,
+        bridge_s3_base=bridge_base,
+        asm_s3_base=asm_base,
+    )
+
+    summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+    lines = [
+        "### S3 upload",
+        "",
+        f"- bridge: `{bridge_base}/`",
+        f"- asm-runner: `{asm_base}/`",
+        "",
+        *(f"- `{uri}`" for uri in uris),
+        "",
+    ]
+    with summary_path.open("a", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
 # ---- entry point -----------------------------------------------------------
 
 COMMANDS = {
     "validate": cmd_validate,
     "fetch": cmd_fetch,
     "summarize": cmd_summarize,
+    "upload": cmd_upload,
 }
 
 

--- a/.github/workflows/publish-guests-and-circuit.yml
+++ b/.github/workflows/publish-guests-and-circuit.yml
@@ -40,6 +40,7 @@ jobs:
     uses: ./.github/workflows/publish-sp1-bridge-guests.yml
     permissions:
       contents: read
+      id-token: write
     with:
       asm_tag: ${{ inputs.asm_tag }}
       asm_params_url: ${{ inputs.asm_params_url }}

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -33,6 +33,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   SP1_VERSION: v6.2.0
+  AWS_REGION: ${{ vars.AWS_REGION || 'us-east-1' }}
+  S3_BUCKET: alpen-mosaic-artifacts
+  S3_PREFIX: elfs
 
 concurrency:
   group: publish-sp1-bridge-guests-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
@@ -64,6 +67,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      id-token: write # assume the artifacts S3 role via OIDC
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -111,7 +115,8 @@ jobs:
           cargo install sp1-core-executor-runner-binary --version 6.2.0 --root "$RUNNER_TEMP/sp1-core-runner" --force
           echo "SP1_CORE_RUNNER_OVERRIDE_BINARY=$RUNNER_TEMP/sp1-core-runner/bin/sp1-core-executor-runner-binary" >> "$GITHUB_ENV"
 
-      - name: Fetch asm-vk, moho-vk, asm-params
+      - name: Fetch asm-vk, moho-vk, asm/moho ELFs, asm-params
+        id: fetch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASM_TAG: ${{ inputs.asm_tag }}
@@ -134,10 +139,28 @@ jobs:
           ELF_DIR: guest-builder/sp1/elfs
           INPUTS_DIR: ${{ runner.temp }}/bridge-genesis
           ASM_TAG: ${{ inputs.asm_tag }}
+          ASM_REV: ${{ steps.fetch.outputs.asm_rev }}
           ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
           BRIDGE_REF: ${{ inputs.ref || github.ref }}
           BRIDGE_SHA: ${{ steps.resolve-sha.outputs.sha }}
         run: python3 .github/scripts/guest_publish.py summarize
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: arn:aws:iam::496607027995:role/github-actions-strata-bridge-circuit-s3
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload ELFs to S3
+        id: upload
+        env:
+          ELF_DIR: guest-builder/sp1/elfs
+          INPUTS_DIR: ${{ runner.temp }}/bridge-genesis
+          ASM_TAG: ${{ inputs.asm_tag }}
+          ASM_REV: ${{ steps.fetch.outputs.asm_rev }}
+          S3_BUCKET: ${{ env.S3_BUCKET }}
+          S3_PREFIX: ${{ env.S3_PREFIX }}
+        run: python3 .github/scripts/guest_publish.py upload
 
       - name: Upload elfs/ as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Description
Extend the **Publish SP1 Bridge Guests** pipeline to upload the guest ELFs to the shared `alpen-mosaic-artifacts` bucket (same OIDC role as `circuit-gen`, #690), and surface both SP1 vkey hashes as hex in the run summary.
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update