### PR TITLE
feat(ci): env-scoped artifact versions + sha256 sidecars

### DIFF
--- a/.github/scripts/ci_common.py
+++ b/.github/scripts/ci_common.py
@@ -47,9 +47,22 @@ def write_sha256_sidecar(digest: str, s3_name: str, dest_dir: Path) -> Path:
     return sidecar
 
 
-# `<genesis>-<sha8>` / `<tag>-<sha8>` — the components are numeric/hex/tag chars,
-# so this is the full legal set for an S3 key segment. Reject anything else.
+# `<env>-<genesis>-<sha8>` / `<env>-<tag>-<sha8>` — the components are numeric/hex/tag
+# chars, so this is the full legal set for an S3 key segment. Reject anything else.
 VERSION_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+ENVIRONMENTS = ("dev", "staging", "prod")
+
+
+def validate_env(env: str) -> str:
+    """Reject anything outside the known environments before it reaches an S3 key.
+
+    `workflow_call` inputs can't be `type: choice`, so the reusable-workflow path has
+    no dropdown to lean on — this is the only guard there.
+    """
+    if env not in ENVIRONMENTS:
+        fail(f"env must be one of {', '.join(ENVIRONMENTS)} (got {env!r})")
+    return env
 
 
 def genesis_l1_height(asm_params: dict) -> int:

--- a/.github/scripts/ci_common.py
+++ b/.github/scripts/ci_common.py
@@ -6,9 +6,11 @@ invoked as `python3 .github/scripts/<name>.py`, so the script's directory is on
 sys.path and a plain `import ci_common` resolves. Pure-stdlib, no install step.
 """
 
+import hashlib
 import os
 import re
 import sys
+from pathlib import Path
 
 
 def fail(message: str) -> None:
@@ -22,6 +24,27 @@ def set_outputs(**outputs: str) -> None:
     with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
         for name, value in outputs.items():
             f.write(f"{name}={value}\n")
+
+
+def sha256_hex(path: Path) -> str:
+    """Return the SHA-256 of `path` as a lowercase hex digest, read in chunks so
+    the 142 GB v5c circuit doesn't have to fit in memory."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8 * 1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def write_sha256_sidecar(digest: str, s3_name: str, dest_dir: Path) -> Path:
+    """Write `<dest_dir>/<s3_name>.sha256` in `sha256sum -c` format (two spaces).
+
+    Records the *S3 object* name, not the local one: the circuit is `v5c.ckt` on
+    disk but `g16.v5c` in the bucket, and the check runs against the download.
+    """
+    sidecar = dest_dir / f"{s3_name}.sha256"
+    sidecar.write_text(f"{digest}  {s3_name}\n", encoding="utf-8")
+    return sidecar
 
 
 # `<genesis>-<sha8>` / `<tag>-<sha8>` — the components are numeric/hex/tag chars,

--- a/.github/scripts/circuit_gen.py
+++ b/.github/scripts/circuit_gen.py
@@ -12,7 +12,7 @@ its inputs from environment variables documented on the per-command function.
 
 Subcommands:
     preflight   Check free disk on the runs-dir mount and required CLIs.
-    version     Validate the vkey and derive `<genesis_l1_height>-<bridge_sha8>`.
+    version     Validate the vkey and derive `<env>-<genesis_l1_height>-<bridge_sha8>`.
     upload      Copy `v5c.ckt` to s3://<bucket>/<prefix>/<version>/g16.v5c, plus a
                 `g16.v5c.sha256` sidecar in `sha256sum -c` format.
     summarize   Append a traceability block to $GITHUB_STEP_SUMMARY.
@@ -31,6 +31,7 @@ from ci_common import (
     genesis_l1_height,
     set_outputs,
     sha256_hex,
+    validate_env,
     write_sha256_sidecar,
 )
 
