### PR TITLE
feat(orchestrator): add event-pipeline observability (STR-3592)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11666,6 +11666,7 @@ dependencies = [
  "btc-tracker",
  "futures",
  "libp2p-identity",
+ "metrics",
  "musig2",
  "rkyv",
  "strata-asm-bridge-types 0.1.0 (git+https://github.com/alpenlabs/asm?rev=93b5ca8c8e73ec9ad46fb448a07b8ba39c3636fb)",

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -27,6 +27,7 @@ strata-p2p.workspace = true
 bitcoin.workspace = true
 bitcoin-bosd.workspace = true
 futures.workspace = true
+metrics.workspace = true
 musig2.workspace = true
 rkyv.workspace = true
 thiserror.workspace = true

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -12,13 +12,12 @@ use std::collections::VecDeque;
 
 use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
 use strata_bridge_sm::{deposit::machine::DepositSM, graph::machine::GraphSM};
-use tracing::warn;
 
 use crate::{
     errors::PipelineError,
     persister::PersistenceTracker,
     signals_router,
-    sm_registry::{IgnoredEventReason, ProcessOutcome, RegistryInsertError, SMRegistry},
+    sm_registry::{ProcessOutcome, RegistryInsertError, SMRegistry},
     sm_types::{SMEvent, SMId, UnifiedDuty},
 };
 
@@ -160,17 +159,7 @@ impl<'a> Applicator<'a> {
 
                 Ok(())
             }
-            Ok(ProcessOutcome::Ignored { id, event, reason }) => {
-                match reason {
-                    IgnoredEventReason::Duplicate => {
-                        warn!(?id, %event, "duplicate event, skipping");
-                    }
-                    IgnoredEventReason::Rejected(rejected_reason) => {
-                        warn!(?id, %event, %rejected_reason, "event rejected by state machine, skipping");
-                    }
-                }
-                Ok(())
-            }
+            Ok(ProcessOutcome::Ignored { .. }) => Ok(()),
             Err(e) => Err(e.into()),
         }
     }

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -130,8 +130,9 @@ impl<'a> Applicator<'a> {
 
     /// Processes a single event through the registry's STF.
     ///
-    /// On success, accumulates duties and enqueues any signal-derived events. Ignored outcomes
-    /// (duplicates, rejections) are non-fatal and logged. Fatal errors are propagated.
+    /// On success, accumulates duties and enqueues any signal-derived events. Ignored outcomes are
+    /// non-fatal: duplicates are debug-logged and rejections are warning-logged by the registry.
+    /// Fatal errors are propagated.
     ///
     /// Persistence tracking follows the state machine's own report: a transition that leaves state
     /// unchanged (e.g. a nag or retry tick) still has its duties accumulated and its signals

--- a/crates/orchestrator/src/applicator.rs
+++ b/crates/orchestrator/src/applicator.rs
@@ -12,12 +12,13 @@ use std::collections::VecDeque;
 
 use strata_bridge_primitives::types::{DepositIdx, GraphIdx};
 use strata_bridge_sm::{deposit::machine::DepositSM, graph::machine::GraphSM};
+use tracing::{debug, warn};
 
 use crate::{
     errors::PipelineError,
     persister::PersistenceTracker,
     signals_router,
-    sm_registry::{ProcessOutcome, RegistryInsertError, SMRegistry},
+    sm_registry::{IgnoredEventReason, ProcessOutcome, RegistryInsertError, SMRegistry},
     sm_types::{SMEvent, SMId, UnifiedDuty},
 };
 
@@ -131,7 +132,7 @@ impl<'a> Applicator<'a> {
     /// Processes a single event through the registry's STF.
     ///
     /// On success, accumulates duties and enqueues any signal-derived events. Ignored outcomes are
-    /// non-fatal: duplicates are debug-logged and rejections are warning-logged by the registry.
+    /// non-fatal: duplicates are debug-logged and rejections are warning-logged by the applicator.
     /// Fatal errors are propagated.
     ///
     /// Persistence tracking follows the state machine's own report: a transition that leaves state
@@ -160,7 +161,17 @@ impl<'a> Applicator<'a> {
 
                 Ok(())
             }
-            Ok(ProcessOutcome::Ignored { .. }) => Ok(()),
+            Ok(ProcessOutcome::Ignored { id, event, reason }) => {
+                match reason {
+                    IgnoredEventReason::Duplicate => {
+                        debug!(?id, %event, "duplicate state-machine event ignored");
+                    }
+                    IgnoredEventReason::Rejected(reason) => {
+                        warn!(?id, %event, %reason, "state-machine event rejected");
+                    }
+                }
+                Ok(())
+            }
             Err(e) => Err(e.into()),
         }
     }

--- a/crates/orchestrator/src/duty_dispatcher.rs
+++ b/crates/orchestrator/src/duty_dispatcher.rs
@@ -1,14 +1,15 @@
 //! Provides interface for dispatching duties to the appropriate executors.
 
-use std::sync::Arc;
+use std::{any::Any, panic::AssertUnwindSafe, sync::Arc, time::Instant};
 
+use futures::FutureExt;
 use strata_bridge_exec::{
-    config::ExecutionConfig, deposit::execute_deposit_duty, graph::execute_graph_duty,
-    output_handles::OutputHandles, stake::execute_stake_duty,
+    config::ExecutionConfig, deposit::execute_deposit_duty, errors::ExecutorError,
+    graph::execute_graph_duty, output_handles::OutputHandles, stake::execute_stake_duty,
 };
-use tracing::error;
+use tracing::{Instrument, debug, error, info_span};
 
-use crate::sm_types::UnifiedDuty;
+use crate::{observability, sm_types::UnifiedDuty};
 
 // TODO: <https://alpenlabs.atlassian.net/browse/STR-2698>
 // Add a `duty_tracker` to track executed, pending, and failed duties for retries and better error
