### PR TITLE
feat(bridge-asm): validate withdrawal fulfillment window at startup

### DIFF
--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -286,18 +286,15 @@ pub(crate) struct MetricsConfig {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_config_serde_toml() {
-        let config = r#"
+pub(crate) fn test_config() -> Config {
+    toml::from_str(
+        r#"
             num_threads = 4
             thread_stack_size = 8_388_608 # 8 * 1024 * 1024
             is_faulty = false
             nag_interval = { secs = 60, nanos = 0 }
             retry_interval = { secs = 21600, nanos = 0 } # 6 hours
-            min_withdrawal_fulfillment_window = 144
+            min_withdrawal_fulfillment_window = 143
             shutdown_timeout = { secs = 15, nanos = 0 }
             cooperative_payout_timeout = 144 # ~24 hours
             max_fee_rate = 10 # sats/vbyte
@@ -373,16 +370,18 @@ mod tests {
 
             [metrics]
             prometheus_listener_addr = "127.0.0.1:9615"
-        "#;
+        "#,
+    )
+    .expect("valid test config")
+}
 
-        let config = toml::from_str::<Config>(config);
-        assert!(
-            config.is_ok(),
-            "must be able to deserialize config from toml but got: {}",
-            config.unwrap_err()
-        );
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let config = config.unwrap();
+    #[test]
+    fn test_config_serde_toml() {
+        let config = test_config();
         let serialized = toml::to_string(&config).unwrap();
         let reparsed = toml::from_str::<Config>(&serialized).unwrap();
         let reserialized = toml::to_string(&reparsed).unwrap();

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -64,9 +64,8 @@ pub(crate) async fn bootstrap(
     } else {
         startup_checks::verify(
             &params,
-            config.min_withdrawal_fulfillment_window,
+            &config,
             &asm_rpc_client,
-            &config.asm_rpc,
             &bridge_proof_host,
             &counterproof_host,
         )

--- a/bin/strata-bridge/src/mode/operator.rs
+++ b/bin/strata-bridge/src/mode/operator.rs
@@ -64,6 +64,7 @@ pub(crate) async fn bootstrap(
     } else {
         startup_checks::verify(
             &params,
+            config.min_withdrawal_fulfillment_window,
             &asm_rpc_client,
             &config.asm_rpc,
             &bridge_proof_host,

--- a/bin/strata-bridge/src/mode/services/startup_checks.rs
+++ b/bin/strata-bridge/src/mode/services/startup_checks.rs
@@ -16,23 +16,22 @@ use strata_predicate::PredicateKey;
 use tokio::time;
 use tracing::warn;
 
+use crate::config::Config;
+
 /// Runs every startup consistency check; a failure aborts node startup.
 pub(in crate::mode) async fn verify(
     params: &Params,
-    min_withdrawal_fulfillment_window: u64,
+    config: &Config,
     asm_rpc_client: &HttpClient,
-    asm_rpc_config: &AsmRpcConfig,
     bridge_proof_host: &BridgeProofHost,
     counterproof_host: &BridgeCounterproofHost,
 ) -> Result<()> {
     verify_predicates(params, bridge_proof_host, counterproof_host)?;
 
-    let asm_params = fetch_asm_params(asm_rpc_client, asm_rpc_config)
+    let asm_params = fetch_asm_params(asm_rpc_client, &config.asm_rpc)
         .await
         .context("fetching ASM params for startup consistency check")?;
-    verify_asm_params(params, min_withdrawal_fulfillment_window, &asm_params)
-        .context("bridge/ASM params mismatch")?;
-    Ok(())
+    verify_asm_params(params, config, &asm_params).context("bridge/ASM params mismatch")
 }
 
 async fn fetch_asm_params(client: &HttpClient, config: &AsmRpcConfig) -> Result<AsmParams> {
@@ -74,11 +73,7 @@ fn verify_predicates(
 }
 
 /// The bridge params and local fulfillment window are compatible with the ASM instance.
-fn verify_asm_params(
-    params: &Params,
-    min_withdrawal_fulfillment_window: u64,
-    asm: &AsmParams,
-) -> Result<()> {
+fn verify_asm_params(params: &Params, config: &Config, asm: &AsmParams) -> Result<()> {
     let Some(bridge) = asm.bridge_config() else {
         anyhow::bail!(
             "ASM params carry no bridge-v1 subprotocol config; point the bridge at an ASM \
@@ -103,10 +98,11 @@ fn verify_asm_params(
         params.protocol.recovery_delay,
         bridge.recovery_delay,
     )?;
-    if min_withdrawal_fulfillment_window >= u64::from(bridge.assignment_duration) {
+    if config.min_withdrawal_fulfillment_window >= u64::from(bridge.assignment_duration) {
         anyhow::bail!(
             "min_withdrawal_fulfillment_window: bridge config value \
-             {min_withdrawal_fulfillment_window} must be less than ASM assignment_duration {}",
+             {} must be less than ASM assignment_duration {}",
+            config.min_withdrawal_fulfillment_window,
             bridge.assignment_duration
         );
     }
@@ -164,13 +160,13 @@ mod tests {
     use strata_l1_txfmt::MagicBytes;
 
     use super::*;
+    use crate::config::test_config;
 
     // Valid x-only/ed25519 test keys, same fixtures as `strata_bridge_common::params` tests.
     const XONLY_KEY_1: &str = "b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d";
     const XONLY_KEY_2: &str = "1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4";
     const P2P_KEY_1: &str = "0de7729dcbeb5069136ee4bff1c4f2fd822fe8fbc9b518df434d4f0c6312d8f5";
     const P2P_KEY_2: &str = "255ab0da6d468a22910a7cf54021763417c63c28bbafd4e2359daf103bb61e9d";
-    const MIN_WITHDRAWAL_FULFILLMENT_WINDOW: u64 = 143;
     const ASSIGNMENT_DURATION: u16 = 144;
 
     fn test_params() -> Params {
@@ -252,24 +248,22 @@ mod tests {
     #[test]
     fn matching_params_pass() {
         let params = test_params();
-        verify_asm_params(
-            &params,
-            MIN_WITHDRAWAL_FULFILLMENT_WINDOW,
-            &matching_asm(&params),
-        )
-        .expect("matching params must verify");
+        verify_asm_params(&params, &test_config(), &matching_asm(&params))
+            .expect("matching params must verify");
     }
 
     #[test]
     fn withdrawal_fulfillment_window_must_be_less_than_assignment_duration() {
         let params = test_params();
+        let mut config = test_config();
         let asm = matching_asm(&params);
 
         for window in [
             u64::from(ASSIGNMENT_DURATION),
             u64::from(ASSIGNMENT_DURATION) + 1,
         ] {
-            let err = verify_asm_params(&params, window, &asm)
+            config.min_withdrawal_fulfillment_window = window;
+            let err = verify_asm_params(&params, &config, &asm)
                 .unwrap_err()
                 .to_string();
             assert!(
@@ -302,10 +296,11 @@ mod tests {
         ];
 
         let params = test_params();
+        let config = test_config();
         for (label, mutate) in cases {
             let mut asm = matching_asm(&params);
             mutate(&mut asm);
-            let err = verify_asm_params(&params, MIN_WITHDRAWAL_FULFILLMENT_WINDOW, &asm)
+            let err = verify_asm_params(&params, &config, &asm)
                 .unwrap_err()
                 .to_string();
             assert!(
@@ -318,11 +313,12 @@ mod tests {
     #[test]
     fn missing_bridge_subprotocol_fails() {
         let params = test_params();
+        let config = test_config();
         let mut asm = matching_asm(&params);
         asm.subprotocols
             .retain(|s| !matches!(s, SubprotocolInstance::Bridge(_)));
 
-        let err = verify_asm_params(&params, MIN_WITHDRAWAL_FULFILLMENT_WINDOW, &asm)
+        let err = verify_asm_params(&params, &config, &asm)
             .unwrap_err()
             .to_string();
         assert!(err.contains("no bridge-v1 subprotocol"), "got: {err}");

--- a/bin/strata-bridge/src/mode/services/startup_checks.rs
+++ b/bin/strata-bridge/src/mode/services/startup_checks.rs
@@ -19,6 +19,7 @@ use tracing::warn;
 /// Runs every startup consistency check; a failure aborts node startup.
 pub(in crate::mode) async fn verify(
     params: &Params,
+    min_withdrawal_fulfillment_window: u64,
     asm_rpc_client: &HttpClient,
     asm_rpc_config: &AsmRpcConfig,
     bridge_proof_host: &BridgeProofHost,
@@ -29,7 +30,8 @@ pub(in crate::mode) async fn verify(
     let asm_params = fetch_asm_params(asm_rpc_client, asm_rpc_config)
         .await
         .context("fetching ASM params for startup consistency check")?;
-    verify_asm_params(params, &asm_params).context("bridge/ASM params mismatch")?;
+    verify_asm_params(params, min_withdrawal_fulfillment_window, &asm_params)
+        .context("bridge/ASM params mismatch")?;
     Ok(())
 }
 
@@ -71,8 +73,12 @@ fn verify_predicates(
     )
 }
 
-/// The params shared between the bridge and the ASM instance agree.
-fn verify_asm_params(params: &Params, asm: &AsmParams) -> Result<()> {
+/// The bridge params and local fulfillment window are compatible with the ASM instance.
+fn verify_asm_params(
+    params: &Params,
+    min_withdrawal_fulfillment_window: u64,
+    asm: &AsmParams,
+) -> Result<()> {
     let Some(bridge) = asm.bridge_config() else {
         anyhow::bail!(
             "ASM params carry no bridge-v1 subprotocol config; point the bridge at an ASM \
@@ -97,6 +103,13 @@ fn verify_asm_params(params: &Params, asm: &AsmParams) -> Result<()> {
         params.protocol.recovery_delay,
         bridge.recovery_delay,
     )?;
+    if min_withdrawal_fulfillment_window >= u64::from(bridge.assignment_duration) {
+        anyhow::bail!(
+            "min_withdrawal_fulfillment_window: bridge config value \
+             {min_withdrawal_fulfillment_window} must be less than ASM assignment_duration {}",
+            bridge.assignment_duration
+        );
+    }
 
     ensure_eq(
         "genesis_height",
@@ -157,6 +170,8 @@ mod tests {
     const XONLY_KEY_2: &str = "1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4";
     const P2P_KEY_1: &str = "0de7729dcbeb5069136ee4bff1c4f2fd822fe8fbc9b518df434d4f0c6312d8f5";
     const P2P_KEY_2: &str = "255ab0da6d468a22910a7cf54021763417c63c28bbafd4e2359daf103bb61e9d";
+    const MIN_WITHDRAWAL_FULFILLMENT_WINDOW: u64 = 143;
+    const ASSIGNMENT_DURATION: u16 = 144;
 
     fn test_params() -> Params {
         let p2tr = |xonly_hex: &str| {
@@ -214,6 +229,7 @@ mod tests {
         bridge.denomination = params.protocol.deposit_amount.into();
         bridge.operator_fee = params.protocol.operator_fee.into();
         bridge.recovery_delay = params.protocol.recovery_delay;
+        bridge.assignment_duration = ASSIGNMENT_DURATION;
         bridge.operators = params
             .keys
             .covenant
@@ -236,7 +252,31 @@ mod tests {
     #[test]
     fn matching_params_pass() {
         let params = test_params();
-        verify_asm_params(&params, &matching_asm(&params)).expect("matching params must verify");
+        verify_asm_params(
+            &params,
+            MIN_WITHDRAWAL_FULFILLMENT_WINDOW,
+            &matching_asm(&params),
+        )
+        .expect("matching params must verify");
+    }
+
+    #[test]
+    fn withdrawal_fulfillment_window_must_be_less_than_assignment_duration() {
+        let params = test_params();
+        let asm = matching_asm(&params);
+
+        for window in [
+            u64::from(ASSIGNMENT_DURATION),
+            u64::from(ASSIGNMENT_DURATION) + 1,
+        ] {
+            let err = verify_asm_params(&params, window, &asm)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.starts_with("min_withdrawal_fulfillment_window"),
+                "expected withdrawal fulfillment window error, got: {err}"
+            );
+        }
     }
 
     #[test]
@@ -265,7 +305,9 @@ mod tests {
         for (label, mutate) in cases {
             let mut asm = matching_asm(&params);
             mutate(&mut asm);
-            let err = verify_asm_params(&params, &asm).unwrap_err().to_string();
+            let err = verify_asm_params(&params, MIN_WITHDRAWAL_FULFILLMENT_WINDOW, &asm)
+                .unwrap_err()
+                .to_string();
             assert!(
                 err.starts_with(label),
                 "expected `{label}` mismatch, got: {err}"
@@ -280,7 +322,9 @@ mod tests {
         asm.subprotocols
             .retain(|s| !matches!(s, SubprotocolInstance::Bridge(_)));
 
-        let err = verify_asm_params(&params, &asm).unwrap_err().to_string();
+        let err = verify_asm_params(&params, MIN_WITHDRAWAL_FULFILLMENT_WINDOW, &asm)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("no bridge-v1 subprotocol"), "got: {err}");
     }
 }


### PR DESCRIPTION
## Description
As a follow-up to #735, validate that the bridge node's `min_withdrawal_fulfillment_window` is strictly less than the ASM's `assignment_duration` during startup. 

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Related Issues

N/A

🤖 This PR was written primarily by Codex.