@@ -90,8 +91,8 @@ def _find_one(root: Path, name: str) -> Path:
 def cmd_version() -> None:
     """Env: ARTIFACT_DIR, GITHUB_OUTPUT.
 
-    Validate the counterproof vkey and derive the S3 version string from the
-    publish run's bundled manifest + asm-params.
+    Validate the counterproof vkey and derive the S3 version string (and env) from
+    the publish run's bundled manifest + asm-params.
     """
     artifact_dir = Path(os.environ["ARTIFACT_DIR"])
     if not artifact_dir.is_dir():
@@ -109,16 +110,20 @@ def cmd_version() -> None:
     bridge_sha = bridge_sha_full[:8]
     if not bridge_sha:
         fail("manifest.json missing strata_bridge.sha")
+    # Taken from the same manifest as bridge_sha, so the circuit's key can never name a
+    # different env than the bridge tree it was generated from.
+    env = validate_env(manifest.get("env", ""))
 
     asm_params = json.loads(_find_one(artifact_dir, ASM_PARAMS_NAME).read_text())
     genesis = genesis_l1_height(asm_params)
 
-    version = f"{genesis}-{bridge_sha}"
+    version = f"{env}-{genesis}-{bridge_sha}"
     if not VERSION_RE.fullmatch(version):
         fail(f"derived version is not S3-key-safe: {version!r}")
 
     set_outputs(
         version=version,
+        env=env,
         bridge_sha=bridge_sha,
         genesis_l1_height=str(genesis),
         vkey_sha256=sha256_hex(vkey_path),
@@ -188,12 +193,14 @@ def cmd_upload() -> None:
 
 
 def cmd_summarize() -> None:
-    """Env: VERSION, S3_URI, PUBLISH_RUN_ID, G16_REF, VKEY_SHA256, CIRCUIT_SHA256,
-    GENESIS_L1_HEIGHT, BRIDGE_SHA, CIRCUIT_SIZE_BYTES, GITHUB_STEP_SUMMARY.
+    """Env: VERSION, DEPLOY_ENV, S3_URI, PUBLISH_RUN_ID, G16_REF, VKEY_SHA256,
+    CIRCUIT_SHA256, GENESIS_L1_HEIGHT, BRIDGE_SHA, CIRCUIT_SIZE_BYTES,
+    GITHUB_STEP_SUMMARY.
 
     Runs with `if: always()`, so upstream step outputs may be empty on failure.
     """
     version = os.environ.get("VERSION", "")
+    env = os.environ.get("DEPLOY_ENV", "")
     s3_uri = os.environ.get("S3_URI", "")
     publish_run_id = os.environ.get("PUBLISH_RUN_ID", "")
     g16_ref = os.environ.get("G16_REF", "")
@@ -209,6 +216,7 @@ def cmd_summarize() -> None:
     lines = [
         "## g16 circuit generation",
         "",
+        f"- env: `{env or 'n/a'}`",
         f"- version: `{version}`",
         f"- S3 object: `{s3_uri or '(not uploaded — see step logs)'}`",
         f"- circuit size: {size_gib}",

--- a/.github/scripts/circuit_gen.py
+++ b/.github/scripts/circuit_gen.py
@@ -13,24 +13,33 @@ its inputs from environment variables documented on the per-command function.
 Subcommands:
     preflight   Check free disk on the runs-dir mount and required CLIs.
     version     Validate the vkey and derive `<genesis_l1_height>-<bridge_sha8>`.
-    upload      Copy `v5c.ckt` to s3://<bucket>/<prefix>/<version>/g16.v5c.
+    upload      Copy `v5c.ckt` to s3://<bucket>/<prefix>/<version>/g16.v5c, plus a
+                `g16.v5c.sha256` sidecar in `sha256sum -c` format.
     summarize   Append a traceability block to $GITHUB_STEP_SUMMARY.
 """
 
 import argparse
-import hashlib
 import json
 import os
 import shutil
 import subprocess
 from pathlib import Path
 
-from ci_common import VERSION_RE, fail, genesis_l1_height, set_outputs
+from ci_common import (
+    VERSION_RE,
+    fail,
+    genesis_l1_height,
+    set_outputs,
+    sha256_hex,
+    write_sha256_sidecar,
+)
 
 VKEY_NAME = "counterproof-vkey.bin"
 MANIFEST_NAME = "manifest.json"
 ASM_PARAMS_NAME = "asm-params.json"
 VKEY_LEN = 32
+# The circuit is `v5c.ckt` on disk but ships under this name in S3.
+S3_CIRCUIT_NAME = "g16.v5c"
 
 
 # ---- preflight -------------------------------------------------------------
@@ -112,7 +121,7 @@ def cmd_version() -> None:
         version=version,
         bridge_sha=bridge_sha,
         genesis_l1_height=str(genesis),
-        vkey_sha256=hashlib.sha256(vkey_bytes).hexdigest(),
+        vkey_sha256=sha256_hex(vkey_path),
         vkey_path=str(vkey_path),
     )
 