@@ -39,36 +40,97 @@ impl DutyDispatcher {
     /// this property falls upon the implementers of the duty executors, and it is crucial for
     /// ensuring the robustness and reliability of the overall system.
     pub fn dispatch(&self, duty: UnifiedDuty) {
+        let duty_kind = observability::duty_kind(&duty);
+        observability::record_duty(duty_kind, "dispatched", "none");
+
         let cfg = self.cfg.clone();
         let handles = self.handles.clone();
-        match duty {
-            UnifiedDuty::Deposit(deposit_duty) => {
-                tokio::task::spawn(async move {
-                    execute_deposit_duty(cfg.clone(), handles.clone(), &deposit_duty)
-                        .await
-                        .inspect_err(|err| {
-                            error!(%err, ?deposit_duty, "failed to execute deposit duty");
-                        })
-                });
+        let span = info_span!(
+            "bridge_duty_execution",
+            duty_kind,
+            duty = %duty,
+            result = tracing::field::Empty,
+        );
+        let task = async move {
+            let started = Instant::now();
+            observability::record_duty_started(duty_kind);
+            let execution = execute_duty(cfg, handles, &duty);
+
+            match AssertUnwindSafe(execution).catch_unwind().await {
+                Ok(Ok(())) => {
+                    observability::record_duty(duty_kind, "success", "none");
+                    observability::record_duty_duration(duty_kind, "success", started.elapsed());
+                    tracing::Span::current().record("result", "success");
+                    debug!(duty_kind, "duty execution completed");
+                }
+                Ok(Err(execution_error)) => {
+                    let error_class = observability::executor_error_class(&execution_error);
+                    observability::record_duty(duty_kind, "error", error_class);
+                    observability::record_duty_duration(duty_kind, "error", started.elapsed());
+                    tracing::Span::current().record("result", "error");
+                    error!(
+                        error = %execution_error,
+                        error_class,
+                        duty_kind,
+                        "duty execution failed"
+                    );
+                }
+                Err(panic_payload) => {
+                    observability::record_duty(duty_kind, "panic", "panic");
+                    observability::record_duty_duration(duty_kind, "panic", started.elapsed());
+                    tracing::Span::current().record("result", "panic");
+                    error!(
+                        panic = panic_payload_message(panic_payload.as_ref()),
+                        duty_kind, "duty execution panicked"
+                    );
+                }
             }
-            UnifiedDuty::Graph(graph_duty) => {
-                tokio::task::spawn(async move {
-                    execute_graph_duty(cfg, handles, &graph_duty)
-                        .await
-                        .inspect_err(|err| {
-                            error!(%err, ?graph_duty, "failed to execute graph duty");
-                        })
-                });
-            }
-            UnifiedDuty::Stake(stake_duty) => {
-                tokio::task::spawn(async move {
-                    execute_stake_duty(cfg, handles, &stake_duty)
-                        .await
-                        .inspect_err(|err| {
-                            error!(%err, ?stake_duty, "failed to execute stake duty");
-                        })
-                });
-            }
+
+            observability::record_duty_settled(duty_kind);
         }
+        .instrument(span);
+
+        // Duty tasks are intentionally detached, but all executor errors and task panics are
+        // handled inside the task before the join handle is dropped.
+        drop(tokio::task::spawn(task));
+    }
+}
+
+async fn execute_duty(
+    cfg: Arc<ExecutionConfig>,
+    handles: Arc<OutputHandles>,
+    duty: &UnifiedDuty,
+) -> Result<(), ExecutorError> {
+    match duty {
+        UnifiedDuty::Deposit(deposit_duty) => {
+            execute_deposit_duty(cfg, handles, deposit_duty).await
+        }
+        UnifiedDuty::Graph(graph_duty) => execute_graph_duty(cfg, handles, graph_duty).await,
+        UnifiedDuty::Stake(stake_duty) => execute_stake_duty(cfg, handles, stake_duty).await,
+    }
+}
+
+fn panic_payload_message(payload: &(dyn Any + Send)) -> &str {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        message
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.as_str()
+    } else {
+        "non-string panic payload"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panic_payload_message_preserves_string_context() {
+        let owned = "owned panic".to_owned();
+        let borrowed = "borrowed panic";
+
+        assert_eq!(panic_payload_message(&owned), "owned panic");
+        assert_eq!(panic_payload_message(&borrowed), "borrowed panic");
+        assert_eq!(panic_payload_message(&42_u64), "non-string panic payload");
     }
 }

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -7,6 +7,7 @@ use strata_asm_proto_bridge::AssignmentEntry;
 use strata_bridge_p2p_types::{
     MuSig2Nonce, MuSig2Partial, NagRequestPayload, UnsignedGossipsubMsg,
 };
+use strata_bridge_primitives::types::P2POperatorPubKey;
 use strata_bridge_sm::{
     deposit::events::{self as DepositEvents, DepositEvent, RetryTickEvent},
     graph::events::{self as GraphEvents, AdaptorsVerifiedEvent, GraphEvent},
@@ -21,6 +22,16 @@ use crate::{
     sm_registry::SMRegistry,
     sm_types::{OperatorKey, SMEvent, SMId},
 };
+
+/// Result of attempting to classify an event for a routed state machine.
+#[derive(Debug)]
+pub(crate) enum ClassificationOutcome {
+    Classified(SMEvent),
+    /// The event was intentionally ignored before state-machine classification.
+    ExpectedDrop,
+    /// The event could not be converted into a state-machine event.
+    Unclassified,
+}
 
 /// Classifies a unified event into the typed event for a specific state machine.
 ///
@@ -61,6 +72,35 @@ pub(crate) fn classify(
         UnifiedEvent::NagTick => classify_nag_tick(sm_id, sm_registry),
         UnifiedEvent::RetryTick => classify_retry_tick(sm_id, sm_registry),
     }
+}
+
+/// Classifies a routed event while preserving intentional recipient filtering as a separate
+/// outcome for pipeline observability.
+pub(crate) fn classify_routed(
+    sm_id: &SMId,
+    event: &UnifiedEvent,
+    sm_registry: &SMRegistry,
+) -> ClassificationOutcome {
+    if let Some(sm_event) = classify(sm_id, event, sm_registry) {
+        return ClassificationOutcome::Classified(sm_event);
+    }
+
+    let gossip = match event {
+        UnifiedEvent::OuroborosMessage(message) => Some(&message.publish),
+        UnifiedEvent::GossipMessage(message) => Some(&message.unsigned),
+        _ => None,
+    };
+
+    if let Some(UnsignedGossipsubMsg::NagRequestExchange(nag_request)) = gossip {
+        let target_sm_id = nag_target_sm_id(&nag_request.payload);
+        if let Some(pov_p2p_key) = pov_p2p_key_for_sm(sm_registry, &target_sm_id)
+            && nag_request.recipient != pov_p2p_key
+        {
+            return ClassificationOutcome::ExpectedDrop;
+        }
+    }
+
+    ClassificationOutcome::Unclassified
 }
 
 /// Classifies an [`UnsignedGossipsubMsg`] into state-machine-specific events.
@@ -511,22 +551,7 @@ pub(crate) fn classify_unsigned_gossip(
         }
 
         UnsignedGossipsubMsg::NagRequestExchange(nag_request) => {
-            let sm_id = match &nag_request.payload {
-                NagRequestPayload::DepositNonce { deposit_idx }
-                | NagRequestPayload::DepositPartial { deposit_idx }
-                | NagRequestPayload::PayoutNonce { deposit_idx }
-                | NagRequestPayload::PayoutPartial { deposit_idx }
-                | NagRequestPayload::SweepNonce { deposit_idx }
-                | NagRequestPayload::SweepPartial { deposit_idx } => SMId::Deposit(*deposit_idx),
-                NagRequestPayload::GraphData { graph_idx }
-                | NagRequestPayload::GraphNonces { graph_idx }
-                | NagRequestPayload::GraphPartials { graph_idx } => SMId::Graph(*graph_idx),
-                NagRequestPayload::UnstakingData { operator_idx }
-                | NagRequestPayload::UnstakingNonces { operator_idx }
-                | NagRequestPayload::UnstakingPartials { operator_idx } => {
-                    SMId::Stake(*operator_idx)
-                }
-            };
+            let sm_id = nag_target_sm_id(&nag_request.payload);
 
             info!(
                 target_sm = %sm_id,
@@ -537,20 +562,13 @@ pub(crate) fn classify_unsigned_gossip(
             );
 
             // Router guarantees target SM exists for routed events.
-            let pov_p2p_key = match sm_id {
-                SMId::Deposit(deposit_idx) => sm_registry
-                    .get_deposit(&deposit_idx)
-                    .map(|sm| sm.context().operator_table().pov_p2p_key().clone())
-                    .expect("router should route nags only to existing deposit SMs"),
-                SMId::Graph(graph_idx) => sm_registry
-                    .get_graph(&graph_idx)
-                    .map(|sm| sm.context().operator_table().pov_p2p_key().clone())
-                    .expect("router should route nags only to existing graph SMs"),
-                SMId::Stake(operator_idx) => sm_registry
-                    .get_stake(&operator_idx)
-                    .map(|sm| sm.context().operator_table().pov_p2p_key().clone())
-                    .expect("router should route nags only to existing stake SMs"),
+            let missing_sm_message = match &sm_id {
+                SMId::Deposit(_) => "router should route nags only to existing deposit SMs",
+                SMId::Graph(_) => "router should route nags only to existing graph SMs",
+                SMId::Stake(_) => "router should route nags only to existing stake SMs",
             };
+            let pov_p2p_key =
+                pov_p2p_key_for_sm(sm_registry, &sm_id).expect(missing_sm_message);
 
             // Check recipient matches POV
             if nag_request.recipient != pov_p2p_key {
@@ -617,6 +635,37 @@ pub(crate) fn classify_unsigned_gossip(
 
             vec![event]
         }
+    }
+}
+
+const fn nag_target_sm_id(payload: &NagRequestPayload) -> SMId {
+    match payload {
+        NagRequestPayload::DepositNonce { deposit_idx }
+        | NagRequestPayload::DepositPartial { deposit_idx }
+        | NagRequestPayload::PayoutNonce { deposit_idx }
+        | NagRequestPayload::PayoutPartial { deposit_idx }
+        | NagRequestPayload::SweepNonce { deposit_idx }
+        | NagRequestPayload::SweepPartial { deposit_idx } => SMId::Deposit(*deposit_idx),
+        NagRequestPayload::GraphData { graph_idx }
+        | NagRequestPayload::GraphNonces { graph_idx }
+        | NagRequestPayload::GraphPartials { graph_idx } => SMId::Graph(*graph_idx),
+        NagRequestPayload::UnstakingData { operator_idx }
+        | NagRequestPayload::UnstakingNonces { operator_idx }
+        | NagRequestPayload::UnstakingPartials { operator_idx } => SMId::Stake(*operator_idx),
+    }
+}
+
+fn pov_p2p_key_for_sm(sm_registry: &SMRegistry, sm_id: &SMId) -> Option<P2POperatorPubKey> {
+    match sm_id {
+        SMId::Deposit(deposit_idx) => sm_registry
+            .get_deposit(deposit_idx)
+            .map(|sm| sm.context().operator_table().pov_p2p_key().clone()),
+        SMId::Graph(graph_idx) => sm_registry
+            .get_graph(graph_idx)
+            .map(|sm| sm.context().operator_table().pov_p2p_key().clone()),
+        SMId::Stake(operator_idx) => sm_registry
+            .get_stake(operator_idx)
+            .map(|sm| sm.context().operator_table().pov_p2p_key().clone()),
     }
 }
 
@@ -699,6 +748,7 @@ fn classify_mosaic_event(sm_id: &SMId, sm_registry: &SMRegistry) -> Option<SMEve
 #[cfg(test)]
 mod tests {
     use bitcoin::{OutPoint, Txid, hashes::Hash};
+    use strata_bridge_p2p_service::message_handler::OuroborosMessage;
     use strata_bridge_p2p_types::{
         GossipsubMsg, GraphData, PayoutDescriptor, UnsignedGossipsubMsg, XOnlyPubKey,
     };
@@ -1398,6 +1448,20 @@ mod tests {
                 classify_unsigned_gossip(&registry, &OperatorKey::Peer(&sender_p2p_key), &msg);
 
             assert!(result.is_empty(), "Should drop nag not addressed to us");
+
+            let ouroboros_event = UnifiedEvent::OuroborosMessage(OuroborosMessage {
+                publish: msg.clone(),
+            });
+            let outcome = classify_routed(&SMId::Deposit(deposit_idx), &ouroboros_event, &registry);
+            assert!(matches!(outcome, ClassificationOutcome::ExpectedDrop));
+
+            let event = UnifiedEvent::GossipMessage(GossipsubMsg {
+                signature: Vec::new(),
+                key: sender_p2p_key,
+                unsigned: msg,
+            });
+            let outcome = classify_routed(&SMId::Deposit(deposit_idx), &event, &registry);
+            assert!(matches!(outcome, ClassificationOutcome::ExpectedDrop));
         }
 
         #[test]
@@ -1423,6 +1487,14 @@ mod tests {
                 classify_unsigned_gossip(&registry, &OperatorKey::Peer(&unknown_sender_key), &msg);
 
             assert!(result.is_empty(), "Should drop nag from unknown sender");
+
+            let event = UnifiedEvent::GossipMessage(GossipsubMsg {
+                signature: Vec::new(),
+                key: unknown_sender_key,
+                unsigned: msg,
+            });
+            let outcome = classify_routed(&SMId::Deposit(deposit_idx), &event, &registry);
+            assert!(matches!(outcome, ClassificationOutcome::Unclassified));
         }
 
         #[test]

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -15,6 +15,7 @@ pub mod errors;
 pub mod events_classifier;
 pub mod events_mux;
 pub mod events_router;
+mod observability;
 pub mod persister;
 pub mod pipeline;
 pub mod safe_harbour_scan;

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -212,11 +212,16 @@ const fn deposit_duty_kind(duty: &DepositDuty) -> &'static str {
         DepositDuty::PublishPayoutNonce { .. } => "publish_payout_nonce",
         DepositDuty::PublishPayoutPartial { .. } => "publish_payout_partial",
         DepositDuty::PublishPayout { .. } => "publish_payout",
+        DepositDuty::PublishSweepNonce { .. } => "publish_sweep_nonce",
+        DepositDuty::PublishSweepPartial { .. } => "publish_sweep_partial",
+        DepositDuty::PublishSweep { .. } => "publish_sweep",
         DepositDuty::Nag { duty } => match duty {
             DepositNagDuty::NagDepositNonce { .. } => "nag_deposit_nonce",
             DepositNagDuty::NagDepositPartial { .. } => "nag_deposit_partial",
             DepositNagDuty::NagPayoutNonce { .. } => "nag_payout_nonce",
             DepositNagDuty::NagPayoutPartial { .. } => "nag_payout_partial",
+            DepositNagDuty::NagSweepNonce { .. } => "nag_sweep_nonce",
+            DepositNagDuty::NagSweepPartial { .. } => "nag_sweep_partial",
         },
     }
 }
@@ -274,6 +279,8 @@ pub(crate) const fn deposit_state_kind(state: &DepositState) -> &'static str {
         DepositState::PayoutDescriptorReceived { .. } => "payout_descriptor_received",
         DepositState::PayoutNoncesCollected { .. } => "payout_nonces_collected",
         DepositState::CooperativePathFailed { .. } => "cooperative_path_failed",
+        DepositState::SweepNoncesPending { .. } => "sweep_nonces_pending",
+        DepositState::SweepNoncesCollected { .. } => "sweep_nonces_collected",
         DepositState::Spent { .. } => "spent",
         DepositState::Aborted => "aborted",
     }

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -1,0 +1,121 @@
+//! Stable metric names, bounded labels, and observability-specific type classification.
+//!
+//! Object identifiers and raw errors deliberately do not appear in this module's metric labels.
+//! They belong in spans and structured logs, where they do not create unbounded Prometheus series.
+
+use std::time::Duration;
+
+use metrics::{Unit, counter, describe_counter, describe_histogram, histogram};
+
+use crate::{
+    errors::{PipelineError, ProcessError},
+    events_mux::UnifiedEvent,
+    persister::PersistError,
+};
+
+const PIPELINE_EVENT_DURATION_SECONDS: &str = "strata_bridge_pipeline_event_duration_seconds";
+const PIPELINE_ROUTING_TOTAL: &str = "strata_bridge_pipeline_routing_total";
+const PERSISTENCE_DURATION_SECONDS: &str = "strata_bridge_persistence_duration_seconds";
+
+pub(crate) fn describe_metrics() {
+    describe_histogram!(
+        PIPELINE_EVENT_DURATION_SECONDS,
+        Unit::Seconds,
+        "End-to-end time to classify, apply, persist, and dispatch one top-level event"
+    );
+    describe_counter!(
+        PIPELINE_ROUTING_TOTAL,
+        "Top-level off-chain event routing and classification outcomes"
+    );
+    describe_histogram!(
+        PERSISTENCE_DURATION_SECONDS,
+        Unit::Seconds,
+        "Atomic state-machine persistence operation time"
+    );
+}
+
+pub(crate) fn record_pipeline_event_finished(
+    event_kind: &'static str,
+    result: &'static str,
+    error_class: &'static str,
+    duration: Duration,
+) {
+    histogram!(
+        PIPELINE_EVENT_DURATION_SECONDS,
+        "event_kind" => event_kind,
+        "result" => result,
+        "error_class" => error_class
+    )
+    .record(duration.as_secs_f64());
+}
+
+pub(crate) fn record_routing(event_kind: &'static str, result: &'static str) {
+    counter!(
+        PIPELINE_ROUTING_TOTAL,
+        "event_kind" => event_kind,
+        "result" => result
+    )
+    .increment(1);
+}
+
+pub(crate) fn record_persistence(
+    result: &'static str,
+    error_class: &'static str,
+    duration: Duration,
+) {
+    histogram!(
+        PERSISTENCE_DURATION_SECONDS,
+        "result" => result,
+        "error_class" => error_class
+    )
+    .record(duration.as_secs_f64());
+}
+
+pub(crate) const fn unified_event_kind(event: &UnifiedEvent) -> &'static str {
+    match event {
+        UnifiedEvent::OuroborosMessage(_) => "ouroboros_message",
+        UnifiedEvent::Shutdown => "shutdown",
+        UnifiedEvent::Block(_) => "block",
+        UnifiedEvent::Assignment(_) => "assignment",
+        UnifiedEvent::GossipMessage(_) => "gossip_message",
+        UnifiedEvent::MosaicEvent(_) => "mosaic_event",
+        UnifiedEvent::NagTick => "nag_tick",
+        UnifiedEvent::RetryTick => "retry_tick",
+        UnifiedEvent::SafeHarbour(_) => "safe_harbour",
+    }
+}
+
+pub(crate) const fn pipeline_error_class(error: &PipelineError) -> &'static str {
+    match error {
+        PipelineError::Process(error) => process_error_class(error),
+        PipelineError::Persist(error) => persist_error_class(error),
+    }
+}
+
+const fn process_error_class(error: &ProcessError) -> &'static str {
+    match error {
+        ProcessError::SMNotFound(_) => "state_machine_not_found",
+        ProcessError::InvalidInvocation(_, _) => "invalid_invocation",
+        ProcessError::InvariantViolation(_, _, _, _) => "invariant_violation",
+        ProcessError::RegistryInsert(_) => "registry_insertion",
+    }
+}
+
+pub(crate) const fn persist_error_class(error: &PersistError) -> &'static str {
+    match error {
+        PersistError::DbErr(_) => "database",
+        PersistError::RegistryInvariant(_) => "registry_invariant",
+        PersistError::MissingStateMachine(_) => "state_machine_not_found",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn periodic_event_kinds_are_stable_and_distinct() {
+        assert_eq!(unified_event_kind(&UnifiedEvent::NagTick), "nag_tick");
+        assert_eq!(unified_event_kind(&UnifiedEvent::RetryTick), "retry_tick");
+    }
+}

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -233,7 +233,7 @@ const fn graph_duty_kind(duty: &GraphDuty) -> &'static str {
         GraphDuty::PublishContest { .. } => "publish_contest",
         GraphDuty::GenerateAndPublishBridgeProof { .. } => "generate_and_publish_bridge_proof",
         GraphDuty::PublishBridgeProofTimeout { .. } => "publish_bridge_proof_timeout",
