### PR TITLE
fix(bridge-sm): reject malformed counterproof signatures

### DIFF
--- a/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
+++ b/crates/bridge-sm/src/graph/tests/contested/process_counterproof.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use bitcoin::Witness;
 use strata_bridge_test_utils::bitcoin::generate_tx;
 use strata_bridge_tx_graph::{
     game_graph::GameConnectors,
@@ -23,8 +24,8 @@ use crate::{
                 all_state_variants, bridge_proof_posted_state, contested_state,
             },
             test_completed_signatures, test_counterproof_tx, test_deposit_params,
-            test_graph_invalid_transition, test_graph_sm_cfg, test_graph_sm_ctx,
-            test_graph_transition,
+            test_graph_invalid_transition, test_graph_invalid_transition_with, test_graph_sm_cfg,
+            test_graph_sm_ctx, test_graph_transition,
         },
         watchtower::watchtower_slot_for_operator,
     },
@@ -376,6 +377,37 @@ fn event_rejected_invalid_counterproof_witness() {
         }),
         expected_error: |e| matches!(e, GSMError::Rejected { .. }),
     });
+}
+
+/// Non-POV operators reject malformed signature encodings instead of panicking while
+/// persisting the counterproof data.
+#[test]
+fn event_rejected_malformed_counterproof_signature_nonpov() {
+    let mut tx = test_counterproof_tx();
+    let expected_txid = tx.compute_txid();
+    let mut witness = tx.input[0].witness.to_vec();
+    witness[0] = vec![0; 32];
+    tx.input[0].witness = Witness::from_slice(&witness);
+    assert_eq!(tx.compute_txid(), expected_txid);
+
+    test_graph_invalid_transition_with(
+        create_nonpov_sm,
+        GraphInvalidTransition {
+            from_state: contested_state(),
+            event: GraphEvent::CounterProofConfirmed(CounterProofConfirmedEvent {
+                counterproof_block_height: COUNTERPROOF_BLOCK_HEIGHT,
+                tx,
+                counterprover_idx: TEST_NONPOV_IDX,
+            }),
+            expected_error: |e| {
+                matches!(
+                    e,
+                    GSMError::Rejected { reason, .. }
+                        if reason.contains("counterproof witness signature")
+                )
+            },
+        },
+    );
 }
 
 /// Returns `true` if the state is valid for [`GraphEvent::CounterProofConfirmed`].

--- a/crates/bridge-sm/src/graph/transitions/counterproof.rs
+++ b/crates/bridge-sm/src/graph/transitions/counterproof.rs
@@ -252,8 +252,24 @@ impl GraphSM {
         let sigs: Vec<Signature> = items
             .into_iter()
             .skip(3)
-            .map(|w| Signature::from_slice(&w).expect("on-chain counterproof signature must parse"))
-            .collect();
-        Ok(sigs.try_into().expect("witness length validated above"))
+            .enumerate()
+            .map(|(idx, w)| {
+                Signature::from_slice(&w).map_err(|_| {
+                    GSMError::rejected(
+                        self.state.clone(),
+                        event.clone().into(),
+                        format!("counterproof witness signature {idx} is malformed"),
+                    )
+                })
+            })
+            .collect::<GSMResult<Vec<_>>>()?;
+
+        sigs.try_into().map_err(|_| {
+            GSMError::rejected(
+                self.state.clone(),
+                event.clone().into(),
+                "counterproof witness has an invalid signature count",
+            )
+        })
     }
 }


### PR DESCRIPTION
## Description

Rejects malformed per-byte operator signatures in confirmed counterproof witnesses with `GSMError::Rejected` instead of panicking while decoding `completed_signatures`. This protects non-POV operators, which now decode and persist those signatures even though witness data is not committed to the transaction ID.

Adds a regression test that changes one signature witness item without changing the txid and verifies that a non-POV node rejects the event.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Related Issues

- [STR-4063](https://alpenlabs.atlassian.net/browse/STR-4063)

🤖 This PR was written primarily by Codex

[STR-4063]: https://alpenlabs.atlassian.net/browse/STR-4063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