@@ -148,7 +157,13 @@ def cmd_upload() -> None:
     if size_bytes == 0:
         fail(f"v5c.ckt is empty: {v5c}")
 
-    s3_uri = f"s3://{bucket}/{prefix}/{version}/g16.v5c"
+    s3_uri = f"s3://{bucket}/{prefix}/{version}/{S3_CIRCUIT_NAME}"
+
+    # Hash before the transfer so a read error surfaces before we push 142 GB.
+    # The pass is disk-bound and silent for minutes; announce it or the log looks hung.
+    print(f"hashing {v5c} ({size_bytes} bytes)")
+    digest = sha256_hex(v5c)
+    print(f"sha256: {digest}")
 
     # Default 8 MB parts would exceed the 10,000-part cap for a 142 GB file;
     # a larger part size keeps the upload to a few thousand parts.
@@ -159,14 +174,21 @@ def cmd_upload() -> None:
     print(f"uploading {v5c} ({size_bytes} bytes) -> {s3_uri}")
     subprocess.run(["aws", "s3", "cp", str(v5c), s3_uri], check=True)
 
-    set_outputs(s3_uri=s3_uri, circuit_size_bytes=str(size_bytes))
+    # Sidecar last, so its presence marks a circuit that finished uploading.
+    sidecar = write_sha256_sidecar(digest, S3_CIRCUIT_NAME, v5c.parent)
+    print(f"uploading {sidecar} -> {s3_uri}.sha256")
+    subprocess.run(["aws", "s3", "cp", str(sidecar), f"{s3_uri}.sha256"], check=True)
+
+    set_outputs(
+        s3_uri=s3_uri, circuit_size_bytes=str(size_bytes), circuit_sha256=digest
+    )
 
 
 # ---- summarize -------------------------------------------------------------
 
 
 def cmd_summarize() -> None:
-    """Env: VERSION, S3_URI, PUBLISH_RUN_ID, G16_REF, VKEY_SHA256,
+    """Env: VERSION, S3_URI, PUBLISH_RUN_ID, G16_REF, VKEY_SHA256, CIRCUIT_SHA256,
     GENESIS_L1_HEIGHT, BRIDGE_SHA, CIRCUIT_SIZE_BYTES, GITHUB_STEP_SUMMARY.
 
     Runs with `if: always()`, so upstream step outputs may be empty on failure.
@@ -176,6 +198,7 @@ def cmd_summarize() -> None:
     publish_run_id = os.environ.get("PUBLISH_RUN_ID", "")
     g16_ref = os.environ.get("G16_REF", "")
     vkey_sha256 = os.environ.get("VKEY_SHA256", "")
+    circuit_sha256 = os.environ.get("CIRCUIT_SHA256", "")
     genesis = os.environ.get("GENESIS_L1_HEIGHT", "")
     bridge_sha = os.environ.get("BRIDGE_SHA", "")
     size_bytes = os.environ.get("CIRCUIT_SIZE_BYTES", "")
