### PR TITLE
fix(bridge-sm): retry payout descriptor while collecting nonces

### DIFF
--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -106,7 +106,16 @@ pub async fn execute_deposit_duty(
         DepositDuty::RequestPayoutNonces {
             deposit_idx,
             pov_operator_idx,
-        } => request_payout_nonces(&output_handles, *deposit_idx, *pov_operator_idx).await,
+            payout_descriptor,
+        } => {
+            request_payout_nonces(
+                &output_handles,
+                *deposit_idx,
+                *pov_operator_idx,
+                payout_descriptor.clone(),
+            )
+            .await
+        }
         DepositDuty::PublishPayoutNonce {
             deposit_idx,
             deposit_outpoint,
@@ -610,18 +619,27 @@ async fn request_payout_nonces(
     output_handles: &OutputHandles,
     deposit_idx: DepositIdx,
     operator_idx: OperatorIdx,
+    payout_descriptor: Option<Descriptor>,
 ) -> Result<(), ExecutorError> {
-    info!(%deposit_idx, "creating descriptor to request payout nonces");
+    let payout_descriptor = match payout_descriptor {
+        Some(descriptor) => {
+            info!(%deposit_idx, "reusing descriptor to request payout nonces");
+            PayoutDescriptor::from(descriptor)
+        }
+        None => {
+            info!(%deposit_idx, "creating descriptor to request payout nonces");
 
-    let descriptor = output_handles
-        .wallet
-        .read()
-        .await
-        .descriptor()
-        .map_err(|e| ExecutorError::WalletErr(format!("failed to create descriptor: {e}")))?;
-
-    // Convert to PayoutDescriptor for P2P transmission
-    let payout_descriptor: PayoutDescriptor = descriptor.into();
+            output_handles
+                .wallet
+                .read()
+                .await
+                .descriptor()
+                .map(PayoutDescriptor::from)
+                .map_err(|e| {
+                    ExecutorError::WalletErr(format!("failed to create descriptor: {e}"))
+                })?
+        }
+    };
 
     // Broadcast to all operators
     output_handles

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -152,6 +152,8 @@ pub enum DepositDuty {
         deposit_idx: DepositIdx,
         /// The index of the point-of-view operator.
         pov_operator_idx: OperatorIdx,
+        /// The operator payout descriptor, if it has already been created.
+        payout_descriptor: Option<Descriptor>,
     },
     /// Publish the nonce for spending the deposit UTXO cooperatively.
     PublishPayoutNonce {

--- a/crates/bridge-sm/src/deposit/handlers/retry.rs
+++ b/crates/bridge-sm/src/deposit/handlers/retry.rs
@@ -38,6 +38,24 @@ impl DepositSM {
                 vec![DepositDuty::RequestPayoutNonces {
                     deposit_idx: self.context().deposit_idx(),
                     pov_operator_idx: self.context().operator_table().pov_idx(),
+                    payout_descriptor: None,
+                }]
+            }
+            // Another node might not have received the broadcasted payout descriptor, so we need to
+            // re-broadcast it. It can also be the case that the other node rejects the descriptor
+            // because it sees the fulfillment late.
+            DepositState::PayoutDescriptorReceived {
+                payout_nonces,
+                cooperative_payout_tx,
+                assignee,
+                ..
+            } if payout_nonces.len() != operator_table_cardinality
+                && self.context().operator_table().pov_idx() == *assignee =>
+            {
+                vec![DepositDuty::RequestPayoutNonces {
+                    deposit_idx: self.context().deposit_idx(),
+                    pov_operator_idx: self.context().operator_table().pov_idx(),
+                    payout_descriptor: Some(cooperative_payout_tx.payout_descriptor(cfg.network())),
                 }]
             }
             DepositState::PayoutNoncesCollected {

--- a/crates/bridge-sm/src/deposit/tests/handlers/process_retry_tick.rs
+++ b/crates/bridge-sm/src/deposit/tests/handlers/process_retry_tick.rs
@@ -65,6 +65,32 @@ mod tests {
             expected_duties: vec![DepositDuty::RequestPayoutNonces {
                 deposit_idx: TEST_DEPOSIT_IDX,
                 pov_operator_idx: TEST_POV_IDX,
+                payout_descriptor: None,
+            }],
+        });
+    }
+
+    #[test]
+    fn test_retry_tick_replays_payout_descriptor_when_missing_nonces() {
+        let operator_desc = random_p2tr_desc();
+        let cooperative_payout_tx = test_cooperative_payout_txn(operator_desc.clone());
+        let mut payout_nonces = BTreeMap::new();
+        payout_nonces.insert(TEST_POV_IDX, generate_pubnonce());
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::PayoutDescriptorReceived {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_POV_IDX,
+                fulfillment_txid: generate_txid(),
+                cooperative_payout_tx,
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                payout_nonces,
+            },
+            event: DepositEvent::RetryTick(RetryTickEvent),
+            expected_duties: vec![DepositDuty::RequestPayoutNonces {
+                deposit_idx: TEST_DEPOSIT_IDX,
+                pov_operator_idx: TEST_POV_IDX,
+                payout_descriptor: Some(operator_desc),
             }],
         });
     }
@@ -120,6 +146,47 @@ mod tests {
             },
             event: DepositEvent::RetryTick(RetryTickEvent),
             expected_duties: vec![], // No duties when POV is not assignee
