### PR TITLE
feat(ci): schedule SP1 proof fn tests with Slack failure alerts

### DIFF
--- a/.github/actions/notify-slack/action.yml
+++ b/.github/actions/notify-slack/action.yml
@@ -1,0 +1,29 @@
+name: Notify Slack
+description: >-
+  Posts a message to a Slack incoming webhook. No-op when the webhook URL is
+  empty, so workflows can wire this up before the secret is configured.
+inputs:
+  webhook-url:
+    description: "Slack incoming webhook URL (pass the secret); empty skips the post"
+    required: true
+  message:
+    description: "Message text (Slack mrkdwn)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Post to Slack
+      shell: bash
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+          echo "webhook-url is empty — skipping notification"
+          exit 0
+        fi
+        jq -n --arg text "${MESSAGE}" '{text: $text}' \
+          | curl -sf -X POST "${SLACK_WEBHOOK_URL}" \
+              -H 'Content-Type: application/json' \
+              -d @-

--- a/.github/scripts/schedule_gate.sh
+++ b/.github/scripts/schedule_gate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# schedule_gate.sh — Decide whether a functional-sp1-proofs tick should run.
+#
+# The workflow cron ticks hourly because GitHub cannot read vars.* inside
+# on.schedule.cron; this script turns those ticks into the real cadence and
+# writes should_run=true|false to GITHUB_OUTPUT.
+#
+# Expected env vars (all injected by the workflow step):
+#   EVENT_NAME      — github.event_name; anything but "schedule" always runs
+#   INTERVAL_HOURS  — vars.SP1_FN_TESTS_INTERVAL_HOURS; falls back to 6 when
+#                     unset or not a positive integer
+#   CACHE_HIT       — "true" when the sp1-fn-tested-<sha> cache marker exists,
+#                     i.e. this commit already passed
+#   GITHUB_OUTPUT   — path to the GHA outputs file (set by the runner)
+
+set -euo pipefail
+
+should_run() {
+  echo "should_run=$1" >> "$GITHUB_OUTPUT"
+  exit 0
+}
+
+if [ "$EVENT_NAME" != "schedule" ]; then
+  echo "Manual trigger — running"
+  should_run true
+fi
+
+INTERVAL="${INTERVAL_HOURS:-6}"
+case "$INTERVAL" in
+  *[!0-9]* | 0)
+    echo "Invalid SP1_FN_TESTS_INTERVAL_HOURS='$INTERVAL' — falling back to 6"
+    INTERVAL=6
+    ;;
+esac
+
+# Intervals dividing 24 give even spacing; others wrap unevenly at midnight UTC.
+HOUR=$((10#$(date -u +%H)))
+if [ $((HOUR % INTERVAL)) -ne 0 ]; then
+  echo "Hour $HOUR is not a multiple of interval $INTERVAL — skipping"
+  should_run false
+fi
+
+if [ "${CACHE_HIT:-}" = "true" ]; then
+  echo "Commit already tested successfully — skipping"
+  should_run false
+fi
+
+echo "Interval hour reached and commit not yet tested — running"
+should_run true

--- a/.github/scripts/schedule_gate.sh
+++ b/.github/scripts/schedule_gate.sh
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
-# schedule_gate.sh — Decide whether a functional-sp1-proofs tick should run.
-#
-# The workflow cron ticks hourly because GitHub cannot read vars.* inside
-# on.schedule.cron; this script turns those ticks into the real cadence and
+# schedule_gate.sh — Decide whether a functional-sp1-proofs tick should run;
+# the hourly cron becomes the real cadence here because GitHub cannot read
+# vars.* inside on.schedule.cron. Reads EVENT_NAME, INTERVAL_HOURS, CACHE_HIT;
 # writes should_run=true|false to GITHUB_OUTPUT.
-#
-# Expected env vars (all injected by the workflow step):
-#   EVENT_NAME      — github.event_name; anything but "schedule" always runs
-#   INTERVAL_HOURS  — vars.SP1_FN_TESTS_INTERVAL_HOURS; falls back to 6 when
-#                     unset or not a positive integer
-#   CACHE_HIT       — "true" when the sp1-fn-tested-<sha> cache marker exists,
-#                     i.e. this commit already passed
-#   GITHUB_OUTPUT   — path to the GHA outputs file (set by the runner)
 
 set -euo pipefail
 
@@ -27,16 +18,18 @@ fi
 
 INTERVAL="${INTERVAL_HOURS:-6}"
 case "$INTERVAL" in
-  *[!0-9]* | 0)
-    echo "Invalid SP1_FN_TESTS_INTERVAL_HOURS='$INTERVAL' — falling back to 6"
-    INTERVAL=6
-    ;;
+  *[!0-9]*) INTERVAL=-1 ;;
+  *) INTERVAL=$((10#$INTERVAL)) ;; # base 10: "08" would be bad octal
 esac
+if [ "$INTERVAL" -lt 1 ]; then
+  echo "Invalid SP1_FN_TESTS_INTERVAL_HOURS='$INTERVAL_HOURS' — falling back to 6"
+  INTERVAL=6
+fi
 
-# Intervals dividing 24 give even spacing; others wrap unevenly at midnight UTC.
-HOUR=$((10#$(date -u +%H)))
-if [ $((HOUR % INTERVAL)) -ne 0 ]; then
-  echo "Hour $HOUR is not a multiple of interval $INTERVAL — skipping"
+# Epoch hours, not hour-of-day: the cadence must not reset at midnight.
+EPOCH_HOUR=$(( $(date -u +%s) / 3600 ))
+if [ $((EPOCH_HOUR % INTERVAL)) -ne 0 ]; then
+  echo "Epoch hour $EPOCH_HOUR is not a multiple of interval $INTERVAL — skipping"
   should_run false
 fi
 

--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -327,7 +327,9 @@ jobs:
     name: Check that all SP1 proof tests pass
     runs-on: ubuntu-latest
     if: always()
-    needs: [schedule-gate, run]
+    # extract-rust-version must be listed: its failure skips `run`, and a skip
+    # is only acceptable when the gate (not a broken dependency) caused it.
+    needs: [schedule-gate, extract-rust-version, run]
     timeout-minutes: 5
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -1,8 +1,16 @@
-# Manually-invokable CI that runs the SP1 proof functional tests with real
-# Succinct network proving.
+# Runs the SP1 proof functional tests with real Succinct network proving, on a
+# schedule and on manual dispatch.
+#
+# The cron ticks hourly; the actual cadence is controlled by the repository
+# variable SP1_FN_TESTS_INTERVAL_HOURS (default 6) via the schedule-gate job,
+# because GitHub cannot read vars.* inside on.schedule.cron. Scheduled runs
+# skip commits that already passed (cache marker keyed by SHA). Failures are
+# reported to Slack through the SLACK_WEBHOOK_URL secret.
 name: Functional tests (SP1 proofs)
 
 on:
+  schedule:
+    - cron: "17 * * * *" # hourly tick; real cadence gated by vars.SP1_FN_TESTS_INTERVAL_HOURS
   workflow_dispatch:
     inputs:
       RUST_LOG:
@@ -15,13 +23,71 @@ env:
   CARGO_TERM_COLOR: always
   SP1_VERSION: v6.2.0
 
+# Scheduled ticks queue behind an in-flight (up to 6 h) proving run instead of
+# cancelling it; manual dispatch keeps the cancel-and-restart behavior.
 concurrency:
   group: functional-sp1-proofs
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 permissions: {}
 
 jobs:
+  schedule-gate:
+    name: Decide whether this tick should run
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Check whether this commit already passed
+        id: tested
+        if: github.event_name == 'schedule'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .sp1-fn-tested-marker
+          key: sp1-fn-tested-${{ github.sha }}
+          lookup-only: true
+
+      - name: Decide
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INTERVAL_HOURS: ${{ vars.SP1_FN_TESTS_INTERVAL_HOURS }}
+          CACHE_HIT: ${{ steps.tested.outputs.cache-hit }}
+        run: |
+          should_run() {
+            echo "should_run=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "Manual trigger — running"
+            should_run true
+          fi
+
+          INTERVAL="${INTERVAL_HOURS:-6}"
+          case "$INTERVAL" in
+            *[!0-9]* | 0)
+              echo "Invalid SP1_FN_TESTS_INTERVAL_HOURS='$INTERVAL_HOURS' — falling back to 6"
+              INTERVAL=6
+              ;;
+          esac
+
+          # Intervals dividing 24 give even spacing; others wrap unevenly at
+          # midnight UTC.
+          HOUR=$((10#$(date -u +%H)))
+          if [ $((HOUR % INTERVAL)) -ne 0 ]; then
+            echo "Hour $HOUR is not a multiple of interval $INTERVAL — skipping"
+            should_run false
+          fi
+
+          if [ "$CACHE_HIT" = "true" ]; then
+            echo "Commit already tested successfully — skipping"
+            should_run false
+          fi
+
+          echo "Interval hour reached and commit not yet tested — running"
+          should_run true
+
   extract-rust-version:
     name: Extract toolchain version
     runs-on: ubuntu-latest
@@ -40,7 +106,8 @@ jobs:
   run:
     name: Run ${{ matrix.test }} with real SP1 proving
     runs-on: 16-core-runner
-    needs: extract-rust-version
+    needs: [extract-rust-version, schedule-gate]
+    if: needs.schedule-gate.outputs.should_run == 'true'
     timeout-minutes: 360
     strategy:
       fail-fast: false
@@ -183,7 +250,7 @@ jobs:
         id: funcTestsRun
         continue-on-error: true
         env:
-          RUST_LOG: ${{ inputs.RUST_LOG }}
+          RUST_LOG: ${{ inputs.RUST_LOG || 'info' }} # inputs is empty on schedule events
           NO_COLOR: "1"
           LOG_LEVEL: "info"
           PYTHON_VERSION: "3.12"
@@ -229,14 +296,63 @@ jobs:
           echo "Functional test ${{ matrix.test }} failed"
           exit 1
 
+  # Marks this SHA as tested so later scheduled ticks skip it. Manual runs
+  # count too: a manually verified commit is not re-proven on schedule.
+  mark-tested:
+    name: Record commit as tested
+    runs-on: ubuntu-latest
+    needs: [run] # default needs semantics: runs only when every matrix leg passed
+    timeout-minutes: 5
+    steps:
+      - name: Save tested marker
+        run: echo "tested" > .sp1-fn-tested-marker
+
+      - name: Cache tested marker
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .sp1-fn-tested-marker
+          key: sp1-fn-tested-${{ github.sha }}
+
+  notify-failure:
+    name: Notify Slack on failure
+    runs-on: ubuntu-latest
+    needs: [schedule-gate, run]
+    if: failure()
+    timeout-minutes: 5
+    steps:
+      - name: Send Slack alert
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "SLACK_WEBHOOK_URL not set — skipping notification"
+            exit 0
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg workflow "${WORKFLOW_NAME}" \
+            --arg run_url "${RUN_URL}" \
+            --arg sha "${COMMIT_SHA:0:7}" \
+            --arg event "${EVENT_NAME}" \
+            '{text: "🚨 *\($workflow) failed* — commit `\($sha)` (\($event) run)\n<\($run_url)|View run>"}')
+
+          curl -sf -X POST "${SLACK_WEBHOOK_URL}" \
+            -H 'Content-Type: application/json' \
+            -d "${PAYLOAD}"
+
   functional-sp1-proofs-success:
     name: Check that all SP1 proof tests pass
     runs-on: ubuntu-latest
     if: always()
-    needs: [run]
+    needs: [schedule-gate, run]
     timeout-minutes: 5
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: run # a gate-skipped tick is green, not a failure

--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -38,6 +38,12 @@ jobs:
     outputs:
       should_run: ${{ steps.decide.outputs.should_run }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github
+
       - name: Check whether this commit already passed
         id: tested
         if: github.event_name == 'schedule'
@@ -53,40 +59,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INTERVAL_HOURS: ${{ vars.SP1_FN_TESTS_INTERVAL_HOURS }}
           CACHE_HIT: ${{ steps.tested.outputs.cache-hit }}
-        run: |
-          should_run() {
-            echo "should_run=$1" >> "$GITHUB_OUTPUT"
-            exit 0
-          }
-
-          if [ "$EVENT_NAME" != "schedule" ]; then
-            echo "Manual trigger — running"
-            should_run true
-          fi
-
-          INTERVAL="${INTERVAL_HOURS:-6}"
-          case "$INTERVAL" in
-            *[!0-9]* | 0)
-              echo "Invalid SP1_FN_TESTS_INTERVAL_HOURS='$INTERVAL_HOURS' — falling back to 6"
-              INTERVAL=6
-              ;;
-          esac
-
-          # Intervals dividing 24 give even spacing; others wrap unevenly at
-          # midnight UTC.
-          HOUR=$((10#$(date -u +%H)))
-          if [ $((HOUR % INTERVAL)) -ne 0 ]; then
-            echo "Hour $HOUR is not a multiple of interval $INTERVAL — skipping"
-            should_run false
-          fi
-
-          if [ "$CACHE_HIT" = "true" ]; then
-            echo "Commit already tested successfully — skipping"
-            should_run false
-          fi
-
-          echo "Interval hour reached and commit not yet tested — running"
-          should_run true
+        # Full logic in .github/scripts/schedule_gate.sh
+        run: bash .github/scripts/schedule_gate.sh
 
   extract-rust-version:
     name: Extract toolchain version
@@ -320,29 +294,34 @@ jobs:
     if: failure()
     timeout-minutes: 5
     steps:
-      - name: Send Slack alert
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: .github
+
+      # Expressions cannot slice strings, so the short SHA is composed in bash.
+      - name: Compose failure message
+        id: msg
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
-            echo "SLACK_WEBHOOK_URL not set — skipping notification"
-            exit 0
-          fi
+          # shellcheck disable=SC2016 # backticks are literal Slack mrkdwn
+          {
+            echo "text<<MSG_EOF"
+            printf '🚨 *%s failed* — commit `%s` (%s run)\n<%s|View run>\n' \
+              "$WORKFLOW_NAME" "${COMMIT_SHA:0:7}" "$EVENT_NAME" "$RUN_URL"
+            echo "MSG_EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          PAYLOAD=$(jq -n \
-            --arg workflow "${WORKFLOW_NAME}" \
-            --arg run_url "${RUN_URL}" \
-            --arg sha "${COMMIT_SHA:0:7}" \
-            --arg event "${EVENT_NAME}" \
-            '{text: "🚨 *\($workflow) failed* — commit `\($sha)` (\($event) run)\n<\($run_url)|View run>"}')
-
-          curl -sf -X POST "${SLACK_WEBHOOK_URL}" \
-            -H 'Content-Type: application/json' \
-            -d "${PAYLOAD}"
+      - name: Send Slack alert
+        uses: ./.github/actions/notify-slack # zizmor: ignore[unpinned-uses]
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: ${{ steps.msg.outputs.text }}
 
   functional-sp1-proofs-success:
     name: Check that all SP1 proof tests pass

--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -65,6 +65,8 @@ jobs:
   extract-rust-version:
     name: Extract toolchain version
     runs-on: ubuntu-latest
+    needs: schedule-gate
+    if: needs.schedule-gate.outputs.should_run == 'true'
     outputs:
       nightly-version: ${{ steps.extract-version.outputs.nightly-version }}
     steps:
@@ -290,7 +292,7 @@ jobs:
   notify-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
-    needs: [schedule-gate, run]
+    needs: [schedule-gate, run, mark-tested]
     if: failure()
     timeout-minutes: 5
     steps:
@@ -329,6 +331,8 @@ jobs:
     if: always()
     # extract-rust-version must be listed: its failure skips `run`, and a skip
     # is only acceptable when the gate (not a broken dependency) caused it.
+    # Both it and `run` only ever skip on gate-declined ticks, where the gate
+    # itself still reports success.
     needs: [schedule-gate, extract-rust-version, run]
     timeout-minutes: 5
     steps:
@@ -336,4 +340,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: run # a gate-skipped tick is green, not a failure
+          allowed-skips: extract-rust-version, run # a gate-skipped tick is green, not a failure


### PR DESCRIPTION
## Description
Runs the SP1 proof functional tests on a schedule configurable via the `SP1_FN_TESTS_INTERVAL_HOURS` repo variable and posts any failure to Slack via the `SLACK_WEBHOOK_URL` secret with a link to the run. Manual dispatch remains available and unconditional.


<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update