@@ -189,6 +212,7 @@ def cmd_summarize() -> None:
         f"- version: `{version}`",
         f"- S3 object: `{s3_uri or '(not uploaded — see step logs)'}`",
         f"- circuit size: {size_gib}",
+        f"- circuit sha256: `{circuit_sha256 or 'n/a'}`",
         "",
         "### Provenance",
         "",

--- a/.github/scripts/guest_publish.py
+++ b/.github/scripts/guest_publish.py
@@ -12,14 +12,14 @@ Subcommands:
     summarize   Verify built artifacts, write the bridge + asm-runner manifests, and
                 append a traceability block to $GITHUB_STEP_SUMMARY.
     upload      Copy the bridge guests (+vkeys) and the asm-runner ELFs to
-                s3://<bucket>/<prefix>/{bridge,asm-runner}/<version>/.
+                s3://<bucket>/<prefix>/{bridge,asm-runner}/<version>/, each with a
+                `<name>.sha256` sidecar in `sha256sum -c` format.
 
 Each subcommand reads its inputs from environment variables documented on the
 per-command function. Shared helpers live in ci_common.py.
 """
 
 import argparse
-import hashlib
 import json
 import os
 import re
@@ -29,7 +29,14 @@ import urllib.request
 from pathlib import Path
 from urllib.parse import urlparse
 
-from ci_common import VERSION_RE, fail, genesis_l1_height, set_outputs
+from ci_common import (
+    VERSION_RE,
+    fail,
+    genesis_l1_height,
+    set_outputs,
+    sha256_hex,
+    write_sha256_sidecar,
+)
 
 
 # ---- validate --------------------------------------------------------------
@@ -189,15 +196,6 @@ EXPECTED_ARTIFACTS = (
 BUNDLED_INPUTS = ("asm-params.json", "asm-vk.json", "moho-vk.json")
 
 
-def sha256_hex(path: Path) -> str:
-    """Return the SHA-256 of `path` as a lowercase hex digest."""
-    h = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(1024 * 1024), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
 def cmd_summarize() -> None:
     """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_REV, ASM_PARAMS_URL, BRIDGE_REF, BRIDGE_SHA,
     GITHUB_STEP_SUMMARY."""
@@ -324,6 +322,9 @@ BRIDGE_UPLOAD_FILES = (
     "manifest.json",
 )
 
+# A manifest needs no sidecar: it already carries the digest of every file beside it.
+NO_SIDECAR = frozenset({"manifest.json"})
+
 
 def s3_cp(src: Path, dst: str) -> None:
     """Copy a single non-empty file to S3, failing fast if it's missing/empty."""
@@ -333,11 +334,40 @@ def s3_cp(src: Path, dst: str) -> None:
     subprocess.run(["aws", "s3", "cp", str(src), dst], check=True)
 
 
+def upload_tree(
+    names: tuple[str, ...], src_dir: Path, base: str, digests: dict[str, str]
+) -> list[str]:
+    """Upload each of `names` from `src_dir` to `<base>/<name>`, following every
+    non-manifest object with its `<name>.sha256` sidecar.
+
+    Digests come from the manifest `summarize` already wrote, so a sidecar can
+    never disagree with the manifest that sits next to it.
+    """
+    # Resolve every digest up front: a missing one means summarize and upload
+    # disagree about what was built, and failing mid-loop would half-publish the tree.
+    missing = [n for n in names if n not in NO_SIDECAR and not digests.get(n)]
+    if missing:
+        fail(f"manifest has no sha256 for {', '.join(missing)}; cannot write sidecars")
+
+    uris: list[str] = []
+    for name in names:
+        dst = f"{base}/{name}"
+        s3_cp(src_dir / name, dst)
+        uris.append(dst)
+        if name in NO_SIDECAR:
+            continue
+        sidecar = write_sha256_sidecar(digests[name], name, src_dir)
+        s3_cp(sidecar, f"{dst}.sha256")
+        uris.append(f"{dst}.sha256")
+    return uris
+
+
 def cmd_upload() -> None:
     """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_REV, S3_BUCKET, S3_PREFIX (default elfs),
     GITHUB_OUTPUT, GITHUB_STEP_SUMMARY.
 
-    Uploads two independently-versioned trees:
+    Uploads two independently-versioned trees, each ELF/vkey followed by its
+    `<name>.sha256` sidecar:
       <prefix>/bridge/<genesis>-<bridge_sha8>/   built guests + vkeys + manifest
       <prefix>/asm-runner/<asm_tag>-<asm_sha8>/  asm.elf, moho.elf + manifest
     """