+        });
+    }
+
+    #[test]
+    fn test_retry_tick_noop_in_payout_descriptor_received_when_pov_is_not_assignee() {
+        let operator_desc = random_p2tr_desc();
+        let cooperative_payout_tx = test_cooperative_payout_txn(operator_desc);
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::PayoutDescriptorReceived {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_NONPOV_IDX,
+                fulfillment_txid: generate_txid(),
+                cooperative_payout_tx,
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                payout_nonces: BTreeMap::new(),
+            },
+            event: DepositEvent::RetryTick(RetryTickEvent),
+            expected_duties: vec![],
+        });
+    }
+
+    #[test]
+    fn test_retry_tick_noop_in_payout_descriptor_received_when_all_nonces_collected() {
+        let operator_desc = random_p2tr_desc();
+        let cooperative_payout_tx = test_cooperative_payout_txn(operator_desc);
+        let payout_nonces: BTreeMap<_, _> = (0..N_TEST_OPERATORS as u32)
+            .map(|idx| (idx, generate_pubnonce()))
+            .collect();
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::PayoutDescriptorReceived {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_POV_IDX,
+                fulfillment_txid: generate_txid(),
+                cooperative_payout_tx,
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                payout_nonces,
+            },
+            event: DepositEvent::RetryTick(RetryTickEvent),
+            expected_duties: vec![],
         });
     }
 
@@ -192,9 +259,6 @@ mod tests {
 
     #[test]
     fn test_retry_tick_noop_for_non_retriable_states() {
-        let operator_desc = random_p2tr_desc();
-        let cooperative_payout_tx = test_cooperative_payout_txn(operator_desc.clone());
-
         let non_retriable_states = [
             DepositState::Created {
                 deposit_transaction: test_deposit_txn(),
@@ -217,14 +281,6 @@ mod tests {
             },
             DepositState::Deposited {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
-            },
-            DepositState::PayoutDescriptorReceived {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                assignee: TEST_POV_IDX,
-                fulfillment_txid: generate_txid(),
-                cooperative_payout_tx,
-                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
-                payout_nonces: BTreeMap::new(),
             },
             DepositState::CooperativePathFailed {
                 last_block_height: INITIAL_BLOCK_HEIGHT,

--- a/crates/bridge-sm/src/deposit/tests/payout/process_fulfillment.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_fulfillment.rs
@@ -48,6 +48,7 @@ mod tests {
             expected_duties: vec![DepositDuty::RequestPayoutNonces {
                 deposit_idx: TEST_DEPOSIT_IDX,
                 pov_operator_idx: TEST_POV_IDX,
+                payout_descriptor: None,
             }],
             expected_signals: vec![],
         });

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -160,6 +160,7 @@ impl DepositSM {
                         DepositDuty::RequestPayoutNonces {
                             deposit_idx: self.context.deposit_idx(),
                             pov_operator_idx,
+                            payout_descriptor: None,
                         },
                     ]))
                 } else {
@@ -303,6 +304,7 @@ impl DepositSM {
                 cooperative_payment_deadline,
                 cooperative_payout_tx,
                 payout_nonces,
+                ..
             } => {
                 let assignee = *assignee;
 

--- a/crates/tx-graph/src/transactions/cooperative_payout.rs
+++ b/crates/tx-graph/src/transactions/cooperative_payout.rs
@@ -4,7 +4,7 @@ use bitcoin::{
     absolute,
     sighash::{Prevouts, SighashCache},
     transaction::Version,
-    OutPoint, Psbt, Transaction, TxIn, TxOut,
+    Address, Network, OutPoint, Psbt, Transaction, TxIn, TxOut,
 };
 use bitcoin_bosd::Descriptor;
 use secp256k1::schnorr;
@@ -124,6 +124,15 @@ impl CooperativePayoutTx {
             0,
         )]
     }
+
+    /// Returns the operator payout descriptor encoded in the payout output.
+    pub fn payout_descriptor(&self, network: Network) -> Descriptor {
+        let script = &self.psbt.unsigned_tx.output[Self::PAYOUT_VOUT as usize].script_pubkey;
+        let address =
+            Address::from_script(script, network).expect("payout output must be addressable");
+
+        Descriptor::try_from(address).expect("payout output must encode a supported descriptor")
+    }
 }
 
 impl ParentTxCombined for CooperativePayoutTx {
@@ -144,5 +153,37 @@ impl ParentTxCombined for CooperativePayoutTx {
 impl AsRef<Transaction> for CooperativePayoutTx {
     fn as_ref(&self) -> &Transaction {
         &self.psbt.unsigned_tx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{Amount, Network, OutPoint};
+    use strata_bridge_primitives::scripts::prelude::get_aggregated_pubkey;
+    use strata_bridge_test_utils::bridge_fixtures::{
+        random_p2tr_desc, test_operator_table, TEST_POV_IDX,
+    };
+
+    use super::*;
+
+    #[test]
+    fn payout_descriptor_round_trips_from_payout_output() {
+        let operator_descriptor = random_p2tr_desc();
+        let operator_table = test_operator_table(3, TEST_POV_IDX);
+        let n_of_n_pubkey = get_aggregated_pubkey(operator_table.btc_keys());
+        let deposit_connector = NOfNConnector::new(
+            Network::Regtest,
+            n_of_n_pubkey,
+            Amount::from_sat(10_000_000),
+        );
+        let tx = CooperativePayoutTx::new(
+            CooperativePayoutData {
+                deposit_outpoint: OutPoint::null(),
+            },
+            deposit_connector,
+            operator_descriptor.clone(),
+        );
+
+        assert_eq!(tx.payout_descriptor(Network::Regtest), operator_descriptor);
     }
 }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR fixes a bug where the duty to publish the cooperative payout descriptor is not retried once the state machine of the assignee moves to the `PayoutDescriptorReceived` state. This assumes that if the assignee has received the descriptor so has all the other peers. This is not true because the other peers might have muted the peer, or may observe the message _before_ it has seen the fulfillment and so, rejected the message.

Codex was used to update the unit tests.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
Design doc PR: https://github.com/alpenlabs/bridge-sm-design-docs/pull/31.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->