### PR TITLE
fix(bridge-exec): reconcile claim refill leases

### DIFF
--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -1,5 +1,7 @@
 //! Executors for uncontested payout graph duties.
 
+use std::collections::BTreeSet;
+
 use algebra::predicate;
 use bitcoin::{
     OutPoint, TapSighashType, TxOut, Txid, XOnlyPublicKey,
@@ -9,7 +11,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
-use operator_wallet::{GeneralUtxoPolicy, UtxoInfo};
+use operator_wallet::{GeneralUtxoPolicy, GeneralWallet, OperatorWallet, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
 use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
@@ -30,7 +32,7 @@ use strata_mosaic_client_api::{
 };
 use tracing::{error, info, warn};
 
-use super::utils::finalize_claim_funding_tx;
+use super::utils::sign_claim_funding_tx;
 use crate::{
     chain::{is_outpoint_unspent, is_txid_onchain, publish_signed_transaction},
     config::ExecutionConfig,
@@ -194,12 +196,38 @@ async fn ensure_claim_funding_outpoint(
                     )
                     .await
                     .map_err(|e| ExecutorError::WalletErr(format!("refill failed: {e}")))?;
-                finalize_claim_funding_tx(
-                    &output_handles.s2_client,
-                    &output_handles.tx_driver,
-                    funded.psbt,
-                )
-                .await?;
+                let spent = funded.spent();
+                let tx = match sign_claim_funding_tx(&output_handles.s2_client, funded.psbt).await {
+                    Ok(tx) => tx,
+                    Err(err) => {
+                        wallet.release(&spent);
+                        warn!(
+                            ?err,
+                            ?spent,
+                            "claim-funding refill signing failed; released inputs"
+                        );
+
+                        return Err(err);
+                    }
+                };
+                let txid = tx.compute_txid();
+                info!(%txid, "submitting claim funding tx to the tx driver");
+                if let Err(err) = output_handles
+                    .tx_driver
+                    .drive(tx, predicate::eq(TxStatus::Mempool))
+                    .await
+                {
+                    warn!(
+                        ?err,
+                        ?spent,
+                        "claim-funding tx driver failed; syncing wallet before reconciling input leases"
+                    );
+                    reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &spent).await;
+
+                    return Err(err.into());
+                }
+                info!(%txid, "claim funding tx detected in mempool");
+
                 wallet.sync().await.map_err(|e| {
                     error!(?e, "could not sync wallet after refilling funding utxos");
                     ExecutorError::WalletErr(format!("wallet sync failed after refill: {e:?}"))
@@ -245,6 +273,47 @@ async fn ensure_claim_funding_outpoint(
     };
 
     Ok(assigned_outpoint)
+}
+
+async fn reconcile_claim_funding_leases_after_driver_failure<G: GeneralWallet>(
+    wallet: &mut OperatorWallet<G>,
+    spent: &[OutPoint],
+) {
+    if let Err(sync_err) = wallet.sync().await {
+        warn!(
+            ?sync_err,
+            ?spent,
+            "could not sync wallet after tx-driver failure; retaining claim-funding input leases"
+        );
+        return;
+    }
+
+    let live_general_outpoints: BTreeSet<_> = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .map(|u| u.outpoint)
+        .collect();
+    let still_unspent: Vec<_> = spent
+        .iter()
+        .copied()
+        .filter(|outpoint| live_general_outpoints.contains(outpoint))
+        .collect();
+    let pruned_count = spent.len().saturating_sub(still_unspent.len());
+
+    if pruned_count > 0 {
+        info!(
+            pruned_count,
+            "wallet sync pruned claim-funding input leases no longer seen as spendable"
+        );
+    }
+    if !still_unspent.is_empty() {
+        wallet.release(&still_unspent);
+        warn!(
+            ?still_unspent,
+            "released claim-funding input leases after wallet sync showed they are still spendable"
+        );
+    }
 }
 
 /// Fetches the owner's adaptor pubkey and the per-watchtower fault pubkeys from mosaic.
@@ -664,9 +733,110 @@ pub(super) async fn publish_claim(
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::BTreeSet, io, sync::Arc, time::Duration};
+
+    use bdk_bitcoind_rpc::bitcoincore_rpc::{Auth, Client as CoreRpcClient};
+    use bitcoin::{
+        Amount, FeeRate, Network, OutPoint, ScriptBuf, Transaction, TxOut, Txid, XOnlyPublicKey,
+        hashes::Hash,
+        secp256k1::{Keypair, SECP256K1, SecretKey},
+    };
+    use corepc_node::{Conf, Node};
+    use operator_wallet::{
+        FundedPsbt, GeneralWallet, OperatorWallet, OperatorWalletConfig, UtxoInfo, sync::Backend,
+    };
     use strata_bridge_test_utils::bridge_fixtures::test_operator_table;
 
-    use super::watchtower_idxs;
+    use super::{reconcile_claim_funding_leases_after_driver_failure, watchtower_idxs};
+
+    #[derive(Debug)]
+    struct ReconciliationGeneralWallet {
+        live_utxos: Vec<UtxoInfo>,
+        sync_fails: bool,
+    }
+
+    impl GeneralWallet for ReconciliationGeneralWallet {
+        type Error = io::Error;
+
+        async fn sync(&mut self) -> Result<(), Self::Error> {
+            if self.sync_fails {
+                Err(io::Error::other("test sync failure"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn script_pubkey(&self) -> ScriptBuf {
+            ScriptBuf::new()
+        }
+
+        fn list_utxos(&self) -> Vec<UtxoInfo> {
+            self.live_utxos.clone()
+        }
+
+        async fn fund_v3_transaction(
+            &mut self,
+            _outputs: Vec<TxOut>,
+            _explicit_inputs: Option<&[OutPoint]>,
+            _fee_rate: FeeRate,
+            _exclude: &[OutPoint],
+        ) -> Result<FundedPsbt, Self::Error> {
+            unreachable!("reconciliation tests do not fund transactions")
+        }
+
+        async fn build_cpfp_child(
+            &mut self,
+            _parent: &Transaction,
+            _anchor_vout: u32,
+            _target_pkg_fee_rate: FeeRate,
+            _exclude: &[OutPoint],
+        ) -> Result<FundedPsbt, Self::Error> {
+            unreachable!("reconciliation tests do not build CPFP transactions")
+        }
+    }
+
+    fn xonly_pubkey(byte: u8) -> XOnlyPublicKey {
+        let secret_key = SecretKey::from_slice(&[byte; 32]).expect("valid secret key");
+        Keypair::from_secret_key(SECP256K1, &secret_key)
+            .x_only_public_key()
+            .0
+    }
+
+    fn core_rpc_client(bitcoind: &Node) -> CoreRpcClient {
+        let auth = Auth::CookieFile(bitcoind.params.cookie_file.clone());
+        CoreRpcClient::new(bitcoind.rpc_url().as_str(), auth).expect("core rpc client")
+    }
+
+    fn reconciliation_wallet(
+        bitcoind: &Node,
+        live_utxos: Vec<UtxoInfo>,
+        sync_fails: bool,
+        initial_leases: BTreeSet<OutPoint>,
+    ) -> OperatorWallet<ReconciliationGeneralWallet> {
+        let general = ReconciliationGeneralWallet {
+            live_utxos,
+            sync_fails,
+        };
+        let config = OperatorWalletConfig::new(Amount::from_sat(330), Network::Regtest)
+            .with_sync_policy(0, 1, Duration::ZERO);
+
+        OperatorWallet::new(
+            general,
+            xonly_pubkey(42),
+            config,
+            Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
+            initial_leases,
+        )
+    }
+
+    fn test_utxo(outpoint: OutPoint) -> UtxoInfo {
+        UtxoInfo {
+            outpoint,
+            amount: Amount::ONE_BTC,
+            confirmations: 1,
+            script_pubkey: ScriptBuf::new(),
+        }
+    }
 
     #[test]
     fn watchtower_order_uses_supplied_operator_table_snapshot() {
@@ -678,5 +848,50 @@ mod tests {
 
         assert_eq!(historical_watchtowers, vec![1, 2]);
         assert_eq!(later_watchtowers, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_prunes_spent_inputs_and_releases_live_inputs() {
+        let bitcoind = Node::with_conf("bitcoind", &Conf::default()).expect("bitcoind starts");
+        let spent = OutPoint {
+            txid: Txid::from_slice(&[1; 32]).expect("valid txid"),
+            vout: 0,
+        };
+        let live = OutPoint {
+            txid: Txid::from_slice(&[2; 32]).expect("valid txid"),
+            vout: 0,
+        };
+        let mut wallet = reconciliation_wallet(
+            &bitcoind,
+            vec![test_utxo(live)],
+            false,
+            BTreeSet::from([spent, live]),
+        );
+
+        reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &[spent, live]).await;
+
+        assert!(
+            wallet.leased_outpoints().is_empty(),
+            "sync should prune the spent input and reconciliation should release the live input"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconciliation_retains_input_leases_when_sync_fails() {
+        let bitcoind = Node::with_conf("bitcoind", &Conf::default()).expect("bitcoind starts");
+        let input = OutPoint {
+            txid: Txid::from_slice(&[3; 32]).expect("valid txid"),
+            vout: 0,
+        };
+        let mut wallet = reconciliation_wallet(
+            &bitcoind,
+            vec![test_utxo(input)],
+            true,
+            BTreeSet::from([input]),
+        );
+
+        reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &[input]).await;
+
+        assert_eq!(wallet.leased_outpoints(), &BTreeSet::from([input]));
     }
 }

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -9,7 +9,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
-use operator_wallet::UtxoInfo;
+use operator_wallet::{GeneralUtxoPolicy, UtxoInfo};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
 use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
@@ -186,7 +186,12 @@ async fn ensure_claim_funding_outpoint(
                 };
                 let batch_size = cfg.funding_uxto_pool_size.saturating_sub(current_pool_size);
                 let funded = wallet
-                    .create_reserved_utxos(fee::FEE_RATE, cfg.claim_funding_utxo_value, batch_size)
+                    .create_reserved_utxos(
+                        fee::FEE_RATE,
+                        cfg.claim_funding_utxo_value,
+                        batch_size,
+                        GeneralUtxoPolicy::ConfirmedOnly,
+                    )
                     .await
                     .map_err(|e| ExecutorError::WalletErr(format!("refill failed: {e}")))?;
                 finalize_claim_funding_tx(

--- a/crates/bridge-exec/src/graph/utils.rs
+++ b/crates/bridge-exec/src/graph/utils.rs
@@ -1,31 +1,27 @@
 //! Shared helpers for graph executors.
 
-use algebra::predicate;
 use bitcoin::{
-    Psbt, TapSighashType,
+    Psbt, TapSighashType, Transaction,
     hashes::Hash,
     sighash::{Prevouts, SighashCache},
     taproot,
 };
-use btc_tracker::{event::TxStatus, tx_driver::TxDriver};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::*;
-use tracing::info;
 
 use crate::errors::ExecutorError;
 
-/// Finalizes and broadcasts a claim funding transaction.
+/// Signs a claim funding transaction.
 ///
 /// This function assumes that the [`Psbt`] has already been funded with `witness_utxo`
 /// populated on every input (which `OperatorWallet::create_reserved_utxos` guarantees by
 /// returning a [`crate::Psbt`] whose inputs all carry the wallet's `witness_utxo`). It signs
-/// all inputs via the caller-provided signer, submits the finalized transaction to the tx
-/// driver for broadcasting, and waits for it to appear in the mempool.
-pub(super) async fn finalize_claim_funding_tx(
+/// all inputs via the caller-provided signer and returns the finalized transaction without
+/// submitting it to the tx driver.
+pub(super) async fn sign_claim_funding_tx(
     s2_client: &SecretServiceClient,
-    tx_driver: &TxDriver,
     psbt: Psbt,
-) -> Result<(), ExecutorError> {
+) -> Result<Transaction, ExecutorError> {
     let txins_as_outs = psbt
         .inputs
         .iter()
@@ -60,13 +56,5 @@ pub(super) async fn finalize_claim_funding_tx(
             .push(signature.to_vec());
     }
 
-    let txid = tx.compute_txid();
-    info!(%txid, "submitting claim funding tx to the tx driver");
-    tx_driver
-        .drive(tx, predicate::eq(TxStatus::Mempool)) // It's our tx, we won't double spend
-        .await?;
-
-    info!(%txid, "claim funding tx detected in mempool");
-
-    Ok(())
+    Ok(tx)
 }

--- a/crates/bridge-exec/src/stake/staking.rs
+++ b/crates/bridge-exec/src/stake/staking.rs
@@ -13,6 +13,7 @@ use bitcoind_async_client::traits::Reader;
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PubNonce};
+use operator_wallet::GeneralUtxoPolicy;
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_connectors::prelude::UnstakingIntentOutput;
 use strata_bridge_db::{
@@ -134,9 +135,14 @@ async fn read_or_create_stake_funding(
     // takes denomination + quantity uniformly (claim-funding pool uses larger quantity
     // with a smaller per-UTXO value); for the stake-funding case it's always quantity 1.
     let funded = wallet
-        .create_reserved_utxos(fee_rate, funding_amount, 1)
+        .create_reserved_utxos(
+            fee_rate,
+            funding_amount,
+            1,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+        )
         .await
-        .expect("must be able to create stake funding transaction");
+        .map_err(|e| ExecutorError::WalletErr(format!("stake funding failed: {e}")))?;
     let reservation = reservation_from_psbt(&funded.psbt);
 
     let candidate_inputs: Vec<OutPoint> = reservation

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::{
     config::OperatorWalletConfig,
     general::{native::NativeGeneralWallet, FundedPsbt, GeneralWallet, UtxoInfo},
     sync::SyncError,
-    wallet::OperatorWallet,
+    wallet::{GeneralUtxoPolicy, OperatorWallet},
 };
 
 /// Errors returned by [`OperatorWallet`] methods. Backend errors are boxed so call sites don't
@@ -40,6 +40,17 @@ pub enum Error {
     /// The general wallet backend reported an error.
     #[error("general wallet: {0}")]
     General(Box<dyn std::error::Error + Send + Sync>),
+    /// Confirmed-only reserved-wallet funding can see only unconfirmed general-wallet funds.
+    #[error(
+        "no confirmed general-wallet UTXOs available for reserved-wallet funding \
+         ({unconfirmed_count} unconfirmed UTXOs totaling {unconfirmed_amount})"
+    )]
+    NoConfirmedGeneralUtxos {
+        /// Number of unconfirmed candidate UTXOs after normal exclusions.
+        unconfirmed_count: usize,
+        /// Total value of unconfirmed candidate UTXOs after normal exclusions.
+        unconfirmed_amount: bdk_wallet::bitcoin::Amount,
+    },
     /// The wallet receive script cannot be represented as a Bitcoin address.
     #[error("wallet receive script is not addressable: {0}")]
     Address(#[from] bdk_wallet::bitcoin::address::FromScriptError),

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -29,6 +29,15 @@ use crate::{
     Error,
 };
 
+/// Whether general-wallet funding may spend unconfirmed UTXOs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeneralUtxoPolicy {
+    /// Allow the general wallet backend to select confirmed or unconfirmed UTXOs.
+    IncludeUnconfirmed,
+    /// Exclude unconfirmed general-wallet UTXOs from automatic input selection.
+    ConfirmedOnly,
+}
+
 /// The operator's wallet: a [`GeneralWallet`] backend composed with the always-native reserved
 /// wallet, shared lease bookkeeping, and cross-wallet transaction construction helpers.
 #[derive(Debug)]
@@ -284,12 +293,14 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// [`Self::reserved_utxos_with_value`] first and request only the delta they're
     /// missing; existing reserved-wallet UTXOs of the same `utxo_value` are
     /// automatically excluded from input selection so the composer doesn't re-spend pool
-    /// members back to themselves.
+    /// members back to themselves. `general_utxo_policy` controls whether unconfirmed
+    /// general-wallet UTXOs may be selected.
     pub async fn create_reserved_utxos(
         &mut self,
         fee_rate: FeeRate,
         utxo_value: Amount,
         quantity: usize,
+        general_utxo_policy: GeneralUtxoPolicy,
     ) -> Result<FundedPsbt, Error> {
         // Exclude already-existing reserved UTXOs of the same value from selection so the
         // composer doesn't accidentally spend pool members back to itself.
@@ -308,6 +319,32 @@ impl<G: GeneralWallet> OperatorWallet<G> {
 
         let mut exclude = self.exclude_anchors_and_leases();
         exclude.extend(existing);
+
+        if general_utxo_policy == GeneralUtxoPolicy::ConfirmedOnly {
+            let excluded: BTreeSet<OutPoint> = exclude.iter().copied().collect();
+            let (confirmed, unconfirmed): (Vec<UtxoInfo>, Vec<UtxoInfo>) = self
+                .general
+                .list_utxos()
+                .into_iter()
+                .filter(|u| !excluded.contains(&u.outpoint))
+                .partition(|u| u.confirmations > 0);
+            if confirmed.is_empty() && !unconfirmed.is_empty() {
+                let unconfirmed_count = unconfirmed.len();
+                let unconfirmed_amount = unconfirmed
+                    .iter()
+                    .fold(Amount::ZERO, |total, u| total + u.amount);
+                warn!(
+                    unconfirmed_count,
+                    %unconfirmed_amount,
+                    "reserved-wallet funding has no confirmed general-wallet UTXOs available"
+                );
+                return Err(Error::NoConfirmedGeneralUtxos {
+                    unconfirmed_count,
+                    unconfirmed_amount,
+                });
+            }
+            exclude.extend(unconfirmed.into_iter().map(|u| u.outpoint));
+        }
 
         let funded = self
             .general

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -36,7 +36,8 @@ use bdk_wallet::bitcoin::{
 };
 use corepc_node::{Conf, Node};
 use operator_wallet::{
-    sync::Backend, GeneralWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
+    sync::Backend, Error as OperatorWalletError, GeneralUtxoPolicy, GeneralWallet,
+    NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
 };
 use serial_test::serial;
 
@@ -205,7 +206,12 @@ async fn create_reserved_utxos_funds_pool_and_leases_inputs() {
     let quantity = 5;
     let fee_rate = FeeRate::from_sat_per_vb(5).unwrap();
     let funded = wallet
-        .create_reserved_utxos(fee_rate, utxo_value, quantity)
+        .create_reserved_utxos(
+            fee_rate,
+            utxo_value,
+            quantity,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+        )
         .await
         .expect("funding must succeed");
 
@@ -264,6 +270,132 @@ async fn create_reserved_utxos_funds_pool_and_leases_inputs() {
 
 #[tokio::test]
 #[serial]
+async fn create_reserved_utxos_reports_only_unconfirmed_general_utxos() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, _, general_pubkey) =
+        build_operator_wallet(&bitcoind, 13, 14, 0, Amount::ZERO).await;
+
+    let unconfirmed_amount = Amount::from_btc(1.0).unwrap();
+    let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
+    bitcoind
+        .client
+        .send_to_address(&general_address, unconfirmed_amount)
+        .expect("send unconfirmed funds");
+    wallet.sync().await.expect("sync unconfirmed deposit");
+
+    let general_utxos = wallet.general().list_utxos();
+    assert_eq!(general_utxos.len(), 1, "one general-wallet UTXO");
+    assert_eq!(
+        general_utxos[0].confirmations, 0,
+        "deposit must be unconfirmed"
+    );
+
+    let err = wallet
+        .create_reserved_utxos(
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            Amount::from_btc(0.01).unwrap(),
+            1,
+            GeneralUtxoPolicy::ConfirmedOnly,
+        )
+        .await
+        .expect_err("unconfirmed general-wallet funds must not be selected");
+
+    match err {
+        OperatorWalletError::NoConfirmedGeneralUtxos {
+            unconfirmed_count,
+            unconfirmed_amount: actual_amount,
+        } => {
+            assert_eq!(unconfirmed_count, 1);
+            assert_eq!(actual_amount, unconfirmed_amount);
+        }
+        other => panic!("expected no-confirmed-UTXO error, got {other:?}"),
+    }
+    assert!(
+        wallet.leased_outpoints().is_empty(),
+        "failed refill must not lease the unconfirmed UTXO"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn create_reserved_utxos_can_include_unconfirmed_general_utxos_when_allowed() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, _, general_pubkey) =
+        build_operator_wallet(&bitcoind, 15, 16, 0, Amount::ZERO).await;
+
+    let unconfirmed_amount = Amount::from_btc(1.0).unwrap();
+    let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
+    bitcoind
+        .client
+        .send_to_address(&general_address, unconfirmed_amount)
+        .expect("send unconfirmed funds");
+    wallet.sync().await.expect("sync unconfirmed deposit");
+
+    let unconfirmed_outpoint = wallet.general().list_utxos()[0].outpoint;
+    let funded = wallet
+        .create_reserved_utxos(
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            Amount::from_btc(0.01).unwrap(),
+            1,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+        )
+        .await
+        .expect("unconfirmed general-wallet funds may be selected when allowed");
+
+    assert!(
+        funded.spent().contains(&unconfirmed_outpoint),
+        "funding transaction should spend the unconfirmed general-wallet UTXO"
+    );
+    assert!(
+        wallet.leased_outpoints().contains(&unconfirmed_outpoint),
+        "selected unconfirmed UTXO must be leased"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn create_reserved_utxos_excludes_unconfirmed_when_confirmed_funds_are_available() {
+    let bitcoind = setup_bitcoind();
+    let (mut wallet, _, general_pubkey) =
+        build_operator_wallet(&bitcoind, 17, 18, 1, Amount::from_btc(1.0).unwrap()).await;
+
+    let confirmed_outpoint = wallet.general().list_utxos()[0].outpoint;
+    let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
+    bitcoind
+        .client
+        .send_to_address(&general_address, Amount::from_btc(0.5).unwrap())
+        .expect("send unconfirmed funds");
+    wallet.sync().await.expect("sync mixed funds");
+
+    let unconfirmed_outpoint = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .find(|utxo| utxo.confirmations == 0)
+        .expect("unconfirmed UTXO")
+        .outpoint;
+    let funded = wallet
+        .create_reserved_utxos(
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            Amount::from_btc(0.01).unwrap(),
+            1,
+            GeneralUtxoPolicy::ConfirmedOnly,
+        )
+        .await
+        .expect("confirmed funds should fund reserved UTXOs");
+
+    assert!(
+        funded.spent().contains(&confirmed_outpoint),
+        "funding transaction should spend the confirmed UTXO"
+    );
+    assert!(
+        !funded.spent().contains(&unconfirmed_outpoint),
+        "funding transaction must exclude the unconfirmed UTXO"
+    );
+}
+
+#[tokio::test]
+#[serial]
 async fn reserve_utxo_with_value_picks_and_leases_one() {
     let bitcoind = setup_bitcoind();
     let (mut wallet, general_kp, _) =
@@ -272,7 +404,12 @@ async fn reserve_utxo_with_value_picks_and_leases_one() {
     // Seed the reserved pool with 3 UTXOs of 0.01 BTC.
     let utxo_value = Amount::from_btc(0.01).unwrap();
     let funded = wallet
-        .create_reserved_utxos(FeeRate::from_sat_per_vb(5).unwrap(), utxo_value, 3)
+        .create_reserved_utxos(
+            FeeRate::from_sat_per_vb(5).unwrap(),
+            utxo_value,
+            3,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+        )
         .await
         .expect("seed funding");
     let signed = sign_and_finalize(funded.psbt, general_kp);
@@ -320,7 +457,12 @@ async fn reserve_utxo_with_value_filters_by_value() {
     let large_value = Amount::from_btc(0.05).unwrap();
     for value in [small_value, large_value] {
         let funded = wallet
-            .create_reserved_utxos(FeeRate::from_sat_per_vb(5).unwrap(), value, 2)
+            .create_reserved_utxos(
+                FeeRate::from_sat_per_vb(5).unwrap(),
+                value,
+                2,
+                GeneralUtxoPolicy::IncludeUnconfirmed,
+            )
             .await
             .unwrap_or_else(|e| panic!("seed funding for {value} failed: {e}"));
         let signed = sign_and_finalize(funded.psbt, general_kp);
@@ -435,7 +577,12 @@ async fn refill_workflow_skips_existing_pool_members() {
 
     // First batch: seed the pool with 2 UTXOs.
     let first = wallet
-        .create_reserved_utxos(fee_rate, utxo_value, 2)
+        .create_reserved_utxos(
+            fee_rate,
+            utxo_value,
+            2,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+        )
         .await
         .expect("first seed");
     let signed = sign_and_finalize(first.psbt, general_kp);
@@ -457,7 +604,12 @@ async fn refill_workflow_skips_existing_pool_members() {
 
     // Refill: ask for 2 more. The composer must NOT spend the existing 2 back to itself.
     let refill = wallet
-        .create_reserved_utxos(fee_rate, utxo_value, 2)
+        .create_reserved_utxos(
+            fee_rate,
+            utxo_value,
+            2,
+            GeneralUtxoPolicy::IncludeUnconfirmed,
+        )
         .await
         .expect("refill");
     for spent in refill.spent() {


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This PR fixes stale input leases after transaction broadcast failures:

- Signing failures release inputs immediately.
- Driver failures trigger a wallet sync.
- Inputs still spendable are released; spent inputs are pruned by sync.
- Leases are retained when sync fails (for safety).
- Stake funding retains its existing unconfirmed-UTXO policy.

This also prevents claim-funding refills from spending unconfirmed general-wallet UTXOs, avoidind TRUC violations from oversized child transactions.

Codex was used to implement these changes.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->