@@ -366,19 +396,19 @@ def cmd_upload() -> None:
     bridge_base = f"s3://{bucket}/{prefix}/bridge/{bridge_version}"
     asm_base = f"s3://{bucket}/{prefix}/asm-runner/{asm_version}"
 
-    uris: list[str] = []
-    for name in BRIDGE_UPLOAD_FILES:
-        dst = f"{bridge_base}/{name}"
-        s3_cp(elf_dir / name, dst)
-        uris.append(dst)
-    for name in ELF_FILES:
-        dst = f"{asm_base}/{name}"
-        s3_cp(inputs_dir / name, dst)
-        uris.append(dst)
+    asm_manifest_src = inputs_dir / "asm-runner-manifest.json"
+    asm_manifest = json.loads(asm_manifest_src.read_text())
+
+    uris = upload_tree(
+        BRIDGE_UPLOAD_FILES, elf_dir, bridge_base, manifest.get("sha256") or {}
+    )
+    uris += upload_tree(
+        ELF_FILES, inputs_dir, asm_base, asm_manifest.get("sha256") or {}
+    )
     # The asm-runner manifest is staged under a distinct local name to avoid
     # colliding with the bridge manifest; it lands in S3 as manifest.json.
     asm_manifest_dst = f"{asm_base}/manifest.json"
