### PR TITLE
STR-3107: validate Bitcoin RPC network at startup

### DIFF
--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -20,7 +20,7 @@ use crate::{
         rpc_server::init_rpc_server,
         services::{
             asm_rpc::init_asm_rpc_client,
-            btc_client::init_btc_rpc_client,
+            btc_client::{init_btc_rpc_client, verify_btc_network},
             health_probes::{
                 spawn_asm_rpc_probe, spawn_bitcoin_rpc_probe, spawn_fdb_probe, spawn_mosaic_probe,
                 spawn_p2p_probe, spawn_s2_probe, spawn_wallet_probe,
@@ -72,6 +72,13 @@ pub(crate) async fn bootstrap(
         .await?;
     }
 
+    debug!("initializing bitcoin client");
+    let btc_rpc_client = init_btc_rpc_client(&config)?;
+    verify_btc_network(&btc_rpc_client, params.network).await?;
+    let cur_height = btc_rpc_client.get_block_count().await?;
+    info!(%cur_height, network = %params.network, "bitcoin client initialized and synced");
+    health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "network_and_block_count_verified");
+
     debug!(config=?config.secret_service_client, "initializing secret service client");
     let s2_client = init_secret_service_client(&config.secret_service_client).await;
     info!("initialized secret service client");
@@ -98,12 +105,6 @@ pub(crate) async fn bootstrap(
     // This is just to speed up syncing when we actually need to use the funds.
     tokio::spawn(async move { spawn_initial_operator_wallet_sync(sync_wallet).await });
     info!("initial operator wallet sync task spawned");
-
-    debug!("initializing bitcoin client");
-    let btc_rpc_client = init_btc_rpc_client(&config)?;
-    let cur_height = btc_rpc_client.get_block_count().await?;
-    info!(%cur_height, "bitcoin client initialized and synced");
-    health_registry.mark_ok(COMPONENT_BITCOIN_RPC, "block_count_read");
 
     debug!("initializing p2p client");
     let P2PHandles {

--- a/bin/strata-bridge/src/mode/services/btc_client.rs
+++ b/bin/strata-bridge/src/mode/services/btc_client.rs
@@ -3,8 +3,8 @@
 use std::{collections::VecDeque, time::Duration};
 
 use algebra::retry::{Strategy, retry_with};
-use anyhow::anyhow;
-use bitcoin::Block;
+use anyhow::{anyhow, ensure};
+use bitcoin::{Block, Network};
 use bitcoind_async_client::{Auth, Client as BitcoinClient, error::ClientError, traits::Reader};
 use btc_tracker::{
     client::{BlockFetcher, BtcNotifyClient, BtcNotifyHealthEvent, Connected},
@@ -28,6 +28,22 @@ pub(in crate::mode) fn init_btc_rpc_client(config: &Config) -> anyhow::Result<Bi
         None,
     )
     .map_err(|e| anyhow!("could not create bitcoin rpc client due to {e:?}"))
+}
+
+/// Verifies that the connected Bitcoin node is on the network configured in bridge params.
+pub(in crate::mode) async fn verify_btc_network(
+    client: &BitcoinClient,
+    configured: Network,
+) -> anyhow::Result<()> {
+    let connected = client
+        .network()
+        .await
+        .map_err(|e| anyhow!("could not query bitcoin node network due to {e:?}"))?;
+    ensure!(
+        configured == connected,
+        "bitcoin network mismatch: configured {configured}, connected node reports {connected}"
+    );
+    Ok(())
 }
 
 /// Initializes the ZMQ client for subscribing to Bitcoin (on-chain) events, starting from the


### PR DESCRIPTION
## Description

Validate the connected Bitcoin node's network during bridge startup before initializing downstream services. The bridge now queries `getblockchaininfo` through the Bitcoin client, compares the reported chain with `params.network`, and exits with a clear error when they differ.

The pinned `strata-asm-runner` revision already performs the equivalent startup validation through its anchor/L1 network check. This closes the remaining bridge-side gap without changing the ASM dependency.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

🤖 This PR was written primarily by Codex.

## Related Issues

[STR-3107](https://alpenlabs.atlassian.net/browse/STR-3107)

[STR-3107]: https://alpenlabs.atlassian.net/browse/STR-3107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