### PR TITLE
feat: assert SP1 guest ELF matches params predicate at startup

### DIFF
--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -30,6 +30,7 @@ strata-mosaic-client-api.workspace = true
 
 strata-asm-rpc.workspace = true
 strata-p2p.workspace = true
+strata-predicate.workspace = true
 strata-tasks.workspace = true
 
 anyhow.workspace = true
@@ -62,7 +63,6 @@ tikv-jemallocator = "0.6"
 
 [dev-dependencies]
 strata-bridge-test-utils.workspace = true
-strata-predicate.workspace = true
 zkaleido.workspace = true
 
 [features]

--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -83,6 +83,10 @@ pub(crate) struct Config {
     /// Backend that produces bridge counterproofs.
     pub counterproof: CounterproofBackendConfig,
 
+    /// Developer/experimentation mode. When `true`, the startup consistency checks are skipped.
+    #[serde(default)]
+    pub dev: bool,
+
     /// Configuration for process-level metrics exporters.
     #[serde(default)]
     pub metrics: MetricsConfig,

--- a/bin/strata-bridge/src/mode/services/mod.rs
+++ b/bin/strata-bridge/src/mode/services/mod.rs
@@ -9,3 +9,4 @@ pub(in crate::mode) mod operator_wallet;
 pub(in crate::mode) mod orchestrator;
 pub(in crate::mode) mod p2p_handles;
 pub(in crate::mode) mod secret_service;
+pub(in crate::mode) mod startup_checks;

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -36,7 +36,7 @@ use tokio::{
     select,
     sync::{RwLock, mpsc, oneshot},
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     config::Config,
@@ -48,6 +48,7 @@ use crate::{
     mode::services::{
         btc_client::init_zmq_client,
         health_probes::{spawn_orchestrator_stale_monitor, spawn_tx_driver_probe},
+        startup_checks,
     },
 };
 
@@ -163,6 +164,11 @@ where
     );
     let bridge_proof_host = strata_bridge_proof::build_host(&config.bridge_proof).await?;
     let counterproof_host = strata_bridge_counterproof::build_host(&config.counterproof).await?;
+    if config.dev {
+        warn!("dev mode: skipping bridge startup consistency checks");
+    } else {
+        startup_checks::verify(params, &bridge_proof_host, &counterproof_host)?;
+    }
     let output_handles = OutputHandles {
         wallet,
         msg_handler: RwLock::new(message_handler),

--- a/bin/strata-bridge/src/mode/services/startup_checks.rs
+++ b/bin/strata-bridge/src/mode/services/startup_checks.rs
@@ -1,0 +1,53 @@
+//! Startup consistency checks between the bridge and its external components
+use anyhow::Result;
+use strata_bridge_common::params::Params;
+use strata_bridge_counterproof::BridgeCounterproofHost;
+use strata_bridge_proof::BridgeProofHost;
+use strata_predicate::PredicateKey;
+
+/// Runs every startup consistency check; the failure aborts node startup.
+pub(in crate::mode) fn verify(
+    params: &Params,
+    bridge_proof_host: &BridgeProofHost,
+    counterproof_host: &BridgeCounterproofHost,
+) -> Result<()> {
+    verify_predicates(params, bridge_proof_host, counterproof_host)?;
+    Ok(())
+}
+
+/// Each proof host's loaded guest ELF matches its corresponding verification predicate.
+fn verify_predicates(
+    params: &Params,
+    bridge_proof_host: &BridgeProofHost,
+    counterproof_host: &BridgeCounterproofHost,
+) -> Result<()> {
+    ensure_predicate_match(
+        "bridge-proof",
+        bridge_proof_host.sp1_predicate()?,
+        &params.protocol.bridge_proof_predicate,
+    )?;
+    ensure_predicate_match(
+        "bridge-counterproof",
+        counterproof_host.sp1_predicate()?,
+        &params.protocol.counterproof_predicate,
+    )
+}
+
+/// Errors unless the ELF's `derived` predicate matches the `expected` params one. `None` (native
+/// host or non-`sp1` build) pins no ELF — nothing to check.
+fn ensure_predicate_match(
+    label: &str,
+    derived: Option<PredicateKey>,
+    expected: &PredicateKey,
+) -> Result<()> {
+    let Some(derived) = derived else {
+        return Ok(());
+    };
+    if derived.id() != expected.id() || derived.condition() != expected.condition() {
+        anyhow::bail!(
+            "{label}: loaded SP1 guest ELF does not match the configured predicate; regenerate it \
+             with `proof-datatool sp1-predicate <elf>` or point at the matching ELF"
+        );
+    }
+    Ok(())
+}

--- a/crates/proofs/common/src/host/backend.rs
+++ b/crates/proofs/common/src/host/backend.rs
@@ -10,12 +10,17 @@ use std::time::Instant;
 #[cfg(feature = "sp1")]
 use anyhow::Context;
 use anyhow::Result;
+use strata_predicate::PredicateKey;
 use tracing::info;
+#[cfg(feature = "sp1")]
+use zkaleido::ZkVmExecutor;
 use zkaleido_native_adapter::{NativeHost, NativeMachine};
 #[cfg(feature = "sp1")]
 use zkaleido_sp1_host::SP1Host;
 
 use crate::host::config::ProofBackendConfig;
+#[cfg(feature = "sp1")]
+use crate::host::predicate::sp1_groth16_predicate_key;
 
 /// Runtime selection of the host used to generate proofs.
 #[derive(Clone, Debug)]
@@ -25,6 +30,19 @@ pub enum Host {
     /// SP1 host loaded from a compiled guest ELF.
     #[cfg(feature = "sp1")]
     Sp1(Box<SP1Host>),
+}
+
+impl Host {
+    /// The predicate derived from the loaded SP1 guest ELF; `None` for the native host or in
+    /// non-`sp1` builds.
+    #[cfg_attr(not(feature = "sp1"), allow(clippy::missing_const_for_fn))]
+    pub fn sp1_predicate(&self) -> Result<Option<PredicateKey>> {
+        #[cfg(feature = "sp1")]
+        if let Host::Sp1(host) = self {
+            return Ok(Some(sp1_groth16_predicate_key(host.program_id().0)?));
+        }
+        Ok(None)
+    }
 }
 
 /// Builds a [`Host`] from operator config, binding the given native statement processor.

--- a/functional-tests/run_test.sh
+++ b/functional-tests/run_test.sh
@@ -78,6 +78,7 @@ mkdir -p functional-tests/_dd/.bin
 CARGO_LOCAL_BIN=$(realpath "functional-tests/_dd/.bin")
 export PATH="$CARGO_LOCAL_BIN/bin:$PATH"
 RUSTFLAGS="" cargo install \
+    --locked \
     --git https://github.com/alpenlabs/mosaic \
     "--$MOSAIC_REF_TYPE" "$MOSAIC_REF" \
     --features=reduced-circuits \


### PR DESCRIPTION
## Description
In SP1 mode the guest ELF that *generates* proofs and the params predicate that *verifies* them are configured independently, so a mismatched ELF silently breaks verification. This adds a startup check that the predicate derived from each loaded guest ELF (bridge-proof + counterproof) matches the one in params, aborting startup on mismatch. A new `dev` flag (default `false`) bypasses it.