-    s3_cp(inputs_dir / "asm-runner-manifest.json", asm_manifest_dst)
+    s3_cp(asm_manifest_src, asm_manifest_dst)
     uris.append(asm_manifest_dst)
 
     set_outputs(

--- a/.github/scripts/guest_publish.py
+++ b/.github/scripts/guest_publish.py
@@ -12,8 +12,8 @@ Subcommands:
     summarize   Verify built artifacts, write the bridge + asm-runner manifests, and
                 append a traceability block to $GITHUB_STEP_SUMMARY.
     upload      Copy the bridge guests (+vkeys) and the asm-runner ELFs to
-                s3://<bucket>/<prefix>/{bridge,asm-runner}/<version>/, each with a
-                `<name>.sha256` sidecar in `sha256sum -c` format.
+                s3://<bucket>/<prefix>/{bridge,asm-runner}/<env>-<version>/, each with
+                a `<name>.sha256` sidecar in `sha256sum -c` format.
 
 Each subcommand reads its inputs from environment variables documented on the
 per-command function. Shared helpers live in ci_common.py.
@@ -35,6 +35,7 @@ from ci_common import (
     genesis_l1_height,
     set_outputs,
     sha256_hex,
+    validate_env,
     write_sha256_sidecar,
 )
 
@@ -60,10 +61,13 @@ BLOB_HINT = (
 
 
 def cmd_validate() -> None:
-    """Env: INPUT_ASM_TAG, INPUT_ASM_PARAMS_URL, INPUT_REF (optional)."""
+    """Env: INPUT_ENV, INPUT_ASM_TAG, INPUT_ASM_PARAMS_URL, INPUT_REF (optional)."""
+    env = os.environ["INPUT_ENV"]
     asm_tag = os.environ["INPUT_ASM_TAG"]
     asm_params_url = os.environ["INPUT_ASM_PARAMS_URL"]
     ref = os.environ.get("INPUT_REF", "")
+
+    validate_env(env)
 
     if WHITESPACE_RE.search(asm_tag):
         fail("asm_tag must not contain whitespace")
@@ -197,10 +201,13 @@ BUNDLED_INPUTS = ("asm-params.json", "asm-vk.json", "moho-vk.json")
 
 
 def cmd_summarize() -> None:
-    """Env: ELF_DIR, INPUTS_DIR, ASM_TAG, ASM_REV, ASM_PARAMS_URL, BRIDGE_REF, BRIDGE_SHA,
-    GITHUB_STEP_SUMMARY."""
+    """Env: ELF_DIR, INPUTS_DIR, DEPLOY_ENV, ASM_TAG, ASM_REV, ASM_PARAMS_URL, BRIDGE_REF,
+    BRIDGE_SHA, GITHUB_STEP_SUMMARY."""
     elf_dir = Path(os.environ["ELF_DIR"])
     inputs_dir = Path(os.environ["INPUTS_DIR"])
+    # DEPLOY_ENV, not ENV: POSIX reserves `ENV` as a shell startup-file path, so keep
+    # it out of the environment of steps that shell out.
+    env = validate_env(os.environ["DEPLOY_ENV"])
     asm_tag = os.environ["ASM_TAG"]
     asm_rev = os.environ["ASM_REV"]
     asm_params_url = os.environ["ASM_PARAMS_URL"]
@@ -222,10 +229,10 @@ def cmd_summarize() -> None:
     # as hex so consumers can grab the vkey without parsing the predicate blob.
     bridge_vkey_hex = (elf_dir / "bridge-proof-vkey.bin").read_bytes().hex()
     counter_vkey_hex = (elf_dir / "counterproof-vkey.bin").read_bytes().hex()
-    digests = dict((name, sha256_hex(elf_dir / name)) for name in EXPECTED_ARTIFACTS)
+    digests = {name: sha256_hex(elf_dir / name) for name in EXPECTED_ARTIFACTS}
 
-    # asm genesis L1 height + run id go into the manifest so `upload` can derive the
-    # S3 version (`<genesis>-<bridge_sha8>`) from a single source of truth.
+    # The manifest carries env + genesis + run id so `upload` and the circuit job both
+    # derive `<env>-<genesis>-<bridge_sha8>` from one source of truth.
     asm_params = json.loads((inputs_dir / "asm-params.json").read_text())
     genesis = genesis_l1_height(asm_params)
     run_id = os.environ.get("GITHUB_RUN_ID", "")
@@ -240,7 +247,8 @@ def cmd_summarize() -> None:
     input_digests = {name: sha256_hex(elf_dir / name) for name in BUNDLED_INPUTS}
 
     manifest = {
-        "schema": 2,
+        "schema": 3,
+        "env": env,
         "asm_tag": asm_tag,
         "asm_params_url": asm_params_url,
         "asm_genesis_l1_height": genesis,
@@ -268,7 +276,8 @@ def cmd_summarize() -> None:
         if not p.is_file() or p.stat().st_size == 0:
             fail(f"expected asm artifact missing or empty: {p}")
     asm_manifest = {
-        "schema": 1,
+        "schema": 2,
+        "env": env,
         "asm_tag": asm_tag,
         "asm_rev": asm_rev,
         "run_id": run_id,
@@ -281,6 +290,7 @@ def cmd_summarize() -> None:
     lines: list[str] = [
         "## SP1 bridge guest publish",
         "",
+        f"- env: `{env}`",
         f"- asm tag (alpenlabs/asm): `{asm_tag}`",
         f"- asm-params source: `{asm_params_url}`",
         f"- strata-bridge ref: `{bridge_ref}` @ `{bridge_sha}`",
@@ -368,8 +378,8 @@ def cmd_upload() -> None:
 
     Uploads two independently-versioned trees, each ELF/vkey followed by its
     `<name>.sha256` sidecar:
-      <prefix>/bridge/<genesis>-<bridge_sha8>/   built guests + vkeys + manifest
-      <prefix>/asm-runner/<asm_tag>-<asm_sha8>/  asm.elf, moho.elf + manifest
+      <prefix>/bridge/<env>-<genesis>-<bridge_sha8>/   built guests + vkeys + manifest
+      <prefix>/asm-runner/<env>-<asm_tag>-<asm_sha8>/  asm.elf, moho.elf + manifest
     """
     elf_dir = Path(os.environ["ELF_DIR"])
     inputs_dir = Path(os.environ["INPUTS_DIR"])
@@ -384,12 +394,15 @@ def cmd_upload() -> None:
     bridge_sha = (manifest.get("strata_bridge") or {}).get("sha", "")[:8]
     if genesis is None or not bridge_sha:
         fail("manifest.json missing asm_genesis_l1_height or strata_bridge.sha")
-    bridge_version = f"{genesis}-{bridge_sha}"
+    # Read env back from the manifest rather than the environment, so the published
+    # key can only ever be the one summarize recorded.
+    env = validate_env(manifest.get("env", ""))
+    bridge_version = f"{env}-{genesis}-{bridge_sha}"
     if not VERSION_RE.fullmatch(bridge_version):
         fail(f"bridge version is not S3-key-safe: {bridge_version!r}")
 
     # asm-runner tree — version pins the asm release the ELFs came from.
-    asm_version = f"{asm_tag}-{asm_rev[:8]}"
+    asm_version = f"{env}-{asm_tag}-{asm_rev[:8]}"
     if not VERSION_RE.fullmatch(asm_version):
         fail(f"asm-runner version is not S3-key-safe: {asm_version!r}")
 

--- a/.github/workflows/circuit-gen.yml
+++ b/.github/workflows/circuit-gen.yml
@@ -126,6 +126,7 @@ jobs:
           PUBLISH_RUN_ID: ${{ github.run_id }}
           G16_REF: ${{ env.G16_REF }}
           VKEY_SHA256: ${{ steps.version.outputs.vkey_sha256 }}
+          CIRCUIT_SHA256: ${{ steps.upload.outputs.circuit_sha256 }}
           GENESIS_L1_HEIGHT: ${{ steps.version.outputs.genesis_l1_height }}
           BRIDGE_SHA: ${{ steps.version.outputs.bridge_sha }}
           CIRCUIT_SIZE_BYTES: ${{ steps.upload.outputs.circuit_size_bytes }}

--- a/.github/workflows/circuit-gen.yml
+++ b/.github/workflows/circuit-gen.yml
@@ -123,6 +123,7 @@ jobs:
         env:
           S3_URI: ${{ steps.upload.outputs.s3_uri }}
           VERSION: ${{ steps.version.outputs.version }}
+          DEPLOY_ENV: ${{ steps.version.outputs.env }}
           PUBLISH_RUN_ID: ${{ github.run_id }}
           G16_REF: ${{ env.G16_REF }}
           VKEY_SHA256: ${{ steps.version.outputs.vkey_sha256 }}

--- a/.github/workflows/publish-guests-and-circuit.yml
+++ b/.github/workflows/publish-guests-and-circuit.yml
@@ -7,6 +7,14 @@ name: Publish Guests + g16 Circuit
 on:
   workflow_dispatch:
     inputs:
+      env:
+        description: Deployment environment. Prefixes the S3 version segment, keeping each env's artifacts distinct.
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
       asm_tag:
         description: Tag in alpenlabs/asm whose release ships asm-vk.json and moho-vk.json (e.g. v0.1-alpha.11).
         required: true
@@ -29,7 +37,7 @@ on:
         type: string
 
 concurrency:
-  group: publish-guests-and-circuit-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
+  group: publish-guests-and-circuit-${{ inputs.env }}-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
   cancel-in-progress: false
 
 permissions: {}
@@ -42,6 +50,7 @@ jobs:
       contents: read
       id-token: write
     with:
+      env: ${{ inputs.env }}
       asm_tag: ${{ inputs.asm_tag }}
       asm_params_url: ${{ inputs.asm_params_url }}
       ref: ${{ inputs.ref }}
@@ -49,6 +58,8 @@ jobs:
   circuit-gen:
     name: Circuit gen
     needs: guest-build
+    # No `env:` input — circuit-gen reads it from the manifest in guest-build's
+    # artifact, so the circuit key can't name a different env than the bridge tree.
     uses: ./.github/workflows/circuit-gen.yml
     permissions:
       contents: read

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -3,6 +3,14 @@ name: Publish SP1 Bridge Guests
 on:
   workflow_dispatch:
     inputs:
+      env:
+        description: Deployment environment. Prefixes the S3 version segment, keeping each env's artifacts distinct.
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
       asm_tag:
         description: Tag in alpenlabs/asm whose release ships asm-vk.json and moho-vk.json (e.g. v0.1-alpha.11).
         required: true
@@ -17,6 +25,12 @@ on:
         type: string
   workflow_call:
     inputs:
+      env:
+        # `type: choice` is dispatch-only; the guest_publish.py `validate` step is what
+        # actually rejects anything outside {dev,staging,prod} on this path.
+        description: Deployment environment (dev | staging | prod).
+        required: true
+        type: string
       asm_tag:
         description: Tag in alpenlabs/asm whose release ships asm-vk.json and moho-vk.json.
         required: true
@@ -38,7 +52,7 @@ env:
   S3_PREFIX: elfs
 
 concurrency:
-  group: publish-sp1-bridge-guests-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
+  group: publish-sp1-bridge-guests-${{ inputs.env }}-${{ inputs.ref || github.ref }}-${{ inputs.asm_tag }}
   cancel-in-progress: false
 
 permissions: {}
@@ -81,6 +95,7 @@ jobs:
 
       - name: Validate manual inputs
         env:
+          INPUT_ENV: ${{ inputs.env }}
           INPUT_ASM_TAG: ${{ inputs.asm_tag }}
           INPUT_ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
           INPUT_REF: ${{ inputs.ref }}
@@ -138,6 +153,7 @@ jobs:
         env:
           ELF_DIR: guest-builder/sp1/elfs
           INPUTS_DIR: ${{ runner.temp }}/bridge-genesis
+          DEPLOY_ENV: ${{ inputs.env }}
           ASM_TAG: ${{ inputs.asm_tag }}
           ASM_REV: ${{ steps.fetch.outputs.asm_rev }}
           ASM_PARAMS_URL: ${{ inputs.asm_params_url }}
@@ -165,7 +181,7 @@ jobs:
       - name: Upload elfs/ as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sp1-bridge-guests-${{ inputs.asm_tag }}-${{ github.run_id }}
+          name: sp1-bridge-guests-${{ inputs.env }}-${{ inputs.asm_tag }}-${{ github.run_id }}
           path: guest-builder/sp1/elfs/
           if-no-files-found: error
           retention-days: 90


### PR DESCRIPTION
## Description
Two enhancements to the Publish Guests + g16 Circuit pipeline:

1. **sha256 sidecars** — every uploaded ELF/vkey/circuit now ships a `<name>.sha256` next to it in `sha256sum c` format, so downloads can be verified. 
2. **env-scoped S3 versions** — every version segment is now prefixed with a deployment environment (`dev`/`staging`/`prod`), keeping each env's artifacts in distinct keys: `bridge/<env>-<genesis>-<sha8>/`, `asm-runner/<env>-<tag>-<sha8>/`, `<env>-<genesis>-<sha8>/g16.v5c`.

The env is chosen once at dispatch, recorded in the guest-build manifest, and read back by both the upload and circuit-gen steps — so the circuit can never be keyed to a different env than the bridge tree it was generated from.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update