-        GraphDuty::GenerateAndPublishCounterProof { .. } => "generate_and_publish_counter_proof",
+        GraphDuty::PotentialCounterProof { .. } => "potential_counter_proof",
         GraphDuty::PublishCounterProofAck { .. } => "publish_counter_proof_ack",
         GraphDuty::PublishCounterProofNack { .. } => "publish_counter_proof_nack",
         GraphDuty::PublishSlash { .. } => "publish_slash",

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -6,15 +6,21 @@
 use std::time::Duration;
 
 use metrics::{Unit, counter, describe_counter, describe_histogram, histogram};
+use strata_bridge_sm::{
+    deposit::state::DepositState, graph::state::GraphState, stake::state::StakeState,
+};
 
 use crate::{
     errors::{PipelineError, ProcessError},
     events_mux::UnifiedEvent,
     persister::PersistError,
+    sm_types::SMId,
 };
 
 const PIPELINE_EVENT_DURATION_SECONDS: &str = "strata_bridge_pipeline_event_duration_seconds";
 const PIPELINE_ROUTING_TOTAL: &str = "strata_bridge_pipeline_routing_total";
+const SM_TRANSITIONS_TOTAL: &str = "strata_bridge_sm_transitions_total";
+const SM_TRANSITION_DURATION_SECONDS: &str = "strata_bridge_sm_transition_duration_seconds";
 const PERSISTENCE_DURATION_SECONDS: &str = "strata_bridge_persistence_duration_seconds";
 
 pub(crate) fn describe_metrics() {
@@ -26,6 +32,15 @@ pub(crate) fn describe_metrics() {
     describe_counter!(
         PIPELINE_ROUTING_TOTAL,
         "Top-level off-chain event routing and classification outcomes"
+    );
+    describe_counter!(
+        SM_TRANSITIONS_TOTAL,
+        "State-machine event processing outcomes by bounded state-machine kind and state pair"
+    );
+    describe_histogram!(
+        SM_TRANSITION_DURATION_SECONDS,
+        Unit::Seconds,
+        "State-machine event processing time"
     );
     describe_histogram!(
         PERSISTENCE_DURATION_SECONDS,
@@ -58,6 +73,31 @@ pub(crate) fn record_routing(event_kind: &'static str, result: &'static str) {
     .increment(1);
 }
 
+pub(crate) fn record_transition(
+    sm_kind: &'static str,
+    from_state: &'static str,
+    to_state: &'static str,
+    result: &'static str,
+    duration: Duration,
+) {
+    counter!(
+        SM_TRANSITIONS_TOTAL,
+        "sm_kind" => sm_kind,
+        "from_state" => from_state,
+        "to_state" => to_state,
+        "result" => result
+    )
+    .increment(1);
+    // State pairs stay on the counter, where they describe lifecycle flow. They are omitted from
+    // the duration distribution because they multiply series without improving latency triage.
+    histogram!(
+        SM_TRANSITION_DURATION_SECONDS,
+        "sm_kind" => sm_kind,
+        "result" => result
+    )
+    .record(duration.as_secs_f64());
+}
+
 pub(crate) fn record_persistence(
     result: &'static str,
     error_class: &'static str,
@@ -82,6 +122,66 @@ pub(crate) const fn unified_event_kind(event: &UnifiedEvent) -> &'static str {
         UnifiedEvent::NagTick => "nag_tick",
         UnifiedEvent::RetryTick => "retry_tick",
         UnifiedEvent::SafeHarbour(_) => "safe_harbour",
+    }
+}
+
+pub(crate) const fn sm_kind(id: &SMId) -> &'static str {
+    match id {
+        SMId::Deposit(_) => "deposit",
+        SMId::Graph(_) => "graph",
+        SMId::Stake(_) => "stake",
+    }
+}
+
+pub(crate) const fn deposit_state_kind(state: &DepositState) -> &'static str {
+    match state {
+        DepositState::Created { .. } => "created",
+        DepositState::GraphGenerated { .. } => "graph_generated",
+        DepositState::DepositNoncesCollected { .. } => "deposit_nonces_collected",
+        DepositState::DepositPartialsCollected { .. } => "deposit_partials_collected",
+        DepositState::Deposited { .. } => "deposited",
+        DepositState::Assigned { .. } => "assigned",
+        DepositState::Fulfilled { .. } => "fulfilled",
+        DepositState::PayoutDescriptorReceived { .. } => "payout_descriptor_received",
+        DepositState::PayoutNoncesCollected { .. } => "payout_nonces_collected",
+        DepositState::CooperativePathFailed { .. } => "cooperative_path_failed",
+        DepositState::Spent { .. } => "spent",
+        DepositState::Aborted => "aborted",
+    }
+}
+
+pub(crate) const fn graph_state_kind(state: &GraphState) -> &'static str {
+    match state {
+        GraphState::Created { .. } => "created",
+        GraphState::GraphGenerated { .. } => "graph_generated",
+        GraphState::AdaptorsVerified { .. } => "adaptors_verified",
+        GraphState::NoncesCollected { .. } => "nonces_collected",
+        GraphState::GraphSigned { .. } => "graph_signed",
+        GraphState::Assigned { .. } => "assigned",
+        GraphState::Fulfilled { .. } => "fulfilled",
+        GraphState::Claimed { .. } => "claimed",
+        GraphState::Contested { .. } => "contested",
+        GraphState::BridgeProofPosted { .. } => "bridge_proof_posted",
+        GraphState::BridgeProofTimedout { .. } => "bridge_proof_timed_out",
+        GraphState::CounterProofPosted { .. } => "counter_proof_posted",
+        GraphState::AllNackd { .. } => "all_nacked",
+        GraphState::Acked { .. } => "acked",
+        GraphState::Withdrawn { .. } => "withdrawn",
+        GraphState::Slashed { .. } => "slashed",
+        GraphState::Aborted { .. } => "aborted",
+    }
+}
+
+pub(crate) const fn stake_state_kind(state: &StakeState) -> &'static str {
+    match state {
+        StakeState::Created { .. } => "created",
+        StakeState::StakeGraphGenerated { .. } => "stake_graph_generated",
+        StakeState::UnstakingNoncesCollected { .. } => "unstaking_nonces_collected",
+        StakeState::UnstakingSigned { .. } => "unstaking_signed",
+        StakeState::Confirmed { .. } => "confirmed",
+        StakeState::PreimageRevealed { .. } => "preimage_revealed",
+        StakeState::Unstaked { .. } => "unstaked",
+        StakeState::Slashed { .. } => "slashed",
     }
 }
 
