### PR TITLE
ci: drop sp1-core-executor-runner pre-build workaround

### DIFF
--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -152,16 +152,6 @@ jobs:
       - name: Verify SP1 toolchain
         run: cargo prove --version
 
-      # `sp1-core-executor-runner` v6.x has a `build.rs` that runs a nested `cargo build`
-      # and embeds the resulting helper binary via `include_bytes!`. In CI the embedded
-      # path resolves under the registry source dir and is unreadable at compile time.
-      # Pre-build the helper and point `SP1_CORE_RUNNER_OVERRIDE_BINARY` at it so the
-      # build script skips the nested build. Keep the version aligned with `sp1-sdk`.
-      - name: Pre-build SP1 core runner binary
-        run: |
-          cargo install sp1-core-executor-runner-binary --version 6.2.0 --root "$RUNNER_TEMP/sp1-core-runner" --force
-          echo "SP1_CORE_RUNNER_OVERRIDE_BINARY=$RUNNER_TEMP/sp1-core-runner/bin/sp1-core-executor-runner-binary" >> "$GITHUB_ENV"
-
       # Ports + creds match functional-tests/sp1-env.bash.sample so run_test.sh /
       # gen_asm_params_external.py pick them up without overrides.
       - name: Start regtest bitcoind

--- a/.github/workflows/guest-build.yml
+++ b/.github/workflows/guest-build.yml
@@ -65,17 +65,6 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
 
-      # `sp1-core-executor-runner` v6.x has a `build.rs` that runs a nested `cargo build`
-      # and embeds the resulting helper binary via `include_bytes!`. In CI the embedded
-      # path resolves under the registry source dir and is unreadable at compile time.
-      # Upstream's documented escape hatch is to pre-build the helper and point
-      # `SP1_CORE_RUNNER_OVERRIDE_BINARY` at it; the build script then skips the nested
-      # build entirely. Keep the version in sync with `sp1-sdk` in workspace `Cargo.toml`.
-      - name: Pre-build SP1 core runner binary
-        run: |
-          cargo install sp1-core-executor-runner-binary --version 6.2.0 --root "$RUNNER_TEMP/sp1-core-runner" --force
-          echo "SP1_CORE_RUNNER_OVERRIDE_BINARY=$RUNNER_TEMP/sp1-core-runner/bin/sp1-core-executor-runner-binary" >> "$GITHUB_ENV"
-
       - name: Build SP1 bridge-proof and counterproof guests with bundled stub params
         run: SKIP_PARAMS=1 cargo build --locked -p strata-bridge-sp1-guest-builder --release --features docker-build
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,17 +56,6 @@ jobs:
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
-      # `sp1-core-executor-runner` v6.x has a `build.rs` that runs a nested `cargo build`
-      # and embeds the resulting helper binary via `include_bytes!`. In CI the embedded
-      # path resolves under the registry source dir and is unreadable at compile time.
-      # Upstream's documented escape hatch is to pre-build the helper and point
-      # `SP1_CORE_RUNNER_OVERRIDE_BINARY` at it; the build script then skips the nested
-      # build entirely. Keep the version in sync with `sp1-sdk` in workspace `Cargo.toml`.
-      - name: Pre-build SP1 core runner binary
-        run: |
-          cargo install sp1-core-executor-runner-binary --version 6.2.0 --root "$RUNNER_TEMP/sp1-core-runner" --force
-          echo "SP1_CORE_RUNNER_OVERRIDE_BINARY=$RUNNER_TEMP/sp1-core-runner/bin/sp1-core-executor-runner-binary" >> "$GITHUB_ENV"
-
       - run: cargo clippy --workspace --lib --bins --locked --examples --tests --benches --all-features --all-targets
         env:
           RUSTFLAGS: -D warnings

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -125,11 +125,6 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
 
-      - name: Pre-build SP1 core runner binary
-        run: |
-          cargo install sp1-core-executor-runner-binary --version 6.2.0 --root "$RUNNER_TEMP/sp1-core-runner" --force
-          echo "SP1_CORE_RUNNER_OVERRIDE_BINARY=$RUNNER_TEMP/sp1-core-runner/bin/sp1-core-executor-runner-binary" >> "$GITHUB_ENV"
-
       - name: Fetch asm-vk, moho-vk, asm/moho ELFs, asm-params
         id: fetch
         env:


### PR DESCRIPTION
## Description
Removes the `Pre-build SP1 core runner binary` workaround step from all four CI
workflows (`lint`, `guest-build`, `functional-sp1-proofs`, `publish-sp1-bridge-guests`).

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update