### PR TITLE
fix(btc-tracker): do not panic on duplicate MempoolAcceptance for previously observed rawtx

### DIFF
--- a/crates/btc-tracker/src/state_machine.rs
+++ b/crates/btc-tracker/src/state_machine.rs
@@ -434,14 +434,11 @@ impl BtcNotifySM {
                             }
                         }
                     }
-                    // In this case we have received a MempoolAcceptance event for this txid, but
-                    // haven't yet processed the accompanying rawtx event.
-                    //
-                    // TODO: <https://alpenlabs.atlassian.net/browse/STR-2686>
-                    // Replace this panic-only assumption with explicit handling if
-                    // `MempoolAcceptance` arrives before the corresponding `rawtx`.
+                    // Reorg reacceptance can deliver duplicate MempoolAcceptance events before
+                    // rawtx catches up; the pending placeholder is enough until tx bytes arrive.
                     Some(None) => {
-                        panic!("invariant violated: MempoolAcceptance received before rawtx")
+                        trace!(?seq, %txid, "ignoring duplicate MempoolAcceptance before rawtx");
+                        (vec![], None)
                     }
                     // In this case we know nothing of this transaction yet.
                     None => {
@@ -839,6 +836,66 @@ mod prop_tests {
 
             let diff = sm.process_sequence(SequenceMessage::MempoolAcceptance { txid: tx.compute_txid(), mempool_sequence: 0 });
             prop_assert!(diff.0.is_empty());
+
+            let diff = sm.process_tx(tx.clone());
+            prop_assert_eq!(diff, vec![TxEvent { rawtx: tx, status: TxStatus::Mempool }]);
+        }
+
+        // Ensures that repeated MempoolAcceptance events remain pending until the rawtx event
+        // supplies transaction data.
+        #[test]
+        fn repeated_seq_before_tx_yields_one_mempool(tx in arb_transaction()) {
+            let mut sm = BtcNotifySM::init(DEFAULT_BURY_DEPTH, VecDeque::new());
+            let txid = tx.compute_txid();
+
+            sm.add_filter(Arc::new(|_|true));
+
+            let diff = sm.process_sequence(SequenceMessage::MempoolAcceptance { txid, mempool_sequence: 0 });
+            prop_assert!(diff.0.is_empty());
+
+            let sm_after_first_acceptance = sm.clone();
+            let diff = sm.process_sequence(SequenceMessage::MempoolAcceptance { txid, mempool_sequence: 1 });
+            prop_assert!(diff.0.is_empty());
+            prop_assert_eq!(&sm, &sm_after_first_acceptance);
+
+            let diff = sm.process_tx(tx.clone());
+            prop_assert_eq!(diff, vec![TxEvent { rawtx: tx, status: TxStatus::Mempool }]);
+        }
+
+        // Ensures that a transaction reaccepted after block disconnection can receive another
+        // MempoolAcceptance before rawtx catches up.
+        #[test]
+        fn duplicate_reorg_reacceptance_before_rawtx_stays_pending(
+            tx in arb_transaction(),
+            mut block in arb_block(BIP34_MIN_HEIGHT, Hash::all_zeros()),
+        ) {
+            let txid = tx.compute_txid();
+            block.txdata.push(tx.clone());
+            block.header.merkle_root = block.compute_merkle_root().unwrap();
+            let blockhash = block.block_hash();
+
+            let mut sm = BtcNotifySM::init(DEFAULT_BURY_DEPTH, VecDeque::new());
+            sm.add_filter(Arc::new(move |candidate| candidate.compute_txid() == txid));
+
+            let (mined, _block_event) = sm.process_block(block);
+            let mined_contains_tx = mined.iter().any(|event| {
+                event.rawtx.compute_txid() == txid && matches!(event.status, TxStatus::Mined { .. })
+            });
+            prop_assert!(mined_contains_tx);
+
+            let (unknown, _block_event) = sm.process_sequence(SequenceMessage::BlockDisconnect { blockhash });
+            let unknown_contains_tx = unknown.iter().any(|event| {
+                event.rawtx.compute_txid() == txid && event.status == TxStatus::Unknown
+            });
+            prop_assert!(unknown_contains_tx);
+
+            let reaccepted = sm.process_sequence(SequenceMessage::MempoolAcceptance { txid, mempool_sequence: 0 });
+            prop_assert!(reaccepted.0.is_empty());
+
+            let sm_after_reacceptance = sm.clone();
+            let duplicate = sm.process_sequence(SequenceMessage::MempoolAcceptance { txid, mempool_sequence: 1 });
+            prop_assert!(duplicate.0.is_empty());
+            prop_assert_eq!(&sm, &sm_after_reacceptance);
 
             let diff = sm.process_tx(tx.clone());
             prop_assert_eq!(diff, vec![TxEvent { rawtx: tx, status: TxStatus::Mempool }]);


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR prevents a panic when a duplicate `MempoolAcceptance` event is observed for a transaction whose `rawtx` event has already been observed. This can happen during reorgs where transactions may be evicted from confirmed blocks into the mempool and to panic in such a scenario is a gross overreaction.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
This was observed on public signet deployment.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-2686