@@ -117,5 +217,11 @@ mod tests {
     fn periodic_event_kinds_are_stable_and_distinct() {
         assert_eq!(unified_event_kind(&UnifiedEvent::NagTick), "nag_tick");
         assert_eq!(unified_event_kind(&UnifiedEvent::RetryTick), "retry_tick");
+    }
+
+    #[test]
+    fn state_machine_kinds_do_not_include_identifiers() {
+        assert_eq!(sm_kind(&SMId::Deposit(42)), "deposit");
+        assert_eq!(sm_kind(&SMId::Stake(7)), "stake");
     }
 }

--- a/crates/orchestrator/src/observability.rs
+++ b/crates/orchestrator/src/observability.rs
@@ -5,22 +5,39 @@
 
 use std::time::Duration;
 
-use metrics::{Unit, counter, describe_counter, describe_histogram, histogram};
+use metrics::{
+    Unit, counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram,
+};
+use strata_bridge_exec::errors::ExecutorError;
 use strata_bridge_sm::{
-    deposit::state::DepositState, graph::state::GraphState, stake::state::StakeState,
+    deposit::{
+        duties::{DepositDuty, NagDuty as DepositNagDuty},
+        state::DepositState,
+    },
+    graph::{
+        duties::{GraphDuty, NagDuty as GraphNagDuty},
+        state::GraphState,
+    },
+    stake::{
+        duties::{NagDuty as StakeNagDuty, StakeDuty},
+        state::StakeState,
+    },
 };
 
 use crate::{
     errors::{PipelineError, ProcessError},
     events_mux::UnifiedEvent,
     persister::PersistError,
-    sm_types::SMId,
+    sm_types::{SMId, UnifiedDuty},
 };
 
 const PIPELINE_EVENT_DURATION_SECONDS: &str = "strata_bridge_pipeline_event_duration_seconds";
 const PIPELINE_ROUTING_TOTAL: &str = "strata_bridge_pipeline_routing_total";
 const SM_TRANSITIONS_TOTAL: &str = "strata_bridge_sm_transitions_total";
 const SM_TRANSITION_DURATION_SECONDS: &str = "strata_bridge_sm_transition_duration_seconds";
+const DUTIES_TOTAL: &str = "strata_bridge_duties_total";
+const DUTIES_IN_FLIGHT: &str = "strata_bridge_duties_in_flight";
+const DUTY_DURATION_SECONDS: &str = "strata_bridge_duty_duration_seconds";
 const PERSISTENCE_DURATION_SECONDS: &str = "strata_bridge_persistence_duration_seconds";
 
 pub(crate) fn describe_metrics() {
@@ -42,6 +59,13 @@ pub(crate) fn describe_metrics() {
         Unit::Seconds,
         "State-machine event processing time"
     );
+    describe_counter!(DUTIES_TOTAL, "Duty dispatch and execution outcomes");
+    describe_gauge!(
+        DUTIES_IN_FLIGHT,
+        "Duties currently executing in detached tasks; resets on restart, so durable stuck-duty \
+         detection remains the duty tracker's job (STR-2698)"
+    );
+    describe_histogram!(DUTY_DURATION_SECONDS, Unit::Seconds, "Duty execution time");
     describe_histogram!(
         PERSISTENCE_DURATION_SECONDS,
         Unit::Seconds,
@@ -98,6 +122,43 @@ pub(crate) fn record_transition(
     .record(duration.as_secs_f64());
 }
 
+pub(crate) fn record_duty(
+    duty_kind: &'static str,
+    result: &'static str,
+    error_class: &'static str,
+) {
+    counter!(
+        DUTIES_TOTAL,
+        "duty_kind" => duty_kind,
+        "result" => result,
+        "error_class" => error_class
+    )
+    .increment(1);
+}
+
+/// Marks one duty as executing in a detached task.
+pub(crate) fn record_duty_started(duty_kind: &'static str) {
+    gauge!(DUTIES_IN_FLIGHT, "duty_kind" => duty_kind).increment(1.0);
+}
+
+/// Marks one detached duty task as settled (success, error, or panic).
+pub(crate) fn record_duty_settled(duty_kind: &'static str) {
+    gauge!(DUTIES_IN_FLIGHT, "duty_kind" => duty_kind).decrement(1.0);
+}
+
+pub(crate) fn record_duty_duration(
+    duty_kind: &'static str,
+    result: &'static str,
+    duration: Duration,
+) {
+    histogram!(
+        DUTY_DURATION_SECONDS,
+        "duty_kind" => duty_kind,
+        "result" => result
+    )
+    .record(duration.as_secs_f64());
+}
+
 pub(crate) fn record_persistence(
     result: &'static str,
     error_class: &'static str,
@@ -130,6 +191,74 @@ pub(crate) const fn sm_kind(id: &SMId) -> &'static str {
         SMId::Deposit(_) => "deposit",
         SMId::Graph(_) => "graph",
         SMId::Stake(_) => "stake",
+    }
+}
+
+pub(crate) const fn duty_kind(duty: &UnifiedDuty) -> &'static str {
+    match duty {
+        UnifiedDuty::Deposit(duty) => deposit_duty_kind(duty),
+        UnifiedDuty::Graph(duty) => graph_duty_kind(duty),
+        UnifiedDuty::Stake(duty) => stake_duty_kind(duty),
+    }
+}
+
+const fn deposit_duty_kind(duty: &DepositDuty) -> &'static str {
+    match duty {
+        DepositDuty::PublishDepositNonce { .. } => "publish_deposit_nonce",
+        DepositDuty::PublishDepositPartial { .. } => "publish_deposit_partial",
+        DepositDuty::PublishDeposit { .. } => "publish_deposit",
+        DepositDuty::FulfillWithdrawalRequest { .. } => "fulfill_withdrawal_request",
+        DepositDuty::RequestPayoutNonces { .. } => "request_payout_nonces",
+        DepositDuty::PublishPayoutNonce { .. } => "publish_payout_nonce",
+        DepositDuty::PublishPayoutPartial { .. } => "publish_payout_partial",
+        DepositDuty::PublishPayout { .. } => "publish_payout",
+        DepositDuty::Nag { duty } => match duty {
+            DepositNagDuty::NagDepositNonce { .. } => "nag_deposit_nonce",
+            DepositNagDuty::NagDepositPartial { .. } => "nag_deposit_partial",
+            DepositNagDuty::NagPayoutNonce { .. } => "nag_payout_nonce",
+            DepositNagDuty::NagPayoutPartial { .. } => "nag_payout_partial",
+        },
+    }
+}
+
+const fn graph_duty_kind(duty: &GraphDuty) -> &'static str {
+    match duty {
+        GraphDuty::GenerateGraphData { .. } => "generate_graph_data",
+        GraphDuty::VerifyAdaptors { .. } => "verify_adaptors",
+        GraphDuty::PublishGraphNonces { .. } => "publish_graph_nonces",
+        GraphDuty::PublishGraphPartials { .. } => "publish_graph_partials",
+        GraphDuty::PublishClaim { .. } => "publish_claim",
+        GraphDuty::PublishUncontestedPayout { .. } => "publish_uncontested_payout",
+        GraphDuty::PublishUnstakingBurn { .. } => "publish_unstaking_burn",
+        GraphDuty::PublishContest { .. } => "publish_contest",
+        GraphDuty::GenerateAndPublishBridgeProof { .. } => "generate_and_publish_bridge_proof",
+        GraphDuty::PublishBridgeProofTimeout { .. } => "publish_bridge_proof_timeout",
+        GraphDuty::GenerateAndPublishCounterProof { .. } => "generate_and_publish_counter_proof",
+        GraphDuty::PublishCounterProofAck { .. } => "publish_counter_proof_ack",
+        GraphDuty::PublishCounterProofNack { .. } => "publish_counter_proof_nack",
+        GraphDuty::PublishSlash { .. } => "publish_slash",
+        GraphDuty::PublishContestedPayout { .. } => "publish_contested_payout",
+        GraphDuty::Nag { duty } => match duty {
+            GraphNagDuty::NagGraphData { .. } => "nag_graph_data",
+            GraphNagDuty::NagGraphNonces { .. } => "nag_graph_nonces",
+            GraphNagDuty::NagGraphPartials { .. } => "nag_graph_partials",
+        },
+    }
+}
+
+const fn stake_duty_kind(duty: &StakeDuty) -> &'static str {
+    match duty {
+        StakeDuty::PublishStakeData { .. } => "publish_stake_data",
+        StakeDuty::PublishStake { .. } => "publish_stake",
+        StakeDuty::PublishUnstakingNonces { .. } => "publish_unstaking_nonces",
+        StakeDuty::PublishUnstakingPartials { .. } => "publish_unstaking_partials",
+        StakeDuty::PublishUnstakingIntent { .. } => "publish_unstaking_intent",
+        StakeDuty::PublishUnstakingTx { .. } => "publish_unstaking_tx",
+        StakeDuty::Nag(duty) => match duty {
+            StakeNagDuty::NagUnstakingData { .. } => "nag_unstaking_data",
+            StakeNagDuty::NagUnstakingNonces { .. } => "nag_unstaking_nonces",
+            StakeNagDuty::NagUnstakingPartials { .. } => "nag_unstaking_partials",
+        },
     }
 }
 
