### PR TITLE
fix(proofs): emit Sp1Groth16 condition in canonical encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11712,7 +11712,6 @@ name = "strata-bridge-proof-common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "borsh",
  "hex",
  "k256",
  "moho-recursive-proof",

--- a/crates/proofs/common/Cargo.toml
+++ b/crates/proofs/common/Cargo.toml
@@ -17,7 +17,6 @@ strata-predicate.workspace = true
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 anyhow.workspace = true
-borsh = { workspace = true, optional = true }
 hex.workspace = true
 k256.workspace = true
 serde.workspace = true
@@ -29,15 +28,12 @@ tokio.workspace = true
 tracing.workspace = true
 zkaleido.workspace = true
 zkaleido-native-adapter.workspace = true
-zkaleido-sp1-groth16-verifier = { workspace = true, optional = true, features = [
-  "borsh",
-] }
+zkaleido-sp1-groth16-verifier = { workspace = true, optional = true }
 zkaleido-sp1-host = { workspace = true, optional = true }
 
 [features]
 default = []
 sp1 = [
-  "dep:borsh",
   "dep:serde_json",
   "dep:sp1-sdk",
   "dep:sp1-verifier",

--- a/crates/proofs/common/src/host/predicate.rs
+++ b/crates/proofs/common/src/host/predicate.rs
@@ -25,7 +25,7 @@ pub fn sp1_program_vkey_hash(elf: &[u8]) -> Result<[u8; 32]> {
 pub fn sp1_groth16_predicate_key(vkey_hash: [u8; 32]) -> Result<PredicateKey> {
     let verifier = SP1Groth16Verifier::load(&GROTH16_VK_BYTES, vkey_hash, *VK_ROOT_BYTES, true)
         .context("load SP1 Groth16 verifier")?;
-    let condition = borsh::to_vec(&verifier).context("borsh-encode SP1 Groth16 verifier")?;
+    let condition = verifier.to_uncompressed_bytes();
 
     Ok(PredicateKey::new(PredicateTypeId::Sp1Groth16, condition))
 }


### PR DESCRIPTION
## Description
Follow-up to the strata-common/zkaleido bump: fixes the CI fn-test SP1 proofs, which failed with Invalid SP1 Groth16 verifier length: got 809 bytes. strata-predicate now parses the condition via SP1Groth16Verifier::parse, so emit it with to_uncompressed_bytes instead of borsh (mirrors alpen #1965).

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update