@@ -206,6 +335,28 @@ pub(crate) const fn persist_error_class(error: &PersistError) -> &'static str {
         PersistError::DbErr(_) => "database",
         PersistError::RegistryInvariant(_) => "registry_invariant",
         PersistError::MissingStateMachine(_) => "state_machine_not_found",
+    }
+}
+
+pub(crate) const fn executor_error_class(error: &ExecutorError) -> &'static str {
+    match error {
+        ExecutorError::SecretServiceErr(_) => "secret_service",
+        ExecutorError::TxDriverErr(_) => "transaction_driver",
+        ExecutorError::OurPubKeyNotInParams => "operator_configuration",
+        ExecutorError::SelfVerifyFailed => "signature_self_verification",
+        ExecutorError::MissingConfig(_) => "missing_configuration",
+        ExecutorError::WalletErr(_) => "wallet",
+        ExecutorError::PsbtErr(_) => "psbt",
+        ExecutorError::SignatureAggregationFailed(_) => "signature_aggregation",
+        ExecutorError::BitcoinRpcErr(_) => "bitcoin_rpc",
+        ExecutorError::ClaimTxAlreadyOnChain(_) => "claim_already_on_chain",
+        ExecutorError::StakeOutPointAlreadySpent(_) => "stake_already_spent",
+        ExecutorError::DatabaseErr(_) => "database",
+        ExecutorError::MosaicErr(_) => "mosaic",
+        ExecutorError::AsmRpcErr(_) => "asm_rpc",
+        ExecutorError::ProofErr(_) => "proof_generation",
+        ExecutorError::InvalidTxStructure(_) => "invalid_transaction_structure",
+        ExecutorError::FeeRateTooHigh { .. } => "fee_rate_too_high",
     }
 }
 

--- a/crates/orchestrator/src/persister.rs
+++ b/crates/orchestrator/src/persister.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     sync::Arc,
+    time::Instant,
 };
 
 use strata_asm_bridge_types::SafeHarbourAddress;
@@ -11,6 +12,7 @@ use thiserror::Error;
 use tracing::error;
 
 use crate::{
+    observability,
     sm_registry::{RegistryInsertError, SMConfig, SMRegistry},
     sm_types::SMId,
 };
@@ -125,18 +127,37 @@ impl Persister {
         batch: BTreeSet<SMId>,
         sm_registry: &SMRegistry,
     ) -> Result<(), PersistError> {
+        let started = Instant::now();
         let batch_size = batch.len();
-        let write_batch = build_write_batch(batch, sm_registry).inspect_err(|error| {
-            error!(%error, batch_size, "failed to build state-machine persistence batch");
-        })?;
+        let write_batch = match build_write_batch(batch, sm_registry) {
+            Ok(write_batch) => write_batch,
+            Err(error) => {
+                observability::record_persistence(
+                    "error",
+                    observability::persist_error_class(&error),
+                    started.elapsed(),
+                );
+                error!(%error, batch_size, "failed to build state-machine persistence batch");
+                return Err(error);
+            }
+        };
 
-        self.db
-            .persist_batch(&write_batch)
-            .await
-            .map_err(PersistError::DbErr)
-            .inspect_err(|error| {
+        match self.db.persist_batch(&write_batch).await {
+            Ok(()) => {
+                observability::record_persistence("success", "none", started.elapsed());
+                Ok(())
+            }
+            Err(source) => {
+                let error = PersistError::DbErr(source);
+                observability::record_persistence(
+                    "error",
+                    observability::persist_error_class(&error),
+                    started.elapsed(),
+                );
                 error!(%error, batch_size, "failed to persist state-machine batch");
-            })
+                Err(error)
+            }
+        }
     }
 
     /// Persists the frozen safe-harbour `address` to disk so the activation latch survives a

--- a/crates/orchestrator/src/persister.rs
+++ b/crates/orchestrator/src/persister.rs
@@ -125,40 +125,18 @@ impl Persister {
         batch: BTreeSet<SMId>,
         sm_registry: &SMRegistry,
     ) -> Result<(), PersistError> {
-        let write_batch = batch
-            .into_iter()
-            .fold(WriteBatch::new(), |mut write_batch, sm_id| {
-                match sm_id {
-                    SMId::Deposit(deposit_idx) => {
-                        if let Some(deposit_sm) = sm_registry.get_deposit(&deposit_idx) {
-                            write_batch.add_deposit(deposit_sm.clone());
-                        } else {
-                            error!("Attempted to persist deposit state machine with index {deposit_idx}, but it was not found in the registry");
-                        }
-                    }
-                    SMId::Graph(graph_idx) => {
-                        if let Some(graph_sm) = sm_registry.get_graph(&graph_idx) {
-                            write_batch.add_graph(graph_sm.clone());
-                        } else {
-                            error!("Attempted to persist graph state machine with index {graph_idx}, but it was not found in the registry");
-                        }
-                    }
-                    SMId::Stake(operator_idx) => {
-                        if let Some(stake_sm) = sm_registry.get_stake(&operator_idx) {
-                            write_batch.add_stake(stake_sm.clone());
-                        } else {
-                            error!("Attempted to persist stake state machine for operator {operator_idx}, but it was not found in the registry");
-                        }
-                    }
-                }
-
-                write_batch
-            });
+        let batch_size = batch.len();
+        let write_batch = build_write_batch(batch, sm_registry).inspect_err(|error| {
+            error!(%error, batch_size, "failed to build state-machine persistence batch");
+        })?;
 
         self.db
             .persist_batch(&write_batch)
             .await
             .map_err(PersistError::DbErr)
+            .inspect_err(|error| {
+                error!(%error, batch_size, "failed to persist state-machine batch");
+            })
     }
 
     /// Persists the frozen safe-harbour `address` to disk so the activation latch survives a
@@ -230,6 +208,42 @@ pub enum PersistError {
     /// Error indicating duplicate or invalid registry state during recovery.
     #[error("registry invariant violation: {0}")]
     RegistryInvariant(#[from] RegistryInsertError),
+
+    /// A tracked state machine was absent when its atomic write batch was constructed.
+    #[error("state machine {0} is missing from the registry during persistence")]
+    MissingStateMachine(SMId),
+}
+
+fn build_write_batch(
+    batch: BTreeSet<SMId>,
+    sm_registry: &SMRegistry,
+) -> Result<WriteBatch, PersistError> {
+    let mut write_batch = WriteBatch::new();
+
+    for sm_id in batch {
+        match sm_id {
+            SMId::Deposit(deposit_idx) => {
+                let deposit_sm = sm_registry
+                    .get_deposit(&deposit_idx)
+                    .ok_or(PersistError::MissingStateMachine(sm_id))?;
+                write_batch.add_deposit(deposit_sm.clone());
+            }
+            SMId::Graph(graph_idx) => {
+                let graph_sm = sm_registry
+                    .get_graph(&graph_idx)
+                    .ok_or(PersistError::MissingStateMachine(sm_id))?;
+                write_batch.add_graph(graph_sm.clone());
+            }
+            SMId::Stake(operator_idx) => {
+                let stake_sm = sm_registry
+                    .get_stake(&operator_idx)
+                    .ok_or(PersistError::MissingStateMachine(sm_id))?;
+                write_batch.add_stake(stake_sm.clone());
+            }
+        }
+    }
+
+    Ok(write_batch)
 }
 
 #[cfg(test)]
@@ -239,6 +253,7 @@ mod tests {
     use strata_bridge_primitives::types::GraphIdx;
 
     use super::*;
+    use crate::testing::test_empty_registry;
 
     fn deposit(idx: u32) -> SMId {
         SMId::Deposit(idx)
@@ -261,6 +276,23 @@ mod tests {
         let batches = tracker.into_batches();
         assert_eq!(batches.len(), 1);
         assert!(batches[0].contains(&deposit(0)));
+    }
+
+    #[test]
+    fn building_batch_fails_if_tracked_state_machine_is_missing() {
+        let registry = test_empty_registry();
+        let missing_id = deposit(99);
+        let batch = BTreeSet::from([missing_id]);
+
+        let result = build_write_batch(batch, &registry);
+        let Err(error) = result else {
+            panic!("missing state machine must fail the entire persistence batch");
+        };
+
+        assert!(matches!(
+            error,
+            PersistError::MissingStateMachine(id) if id == missing_id
+        ));
     }
 
     #[test]

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::BTreeSet, time::Instant};
 
+use strata_bridge_p2p_types::UnsignedGossipsubMsg;
 use strata_bridge_primitives::{operator_table::OperatorTable, types::BitcoinBlockHeight};
 use strata_bridge_sm::stake::{context::StakeSMCtx, machine::StakeSM};
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
@@ -184,7 +185,11 @@ impl Pipeline {
                             && !matches!(&event, UnifiedEvent::NagTick | UnifiedEvent::RetryTick)
                         {
                             debug!(event_kind, "event did not route to any state machine");
-                        } else if target_count > 0 && classified_count == 0 {
+                        } else if should_warn_on_unclassified_event(
+                            &event,
+                            target_count,
+                            classified_count,
+                        ) {
                             warn!(
                                 event_kind,
                                 target_count,
@@ -353,12 +358,49 @@ fn apply_safe_harbour_scan(applicator: &mut Applicator<'_>) -> Result<(), Pipeli
     Ok(())
 }
 
+/// Returns whether an event that produced no state-machine event needs the pipeline's generic
+/// warning. Nag requests report their specific drop reason in the router or classifier, so another
+/// warning here would either be misleading for an expected wrong-recipient drop or duplicate a
+/// more useful warning.
+const fn should_warn_on_unclassified_event(
+    event: &UnifiedEvent,
+    target_count: usize,
+    classified_count: usize,
+) -> bool {
+    target_count > 0 && classified_count == 0 && !is_nag_request(event)
+}
+
+const fn is_nag_request(event: &UnifiedEvent) -> bool {
+    match event {
+        UnifiedEvent::OuroborosMessage(message) => matches!(
+            &message.publish,
+            UnsignedGossipsubMsg::NagRequestExchange(_)
+        ),
+        UnifiedEvent::GossipMessage(message) => matches!(
+            &message.unsigned,
+            UnsignedGossipsubMsg::NagRequestExchange(_)
+        ),
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use strata_bridge_p2p_service::message_handler::OuroborosMessage;
+    use strata_bridge_p2p_types::{
+        GossipsubMsg, NagRequest, NagRequestPayload, UnsignedGossipsubMsg,
+    };
     use strata_bridge_sm::deposit::state::DepositState;
 
     use super::*;
     use crate::testing::{test_populated_registry, test_safe_harbour_address};
+
+    fn nag_request() -> UnsignedGossipsubMsg {
+        UnsignedGossipsubMsg::NagRequestExchange(NagRequest {
+            recipient: vec![0; 32].into(),
+            payload: NagRequestPayload::DepositNonce { deposit_idx: 0 },
+        })
+    }
 
     #[test]
     fn scan_helper_is_a_noop_while_not_latched() {
@@ -396,5 +438,42 @@ mod tests {
             !tracker.into_batches().is_empty(),
             "scan-seeded transitions must be tracked for persistence"
         );
+    }
+
+    #[test]
+    fn unclassified_peer_nag_does_not_emit_generic_warning() {
+        let event = UnifiedEvent::GossipMessage(GossipsubMsg {
+            signature: Vec::new(),
+            key: vec![1; 32].into(),
+            unsigned: nag_request(),
+        });
+
+        assert!(!should_warn_on_unclassified_event(&event, 1, 0));
+    }
+
+    #[test]
+    fn unclassified_ouroboros_nag_does_not_emit_generic_warning() {
+        let event = UnifiedEvent::OuroborosMessage(OuroborosMessage {
+            publish: nag_request(),
+        });
+
+        assert!(!should_warn_on_unclassified_event(&event, 1, 0));
+    }
+
+    #[test]
+    fn other_unclassified_routed_events_still_emit_generic_warning() {
+        assert!(should_warn_on_unclassified_event(
+            &UnifiedEvent::NagTick,
+            1,
+            0
+        ));
+    }
+
+    #[test]
+    fn classified_or_unrouted_events_do_not_emit_generic_warning() {
+        let event = UnifiedEvent::NagTick;
+
+        assert!(!should_warn_on_unclassified_event(&event, 1, 1));
+        assert!(!should_warn_on_unclassified_event(&event, 0, 0));
     }
 }

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -1,11 +1,11 @@
 //! The main event loop that wires all pipeline stages together:
 //! `EventsMux` → classify → `Applicator::apply_batch` → persist → dispatch.
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, time::Instant};
 
 use strata_bridge_primitives::{operator_table::OperatorTable, types::BitcoinBlockHeight};
 use strata_bridge_sm::stake::{context::StakeSMCtx, machine::StakeSM};
-use tracing::{info, trace, warn};
+use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 
 use crate::{
     applicator::Applicator,
@@ -13,7 +13,7 @@ use crate::{
     errors::{PipelineError, ProcessError},
     events_classifier::{offchain, onchain},
     events_mux::{EventsMux, SafeHarbourEvent, UnifiedEvent},
-    events_router,
+    events_router, observability,
     persister::{PersistenceTracker, Persister},
     safe_harbour_scan::safe_harbour_scan,
     sm_registry::SMRegistry,
@@ -80,8 +80,15 @@ impl Pipeline {
         start_height: BitcoinBlockHeight,
         mut on_event: impl FnMut(),
     ) -> Result<(), PipelineError> {
-        self.bootstrap_stake_sms(&initial_operator_table, start_height)
-            .await?;
+        observability::describe_metrics();
+        if let Err(error) = self
+            .bootstrap_stake_sms(&initial_operator_table, start_height)
+            .instrument(info_span!("bridge_stake_bootstrap"))
+            .await
+        {
+            error!(%error, "failed to bootstrap stake state machines");
+            return Err(error);
+        }
 
         // A recovered latch may cover deposits that were never scanned, and no buried block is
         // guaranteed to arrive to retry: seed sweeps and aborts once before the loop.
@@ -97,7 +104,6 @@ impl Pipeline {
         loop {
             // Stage 1: Multiplex event streams
             let event = self.event_mux.next().await;
-            trace!(?event, "received new event from multiplexer");
 
             // Handle non-routable events (consume `event` on early exit, rebind otherwise)
             let event = match event {
@@ -109,59 +115,132 @@ impl Pipeline {
                 // Routable events — pass through to the classification stage
                 routable => routable,
             };
+            let event_kind = observability::unified_event_kind(&event);
+            let started = Instant::now();
             on_event();
 
-            // Safe harbour is registry-level, not SM-scoped: latch and persist it before
-            // borrowing the registry for the applicator. Only a first latch proceeds to the
-            // scan below; replayed activations from the monotonic feed are skipped.
-            if let UnifiedEvent::SafeHarbour(safe_harbour) = &event
-                && !self.process_safe_harbour(safe_harbour.clone()).await?
-            {
-                continue;
-            }
+            let span = info_span!(
+                "bridge_event",
+                event_kind,
+                result = tracing::field::Empty,
+                error_class = tracing::field::Empty,
+            );
+            let outcome = async {
+                trace!(?event, "processing routable event");
 
-            // Stage 2+3: Classify and process through Applicator
-            let mut applicator = Applicator::new(&mut self.registry);
-
-            match &event {
-                // On first latch: sweep and abort immediately rather than waiting for the next
-                // buried block.
-                UnifiedEvent::SafeHarbour(_) => apply_safe_harbour_scan(&mut applicator)?,
-
-                UnifiedEvent::Block(block_event) => {
-                    onchain::process_block(&mut applicator, &initial_operator_table, block_event)?;
-
-                    // While safe harbour is active, drive sweeps and aborts from the post-block
-                    // deposit states; the per-block replay is the retry mechanism.
-                    apply_safe_harbour_scan(&mut applicator)?;
+                // Safe harbour is registry-level, not SM-scoped: latch and persist it before
+                // borrowing the registry for the applicator. Only a first latch proceeds to the
+                // scan below; replayed activations from the monotonic feed are skipped.
+                if let UnifiedEvent::SafeHarbour(safe_harbour) = &event
+                    && !self.process_safe_harbour(safe_harbour.clone()).await?
+                {
+                    return Ok::<(), PipelineError>(());
                 }
 
-                _ => {
-                    // P2P / assignment / ticks: route to SM ids, then classify each
-                    trace!(
-                        ?event,
-                        "classifying event and determining target state machines"
+                // Stage 2+3: Classify and process through Applicator.
+                let mut applicator = Applicator::new(&mut self.registry);
+
+                match &event {
+                    // On first latch: sweep and abort immediately rather than waiting for the next
+                    // buried block.
+                    UnifiedEvent::SafeHarbour(_) => apply_safe_harbour_scan(&mut applicator)?,
+
+                    UnifiedEvent::Block(block_event) => {
+                        onchain::process_block(
+                            &mut applicator,
+                            &initial_operator_table,
+                            block_event,
+                        )?;
+
+                        // While safe harbour is active, drive sweeps and aborts from the post-block
+                        // deposit states; the per-block replay is the retry mechanism.
+                        apply_safe_harbour_scan(&mut applicator)?;
+                    }
+                    _ => {
+                        trace!(
+                            ?event,
+                            "classifying event and determining target state machines"
+                        );
+                        let sm_ids = events_router::route(&event, applicator.registry());
+                        let target_count = sm_ids.len();
+                        let seed_events: Vec<_> = sm_ids
+                            .into_iter()
+                            .filter_map(|sm_id| {
+                                offchain::classify(&sm_id, &event, applicator.registry())
+                                    .map(|sm_event| (sm_id, sm_event))
+                            })
+                            .collect();
+                        let classified_count = seed_events.len();
+                        let routing_result = if target_count == 0 {
+                            "no_targets"
+                        } else if classified_count == 0 {
+                            "no_classification"
+                        } else {
+                            "classified"
+                        };
+                        observability::record_routing(event_kind, routing_result);
+
+                        if target_count == 0
+                            && !matches!(&event, UnifiedEvent::NagTick | UnifiedEvent::RetryTick)
+                        {
+                            debug!(event_kind, "event did not route to any state machine");
+                        } else if target_count > 0 && classified_count == 0 {
+                            warn!(
+                                event_kind,
+                                target_count,
+                                "event routed but did not classify into a state-machine event"
+                            );
+                        }
+
+                        applicator.apply_batch(seed_events)?;
+                    }
+                }
+
+                let (all_duties, tracker) = applicator.finish();
+
+                // Stage 4: Batch persistence.
+                self.persist_batches(tracker).await?;
+
+                // Stage 5: Dispatch duties after persistence, suppressing withdrawal-path duties
+                // while safe harbour is active.
+                self.dispatch_duties(all_duties);
+
+                Ok::<(), PipelineError>(())
+            }
+            .instrument(span.clone())
+            .await;
+
+            match outcome {
+                Ok(()) => {
+                    span.record("result", "success");
+                    span.record("error_class", "none");
+                    observability::record_pipeline_event_finished(
+                        event_kind,
+                        "success",
+                        "none",
+                        started.elapsed(),
                     );
-                    let sm_ids = events_router::route(&event, applicator.registry());
-                    let seed_events: Vec<_> = sm_ids
-                        .into_iter()
-                        .filter_map(|sm_id| {
-                            offchain::classify(&sm_id, &event, applicator.registry())
-                                .map(|sm_event| (sm_id, sm_event))
-                        })
-                        .collect();
-
-                    applicator.apply_batch(seed_events)?;
+                }
+                Err(processing_error) => {
+                    let error_class = observability::pipeline_error_class(&processing_error);
+                    span.record("result", "error");
+                    span.record("error_class", error_class);
+                    observability::record_pipeline_event_finished(
+                        event_kind,
+                        "error",
+                        error_class,
+                        started.elapsed(),
+                    );
+                    error!(
+                        parent: &span,
+                        error = %processing_error,
+                        error_class,
+                        event_kind,
+                        "bridge event processing failed"
+                    );
+                    return Err(processing_error);
                 }
             }
-
-            let (all_duties, tracker) = applicator.finish();
-
-            // Stage 4: Batch persistence.
-            self.persist_batches(tracker).await?;
-
-            // Stage 5: Dispatch duties.
-            self.dispatch_duties(all_duties);
         }
     }
 

--- a/crates/orchestrator/src/pipeline.rs
+++ b/crates/orchestrator/src/pipeline.rs
@@ -164,21 +164,29 @@ impl Pipeline {
                         );
                         let sm_ids = events_router::route(&event, applicator.registry());
                         let target_count = sm_ids.len();
+                        let mut expected_drop_count = 0;
                         let seed_events: Vec<_> = sm_ids
                             .into_iter()
                             .filter_map(|sm_id| {
-                                offchain::classify(&sm_id, &event, applicator.registry())
-                                    .map(|sm_event| (sm_id, sm_event))
+                                match offchain::classify_routed(
+                                    &sm_id,
+                                    &event,
+                                    applicator.registry(),
+                                ) {
+                                    offchain::ClassificationOutcome::Classified(sm_event) => {
+                                        Some((sm_id, sm_event))
+                                    }
+                                    offchain::ClassificationOutcome::ExpectedDrop => {
+                                        expected_drop_count += 1;
+                                        None
+                                    }
+                                    offchain::ClassificationOutcome::Unclassified => None,
+                                }
                             })
                             .collect();
                         let classified_count = seed_events.len();
-                        let routing_result = if target_count == 0 {
-                            "no_targets"
-                        } else if classified_count == 0 {
-                            "no_classification"
-                        } else {
-                            "classified"
-                        };
+                        let routing_result =
+                            routing_result(target_count, classified_count, expected_drop_count);
                         observability::record_routing(event_kind, routing_result);
 
                         if target_count == 0
@@ -358,6 +366,22 @@ fn apply_safe_harbour_scan(applicator: &mut Applicator<'_>) -> Result<(), Pipeli
     Ok(())
 }
 
+const fn routing_result(
+    target_count: usize,
+    classified_count: usize,
+    expected_drop_count: usize,
+) -> &'static str {
+    if target_count == 0 {
+        "no_targets"
+    } else if classified_count > 0 {
+        "classified"
+    } else if expected_drop_count == target_count {
+        "expected_drop"
+    } else {
+        "no_classification"
+    }
+}
+
 /// Returns whether an event that produced no state-machine event needs the pipeline's generic
 /// warning. Nag requests report their specific drop reason in the router or classifier, so another
 /// warning here would either be misleading for an expected wrong-recipient drop or duplicate a
@@ -475,5 +499,14 @@ mod tests {
 
         assert!(!should_warn_on_unclassified_event(&event, 1, 1));
         assert!(!should_warn_on_unclassified_event(&event, 0, 0));
+    }
+
+    #[test]
+    fn routing_result_separates_expected_drops_from_failures() {
+        assert_eq!(routing_result(0, 0, 0), "no_targets");
+        assert_eq!(routing_result(1, 1, 0), "classified");
+        assert_eq!(routing_result(1, 0, 1), "expected_drop");
+        assert_eq!(routing_result(1, 0, 0), "no_classification");
+        assert_eq!(routing_result(2, 0, 1), "no_classification");
     }
 }

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -491,11 +491,21 @@ impl SMRegistry {
                     "state-machine transition applied"
                 );
             }
-            Ok(ProcessOutcome::Applied(_))
-            | Ok(ProcessOutcome::Ignored {
+            Ok(ProcessOutcome::Applied(_)) => {}
+            Ok(ProcessOutcome::Ignored {
+                event,
                 reason: IgnoredEventReason::Duplicate,
                 ..
-            }) => {}
+            }) => {
+                debug!(
+                    sm_kind,
+                    sm_id = %id,
+                    from_state,
+                    to_state,
+                    event = %event,
+                    "duplicate state-machine event ignored"
+                );
+            }
             Ok(ProcessOutcome::Ignored {
                 event,
                 reason: IgnoredEventReason::Rejected(reason),

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeMap, btree_map::Entry},
     fmt::{Debug, Display},
     sync::Arc,
+    time::Instant,
 };
 
 use bitcoin::{OutPoint, hashes::sha256};
@@ -15,19 +16,20 @@ use strata_bridge_primitives::{
 };
 use strata_bridge_sm::{
     cross_sm_context::CrossSmContext,
-    deposit::{config::DepositSMCfg, machine::DepositSM},
+    deposit::{config::DepositSMCfg, events::DepositEvent, machine::DepositSM},
     errors::BridgeSMError,
-    graph::{config::GraphSMCfg, machine::GraphSM},
+    graph::{config::GraphSMCfg, events::GraphEvent, machine::GraphSM},
     signals,
-    stake::{config::StakeSMCfg, machine::StakeSM, state::StakeState},
+    stake::{config::StakeSMCfg, events::StakeEvent, machine::StakeSM, state::StakeState},
     state_machine::{SMOutput, StateMachine},
 };
 use strata_bridge_tx_graph::transactions::stake::StakeTx;
 use thiserror::Error;
-use tracing::error;
+use tracing::{debug, error, info, info_span, warn};
 
 use crate::{
     errors::{ProcessError, ProcessOutput},
+    observability,
     sm_types::{OperatorKey, SMEvent, SMId, UnifiedDuty},
 };
 
@@ -442,6 +444,93 @@ impl SMRegistry {
         id: &SMId,
         event: SMEvent,
     ) -> Result<ProcessOutcome, ProcessError> {
+        let sm_kind = observability::sm_kind(id);
+        let is_periodic = is_periodic_event(&event);
+        let from_state = self.state_kind(id).unwrap_or("missing");
+        // Info-level so the transition span exists under the default INFO filter; span creation
+        // emits no log lines, and the per-tick log statements below stay at debug.
+        let span = info_span!(
+            "bridge_sm_transition",
+            sm_kind,
+            sm_id = %id,
+            event = %event,
+            from_state,
+            to_state = tracing::field::Empty,
+            result = tracing::field::Empty,
+        );
+        let _entered = span.enter();
+        let started = Instant::now();
+        let outcome = self.process_event_inner(id, event);
+        let to_state = self.state_kind(id).unwrap_or("missing");
+        let result = transition_result(&outcome);
+
+        span.record("to_state", to_state);
+        span.record("result", result);
+        observability::record_transition(sm_kind, from_state, to_state, result, started.elapsed());
+
+        match &outcome {
+            Ok(ProcessOutcome::Applied(output)) if output.did_mutate() && is_periodic => {
+                debug!(
+                    sm_kind,
+                    sm_id = %id,
+                    from_state,
+                    to_state,
+                    duty_count = output.duties.len(),
+                    signal_count = output.signals.len(),
+                    "periodic state-machine transition applied"
+                );
+            }
+            Ok(ProcessOutcome::Applied(output)) if output.did_mutate() => {
+                info!(
+                    sm_kind,
+                    sm_id = %id,
+                    from_state,
+                    to_state,
+                    duty_count = output.duties.len(),
+                    signal_count = output.signals.len(),
+                    "state-machine transition applied"
+                );
+            }
+            Ok(ProcessOutcome::Applied(_))
+            | Ok(ProcessOutcome::Ignored {
+                reason: IgnoredEventReason::Duplicate,
+                ..
+            }) => {}
+            Ok(ProcessOutcome::Ignored {
+                event,
+                reason: IgnoredEventReason::Rejected(reason),
+                ..
+            }) => {
+                warn!(
+                    sm_kind,
+                    sm_id = %id,
+                    from_state,
+                    to_state,
+                    event = %event,
+                    reason,
+                    "state-machine event rejected"
+                );
+            }
+            Err(error) => {
+                error!(
+                    %error,
+                    sm_kind,
+                    sm_id = %id,
+                    from_state,
+                    to_state,
+                    "state-machine event processing failed"
+                );
+            }
+        }
+
+        outcome
+    }
+
+    fn process_event_inner(
+        &mut self,
+        id: &SMId,
+        event: SMEvent,
+    ) -> Result<ProcessOutcome, ProcessError> {
         let cross_sm_context = self.resolve_cross_sm_context(id);
 
         match (id, event) {
@@ -497,6 +586,23 @@ impl SMRegistry {
         }
     }
 
+    fn state_kind(&self, id: &SMId) -> Option<&'static str> {
+        match id {
+            SMId::Deposit(idx) => self
+                .deposits
+                .get(idx)
+                .map(|sm| observability::deposit_state_kind(sm.state())),
+            SMId::Graph(idx) => self
+                .graphs
+                .get(idx)
+                .map(|sm| observability::graph_state_kind(sm.state())),
+            SMId::Stake(idx) => self
+                .stakes
+                .get(idx)
+                .map(|sm| observability::stake_state_kind(sm.state())),
+        }
+    }
+
     /// Resolves auxiliary state from sibling state machines for the destination `id`.
     ///
     /// This context is intentionally not routed as a signal: resolving it does not create a
@@ -521,6 +627,39 @@ impl SMRegistry {
                 CrossSmContext::default,
                 CrossSmContext::with_unstaking_preimage,
             )
+    }
+}
+
+const fn transition_result(outcome: &Result<ProcessOutcome, ProcessError>) -> &'static str {
+    match outcome {
+        Ok(ProcessOutcome::Applied(output)) if output.did_mutate() => "applied_mutated",
+        Ok(ProcessOutcome::Applied(_)) => "applied_unchanged",
+        Ok(ProcessOutcome::Ignored {
+            reason: IgnoredEventReason::Duplicate,
+            ..
+        }) => "duplicate",
+        Ok(ProcessOutcome::Ignored {
+            reason: IgnoredEventReason::Rejected(_),
+            ..
+        }) => "rejected",
+        Err(_) => "invalid",
+    }
+}
+
+fn is_periodic_event(event: &SMEvent) -> bool {
+    match event {
+        SMEvent::Deposit(event) => matches!(
+            event.as_ref(),
+            DepositEvent::NewBlock(_) | DepositEvent::RetryTick(_) | DepositEvent::NagTick(_)
+        ),
+        SMEvent::Graph(event) => matches!(
+            event.as_ref(),
+            GraphEvent::NewBlock(_) | GraphEvent::RetryTick(_) | GraphEvent::NagTick(_)
+        ),
+        SMEvent::Stake(event) => matches!(
+            event.as_ref(),
+            StakeEvent::NewBlock(_) | StakeEvent::RetryTick(_) | StakeEvent::NagTick(_)
+        ),
     }
 }
 

--- a/crates/orchestrator/src/sm_registry.rs
+++ b/crates/orchestrator/src/sm_registry.rs
@@ -25,7 +25,7 @@ use strata_bridge_sm::{
 };
 use strata_bridge_tx_graph::transactions::stake::StakeTx;
 use thiserror::Error;
-use tracing::{debug, error, info, info_span, warn};
+use tracing::{debug, error, info, info_span};
 
 use crate::{
     errors::{ProcessError, ProcessOutput},
@@ -468,6 +468,8 @@ impl SMRegistry {
         span.record("result", result);
         observability::record_transition(sm_kind, from_state, to_state, result, started.elapsed());
 
+        // Keep transition telemetry here, but leave ignored-outcome and fatal-error severity to
+        // the applicator and pipeline respectively.
         match &outcome {
             Ok(ProcessOutcome::Applied(output)) if output.did_mutate() && is_periodic => {
                 debug!(
@@ -491,46 +493,7 @@ impl SMRegistry {
                     "state-machine transition applied"
                 );
             }
-            Ok(ProcessOutcome::Applied(_)) => {}
-            Ok(ProcessOutcome::Ignored {
-                event,
-                reason: IgnoredEventReason::Duplicate,
-                ..
-            }) => {
-                debug!(
-                    sm_kind,
-                    sm_id = %id,
-                    from_state,
-                    to_state,
-                    event = %event,
-                    "duplicate state-machine event ignored"
-                );
-            }
-            Ok(ProcessOutcome::Ignored {
-                event,
-                reason: IgnoredEventReason::Rejected(reason),
-                ..
-            }) => {
-                warn!(
-                    sm_kind,
-                    sm_id = %id,
-                    from_state,
-                    to_state,
-                    event = %event,
-                    reason,
-                    "state-machine event rejected"
-                );
-            }
-            Err(error) => {
-                error!(
-                    %error,
-                    sm_kind,
-                    sm_id = %id,
-                    from_state,
-                    to_state,
-                    "state-machine event processing failed"
-                );
-            }
+            Ok(ProcessOutcome::Applied(_)) | Ok(ProcessOutcome::Ignored { .. }) | Err(_) => {}
         }
 
         outcome

--- a/crates/orchestrator/src/sm_types.rs
+++ b/crates/orchestrator/src/sm_types.rs
@@ -121,6 +121,16 @@ impl UnifiedDuty {
     }
 }
 
+impl Display for UnifiedDuty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Deposit(duty) => Display::fmt(duty, f),
+            Self::Graph(duty) => Display::fmt(duty, f),
+            Self::Stake(duty) => Display::fmt(duty, f),
+        }
+    }
+}
+
 impl From<DepositDuty> for UnifiedDuty {
     fn from(duty: DepositDuty) -> Self {
         UnifiedDuty::Deposit(duty)


### PR DESCRIPTION
## Summary

Implements the runtime portion of STR-3592: bounded metrics and structured spans across the orchestrator event pipeline, plus the failure-path fixes needed to make those signals trustworthy.

This PR is intentionally limited to the orchestrator. Prometheus/Grafana/Loki configuration, dashboards, alert thresholds, retention, authentication, and scrape wiring belong in the deployment repository and are not included here.

## What changed

- Adds `bridge_event`, `bridge_sm_transition`, and `bridge_duty_execution` spans around the pipeline's causal stages. Transition spans are `INFO` level so they exist under the default filter; periodic transition logs remain `DEBUG` to avoid log noise.
- Adds eight `strata_bridge_*` metric families:
  - end-to-end pipeline event duration and routing outcomes
  - state-machine transition outcomes and duration
  - duty outcomes, in-flight count, and duration
  - persistence duration and outcome
- Keeps metric labels bounded to explicit classifiers such as event kind, state-machine kind/state, result, error class, and duty kind. IDs, transaction data, peer keys, payloads, and raw errors remain in spans or structured logs rather than metric labels.
- Catches detached duty-future panics and logs executor failures with bounded error classes. Duty span context uses the existing redacted `Display` implementations rather than potentially sensitive `Debug` output.
- Fails an entire persistence batch when a tracked state machine is missing instead of silently writing a partial batch.
- Persists every causally linked state-machine batch before dispatching any duty from the event.
- Removes duplicate/no-op transition logging while retaining those outcomes in metrics.

## Operational impact

Operators can correlate a top-level event with its state-machine transitions and detached duties, measure failure rates and latency, and distinguish bounded failure classes without creating identifier-driven Prometheus cardinality.

The `metrics` histogram instruments currently follow the existing recorder configuration. In the current exporter setup they render as summaries unless bucket configuration is added centrally, so consumers must not assume `_bucket` series exist.

## Explicitly out of scope

- Production metrics endpoint/scrape configuration, dashboards, alerts, retention, and authentication (deployment repository).
- Durable per-deposit lifecycle records and timeline RPC (STR-3598).
- Cross-service trace/deposit-ID propagation (STR-1975).
- Durable duty scheduling, retries, and backpressure (STR-2698). The in-flight gauge and outcome metrics make the current detached-execution behavior observable; they do not make it durable.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p strata-bridge-orchestrator --all-targets`
- `cargo clippy -p strata-bridge-orchestrator --all-targets -- -D warnings`
- `git diff --check main`
- Full linked unit and functional suites run in GitHub CI, which provisions the required FoundationDB client/server.
