### PR TITLE
feat: safe harbour activation groundwork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11834,6 +11834,7 @@ dependencies = [
  "bitcoin-bosd",
  "borsh",
  "musig2",
+ "postcard",
  "proptest",
  "secp256k1 0.29.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11584,6 +11584,7 @@ dependencies = [
  "secp256k1 0.29.1",
  "serde",
  "strata-asm-bridge-types 0.1.0 (git+https://github.com/alpenlabs/asm?rev=93b5ca8c8e73ec9ad46fb448a07b8ba39c3636fb)",
+ "strata-bridge-connectors",
  "strata-bridge-primitives",
  "strata-bridge-sm",
  "strata-bridge-test-utils",

--- a/bin/dev-cli/params.toml
+++ b/bin/dev-cli/params.toml
@@ -31,6 +31,7 @@ magic_bytes = "ALPN"
 deposit_amount = 1_000_000_000
 stake_amount = 100_000_000
 operator_fee = 10_000_000
+sweep_fee_rate = 10
 recovery_delay = 1_008
 contest_timelock = 144
 proof_timelock = 144

--- a/bin/strata-bridge/src/mode/rpc_server/monitoring.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/monitoring.rs
@@ -145,7 +145,9 @@ pub(super) const fn withdrawal_status(deposit_state: &DepositState) -> Option<Rp
         | DepositState::GraphGenerated { .. }
         | DepositState::DepositNoncesCollected { .. }
         | DepositState::DepositPartialsCollected { .. }
-        | DepositState::Deposited { .. } => None,
+        | DepositState::Deposited { .. }
+        | DepositState::SweepNoncesPending { .. }
+        | DepositState::SweepNoncesCollected { .. } => None,
 
         // Withdrawal in progress states
         DepositState::Assigned { .. } => Some(RpcWithdrawalStatus::InProgress),

--- a/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
@@ -32,7 +32,7 @@ use strata_bridge_test_utils::{
     bitcoin::{generate_tx, generate_xonly_pubkey},
     bridge_fixtures::{
         TEST_DEPOSIT_AMOUNT, TEST_MAGIC_BYTES, TEST_OPERATOR_FEE, TEST_POV_IDX,
-        TEST_RECOVERY_DELAY, random_p2tr_desc, test_operator_table,
+        TEST_RECOVERY_DELAY, TEST_SWEEP_FEE_RATE, random_p2tr_desc, test_operator_table,
     },
     musig2::{generate_agg_nonce, generate_partial_signature, generate_pubnonce},
     prelude::generate_txid,
@@ -43,6 +43,7 @@ use strata_bridge_tx_graph::{
     transactions::{
         cooperative_payout::{CooperativePayoutData, CooperativePayoutTx},
         deposit::{DepositData, DepositTx},
+        sweep::{SweepData, SweepTx},
     },
 };
 use strata_predicate::PredicateKey;
@@ -148,6 +149,24 @@ fn test_cooperative_payout_tx() -> CooperativePayoutTx {
     )
 }
 
+fn test_sweep_tx() -> SweepTx {
+    let deposit_connector = NOfNConnector::new(
+        Network::Regtest,
+        generate_xonly_pubkey(),
+        TEST_DEPOSIT_AMOUNT,
+    );
+
+    SweepTx::new(
+        SweepData {
+            deposit_outpoint: OutPoint::new(Txid::all_zeros(), 1),
+        },
+        deposit_connector,
+        random_p2tr_desc(),
+        vec![generate_xonly_pubkey()],
+        TEST_SWEEP_FEE_RATE,
+    )
+}
+
 fn test_sm_config() -> SMConfig {
     SMConfig {
         deposit: Arc::new(DepositSMCfg {
@@ -157,6 +176,7 @@ fn test_sm_config() -> SMConfig {
             operator_fee: TEST_OPERATOR_FEE,
             magic_bytes: TEST_MAGIC_BYTES.into(),
             recovery_delay: TEST_RECOVERY_DELAY,
+            sweep_fee_rate: TEST_SWEEP_FEE_RATE,
         }),
         graph: Arc::new(test_graph_cfg()),
         stake: Arc::new(StakeSMCfg {
@@ -487,7 +507,27 @@ fn bridge_duties_for_deposit_reports_each_deposit_state() {
             },
             no_duties.clone(),
         ),
-        ("Aborted", DepositState::Aborted, no_duties),
+        ("Aborted", DepositState::Aborted, no_duties.clone()),
+        (
+            "SweepNoncesPending",
+            DepositState::SweepNoncesPending {
+                last_block_height: 100,
+                sweep_tx: test_sweep_tx(),
+                sweep_nonces: BTreeMap::new(),
+            },
+            no_duties.clone(),
+        ),
+        (
+            "SweepNoncesCollected",
+            DepositState::SweepNoncesCollected {
+                last_block_height: 100,
+                sweep_tx: test_sweep_tx(),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+            no_duties,
+        ),
     ];
 
     for (state_name, state, expected_duties) in cases {
@@ -719,6 +759,24 @@ fn withdrawal_status_reports_each_deposit_state() {
             },
         ),
         ("Aborted", DepositState::Aborted),
+        (
+            "SweepNoncesPending",
+            DepositState::SweepNoncesPending {
+                last_block_height: 100,
+                sweep_tx: test_sweep_tx(),
+                sweep_nonces: BTreeMap::new(),
+            },
+        ),
+        (
+            "SweepNoncesCollected",
+            DepositState::SweepNoncesCollected {
+                last_block_height: 100,
+                sweep_tx: test_sweep_tx(),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+        ),
     ];
 
     for (state_name, state) in cases {

--- a/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
+++ b/bin/strata-bridge/src/mode/rpc_server/tests/monitoring.rs
@@ -642,6 +642,19 @@ fn reimbursement_operator_uses_terminal_spent_assignee_without_marking_it_pendin
 
     assert_eq!(get_reimbursement_operator(&state), Some(OPERATOR_IDX));
     assert_eq!(get_pending_assigned_operator(&state), None);
+
+    // A deposit swept out of `Assigned` terminates with an assignee but no fulfillment; the
+    // assignee still backs the reimbursement view without being marked pending.
+    let swept_from_assigned = DepositState::Spent {
+        fulfillment_txid: None,
+        assignee: Some(OPERATOR_IDX),
+    };
+
+    assert_eq!(
+        get_reimbursement_operator(&swept_from_assigned),
+        Some(OPERATOR_IDX)
+    );
+    assert_eq!(get_pending_assigned_operator(&swept_from_assigned), None);
 }
 
 #[test]
@@ -756,6 +769,13 @@ fn withdrawal_status_reports_each_deposit_state() {
             DepositState::Spent {
                 fulfillment_txid: None,
                 assignee: None,
+            },
+        ),
+        (
+            "SpentSweptFromAssigned",
+            DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: Some(OPERATOR_IDX),
             },
         ),
         ("Aborted", DepositState::Aborted),

--- a/bin/strata-bridge/src/mode/services/orchestrator.rs
+++ b/bin/strata-bridge/src/mode/services/orchestrator.rs
@@ -251,6 +251,10 @@ pub(in crate::mode) fn build_sm_config(config: &Config, params: &Params) -> SMCo
     let deposit_amount = params.protocol.deposit_amount;
     let operator_fee = params.protocol.operator_fee;
 
+    // Fail fast on a mis-set sweep_fee_rate instead of panicking at sweep time.
+    strata_bridge_tx_graph::fee::sweep_payout_value(params.protocol.sweep_fee_rate, deposit_amount)
+        .expect("sweep_fee_rate must leave a sweep payout above dust");
+
     let deposit_config = DepositSMCfg {
         network,
         cooperative_payout_timeout_blocks: config.cooperative_payout_timeout as u64,
@@ -258,6 +262,7 @@ pub(in crate::mode) fn build_sm_config(config: &Config, params: &Params) -> SMCo
         operator_fee,
         magic_bytes,
         recovery_delay: params.protocol.recovery_delay,
+        sweep_fee_rate: params.protocol.sweep_fee_rate,
     };
 
     let game_graph_params = TxGraphProtocolParams {

--- a/bin/strata-bridge/src/mode/services/startup_checks.rs
+++ b/bin/strata-bridge/src/mode/services/startup_checks.rs
@@ -263,6 +263,7 @@ mod tests {
             nack_timelock = 144
             contested_payout_timelock = 1_008
             unstaking_timelock = 2_016
+            sweep_fee_rate = 10
             "#
         ))
         .expect("valid test params")

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -27,7 +27,7 @@ use strata_bridge_sm::deposit::duties::{DepositDuty, NagDuty};
 use strata_bridge_tx_graph::{
     fee,
     transactions::prelude::{
-        CooperativePayoutTx, WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
+        CooperativePayoutTx, SweepTx, WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
     },
 };
 use tracing::{error, info, warn};
@@ -166,6 +166,57 @@ pub async fn execute_deposit_duty(
                 payout_coop_tx.clone(),
                 ordered_pubkeys,
                 *pov_operator_idx,
+            )
+            .await
+        }
+        DepositDuty::PublishSweepNonce {
+            deposit_idx,
+            deposit_outpoint,
+            ordered_pubkeys,
+            tweak,
+            sweep_sighash,
+        } => {
+            publish_sweep_nonce(
+                &output_handles,
+                *deposit_idx,
+                *deposit_outpoint,
+                ordered_pubkeys,
+                *tweak,
+                *sweep_sighash,
+            )
+            .await
+        }
+        DepositDuty::PublishSweepPartial {
+            deposit_idx,
+            deposit_outpoint,
+            sweep_sighash,
+            agg_nonce,
+            ordered_pubkeys,
+        } => {
+            publish_sweep_partial(
+                &output_handles,
+                *deposit_idx,
+                *deposit_outpoint,
+                *sweep_sighash,
+                agg_nonce.clone(),
+                ordered_pubkeys,
+            )
+            .await
+        }
+        DepositDuty::PublishSweep {
+            deposit_outpoint,
+            agg_nonce,
+            collected_partials,
+            sweep_tx,
+            ordered_pubkeys,
+        } => {
+            publish_sweep(
+                &output_handles,
+                *deposit_outpoint,
+                agg_nonce.clone(),
+                collected_partials.clone(),
+                sweep_tx.clone(),
+                ordered_pubkeys,
             )
             .await
         }
@@ -827,5 +878,152 @@ async fn publish_payout(
     .await?;
 
     info!(%txid, "cooperative payout transaction confirmed");
+    Ok(())
+}
+
+/// Publishes the operator's nonce for the safe-harbour sweep signing session.
+async fn publish_sweep_nonce(
+    output_handles: &OutputHandles,
+    deposit_idx: DepositIdx,
+    deposit_outpoint: OutPoint,
+    ordered_pubkeys: &[XOnlyPublicKey],
+    tweak: TaprootTweak,
+    sweep_sighash: Message,
+) -> Result<(), ExecutorError> {
+    info!(%deposit_outpoint, "generating sweep nonce");
+
+    // Create Musig2Params for key-path spend (n-of-n)
+    let params = Musig2Params {
+        ordered_pubkeys: ordered_pubkeys.to_vec(),
+        tweak,
+        sighash: *sweep_sighash.as_ref(),
+    };
+
+    // Generate nonce via secret service
+    let nonce: PubNonce = output_handles
+        .s2_client
+        .musig2_signer()
+        .get_pub_nonce(params)
+        .await?
+        .map_err(|_| ExecutorError::OurPubKeyNotInParams)?;
+
+    info!(%deposit_outpoint, %deposit_idx, "publishing sweep nonce");
+
+    // Broadcast via MessageHandler
+    output_handles
+        .msg_handler
+        .write()
+        .await
+        .send_sweep_nonce(deposit_idx, nonce, None)
+        .await;
+
+    info!(%deposit_outpoint, %deposit_idx, "published sweep nonce");
+    Ok(())
+}
+
+/// Publishes the operator's partial signature for the safe-harbour sweep signing session.
+///
+/// Unlike the cooperative payout, every operator executes this duty: the sweep round is
+/// symmetric, so no partial is withheld.
+async fn publish_sweep_partial(
+    output_handles: &OutputHandles,
+    deposit_idx: DepositIdx,
+    deposit_outpoint: OutPoint,
+    sweep_sighash: Message,
+    sweep_agg_nonce: AggNonce,
+    ordered_pubkeys: &[XOnlyPublicKey],
+) -> Result<(), ExecutorError> {
+    info!(%deposit_outpoint, "generating sweep partial");
+
+    // Create Musig2Params for key-path spend (n-of-n)
+    // Same params as nonce generation for deterministic nonce recovery
+    let params = Musig2Params {
+        ordered_pubkeys: ordered_pubkeys.to_vec(),
+        tweak: TaprootTweak::Key { tweak: None },
+        sighash: *sweep_sighash.as_ref(),
+    };
+
+    // Generate partial signature via secret service
+    let partial_sig: PartialSignature = output_handles
+        .s2_client
+        .musig2_signer()
+        .get_our_partial_sig(params, sweep_agg_nonce)
+        .await?
+        .map_err(|e| match e.to_enum() {
+            terrors::E2::A(_) => ExecutorError::OurPubKeyNotInParams,
+            terrors::E2::B(_) => ExecutorError::SelfVerifyFailed,
+        })?;
+
+    info!(%deposit_outpoint, %deposit_idx, "publishing sweep partial");
+
+    // Broadcast via MessageHandler
+    output_handles
+        .msg_handler
+        .write()
+        .await
+        .send_sweep_partial(deposit_idx, partial_sig, None)
+        .await;
+
+    info!(%deposit_outpoint, %deposit_idx, "published sweep partial");
+    Ok(())
+}
+
+/// Finalizes and broadcasts the safe-harbour sweep transaction to the Bitcoin network.
+///
+/// Every operator executes this duty with the full set of gossiped partials, so no further
+/// signing is needed: each operator aggregates and broadcasts the identical deterministic
+/// transaction, and duplicates are rejected as already-known by the network.
+async fn publish_sweep(
+    output_handles: &OutputHandles,
+    deposit_outpoint: OutPoint,
+    sweep_agg_nonce: AggNonce,
+    collected_partials: BTreeMap<OperatorIdx, PartialSignature>,
+    sweep_tx: Box<SweepTx>,
+    ordered_pubkeys: &[XOnlyPublicKey],
+) -> Result<(), ExecutorError> {
+    let txid = (*sweep_tx).as_ref().compute_txid();
+    info!(%deposit_outpoint, %txid, "signing sweep");
+
+    // Derive the sighash from the sweep transaction
+    let sweep_sighash = sweep_tx
+        .signing_info()
+        .first()
+        .expect("sweep transaction must have signing info")
+        .sighash;
+
+    // Extract partials in operator index order for deterministic aggregation
+    let ordered_partials: Vec<PartialSignature> = collected_partials.into_values().collect();
+
+    // Create key aggregation context with taproot tweak
+    let btc_keys: Vec<PublicKey> = ordered_pubkeys
+        .iter()
+        .map(|xonly| xonly.public_key(bitcoin::secp256k1::Parity::Even))
+        .collect();
+    let key_agg_ctx = create_agg_ctx(btc_keys, &TaprootTweak::Key { tweak: None })
+        .map_err(|e| ExecutorError::SignatureAggregationFailed(format!("key agg failed: {e}")))?;
+
+    // Aggregate all partial signatures into final Schnorr signature
+    let agg_signature: schnorr::Signature = aggregate_partial_signatures(
+        &key_agg_ctx,
+        &sweep_agg_nonce,
+        ordered_partials,
+        sweep_sighash.as_ref(),
+    )
+    .map_err(|e| ExecutorError::SignatureAggregationFailed(format!("{e}")))?;
+
+    // Finalize the transaction using SweepTx.finalize()
+    let finalized_tx = (*sweep_tx).finalize(agg_signature);
+
+    info!(%txid, "broadcasting sweep transaction");
+
+    publish_signed_transaction(
+        &output_handles.tx_driver,
+        &finalized_tx,
+        "sweep",
+        TxStatus::is_buried,
+    )
+    .await?;
+
+    info!(%txid, "sweep transaction confirmed");
     Ok(())
 }

--- a/crates/bridge-exec/src/deposit.rs
+++ b/crates/bridge-exec/src/deposit.rs
@@ -278,6 +278,34 @@ pub async fn execute_deposit_duty(
                         },
                     },
                 ),
+                NagDuty::NagSweepNonce {
+                    deposit_idx,
+                    operator_idx,
+                    operator_pubkey,
+                } => (
+                    *deposit_idx,
+                    *operator_idx,
+                    NagRequest {
+                        recipient: operator_pubkey.clone(),
+                        payload: NagRequestPayload::SweepNonce {
+                            deposit_idx: *deposit_idx,
+                        },
+                    },
+                ),
+                NagDuty::NagSweepPartial {
+                    deposit_idx,
+                    operator_idx,
+                    operator_pubkey,
+                } => (
+                    *deposit_idx,
+                    *operator_idx,
+                    NagRequest {
+                        recipient: operator_pubkey.clone(),
+                        payload: NagRequestPayload::SweepPartial {
+                            deposit_idx: *deposit_idx,
+                        },
+                    },
+                ),
             };
 
             info!(%deposit_idx, %operator_idx, payload = ?nag_request.payload, "nagging peer for missing data");

--- a/crates/bridge-sm/Cargo.toml
+++ b/crates/bridge-sm/Cargo.toml
@@ -33,5 +33,6 @@ zkaleido.workspace = true
 strata-bridge-test-utils.workspace = true
 
 musig2.workspace = true
+postcard.workspace = true
 proptest.workspace = true
 secp256k1.workspace = true

--- a/crates/bridge-sm/src/deposit/config.rs
+++ b/crates/bridge-sm/src/deposit/config.rs
@@ -1,6 +1,6 @@
 //! Configuration shared across all deposit state machines.
 
-use bitcoin::{Amount, Network};
+use bitcoin::{Amount, FeeRate, Network};
 use strata_l1_txfmt::MagicBytes;
 
 /// Bridge-wide configuration shared across all deposit state machines.
@@ -23,6 +23,8 @@ pub struct DepositSMCfg {
     pub magic_bytes: MagicBytes,
     /// The number of blocks after which the user can take back their deposit request.
     pub recovery_delay: u16,
+    /// The fee rate that the safe-harbour sweep transaction pays.
+    pub sweep_fee_rate: FeeRate,
 }
 
 impl DepositSMCfg {
@@ -49,5 +51,10 @@ impl DepositSMCfg {
     /// Returns the magic bytes used in the OP_RETURN of relevant transactions.
     pub const fn magic_bytes(&self) -> MagicBytes {
         self.magic_bytes
+    }
+
+    /// Returns the fee rate that the safe-harbour sweep transaction pays.
+    pub const fn sweep_fee_rate(&self) -> FeeRate {
+        self.sweep_fee_rate
     }
 }

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -11,7 +11,7 @@ use strata_bridge_primitives::{
     scripts::taproot::TaprootTweak,
     types::{BitcoinBlockHeight, DepositIdx, OperatorIdx, P2POperatorPubKey},
 };
-use strata_bridge_tx_graph::transactions::prelude::CooperativePayoutTx;
+use strata_bridge_tx_graph::transactions::prelude::{CooperativePayoutTx, SweepTx};
 
 /// The nag duties that can be emitted to remind operators of missing data.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -199,6 +199,51 @@ pub enum DepositDuty {
         /// The index of the point-of-view operator (the assignee).
         pov_operator_idx: OperatorIdx,
     },
+    /// Publish the nonce for sweeping the deposit UTXO to the safe-harbour descriptor.
+    PublishSweepNonce {
+        /// The index of the deposit.
+        deposit_idx: DepositIdx,
+        /// Outpoint referencing the deposit UTXO.
+        deposit_outpoint: OutPoint,
+        /// Ordered public keys of all operators for MuSig2 signing.
+        ordered_pubkeys: Vec<XOnlyPublicKey>,
+        /// The taproot tweak for the deposit output.
+        tweak: TaprootTweak,
+        /// Sighash for the sweep input. Used to bind the MuSig2 nonce to the message.
+        sweep_sighash: Message,
+    },
+    /// Publish the partial signature for the sweep transaction.
+    ///
+    /// Unlike the cooperative payout, *every* operator publishes its sweep partial: there is
+    /// no assignee to protect from a payout-hostage attack.
+    PublishSweepPartial {
+        /// The index of the deposit.
+        deposit_idx: DepositIdx,
+        /// Outpoint referencing the deposit UTXO.
+        deposit_outpoint: OutPoint,
+        /// Sighash to be signed for the sweep transaction.
+        sweep_sighash: Message,
+        /// Aggregated nonce for the sweep transaction signing.
+        agg_nonce: AggNonce,
+        /// Ordered public keys of all operators for MuSig2 signing.
+        ordered_pubkeys: Vec<XOnlyPublicKey>,
+    },
+    /// Finalize and broadcast the sweep transaction to the Bitcoin network.
+    ///
+    /// Every operator receives this duty: all partials are collected via gossip, so each
+    /// operator aggregates and broadcasts the identical deterministic transaction.
+    PublishSweep {
+        /// Outpoint referencing the deposit UTXO.
+        deposit_outpoint: OutPoint,
+        /// Aggregated nonce for signature aggregation.
+        agg_nonce: AggNonce,
+        /// Partial signatures collected from all operators.
+        collected_partials: BTreeMap<OperatorIdx, PartialSignature>,
+        /// The sweep transaction for finalization.
+        sweep_tx: Box<SweepTx>,
+        /// Ordered public keys of all operators for MuSig2 signing.
+        ordered_pubkeys: Vec<XOnlyPublicKey>,
+    },
     /// Nag other operators for missing information.
     Nag {
         /// The specific nag duty to perform.
@@ -235,6 +280,9 @@ impl std::fmt::Display for DepositDuty {
             DepositDuty::PublishPayoutNonce { .. } => "PublishPayoutNonce".to_string(),
             DepositDuty::PublishPayoutPartial { .. } => "PublishPayoutPartial".to_string(),
             DepositDuty::PublishPayout { .. } => "PublishPayout".to_string(),
+            DepositDuty::PublishSweepNonce { .. } => "PublishSweepNonce".to_string(),
+            DepositDuty::PublishSweepPartial { .. } => "PublishSweepPartial".to_string(),
+            DepositDuty::PublishSweep { .. } => "PublishSweep".to_string(),
             DepositDuty::Nag { duty } => format!("Nag({})", duty),
         };
         write!(f, "{}", display_str)

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -52,6 +52,24 @@ pub enum NagDuty {
         /// The P2P public key of the operator to nag.
         operator_pubkey: P2POperatorPubKey,
     },
+    /// Nag an operator for their missing sweep nonce.
+    NagSweepNonce {
+        /// The index of the deposit.
+        deposit_idx: DepositIdx,
+        /// The index of the operator to nag.
+        operator_idx: OperatorIdx,
+        /// The P2P public key of the operator to nag.
+        operator_pubkey: P2POperatorPubKey,
+    },
+    /// Nag an operator for their missing sweep partial signature.
+    NagSweepPartial {
+        /// The index of the deposit.
+        deposit_idx: DepositIdx,
+        /// The index of the operator to nag.
+        operator_idx: OperatorIdx,
+        /// The P2P public key of the operator to nag.
+        operator_pubkey: P2POperatorPubKey,
+    },
 }
 
 impl std::fmt::Display for NagDuty {
@@ -91,6 +109,24 @@ impl std::fmt::Display for NagDuty {
             } => write!(
                 f,
                 "NagPayoutPartial (deposit_idx: {}, operator_idx: {})",
+                deposit_idx, operator_idx
+            ),
+            NagDuty::NagSweepNonce {
+                deposit_idx,
+                operator_idx,
+                ..
+            } => write!(
+                f,
+                "NagSweepNonce (deposit_idx: {}, operator_idx: {})",
+                deposit_idx, operator_idx
+            ),
+            NagDuty::NagSweepPartial {
+                deposit_idx,
+                operator_idx,
+                ..
+            } => write!(
+                f,
+                "NagSweepPartial (deposit_idx: {}, operator_idx: {})",
                 deposit_idx, operator_idx
             ),
         }

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -72,6 +72,21 @@ pub enum NagDuty {
     },
 }
 
+impl NagDuty {
+    /// Whether this nag solicits progress on the cooperative payout signing session.
+    ///
+    /// See [`DepositDuty::is_withdrawal_path`].
+    pub const fn is_withdrawal_path(&self) -> bool {
+        match self {
+            NagDuty::NagPayoutNonce { .. } | NagDuty::NagPayoutPartial { .. } => true,
+            NagDuty::NagDepositNonce { .. }
+            | NagDuty::NagDepositPartial { .. }
+            | NagDuty::NagSweepNonce { .. }
+            | NagDuty::NagSweepPartial { .. } => false,
+        }
+    }
+}
+
 impl std::fmt::Display for NagDuty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -285,6 +300,31 @@ pub enum DepositDuty {
         /// The specific nag duty to perform.
         duty: NagDuty,
     },
+}
+
+impl DepositDuty {
+    /// Whether this duty fronts a user or advances the cooperative payout towards spending the
+    /// deposit UTXO.
+    ///
+    /// Under safe harbour these duties are suppressed at dispatch so no withdrawal advances
+    /// while deposits are being swept. Everything else — deposit setup (in-flight deposits must
+    /// finish before they can be swept) and the sweep duties themselves — is never suppressed.
+    pub const fn is_withdrawal_path(&self) -> bool {
+        match self {
+            DepositDuty::FulfillWithdrawalRequest { .. }
+            | DepositDuty::RequestPayoutNonces { .. }
+            | DepositDuty::PublishPayoutNonce { .. }
+            | DepositDuty::PublishPayoutPartial { .. }
+            | DepositDuty::PublishPayout { .. } => true,
+            DepositDuty::Nag { duty } => duty.is_withdrawal_path(),
+            DepositDuty::PublishDepositNonce { .. }
+            | DepositDuty::PublishDepositPartial { .. }
+            | DepositDuty::PublishDeposit { .. }
+            | DepositDuty::PublishSweepNonce { .. }
+            | DepositDuty::PublishSweepPartial { .. }
+            | DepositDuty::PublishSweep { .. } => false,
+        }
+    }
 }
 
 impl std::fmt::Display for DepositDuty {

--- a/crates/bridge-sm/src/deposit/duties.rs
+++ b/crates/bridge-sm/src/deposit/duties.rs
@@ -73,10 +73,11 @@ pub enum NagDuty {
 }
 
 impl NagDuty {
-    /// Whether this nag solicits progress on the cooperative payout signing session.
+    /// Whether to suppress this nag at dispatch while the safe harbour is active: true for the
+    /// nags soliciting progress on the cooperative payout signing session.
     ///
-    /// See [`DepositDuty::is_withdrawal_path`].
-    pub const fn is_withdrawal_path(&self) -> bool {
+    /// See [`DepositDuty::should_suppress_under_safe_harbour`].
+    pub const fn should_suppress_under_safe_harbour(&self) -> bool {
         match self {
             NagDuty::NagPayoutNonce { .. } | NagDuty::NagPayoutPartial { .. } => true,
             NagDuty::NagDepositNonce { .. }
@@ -303,20 +304,20 @@ pub enum DepositDuty {
 }
 
 impl DepositDuty {
-    /// Whether this duty fronts a user or advances the cooperative payout towards spending the
-    /// deposit UTXO.
+    /// Whether to suppress this duty at dispatch while the safe harbour is active: true for the
+    /// duties that front a user or advance the cooperative payout towards spending the deposit
+    /// UTXO, so no withdrawal advances while deposits are being swept.
     ///
-    /// Under safe harbour these duties are suppressed at dispatch so no withdrawal advances
-    /// while deposits are being swept. Everything else — deposit setup (in-flight deposits must
-    /// finish before they can be swept) and the sweep duties themselves — is never suppressed.
-    pub const fn is_withdrawal_path(&self) -> bool {
+    /// Everything else — deposit setup (in-flight deposits must finish before they can be swept)
+    /// and the sweep duties themselves — is never suppressed.
+    pub const fn should_suppress_under_safe_harbour(&self) -> bool {
         match self {
             DepositDuty::FulfillWithdrawalRequest { .. }
             | DepositDuty::RequestPayoutNonces { .. }
             | DepositDuty::PublishPayoutNonce { .. }
             | DepositDuty::PublishPayoutPartial { .. }
             | DepositDuty::PublishPayout { .. } => true,
-            DepositDuty::Nag { duty } => duty.is_withdrawal_path(),
+            DepositDuty::Nag { duty } => duty.should_suppress_under_safe_harbour(),
             DepositDuty::PublishDepositNonce { .. }
             | DepositDuty::PublishDepositPartial { .. }
             | DepositDuty::PublishDeposit { .. }

--- a/crates/bridge-sm/src/deposit/events.rs
+++ b/crates/bridge-sm/src/deposit/events.rs
@@ -103,6 +103,33 @@ pub struct PayoutConfirmedEvent {
     pub tx: Transaction,
 }
 
+/// Event requesting that this deposit be swept to the frozen safe-harbour descriptor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweepRequestedEvent {
+    /// The frozen safe-harbour descriptor that the sweep pays out to.
+    pub safe_harbour_desc: Descriptor,
+}
+
+/// Event notifying that a pubnonce from some operator for the sweep transaction has been
+/// received.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweepNonceReceivedEvent {
+    /// The pubnonce for the sweep transaction that was received.
+    pub sweep_nonce: PubNonce,
+    /// The operator who sent the pubnonce.
+    pub operator_idx: OperatorIdx,
+}
+
+/// Event notifying that a partial signature from some operator for the sweep transaction has
+/// been received.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SweepPartialReceivedEvent {
+    /// The partial signature for the sweep transaction that was received.
+    pub partial_signature: PartialSignature,
+    /// The operator who sent the partial signature.
+    pub operator_idx: OperatorIdx,
+}
+
 /// Event signalling that a new block has been observed on chain.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewBlockEvent {
@@ -157,6 +184,14 @@ pub enum DepositEvent {
     PayoutPartialReceived(PayoutPartialReceivedEvent),
     /// This event notifies that a payout has been confirmed.
     PayoutConfirmed(PayoutConfirmedEvent),
+    /// This event requests that this deposit be swept to the frozen safe-harbour descriptor.
+    SweepRequested(SweepRequestedEvent),
+    /// This event notifies that a pubnonce from some operator for the sweep transaction has been
+    /// received.
+    SweepNonceReceived(SweepNonceReceivedEvent),
+    /// This event notifies that a partial signature from some operator for the sweep transaction
+    /// has been received.
+    SweepPartialReceived(SweepPartialReceivedEvent),
     /// Event signalling that a new block has been observed on chain.
     ///
     /// This is required to deal with timelocks in various states and to track the last observed
@@ -184,6 +219,9 @@ impl std::fmt::Display for DepositEvent {
             DepositEvent::PayoutNonceReceived(event) => write!(f, "{}", event),
             DepositEvent::PayoutPartialReceived(event) => write!(f, "{}", event),
             DepositEvent::PayoutConfirmed(event) => write!(f, "{}", event),
+            DepositEvent::SweepRequested(event) => write!(f, "{}", event),
+            DepositEvent::SweepNonceReceived(event) => write!(f, "{}", event),
+            DepositEvent::SweepPartialReceived(event) => write!(f, "{}", event),
             DepositEvent::NewBlock(event) => write!(f, "{}", event),
             DepositEvent::RetryTick(event) => write!(f, "{}", event),
             DepositEvent::NagTick(event) => write!(f, "{}", event),
@@ -256,6 +294,32 @@ impl std::fmt::Display for PayoutConfirmedEvent {
     }
 }
 
+impl std::fmt::Display for SweepRequestedEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SweepRequested")
+    }
+}
+
+impl std::fmt::Display for SweepNonceReceivedEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SweepNonceReceived from operator_idx: {}",
+            self.operator_idx
+        )
+    }
+}
+
+impl std::fmt::Display for SweepPartialReceivedEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SweepPartialReceived from operator_idx: {}",
+            self.operator_idx
+        )
+    }
+}
+
 impl std::fmt::Display for NewBlockEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "NewBlock at height {}", self.block_height)
@@ -310,6 +374,9 @@ impl_into_deposit_event!(PayoutDescriptorReceivedEvent, PayoutDescriptorReceived
 impl_into_deposit_event!(PayoutNonceReceivedEvent, PayoutNonceReceived);
 impl_into_deposit_event!(PayoutPartialReceivedEvent, PayoutPartialReceived);
 impl_into_deposit_event!(PayoutConfirmedEvent, PayoutConfirmed);
+impl_into_deposit_event!(SweepRequestedEvent, SweepRequested);
+impl_into_deposit_event!(SweepNonceReceivedEvent, SweepNonceReceived);
+impl_into_deposit_event!(SweepPartialReceivedEvent, SweepPartialReceived);
 impl_into_deposit_event!(NewBlockEvent, NewBlock);
 impl_into_deposit_event!(RetryTickEvent, RetryTick);
 impl_into_deposit_event!(NagTickEvent, NagTick);

--- a/crates/bridge-sm/src/deposit/handlers/nag.rs
+++ b/crates/bridge-sm/src/deposit/handlers/nag.rs
@@ -112,6 +112,47 @@ impl DepositSM {
                     })
                     .collect()
             }
+            DepositState::SweepNoncesPending { sweep_nonces, .. } => {
+                let expected_ids = &all_operator_ids;
+                let present_ids: BTreeSet<_> = sweep_nonces.keys().copied().collect();
+                expected_ids
+                    .difference(&present_ids)
+                    .map(|&operator_idx| {
+                        let operator_pubkey = operator_table
+                            .idx_to_p2p_key(&operator_idx)
+                            .expect("operator idx from table must exist")
+                            .clone();
+                        DepositDuty::Nag {
+                            duty: NagDuty::NagSweepNonce {
+                                deposit_idx,
+                                operator_idx,
+                                operator_pubkey,
+                            },
+                        }
+                    })
+                    .collect()
+            }
+            // The sweep round is symmetric: every operator's partial is expected.
+            DepositState::SweepNoncesCollected { sweep_partials, .. } => {
+                let expected_ids = &all_operator_ids;
+                let present_ids: BTreeSet<_> = sweep_partials.keys().copied().collect();
+                expected_ids
+                    .difference(&present_ids)
+                    .map(|&operator_idx| {
+                        let operator_pubkey = operator_table
+                            .idx_to_p2p_key(&operator_idx)
+                            .expect("operator idx from table must exist")
+                            .clone();
+                        DepositDuty::Nag {
+                            duty: NagDuty::NagSweepPartial {
+                                deposit_idx,
+                                operator_idx,
+                                operator_pubkey,
+                            },
+                        }
+                    })
+                    .collect()
+            }
             _ => Vec::new(),
         };
 
@@ -127,6 +168,8 @@ impl DepositSM {
             NagRequestPayload::DepositPartial { .. } => self.process_deposit_partial_nag(&event),
             NagRequestPayload::PayoutNonce { .. } => self.process_payout_nonce_nag(&event),
             NagRequestPayload::PayoutPartial { .. } => self.process_payout_partial_nag(&event),
+            NagRequestPayload::SweepNonce { .. } => self.process_sweep_nonce_nag(&event),
+            NagRequestPayload::SweepPartial { .. } => self.process_sweep_partial_nag(&event),
             NagRequestPayload::GraphData { .. }
             | NagRequestPayload::GraphNonces { .. }
             | NagRequestPayload::GraphPartials { .. } => {
@@ -343,6 +386,87 @@ impl DepositSM {
                 Err(self.reject_nag(
                     event,
                     "Inapplicable PayoutPartial nag; expected state(s): PayoutNoncesCollected with POV != assignee",
+                ))
+            }
+        }
+    }
+
+    fn process_sweep_nonce_nag(&self, event: &NagReceivedEvent) -> DSMResult<Vec<DepositDuty>> {
+        let deposit_idx = self.context().deposit_idx();
+        match self.state() {
+            DepositState::SweepNoncesPending { sweep_tx, .. }
+            | DepositState::SweepNoncesCollected { sweep_tx, .. } => {
+                let sweep_sighash = sweep_tx
+                    .signing_info()
+                    .first()
+                    .expect("sweep transaction must have signing info")
+                    .sighash;
+                let ordered_pubkeys = self
+                    .context()
+                    .operator_table()
+                    .btc_keys()
+                    .into_iter()
+                    .map(|pk| pk.x_only_public_key().0)
+                    .collect();
+                Ok(vec![DepositDuty::PublishSweepNonce {
+                    deposit_idx,
+                    deposit_outpoint: self.context().deposit_outpoint(),
+                    ordered_pubkeys,
+                    // NOfNConnector uses key-path spend with no script tree
+                    tweak: TaprootTweak::Key { tweak: None },
+                    sweep_sighash,
+                }])
+            }
+            _ => {
+                tracing::debug!(
+                    "Rejecting inapplicable nag SweepNonce in state {}",
+                    self.state()
+                );
+                Err(self.reject_nag(
+                    event,
+                    "Inapplicable SweepNonce nag; expected state(s): SweepNoncesPending | SweepNoncesCollected",
+                ))
+            }
+        }
+    }
+
+    fn process_sweep_partial_nag(&self, event: &NagReceivedEvent) -> DSMResult<Vec<DepositDuty>> {
+        let deposit_idx = self.context().deposit_idx();
+        match self.state() {
+            // The sweep round is symmetric: every operator (re-)publishes its partial.
+            DepositState::SweepNoncesCollected {
+                sweep_tx,
+                sweep_agg_nonce,
+                ..
+            } => {
+                let sweep_sighash = sweep_tx
+                    .signing_info()
+                    .first()
+                    .expect("sweep transaction must have signing info")
+                    .sighash;
+                let ordered_pubkeys = self
+                    .context()
+                    .operator_table()
+                    .btc_keys()
+                    .into_iter()
+                    .map(|pk| pk.x_only_public_key().0)
+                    .collect();
+                Ok(vec![DepositDuty::PublishSweepPartial {
+                    deposit_idx,
+                    deposit_outpoint: self.context().deposit_outpoint(),
+                    sweep_sighash,
+                    agg_nonce: sweep_agg_nonce.clone(),
+                    ordered_pubkeys,
+                }])
+            }
+            _ => {
+                tracing::debug!(
+                    "Rejecting inapplicable nag SweepPartial in state {}",
+                    self.state()
+                );
+                Err(self.reject_nag(
+                    event,
+                    "Inapplicable SweepPartial nag; expected state(s): SweepNoncesCollected",
                 ))
             }
         }

--- a/crates/bridge-sm/src/deposit/handlers/retry.rs
+++ b/crates/bridge-sm/src/deposit/handlers/retry.rs
@@ -88,6 +88,30 @@ impl DepositSM {
                     pov_operator_idx: self.context().operator_table().pov_idx(),
                 }]
             }
+            // Re-broadcast the sweep until the spend is observed on chain. Every operator
+            // retries: the transaction is deterministic, so duplicates are harmless.
+            DepositState::SweepNoncesCollected {
+                sweep_tx,
+                sweep_agg_nonce,
+                sweep_partials,
+                ..
+            } if operator_table_cardinality == sweep_partials.len() => {
+                let ordered_pubkeys = self
+                    .context()
+                    .operator_table()
+                    .btc_keys()
+                    .into_iter()
+                    .map(|pk| pk.x_only_public_key().0)
+                    .collect();
+
+                vec![DepositDuty::PublishSweep {
+                    deposit_outpoint: self.context().deposit_outpoint(),
+                    agg_nonce: sweep_agg_nonce.clone(),
+                    collected_partials: sweep_partials.clone(),
+                    sweep_tx: Box::new(sweep_tx.clone()),
+                    ordered_pubkeys,
+                }]
+            }
             _ => Vec::new(),
         };
 

--- a/crates/bridge-sm/src/deposit/machine.rs
+++ b/crates/bridge-sm/src/deposit/machine.rs
@@ -85,6 +85,19 @@ impl StateMachine for DepositSM {
             DepositEvent::PayoutConfirmed(payout_confirmed) => {
                 self.process_payout_confirmed(&payout_confirmed)
             }
+            DepositEvent::SweepRequested(sweep_request) => {
+                self.process_sweep_request(cfg, sweep_request)
+            }
+            DepositEvent::SweepNonceReceived(sweep_nonce) => {
+                let event = DepositEvent::SweepNonceReceived(sweep_nonce.clone());
+                self.process_sweep_nonce_received(sweep_nonce)
+                    .map_err(|err| soften_peer_event_error(event, err))
+            }
+            DepositEvent::SweepPartialReceived(sweep_partial) => {
+                let event = DepositEvent::SweepPartialReceived(sweep_partial.clone());
+                self.process_sweep_partial_received(sweep_partial)
+                    .map_err(|err| soften_peer_event_error(event, err))
+            }
             DepositEvent::NewBlock(new_block) => self.process_new_block(new_block),
             DepositEvent::RetryTick(_) => self.process_retry_tick(cfg),
             DepositEvent::NagTick(_) => self.process_nag_tick(cfg),

--- a/crates/bridge-sm/src/deposit/state.rs
+++ b/crates/bridge-sm/src/deposit/state.rs
@@ -11,7 +11,10 @@ use bitcoin_bosd::Descriptor;
 use musig2::{AggNonce, PartialSignature, PubNonce};
 use serde::{Deserialize, Serialize};
 use strata_bridge_primitives::types::{BitcoinBlockHeight, OperatorIdx};
-use strata_bridge_tx_graph::transactions::{deposit::DepositTx, prelude::CooperativePayoutTx};
+use strata_bridge_tx_graph::transactions::{
+    deposit::DepositTx,
+    prelude::{CooperativePayoutTx, SweepTx},
+};
 
 /// The state of a Deposit.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -172,6 +175,30 @@ pub enum DepositState {
         /// The height of the latest block that this state machine is aware of.
         last_block_height: u64,
     },
+    /// This state represents the phase where the safe-harbour sweep has been initiated and the
+    /// sweep pubnonces are being collected.
+    SweepNoncesPending {
+        /// The last block height observed by this state machine.
+        last_block_height: BitcoinBlockHeight,
+        /// The sweep transaction paying the frozen safe-harbour descriptor.
+        sweep_tx: SweepTx,
+        /// The pubnonces, indexed by operator, required to sign the sweep transaction.
+        sweep_nonces: BTreeMap<OperatorIdx, PubNonce>,
+    },
+    /// This state indicates that all pubnonces required for the sweep have been collected and
+    /// partial signatures are being collected from *every* operator.
+    SweepNoncesCollected {
+        /// The last block height observed by this state machine.
+        last_block_height: BitcoinBlockHeight,
+        /// The sweep transaction paying the frozen safe-harbour descriptor.
+        sweep_tx: SweepTx,
+        /// The aggregated nonce for signing the sweep transaction.
+        sweep_agg_nonce: AggNonce,
+        /// The pubnonces, indexed by operator, required to sign the sweep transaction.
+        sweep_nonces: BTreeMap<OperatorIdx, PubNonce>,
+        /// The partial signatures, indexed by operator, for signing the sweep transaction.
+        sweep_partials: BTreeMap<OperatorIdx, PartialSignature>,
+    },
     /// This represents the terminal state where the deposit has been spent.
     Spent {
         /// The txid of the fulfillment transaction, if known.
@@ -199,6 +226,8 @@ impl Display for DepositState {
             DepositState::PayoutDescriptorReceived { .. } => "PayoutDescriptorReceived".to_string(),
             DepositState::PayoutNoncesCollected { .. } => "PayoutNoncesCollected".to_string(),
             DepositState::CooperativePathFailed { .. } => "CooperativePathFailed".to_string(),
+            DepositState::SweepNoncesPending { .. } => "SweepNoncesPending".to_string(),
+            DepositState::SweepNoncesCollected { .. } => "SweepNoncesCollected".to_string(),
             DepositState::Spent { .. } => "Spent".to_string(),
             DepositState::Aborted => "Aborted".to_string(),
         };
@@ -261,11 +290,35 @@ impl DepositState {
             | DepositState::CooperativePathFailed {
                 last_block_height: block_height,
                 ..
+            }
+            | DepositState::SweepNoncesPending {
+                last_block_height: block_height,
+                ..
+            }
+            | DepositState::SweepNoncesCollected {
+                last_block_height: block_height,
+                ..
             } => Some(block_height),
             DepositState::Spent { .. } | DepositState::Aborted => {
                 // Terminal states do not track block height
                 None
             }
         }
+    }
+
+    /// Whether the deposit outpoint is confirmed on chain and still unspent from this state
+    /// machine's perspective, i.e. the states in which a transaction spending it may be observed.
+    ///
+    /// NOTE: `Assigned`, `Fulfilled` and `PayoutDescriptorReceived` also hold a live deposit
+    /// UTXO but are excluded until the sweep of assigned deposits is implemented.
+    pub const fn has_live_deposit_utxo(&self) -> bool {
+        matches!(
+            self,
+            DepositState::Deposited { .. }
+                | DepositState::PayoutNoncesCollected { .. }
+                | DepositState::CooperativePathFailed { .. }
+                | DepositState::SweepNoncesPending { .. }
+                | DepositState::SweepNoncesCollected { .. }
+        )
     }
 }

--- a/crates/bridge-sm/src/deposit/state.rs
+++ b/crates/bridge-sm/src/deposit/state.rs
@@ -309,12 +309,15 @@ impl DepositState {
     /// Whether the deposit outpoint is confirmed on chain and still unspent from this state
     /// machine's perspective, i.e. the states in which a transaction spending it may be observed.
     ///
-    /// NOTE: `Assigned`, `Fulfilled` and `PayoutDescriptorReceived` also hold a live deposit
-    /// UTXO but are excluded until the sweep of assigned deposits is implemented.
+    /// Withdrawal progress never touches the deposit outpoint (the assignee fronts the user from
+    /// its own wallet), so every post-`Deposited` non-terminal state holds a live deposit UTXO.
     pub const fn has_live_deposit_utxo(&self) -> bool {
         matches!(
             self,
             DepositState::Deposited { .. }
+                | DepositState::Assigned { .. }
+                | DepositState::Fulfilled { .. }
+                | DepositState::PayoutDescriptorReceived { .. }
                 | DepositState::PayoutNoncesCollected { .. }
                 | DepositState::CooperativePathFailed { .. }
                 | DepositState::SweepNoncesPending { .. }

--- a/crates/bridge-sm/src/deposit/state.rs
+++ b/crates/bridge-sm/src/deposit/state.rs
@@ -17,6 +17,8 @@ use strata_bridge_tx_graph::transactions::{
 };
 
 /// The state of a Deposit.
+///
+/// Postcard encodes variants by declaration index: append new ones, never reorder.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DepositState {
     /// This state represents the initial phase after deposit request confirmation.
@@ -175,6 +177,18 @@ pub enum DepositState {
         /// The height of the latest block that this state machine is aware of.
         last_block_height: u64,
     },
+    /// This represents the terminal state where the deposit has been spent.
+    Spent {
+        /// The txid of the fulfillment transaction, if known.
+        // NOTE: (@Rajil1213) this field is required purely for monitoring/introspection purposes.
+        fulfillment_txid: Option<Txid>,
+
+        /// The operator assigned to fulfill the withdrawal, if known.
+        // NOTE: (@Rajil1213) this field is required purely for monitoring/introspection purposes.
+        assignee: Option<OperatorIdx>,
+    },
+    /// This represents the terminal state where the deposit request has been spent elsewhere.
+    Aborted,
     /// This state represents the phase where the safe-harbour sweep has been initiated and the
     /// sweep pubnonces are being collected.
     SweepNoncesPending {
@@ -199,18 +213,6 @@ pub enum DepositState {
         /// The partial signatures, indexed by operator, for signing the sweep transaction.
         sweep_partials: BTreeMap<OperatorIdx, PartialSignature>,
     },
-    /// This represents the terminal state where the deposit has been spent.
-    Spent {
-        /// The txid of the fulfillment transaction, if known.
-        // NOTE: (@Rajil1213) this field is required purely for monitoring/introspection purposes.
-        fulfillment_txid: Option<Txid>,
-
-        /// The operator assigned to fulfill the withdrawal, if known.
-        // NOTE: (@Rajil1213) this field is required purely for monitoring/introspection purposes.
-        assignee: Option<OperatorIdx>,
-    },
-    /// This represents the terminal state where the deposit request has been spent elsewhere.
-    Aborted,
 }
 
 impl Display for DepositState {

--- a/crates/bridge-sm/src/deposit/tests/duties.rs
+++ b/crates/bridge-sm/src/deposit/tests/duties.rs
@@ -1,4 +1,4 @@
-//! Unit tests for the DepositDuty withdrawal-path taxonomy.
+//! Unit tests for the DepositDuty safe-harbour suppression taxonomy.
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -63,10 +63,10 @@ mod tests {
         ]
     }
 
-    /// Pins the withdrawal-path classification of every deposit duty: only the duties that front
-    /// a user or advance the cooperative payout are suppressible under safe harbour.
+    /// Pins the safe-harbour suppression classification of every deposit duty: only the duties that
+    /// front a user or advance the cooperative payout are suppressible under safe harbour.
     #[test]
-    fn test_is_withdrawal_path_per_deposit_duty() {
+    fn test_should_suppress_under_safe_harbour_per_deposit_duty() {
         let desc = random_p2tr_desc();
         let sweep_tx = test_sweep_txn(desc.clone());
         let sighash = sweep_tx.signing_info()[0].sighash;
@@ -187,28 +187,28 @@ mod tests {
 
         for (duty, expected) in cases {
             assert_eq!(
-                duty.is_withdrawal_path(),
+                duty.should_suppress_under_safe_harbour(),
                 expected,
-                "unexpected withdrawal-path classification for {duty}"
+                "unexpected safe-harbour suppression for {duty}"
             );
         }
     }
 
-    /// Pins the withdrawal-path classification of every nag duty, directly and wrapped in
+    /// Pins the safe-harbour suppression classification of every nag duty, directly and wrapped in
     /// [`DepositDuty::Nag`]: only the payout-session nags solicit withdrawal progress.
     #[test]
-    fn test_is_withdrawal_path_per_nag_duty() {
+    fn test_should_suppress_under_safe_harbour_per_nag_duty() {
         for (nag, expected) in nag_duties() {
             assert_eq!(
-                nag.is_withdrawal_path(),
+                nag.should_suppress_under_safe_harbour(),
                 expected,
-                "unexpected withdrawal-path classification for {nag}"
+                "unexpected safe-harbour suppression for {nag}"
             );
             let duty = DepositDuty::Nag { duty: nag };
             assert_eq!(
-                duty.is_withdrawal_path(),
+                duty.should_suppress_under_safe_harbour(),
                 expected,
-                "unexpected withdrawal-path classification for {duty}"
+                "unexpected safe-harbour suppression for {duty}"
             );
         }
     }

--- a/crates/bridge-sm/src/deposit/tests/duties.rs
+++ b/crates/bridge-sm/src/deposit/tests/duties.rs
@@ -1,0 +1,215 @@
+//! Unit tests for the DepositDuty withdrawal-path taxonomy.
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::deposit::{duties::NagDuty, tests::*};
+
+    fn nag_duties() -> Vec<(NagDuty, bool)> {
+        let operator_pubkey = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+            .idx_to_p2p_key(&TEST_ASSIGNEE)
+            .expect("assignee must be in the operator table")
+            .clone();
+
+        vec![
+            (
+                NagDuty::NagDepositNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    operator_idx: TEST_ASSIGNEE,
+                    operator_pubkey: operator_pubkey.clone(),
+                },
+                false,
+            ),
+            (
+                NagDuty::NagDepositPartial {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    operator_idx: TEST_ASSIGNEE,
+                    operator_pubkey: operator_pubkey.clone(),
+                },
+                false,
+            ),
+            (
+                NagDuty::NagPayoutNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    operator_idx: TEST_ASSIGNEE,
+                    operator_pubkey: operator_pubkey.clone(),
+                },
+                true,
+            ),
+            (
+                NagDuty::NagPayoutPartial {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    operator_idx: TEST_ASSIGNEE,
+                    operator_pubkey: operator_pubkey.clone(),
+                },
+                true,
+            ),
+            (
+                NagDuty::NagSweepNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    operator_idx: TEST_ASSIGNEE,
+                    operator_pubkey: operator_pubkey.clone(),
+                },
+                false,
+            ),
+            (
+                NagDuty::NagSweepPartial {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    operator_idx: TEST_ASSIGNEE,
+                    operator_pubkey,
+                },
+                false,
+            ),
+        ]
+    }
+
+    /// Pins the withdrawal-path classification of every deposit duty: only the duties that front
+    /// a user or advance the cooperative payout are suppressible under safe harbour.
+    #[test]
+    fn test_is_withdrawal_path_per_deposit_duty() {
+        let desc = random_p2tr_desc();
+        let sweep_tx = test_sweep_txn(desc.clone());
+        let sighash = sweep_tx.signing_info()[0].sighash;
+        let deposit_signing_info = test_deposit_txn()
+            .signing_info()
+            .into_iter()
+            .next()
+            .expect("deposit transaction must have signing info");
+
+        let cases = vec![
+            (
+                DepositDuty::PublishDepositNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    drt_outpoint: OutPoint::default(),
+                    claim_txids: vec![],
+                    ordered_pubkeys: vec![],
+                    drt_tweak: TaprootTweak::Key { tweak: None },
+                    sighash,
+                },
+                false,
+            ),
+            (
+                DepositDuty::PublishDepositPartial {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    drt_outpoint: OutPoint::default(),
+                    claim_txids: vec![],
+                    signing_info: deposit_signing_info,
+                    deposit_agg_nonce: generate_agg_nonce(),
+                    ordered_pubkeys: vec![],
+                },
+                false,
+            ),
+            (
+                DepositDuty::PublishDeposit {
+                    signed_deposit_transaction: test_deposit_txn().as_ref().clone(),
+                },
+                false,
+            ),
+            (
+                DepositDuty::FulfillWithdrawalRequest {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    deadline: LATER_BLOCK_HEIGHT,
+                    recipient_desc: desc.clone(),
+                    deposit_amount: TEST_DEPOSIT_AMOUNT,
+                },
+                true,
+            ),
+            (
+                DepositDuty::RequestPayoutNonces {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    pov_operator_idx: TEST_POV_IDX,
+                    payout_descriptor: None,
+                },
+                true,
+            ),
+            (
+                DepositDuty::PublishPayoutNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    deposit_outpoint: test_deposit_outpoint(),
+                    ordered_pubkeys: vec![],
+                    tweak: TaprootTweak::Key { tweak: None },
+                    payout_sighash: sighash,
+                },
+                true,
+            ),
+            (
+                DepositDuty::PublishPayoutPartial {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    deposit_outpoint: test_deposit_outpoint(),
+                    payout_sighash: sighash,
+                    agg_nonce: generate_agg_nonce(),
+                    ordered_pubkeys: vec![],
+                },
+                true,
+            ),
+            (
+                DepositDuty::PublishPayout {
+                    deposit_outpoint: test_deposit_outpoint(),
+                    agg_nonce: generate_agg_nonce(),
+                    collected_partials: BTreeMap::new(),
+                    payout_coop_tx: Box::new(test_cooperative_payout_txn(desc.clone())),
+                    ordered_pubkeys: vec![],
+                    pov_operator_idx: TEST_POV_IDX,
+                },
+                true,
+            ),
+            (
+                DepositDuty::PublishSweepNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    deposit_outpoint: test_deposit_outpoint(),
+                    ordered_pubkeys: vec![],
+                    tweak: TaprootTweak::Key { tweak: None },
+                    sweep_sighash: sighash,
+                },
+                false,
+            ),
+            (
+                DepositDuty::PublishSweepPartial {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    deposit_outpoint: test_deposit_outpoint(),
+                    sweep_sighash: sighash,
+                    agg_nonce: generate_agg_nonce(),
+                    ordered_pubkeys: vec![],
+                },
+                false,
+            ),
+            (
+                DepositDuty::PublishSweep {
+                    deposit_outpoint: test_deposit_outpoint(),
+                    agg_nonce: generate_agg_nonce(),
+                    collected_partials: BTreeMap::new(),
+                    sweep_tx: Box::new(sweep_tx),
+                    ordered_pubkeys: vec![],
+                },
+                false,
+            ),
+        ];
+
+        for (duty, expected) in cases {
+            assert_eq!(
+                duty.is_withdrawal_path(),
+                expected,
+                "unexpected withdrawal-path classification for {duty}"
+            );
+        }
+    }
+
+    /// Pins the withdrawal-path classification of every nag duty, directly and wrapped in
+    /// [`DepositDuty::Nag`]: only the payout-session nags solicit withdrawal progress.
+    #[test]
+    fn test_is_withdrawal_path_per_nag_duty() {
+        for (nag, expected) in nag_duties() {
+            assert_eq!(
+                nag.is_withdrawal_path(),
+                expected,
+                "unexpected withdrawal-path classification for {nag}"
+            );
+            let duty = DepositDuty::Nag { duty: nag };
+            assert_eq!(
+                duty.is_withdrawal_path(),
+                expected,
+                "unexpected withdrawal-path classification for {duty}"
+            );
+        }
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/handlers/process_nag_received.rs
+++ b/crates/bridge-sm/src/deposit/tests/handlers/process_nag_received.rs
@@ -689,4 +689,143 @@ mod tests {
             });
         }
     }
+
+    // ===== Sweep nag tests =====
+
+    #[test]
+    fn test_nag_received_sweep_nonce_in_sweep_states_emits_publish_sweep_nonce() {
+        let sweep_tx = test_sweep_txn(random_p2tr_desc());
+        let sweep_sighash = sweep_tx
+            .signing_info()
+            .first()
+            .expect("sweep transaction must have signing info")
+            .sighash;
+        let ordered_pubkeys: Vec<_> = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+            .btc_keys()
+            .into_iter()
+            .map(|pk| pk.x_only_public_key().0)
+            .collect();
+
+        let expected_duty = DepositDuty::PublishSweepNonce {
+            deposit_idx: TEST_DEPOSIT_IDX,
+            deposit_outpoint: test_deposit_outpoint(),
+            ordered_pubkeys,
+            tweak: TaprootTweak::Key { tweak: None },
+            sweep_sighash,
+        };
+
+        let sweep_states = [
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: sweep_tx.clone(),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+        ];
+
+        for state in sweep_states {
+            test_handler_output(DepositHandlerOutput {
+                state,
+                event: DepositEvent::NagReceived(create_nag_event(NagRequestPayload::SweepNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                })),
+                expected_duties: vec![expected_duty.clone()],
+            });
+        }
+    }
+
+    /// Unlike the payout partial nag, the POV operator always answers: the sweep round is
+    /// symmetric and no partial is withheld.
+    #[test]
+    fn test_nag_received_sweep_partial_in_sweep_nonces_collected_emits_publish_sweep_partial() {
+        let sweep_tx = test_sweep_txn(random_p2tr_desc());
+        let sweep_sighash = sweep_tx
+            .signing_info()
+            .first()
+            .expect("sweep transaction must have signing info")
+            .sighash;
+        let sweep_agg_nonce = generate_agg_nonce();
+        let ordered_pubkeys: Vec<_> = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+            .btc_keys()
+            .into_iter()
+            .map(|pk| pk.x_only_public_key().0)
+            .collect();
+
+        let expected_duty = DepositDuty::PublishSweepPartial {
+            deposit_idx: TEST_DEPOSIT_IDX,
+            deposit_outpoint: test_deposit_outpoint(),
+            sweep_sighash,
+            agg_nonce: sweep_agg_nonce.clone(),
+            ordered_pubkeys,
+        };
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_agg_nonce,
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+            event: DepositEvent::NagReceived(create_nag_event(NagRequestPayload::SweepPartial {
+                deposit_idx: TEST_DEPOSIT_IDX,
+            })),
+            expected_duties: vec![expected_duty],
+        });
+    }
+
+    #[test]
+    fn test_nag_received_sweep_nags_rejected_in_non_sweep_states() {
+        let non_sweep_states = [
+            DepositState::Deposited {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+            },
+            DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            },
+            DepositState::Aborted,
+        ];
+
+        for state in non_sweep_states {
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state.clone(),
+                event: DepositEvent::NagReceived(create_nag_event(NagRequestPayload::SweepNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                })),
+                expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+            });
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state,
+                event: DepositEvent::NagReceived(create_nag_event(
+                    NagRequestPayload::SweepPartial {
+                        deposit_idx: TEST_DEPOSIT_IDX,
+                    },
+                )),
+                expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+            });
+        }
+    }
+
+    /// A sweep partial nag while nonces are still pending is rejected (no agg nonce yet).
+    #[test]
+    fn test_nag_received_sweep_partial_rejected_in_sweep_nonces_pending() {
+        test_deposit_invalid_transition(DepositInvalidTransition {
+            from_state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            event: DepositEvent::NagReceived(create_nag_event(NagRequestPayload::SweepPartial {
+                deposit_idx: TEST_DEPOSIT_IDX,
+            })),
+            expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+        });
+    }
 }

--- a/crates/bridge-sm/src/deposit/tests/handlers/process_nag_tick.rs
+++ b/crates/bridge-sm/src/deposit/tests/handlers/process_nag_tick.rs
@@ -478,4 +478,94 @@ mod tests {
             });
         }
     }
+
+    // ===== Sweep state tests (NagSweepNonce / NagSweepPartial) =====
+
+    #[test]
+    fn test_nag_tick_emits_nag_sweep_nonce_for_missing_operators() {
+        // Only one operator has submitted their sweep nonce
+        let mut sweep_nonces = BTreeMap::new();
+        sweep_nonces.insert(TEST_ARBITRARY_OPERATOR_IDX, generate_pubnonce());
+
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let expected = operator_table.operator_idxs();
+        let present: BTreeSet<_> = sweep_nonces.keys().copied().collect();
+        let expected_duties: Vec<DepositDuty> = expected
+            .difference(&present)
+            .map(|&op_idx| {
+                let operator_pubkey = operator_table.idx_to_p2p_key(&op_idx).unwrap().clone();
+                DepositDuty::Nag {
+                    duty: NagDuty::NagSweepNonce {
+                        deposit_idx: TEST_DEPOSIT_IDX,
+                        operator_idx: op_idx,
+                        operator_pubkey,
+                    },
+                }
+            })
+            .collect();
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces,
+            },
+            event: DepositEvent::NagTick(NagTickEvent),
+            expected_duties,
+        });
+    }
+
+    /// Unlike the payout partial nag, no operator is excluded: the sweep round is symmetric.
+    #[test]
+    fn test_nag_tick_emits_nag_sweep_partial_for_all_missing_operators() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let expected_duties: Vec<DepositDuty> = operator_table
+            .operator_idxs()
+            .iter()
+            .map(|&op_idx| {
+                let operator_pubkey = operator_table.idx_to_p2p_key(&op_idx).unwrap().clone();
+                DepositDuty::Nag {
+                    duty: NagDuty::NagSweepPartial {
+                        deposit_idx: TEST_DEPOSIT_IDX,
+                        operator_idx: op_idx,
+                        operator_pubkey,
+                    },
+                }
+            })
+            .collect();
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+            event: DepositEvent::NagTick(NagTickEvent),
+            expected_duties,
+        });
+    }
+
+    #[test]
+    fn test_nag_tick_noop_when_all_sweep_partials_collected() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let sweep_partials: BTreeMap<_, _> = operator_table
+            .operator_idxs()
+            .iter()
+            .map(|&idx| (idx, generate_partial_signature()))
+            .collect();
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials,
+            },
+            event: DepositEvent::NagTick(NagTickEvent),
+            expected_duties: vec![],
+        });
+    }
 }

--- a/crates/bridge-sm/src/deposit/tests/handlers/process_retry_tick.rs
+++ b/crates/bridge-sm/src/deposit/tests/handlers/process_retry_tick.rs
@@ -302,4 +302,70 @@ mod tests {
             });
         }
     }
+
+    // ===== Sweep state tests (PublishSweep re-emission) =====
+
+    /// Every operator re-emits PublishSweep until the spend is observed on chain.
+    #[test]
+    fn test_retry_tick_emits_publish_sweep_when_all_partials_collected() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let sweep_tx = test_sweep_txn(random_p2tr_desc());
+        let sweep_agg_nonce = generate_agg_nonce();
+        let sweep_partials: BTreeMap<_, _> = operator_table
+            .operator_idxs()
+            .iter()
+            .map(|&idx| (idx, generate_partial_signature()))
+            .collect();
+        let ordered_pubkeys: Vec<_> = operator_table
+            .btc_keys()
+            .into_iter()
+            .map(|pk| pk.x_only_public_key().0)
+            .collect();
+
+        let expected_duty = DepositDuty::PublishSweep {
+            deposit_outpoint: test_deposit_outpoint(),
+            agg_nonce: sweep_agg_nonce.clone(),
+            collected_partials: sweep_partials.clone(),
+            sweep_tx: Box::new(sweep_tx.clone()),
+            ordered_pubkeys,
+        };
+
+        test_handler_output(DepositHandlerOutput {
+            state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_agg_nonce,
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials,
+            },
+            event: DepositEvent::RetryTick(RetryTickEvent),
+            expected_duties: vec![expected_duty],
+        });
+    }
+
+    #[test]
+    fn test_retry_tick_noop_in_sweep_states_when_partials_incomplete() {
+        let sweep_states = [
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+        ];
+
+        for state in sweep_states {
+            test_handler_output(DepositHandlerOutput {
+                state,
+                event: DepositEvent::RetryTick(RetryTickEvent),
+                expected_duties: vec![],
+            });
+        }
+    }
 }

--- a/crates/bridge-sm/src/deposit/tests/mod.rs
+++ b/crates/bridge-sm/src/deposit/tests/mod.rs
@@ -7,6 +7,7 @@ mod deposit;
 mod handlers;
 mod payout;
 mod prop_tests;
+mod sweep;
 mod test_new_blocks;
 mod test_timeout_sequence;
 mod tx_classifier;
@@ -33,7 +34,7 @@ use strata_bridge_test_utils::{
 use strata_bridge_tx_graph::transactions::{
     PresignedTx,
     prelude::{
-        CooperativePayoutData, CooperativePayoutTx, DepositData, DepositTx,
+        CooperativePayoutData, CooperativePayoutTx, DepositData, DepositTx, SweepData, SweepTx,
         WithdrawalFulfillmentData, WithdrawalFulfillmentTx,
     },
 };
@@ -48,7 +49,9 @@ use crate::{
         events::{
             DepositConfirmedEvent, DepositEvent, FulfillmentConfirmedEvent, NagTickEvent,
             NewBlockEvent, NonceReceivedEvent, PayoutConfirmedEvent, PayoutNonceReceivedEvent,
-            PayoutPartialReceivedEvent, RetryTickEvent, UserTakeBackEvent, WithdrawalAssignedEvent,
+            PayoutPartialReceivedEvent, RetryTickEvent, SweepNonceReceivedEvent,
+            SweepPartialReceivedEvent, SweepRequestedEvent, UserTakeBackEvent,
+            WithdrawalAssignedEvent,
         },
         machine::DepositSM,
         state::DepositState,
@@ -57,9 +60,9 @@ use crate::{
     testing::{
         fixtures::{
             LATER_BLOCK_HEIGHT, TEST_ASSIGNEE, TEST_DEPOSIT_AMOUNT, TEST_DEPOSIT_IDX,
-            TEST_MAGIC_BYTES, TEST_OPERATOR_FEE, TEST_POV_IDX, random_p2tr_desc,
-            test_fulfillment_tx, test_operator_table, test_payout_tx, test_recipient_desc,
-            test_takeback_tx,
+            TEST_MAGIC_BYTES, TEST_OPERATOR_FEE, TEST_POV_IDX, TEST_SWEEP_FEE_RATE,
+            random_p2tr_desc, test_fulfillment_tx, test_operator_table, test_payout_tx,
+            test_recipient_desc, test_takeback_tx,
         },
         signer::TestMusigSigner,
         transition::{InvalidTransition, Transition, test_invalid_transition, test_transition},
@@ -108,6 +111,7 @@ pub(super) fn test_deposit_sm_cfg() -> Arc<DepositSMCfg> {
         operator_fee: TEST_OPERATOR_FEE,
         magic_bytes,
         recovery_delay: TEST_RECOVERY_DELAY,
+        sweep_fee_rate: TEST_SWEEP_FEE_RATE,
     })
 }
 
@@ -235,6 +239,43 @@ pub(super) fn get_payout_signing_info(
     let key_agg_ctx = create_agg_ctx(btc_keys, &TaprootTweak::Key { tweak: None })
         .expect("must create key agg context");
     let message = payout_tx.signing_info()[0].sighash;
+    (key_agg_ctx, message)
+}
+
+// ===== Sweep Transaction Helpers =====
+
+/// Creates a test sweep transaction with deterministic values.
+pub(super) fn test_sweep_txn(safe_harbour_desc: Descriptor) -> SweepTx {
+    let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+    let n_of_n_pubkey = get_aggregated_pubkey(operator_table.btc_keys());
+    let deposit_connector =
+        NOfNConnector::new(Network::Regtest, n_of_n_pubkey, TEST_DEPOSIT_AMOUNT);
+    let operator_pubkeys = operator_table
+        .btc_keys()
+        .into_iter()
+        .map(|pk| pk.x_only_public_key().0)
+        .collect();
+
+    SweepTx::new(
+        SweepData {
+            deposit_outpoint: test_deposit_outpoint(),
+        },
+        deposit_connector,
+        safe_harbour_desc,
+        operator_pubkeys,
+        TEST_SWEEP_FEE_RATE,
+    )
+}
+
+/// Retrieves the key aggregation context and message for signing a sweep transaction.
+pub(super) fn get_sweep_signing_info(
+    sweep_tx: &SweepTx,
+    operator_signers: &[TestMusigSigner],
+) -> (KeyAggContext, musig2::secp256k1::Message) {
+    let btc_keys: Vec<_> = operator_signers.iter().map(|s| s.pubkey()).collect();
+    let key_agg_ctx = create_agg_ctx(btc_keys, &TaprootTweak::Key { tweak: None })
+        .expect("must create key agg context");
+    let message = sweep_tx.signing_info()[0].sighash;
     (key_agg_ctx, message)
 }
 
@@ -406,6 +447,27 @@ impl Arbitrary for DepositState {
                     payout_partial_signatures: BTreeMap::new(),
                 }
             }),
+            block_height.clone().prop_map(|height| {
+                DepositState::SweepNoncesPending {
+                    last_block_height: height,
+                    sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                    sweep_nonces: BTreeMap::new(),
+                }
+            }),
+            block_height.clone().prop_map(move |height| {
+                // SweepNoncesCollected requires all nonces to be present
+                let nonces: BTreeMap<_, _> = (0..num_operators)
+                    .map(|idx| (idx, generate_pubnonce()))
+                    .collect();
+                let agg_nonce = musig2::AggNonce::sum(nonces.values().cloned());
+                DepositState::SweepNoncesCollected {
+                    last_block_height: height,
+                    sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                    sweep_agg_nonce: agg_nonce,
+                    sweep_nonces: nonces,
+                    sweep_partials: BTreeMap::new(),
+                }
+            }),
             block_height.prop_map(|height| DepositState::CooperativePathFailed {
                 last_block_height: height,
                 assignee: TEST_ASSIGNEE,
@@ -480,6 +542,21 @@ impl Arbitrary for DepositEvent {
             Just(DepositEvent::PayoutConfirmed(PayoutConfirmedEvent {
                 tx: test_payout_tx(OutPoint::default())
             })),
+            Just(DepositEvent::SweepRequested(SweepRequestedEvent {
+                safe_harbour_desc: random_p2tr_desc(),
+            })),
+            operator_idx.clone().prop_map(|idx| {
+                DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                    sweep_nonce: generate_pubnonce(),
+                    operator_idx: idx,
+                })
+            }),
+            operator_idx.clone().prop_map(|idx| {
+                DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                    partial_signature: generate_partial_signature(),
+                    operator_idx: idx,
+                })
+            }),
             block_height.prop_map(|height| DepositEvent::NewBlock(NewBlockEvent {
                 block_height: height
             })),
@@ -562,6 +639,21 @@ pub(super) fn arb_handled_events() -> impl Strategy<Value = DepositEvent> {
         )),
         (0..num_operators).prop_map(|idx| DepositEvent::PayoutPartialReceived(
             PayoutPartialReceivedEvent {
+                partial_signature: generate_partial_signature(),
+                operator_idx: idx,
+            }
+        )),
+        Just(DepositEvent::SweepRequested(SweepRequestedEvent {
+            safe_harbour_desc: random_p2tr_desc(),
+        })),
+        (0..num_operators).prop_map(|idx| DepositEvent::SweepNonceReceived(
+            SweepNonceReceivedEvent {
+                sweep_nonce: generate_pubnonce(),
+                operator_idx: idx,
+            }
+        )),
+        (0..num_operators).prop_map(|idx| DepositEvent::SweepPartialReceived(
+            SweepPartialReceivedEvent {
                 partial_signature: generate_partial_signature(),
                 operator_idx: idx,
             }

--- a/crates/bridge-sm/src/deposit/tests/mod.rs
+++ b/crates/bridge-sm/src/deposit/tests/mod.rs
@@ -4,6 +4,7 @@
 //! the DepositSM across multiple state transition functions.
 
 mod deposit;
+mod duties;
 mod handlers;
 mod payout;
 mod prop_tests;

--- a/crates/bridge-sm/src/deposit/tests/mod.rs
+++ b/crates/bridge-sm/src/deposit/tests/mod.rs
@@ -8,6 +8,7 @@ mod duties;
 mod handlers;
 mod payout;
 mod prop_tests;
+mod state;
 mod sweep;
 mod test_new_blocks;
 mod test_timeout_sequence;

--- a/crates/bridge-sm/src/deposit/tests/payout/process_assignment.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_assignment.rs
@@ -277,6 +277,19 @@ mod tests {
                 assignee: TEST_ASSIGNEE,
                 fulfillment_txid: generate_txid(),
             },
+            // The ASM keeps re-listing the assignment for a deposit being swept.
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(desc.clone()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(desc.clone()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
             DepositState::Spent {
                 fulfillment_txid: Some(generate_txid()),
                 assignee: Some(TEST_ASSIGNEE),

--- a/crates/bridge-sm/src/deposit/tests/payout/process_assignment.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_assignment.rs
@@ -277,19 +277,6 @@ mod tests {
                 assignee: TEST_ASSIGNEE,
                 fulfillment_txid: generate_txid(),
             },
-            // The ASM keeps re-listing the assignment for a deposit being swept.
-            DepositState::SweepNoncesPending {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                sweep_tx: test_sweep_txn(desc.clone()),
-                sweep_nonces: BTreeMap::new(),
-            },
-            DepositState::SweepNoncesCollected {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                sweep_tx: test_sweep_txn(desc.clone()),
-                sweep_agg_nonce: generate_agg_nonce(),
-                sweep_nonces: BTreeMap::new(),
-                sweep_partials: BTreeMap::new(),
-            },
             DepositState::Spent {
                 fulfillment_txid: Some(generate_txid()),
                 assignee: Some(TEST_ASSIGNEE),
@@ -305,6 +292,41 @@ mod tests {
                     recipient_desc: desc.clone(),
                 }),
                 expected_error: |e| matches!(e, DSMError::Duplicate { .. }),
+            });
+        }
+    }
+
+    /// tests that assignments re-listed by the ASM for a deposit in the sweep flow are rejected
+    #[test]
+    fn test_assignment_rejected_from_sweep_states() {
+        let desc = random_p2tr_desc();
+
+        // The ASM does not gate assignment creation on safe harbour, so it keeps re-listing
+        // the assignment for a deposit being swept.
+        let sweep_states = [
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(desc.clone()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(desc.clone()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+        ];
+
+        for state in sweep_states {
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state,
+                event: DepositEvent::WithdrawalAssigned(WithdrawalAssignedEvent {
+                    assignee: TEST_ASSIGNEE,
+                    deadline: LATER_BLOCK_HEIGHT,
+                    recipient_desc: desc.clone(),
+                }),
+                expected_error: |e| matches!(e, DSMError::Rejected { .. }),
             });
         }
     }

--- a/crates/bridge-sm/src/deposit/tests/payout/process_payout_confirmed.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_payout_confirmed.rs
@@ -83,6 +83,39 @@ mod tests {
         });
     }
 
+    /// Tests correct transition from the sweep states to Spent with unknown fulfillment txid:
+    /// either the sweep itself or a racing payout spent the deposit outpoint.
+    #[test]
+    fn test_payout_confirmed_from_sweep_states_records_unknown_fulfillment_txid() {
+        let sweep_states = [
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+        ];
+
+        for state in sweep_states {
+            test_deposit_transition(DepositTransition {
+                from_state: state,
+                event: payout_confirmed_event(test_deposit_outpoint()),
+                expected_state: DepositState::Spent {
+                    fulfillment_txid: None,
+                    assignee: None,
+                },
+                expected_duties: vec![],
+                expected_signals: vec![],
+            });
+        }
+    }
+
     /// Tests that PayoutConfirmed is rejected if the payout tx does not spend the deposit outpoint.
     #[test]
     fn test_payout_confirmed_rejected_for_wrong_outpoint_from_valid_states() {
@@ -111,6 +144,18 @@ mod tests {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
                 assignee: TEST_ASSIGNEE,
                 fulfillment_txid,
+            },
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
             },
         ];
 

--- a/crates/bridge-sm/src/deposit/tests/payout/process_payout_confirmed.rs
+++ b/crates/bridge-sm/src/deposit/tests/payout/process_payout_confirmed.rs
@@ -62,6 +62,76 @@ mod tests {
         });
     }
 
+    /// Tests correct transition from Assigned to Spent: the assignee is preserved but no
+    /// fulfillment has happened, so the fulfillment txid is unknown.
+    #[test]
+    fn test_payout_confirmed_from_assigned_preserves_assignee_only() {
+        test_deposit_transition(DepositTransition {
+            from_state: DepositState::Assigned {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                deadline: LATER_BLOCK_HEIGHT,
+                recipient_desc: random_p2tr_desc(),
+            },
+            event: payout_confirmed_event(test_deposit_outpoint()),
+            expected_state: DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: Some(TEST_ASSIGNEE),
+            },
+            expected_duties: vec![],
+            expected_signals: vec![],
+        });
+    }
+
+    /// Tests correct transition from Fulfilled to Spent preserving assignee and fulfillment txid.
+    #[test]
+    fn test_payout_confirmed_from_fulfilled_preserves_fulfillment_txid() {
+        let fulfillment_txid = generate_txid();
+
+        test_deposit_transition(DepositTransition {
+            from_state: DepositState::Fulfilled {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid,
+                fulfillment_height: LATER_BLOCK_HEIGHT,
+                cooperative_payout_deadline: LATER_BLOCK_HEIGHT
+                    + test_deposit_sm_cfg().cooperative_payout_timeout_blocks(),
+            },
+            event: payout_confirmed_event(test_deposit_outpoint()),
+            expected_state: DepositState::Spent {
+                fulfillment_txid: Some(fulfillment_txid),
+                assignee: Some(TEST_ASSIGNEE),
+            },
+            expected_duties: vec![],
+            expected_signals: vec![],
+        });
+    }
+
+    /// Tests correct transition from PayoutDescriptorReceived to Spent preserving assignee and
+    /// fulfillment txid.
+    #[test]
+    fn test_payout_confirmed_from_payout_descriptor_received_preserves_fulfillment_txid() {
+        let fulfillment_txid = generate_txid();
+
+        test_deposit_transition(DepositTransition {
+            from_state: DepositState::PayoutDescriptorReceived {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid,
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                cooperative_payout_tx: test_cooperative_payout_txn(random_p2tr_desc()),
+                payout_nonces: BTreeMap::new(),
+            },
+            event: payout_confirmed_event(test_deposit_outpoint()),
+            expected_state: DepositState::Spent {
+                fulfillment_txid: Some(fulfillment_txid),
+                assignee: Some(TEST_ASSIGNEE),
+            },
+            expected_duties: vec![],
+            expected_signals: vec![],
+        });
+    }
+
     /// Tests correct transition from CooperativePathFailed to Spent with known fulfillment txid.
     #[test]
     fn test_payout_confirmed_from_cooperative_path_failed_preserves_fulfillment_txid() {
@@ -130,6 +200,28 @@ mod tests {
             DepositState::Deposited {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
             },
+            DepositState::Assigned {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                deadline: LATER_BLOCK_HEIGHT,
+                recipient_desc: random_p2tr_desc(),
+            },
+            DepositState::Fulfilled {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid,
+                fulfillment_height: LATER_BLOCK_HEIGHT,
+                cooperative_payout_deadline: LATER_BLOCK_HEIGHT
+                    + test_deposit_sm_cfg().cooperative_payout_timeout_blocks(),
+            },
+            DepositState::PayoutDescriptorReceived {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid,
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                cooperative_payout_tx: test_cooperative_payout_txn(desc.clone()),
+                payout_nonces: BTreeMap::new(),
+            },
             DepositState::PayoutNoncesCollected {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
                 assignee: TEST_ASSIGNEE,
@@ -191,12 +283,10 @@ mod tests {
         }
     }
 
-    /// Tests that all states apart from Deposited, PayoutNoncesCollected,
-    /// CooperativePathFailed, and Spent should NOT accept the PayoutConfirmed event.
+    /// Tests that the pre-deposit states and Aborted (the states with no live deposit UTXO)
+    /// should NOT accept the PayoutConfirmed event.
     #[test]
     fn test_payout_confirmed_invalid_from_other_states() {
-        let desc = random_p2tr_desc();
-
         let invalid_states = [
             DepositState::Created {
                 deposit_transaction: test_deposit_txn(),
@@ -220,28 +310,6 @@ mod tests {
             DepositState::DepositPartialsCollected {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
                 deposit_transaction: test_deposit_txn().as_ref().clone(),
-            },
-            DepositState::Assigned {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                assignee: TEST_ASSIGNEE,
-                deadline: LATER_BLOCK_HEIGHT,
-                recipient_desc: desc.clone(),
-            },
-            DepositState::Fulfilled {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                assignee: TEST_ASSIGNEE,
-                fulfillment_txid: generate_txid(),
-                fulfillment_height: LATER_BLOCK_HEIGHT,
-                cooperative_payout_deadline: LATER_BLOCK_HEIGHT
-                    + test_deposit_sm_cfg().cooperative_payout_timeout_blocks(),
-            },
-            DepositState::PayoutDescriptorReceived {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                assignee: TEST_ASSIGNEE,
-                fulfillment_txid: generate_txid(),
-                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
-                cooperative_payout_tx: test_cooperative_payout_txn(desc),
-                payout_nonces: BTreeMap::new(),
             },
             DepositState::Aborted,
         ];

--- a/crates/bridge-sm/src/deposit/tests/state.rs
+++ b/crates/bridge-sm/src/deposit/tests/state.rs
@@ -1,0 +1,142 @@
+//! Pinning tests for [`DepositState`]'s persisted encoding.
+#[cfg(test)]
+mod tests {
+    use crate::deposit::{state::DepositState, tests::*};
+
+    /// A failure here means the enum was reordered, which needs a database migration rather
+    /// than a recompile.
+    #[test]
+    fn deposit_state_variant_indices_are_stable() {
+        let desc = random_p2tr_desc();
+
+        let cases: [(u8, DepositState); 14] = [
+            (
+                0,
+                DepositState::Created {
+                    deposit_transaction: test_deposit_txn(),
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    claim_txids: BTreeMap::new(),
+                },
+            ),
+            (
+                1,
+                DepositState::GraphGenerated {
+                    deposit_transaction: test_deposit_txn(),
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    claim_txids: BTreeMap::new(),
+                    pubnonces: BTreeMap::new(),
+                },
+            ),
+            (
+                2,
+                DepositState::DepositNoncesCollected {
+                    deposit_transaction: test_deposit_txn(),
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    claim_txids: BTreeMap::new(),
+                    agg_nonce: generate_agg_nonce(),
+                    pubnonces: BTreeMap::new(),
+                    partial_signatures: BTreeMap::new(),
+                },
+            ),
+            (
+                3,
+                DepositState::DepositPartialsCollected {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    deposit_transaction: test_deposit_txn().as_ref().clone(),
+                },
+            ),
+            (
+                4,
+                DepositState::Deposited {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                },
+            ),
+            (
+                5,
+                DepositState::Assigned {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    assignee: TEST_ASSIGNEE,
+                    deadline: LATER_BLOCK_HEIGHT,
+                    recipient_desc: desc.clone(),
+                },
+            ),
+            (
+                6,
+                DepositState::Fulfilled {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    assignee: TEST_ASSIGNEE,
+                    fulfillment_txid: generate_txid(),
+                    fulfillment_height: INITIAL_BLOCK_HEIGHT,
+                    cooperative_payout_deadline: LATER_BLOCK_HEIGHT,
+                },
+            ),
+            (
+                7,
+                DepositState::PayoutDescriptorReceived {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    assignee: TEST_ASSIGNEE,
+                    fulfillment_txid: generate_txid(),
+                    cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                    cooperative_payout_tx: test_cooperative_payout_txn(desc.clone()),
+                    payout_nonces: BTreeMap::new(),
+                },
+            ),
+            (
+                8,
+                DepositState::PayoutNoncesCollected {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    assignee: TEST_ASSIGNEE,
+                    fulfillment_txid: generate_txid(),
+                    cooperative_payout_tx: test_cooperative_payout_txn(desc.clone()),
+                    cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                    payout_nonces: BTreeMap::new(),
+                    payout_aggregated_nonce: generate_agg_nonce(),
+                    payout_partial_signatures: BTreeMap::new(),
+                },
+            ),
+            (
+                9,
+                DepositState::CooperativePathFailed {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    assignee: TEST_ASSIGNEE,
+                    fulfillment_txid: generate_txid(),
+                },
+            ),
+            (
+                10,
+                DepositState::Spent {
+                    fulfillment_txid: None,
+                    assignee: None,
+                },
+            ),
+            (11, DepositState::Aborted),
+            (
+                12,
+                DepositState::SweepNoncesPending {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    sweep_tx: test_sweep_txn(desc.clone()),
+                    sweep_nonces: BTreeMap::new(),
+                },
+            ),
+            (
+                13,
+                DepositState::SweepNoncesCollected {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    sweep_tx: test_sweep_txn(desc.clone()),
+                    sweep_agg_nonce: generate_agg_nonce(),
+                    sweep_nonces: BTreeMap::new(),
+                    sweep_partials: BTreeMap::new(),
+                },
+            ),
+        ];
+
+        for (expected_index, state) in cases {
+            let encoded = postcard::to_allocvec(&state).expect("state must serialize");
+            assert_eq!(
+                encoded.first().copied(),
+                Some(expected_index),
+                "{state} must encode as variant index {expected_index}"
+            );
+        }
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/sweep/full_round.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/full_round.rs
@@ -1,0 +1,135 @@
+//! End-to-end test of the symmetric sweep signing round.
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use musig2::{AggNonce, aggregate_partial_signatures};
+    use strata_bridge_tx_graph::fee::sweep_payout_value;
+
+    use crate::{
+        deposit::{
+            duties::DepositDuty,
+            events::{
+                DepositEvent, PayoutConfirmedEvent, SweepNonceReceivedEvent,
+                SweepPartialReceivedEvent, SweepRequestedEvent,
+            },
+            state::DepositState,
+            tests::*,
+        },
+        testing::{fixtures::TEST_SWEEP_FEE_RATE, transition::EventSequence},
+    };
+
+    /// Drives a full sweep round from `Deposited` through nonce and partial collection, then
+    /// proves the emitted [`DepositDuty::PublishSweep`] aggregates into a valid signature and
+    /// finalizes into the expected transaction.
+    #[test]
+    fn test_full_symmetric_sweep_round() {
+        let signers = test_operator_signers();
+        let desc = random_p2tr_desc();
+        let sweep_tx = test_sweep_txn(desc.clone());
+        let (key_agg_ctx, message) = get_sweep_signing_info(&sweep_tx, &signers);
+        let agg_pubkey = key_agg_ctx.aggregated_pubkey();
+        let nonce_counter = 0u64;
+
+        let sm = create_sm(DepositState::Deposited {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+        });
+        let mut seq = EventSequence::new(sm, get_state);
+
+        // Seed the sweep with the injected safe-harbour descriptor.
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::SweepRequested(SweepRequestedEvent {
+                safe_harbour_desc: desc.clone(),
+            }),
+        );
+
+        // Every operator's nonce arrives (own nonce loops back via ouroboros in production).
+        let nonces: BTreeMap<_, _> = signers
+            .iter()
+            .map(|s| (s.operator_idx(), s.pubnonce(agg_pubkey, nonce_counter)))
+            .collect();
+        for (operator_idx, sweep_nonce) in &nonces {
+            seq.process(
+                test_deposit_sm_cfg(),
+                DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                    sweep_nonce: sweep_nonce.clone(),
+                    operator_idx: *operator_idx,
+                }),
+            );
+        }
+        let agg_nonce = AggNonce::sum(nonces.values().cloned());
+
+        // Every operator's partial arrives - the round is symmetric, none is withheld.
+        for signer in &signers {
+            let partial = signer.sign(&key_agg_ctx, nonce_counter, &agg_nonce, message);
+            seq.process(
+                test_deposit_sm_cfg(),
+                DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                    partial_signature: partial,
+                    operator_idx: signer.operator_idx(),
+                }),
+            );
+        }
+
+        seq.assert_no_errors();
+
+        // The final partial must trigger the PublishSweep duty with all N partials.
+        let duties = seq.all_duties();
+        let publish_sweep = duties
+            .iter()
+            .find_map(|duty| match duty {
+                DepositDuty::PublishSweep {
+                    agg_nonce,
+                    collected_partials,
+                    sweep_tx,
+                    ..
+                } => Some((agg_nonce, collected_partials, sweep_tx)),
+                _ => None,
+            })
+            .expect("PublishSweep duty must be emitted");
+        let (duty_agg_nonce, collected_partials, duty_sweep_tx) = publish_sweep;
+        assert_eq!(collected_partials.len(), N_TEST_OPERATORS);
+
+        // The collected partials aggregate into a valid signature (aggregation verifies the
+        // final signature against the aggregated key internally).
+        let ordered_partials: Vec<_> = collected_partials.values().copied().collect();
+        let agg_signature = aggregate_partial_signatures(
+            &key_agg_ctx,
+            duty_agg_nonce,
+            ordered_partials,
+            message.as_ref(),
+        )
+        .expect("aggregated sweep signature must verify");
+
+        // The finalized transaction spends the deposit and pays the safe-harbour descriptor.
+        let finalized = (**duty_sweep_tx).clone().finalize(agg_signature);
+        assert_eq!(
+            finalized.input[0].previous_output,
+            test_deposit_outpoint(),
+            "sweep must spend the deposit outpoint"
+        );
+        assert_eq!(
+            finalized.output[0].script_pubkey,
+            desc.to_script(),
+            "sweep must pay the safe-harbour descriptor"
+        );
+        assert_eq!(
+            finalized.output[0].value,
+            sweep_payout_value(TEST_SWEEP_FEE_RATE, TEST_DEPOSIT_AMOUNT)
+                .expect("test sweep fee rate must be valid"),
+            "sweep must pay the deposit minus fee and anchor"
+        );
+
+        // Observing the sweep confirm on chain lands the deposit in Spent.
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::PayoutConfirmed(PayoutConfirmedEvent { tx: finalized }),
+        );
+        seq.assert_no_errors()
+            .assert_final_state(&DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            });
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/sweep/mod.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/mod.rs
@@ -1,0 +1,4 @@
+mod full_round;
+mod process_sweep_nonce_received;
+mod process_sweep_partial_received;
+mod process_sweep_request;

--- a/crates/bridge-sm/src/deposit/tests/sweep/mod.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/mod.rs
@@ -2,3 +2,4 @@ mod full_round;
 mod process_sweep_nonce_received;
 mod process_sweep_partial_received;
 mod process_sweep_request;
+mod races;

--- a/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_nonce_received.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_nonce_received.rs
@@ -1,0 +1,202 @@
+//! Unit Tests for process_sweep_nonce_received
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use musig2::{AggNonce, PubNonce};
+
+    use crate::{
+        deposit::{
+            duties::DepositDuty,
+            errors::DSMError,
+            events::{DepositEvent, SweepNonceReceivedEvent},
+            state::DepositState,
+            tests::*,
+        },
+        testing::transition::*,
+    };
+
+    /// tests partial collection: first nonce received, stays in SweepNoncesPending state
+    #[test]
+    fn test_sweep_nonce_received_partial_collection() {
+        let sweep_tx = test_sweep_txn(random_p2tr_desc());
+        let nonce = generate_pubnonce();
+
+        let mut expected_nonces = BTreeMap::new();
+        expected_nonces.insert(TEST_ARBITRARY_OPERATOR_IDX, nonce.clone());
+
+        test_deposit_transition(DepositTransition {
+            from_state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: sweep_tx.clone(),
+                sweep_nonces: BTreeMap::new(),
+            },
+            event: DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                sweep_nonce: nonce,
+                operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+            }),
+            expected_state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_nonces: expected_nonces,
+            },
+            expected_duties: vec![],
+            expected_signals: vec![],
+        });
+    }
+
+    /// tests all nonces collected - every operator emits the PublishSweepPartial duty
+    /// (no assignee asymmetry, unlike the cooperative payout)
+    #[test]
+    fn test_sweep_nonce_received_all_collected() {
+        let sweep_tx = test_sweep_txn(random_p2tr_desc());
+
+        // Generate nonces for all operators
+        let all_nonces: BTreeMap<OperatorIdx, PubNonce> = (0..N_TEST_OPERATORS)
+            .map(|idx| (idx as OperatorIdx, generate_pubnonce()))
+            .collect();
+
+        // Split into initial (all but last) and incoming (last)
+        let (&incoming_idx, _) = all_nonces.iter().last().unwrap();
+        let initial_nonces: BTreeMap<_, _> = all_nonces
+            .iter()
+            .filter(|&(&k, _)| k != incoming_idx)
+            .map(|(&k, v)| (k, v.clone()))
+            .collect();
+        let incoming_nonce = all_nonces[&incoming_idx].clone();
+
+        // Compute expected aggregated nonce
+        let expected_agg_nonce = AggNonce::sum(all_nonces.values().cloned());
+
+        let sweep_sighash = sweep_tx
+            .signing_info()
+            .first()
+            .expect("sweep transaction must have signing info")
+            .sighash;
+
+        test_deposit_transition(DepositTransition {
+            from_state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: sweep_tx.clone(),
+                sweep_nonces: initial_nonces,
+            },
+            event: DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                sweep_nonce: incoming_nonce,
+                operator_idx: incoming_idx,
+            }),
+            expected_state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_agg_nonce: expected_agg_nonce.clone(),
+                sweep_nonces: all_nonces,
+                sweep_partials: BTreeMap::new(),
+            },
+            expected_duties: vec![DepositDuty::PublishSweepPartial {
+                deposit_idx: TEST_DEPOSIT_IDX,
+                deposit_outpoint: test_deposit_outpoint(),
+                sweep_sighash,
+                agg_nonce: expected_agg_nonce,
+                ordered_pubkeys: test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+                    .btc_keys()
+                    .into_iter()
+                    .map(|pk| pk.x_only_public_key().0)
+                    .collect(),
+            }],
+            expected_signals: vec![],
+        });
+    }
+
+    /// tests duplicate detection: same operator sends a nonce twice
+    #[test]
+    fn test_sweep_nonce_received_duplicate() {
+        let initial_state = DepositState::SweepNoncesPending {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            sweep_tx: test_sweep_txn(random_p2tr_desc()),
+            sweep_nonces: BTreeMap::new(),
+        };
+
+        let sm = create_sm(initial_state);
+        let mut sequence = EventSequence::new(sm, get_state);
+
+        let nonce_event = DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+            sweep_nonce: generate_pubnonce(),
+            operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+        });
+
+        sequence.process(test_deposit_sm_cfg(), nonce_event.clone());
+        sequence.assert_no_errors();
+        // Second submission from the same operator - should fail with Duplicate
+        sequence.process(test_deposit_sm_cfg(), nonce_event);
+
+        let errors = sequence.all_errors();
+        assert_eq!(
+            errors.len(),
+            1,
+            "Expected 1 error (duplicate), got {}",
+            errors.len()
+        );
+        assert!(
+            matches!(errors[0], DSMError::Duplicate { .. }),
+            "Expected Duplicate error, got {:?}",
+            errors[0]
+        );
+    }
+
+    /// tests that invalid operator index is rejected
+    #[test]
+    fn test_invalid_operator_idx_in_sweep_nonce_received() {
+        test_deposit_invalid_transition(DepositInvalidTransition {
+            from_state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            event: DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                sweep_nonce: generate_pubnonce(),
+                operator_idx: u32::MAX,
+            }),
+            expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+        });
+    }
+
+    /// tests that all states except SweepNoncesPending reject SweepNonceReceived
+    #[test]
+    fn test_sweep_nonce_received_invalid_from_other_states() {
+        let nonce = generate_pubnonce();
+
+        let invalid_states = [
+            DepositState::Created {
+                deposit_transaction: test_deposit_txn(),
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                claim_txids: BTreeMap::new(),
+            },
+            DepositState::Deposited {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+            DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            },
+            DepositState::Aborted,
+        ];
+
+        for state in invalid_states {
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state,
+                event: DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                    sweep_nonce: nonce.clone(),
+                    operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+                }),
+                // Peer-facing errors are softened to Rejected by the state machine.
+                expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+            });
+        }
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_partial_received.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_partial_received.rs
@@ -1,0 +1,286 @@
+//! Unit Tests for process_sweep_partial_received
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use musig2::{AggNonce, PubNonce};
+    use strata_bridge_tx_graph::transactions::sweep::SweepTx;
+
+    use crate::{
+        deposit::{
+            duties::DepositDuty,
+            errors::DSMError,
+            events::{DepositEvent, SweepPartialReceivedEvent},
+            state::DepositState,
+            tests::*,
+        },
+        testing::transition::*,
+    };
+
+    /// Helper to create test setup for sweep partial tests.
+    /// Returns (state, signers, key_agg_ctx, agg_nonce, message, sweep_tx).
+    fn create_sweep_partial_test_setup() -> (
+        DepositState,
+        Vec<TestMusigSigner>,
+        musig2::KeyAggContext,
+        AggNonce,
+        Message,
+        SweepTx,
+    ) {
+        let signers = test_operator_signers();
+
+        // Build sweep tx and get signing info
+        let sweep_tx = test_sweep_txn(random_p2tr_desc());
+        let (key_agg_ctx, message) = get_sweep_signing_info(&sweep_tx, &signers);
+
+        // Generate nonces (counter=0 for this signing round)
+        let agg_pubkey = key_agg_ctx.aggregated_pubkey();
+        let nonce_counter = 0u64;
+        let nonces: BTreeMap<OperatorIdx, PubNonce> = signers
+            .iter()
+            .map(|s| (s.operator_idx(), s.pubnonce(agg_pubkey, nonce_counter)))
+            .collect();
+        let agg_nonce = AggNonce::sum(nonces.values().cloned());
+
+        let state = DepositState::SweepNoncesCollected {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            sweep_tx: sweep_tx.clone(),
+            sweep_agg_nonce: agg_nonce.clone(),
+            sweep_nonces: nonces,
+            sweep_partials: BTreeMap::new(),
+        };
+
+        (state, signers, key_agg_ctx, agg_nonce, message, sweep_tx)
+    }
+
+    /// tests partial collection: first partial received, stays in SweepNoncesCollected state
+    #[test]
+    fn test_sweep_partial_received_partial_collection() {
+        let (state, signers, key_agg_ctx, agg_nonce, message, sweep_tx) =
+            create_sweep_partial_test_setup();
+
+        // Extract nonces from state for expected state construction
+        let nonces = if let DepositState::SweepNoncesCollected { sweep_nonces, .. } = &state {
+            sweep_nonces.clone()
+        } else {
+            panic!("Expected SweepNoncesCollected state");
+        };
+
+        // Generate a valid partial signature from an arbitrary operator
+        let nonce_counter = 0u64;
+        let partial_sig = signers[TEST_ARBITRARY_OPERATOR_IDX as usize].sign(
+            &key_agg_ctx,
+            nonce_counter,
+            &agg_nonce,
+            message,
+        );
+
+        let mut expected_partials = BTreeMap::new();
+        expected_partials.insert(TEST_ARBITRARY_OPERATOR_IDX, partial_sig);
+
+        test_deposit_transition(DepositTransition {
+            from_state: state,
+            event: DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                partial_signature: partial_sig,
+                operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+            }),
+            expected_state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_agg_nonce: agg_nonce,
+                sweep_nonces: nonces,
+                sweep_partials: expected_partials,
+            },
+            expected_duties: vec![],
+            expected_signals: vec![],
+        });
+    }
+
+    /// tests all partials collected - every operator emits the PublishSweep duty with all N
+    /// partials (unlike the cooperative payout, which waits for N-1 and only the assignee
+    /// publishes)
+    #[test]
+    fn test_sweep_partial_received_all_collected() {
+        let (mut state, signers, key_agg_ctx, agg_nonce, message, sweep_tx) =
+            create_sweep_partial_test_setup();
+
+        // Extract nonces from state for expected state construction
+        let nonces = if let DepositState::SweepNoncesCollected { sweep_nonces, .. } = &state {
+            sweep_nonces.clone()
+        } else {
+            panic!("Expected SweepNoncesCollected state");
+        };
+
+        // Generate partial signatures for *all* operators
+        let nonce_counter = 0u64;
+        let all_partials: BTreeMap<OperatorIdx, _> = signers
+            .iter()
+            .map(|s| {
+                let sig = s.sign(&key_agg_ctx, nonce_counter, &agg_nonce, message);
+                (s.operator_idx(), sig)
+            })
+            .collect();
+
+        // Split into initial (all but last) and incoming (last)
+        let (&incoming_idx, _) = all_partials.iter().last().unwrap();
+        let initial_partials: BTreeMap<_, _> = all_partials
+            .iter()
+            .filter(|&(&k, _)| k != incoming_idx)
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        let incoming_partial = all_partials[&incoming_idx];
+
+        // Pre-populate state with initial partials
+        if let DepositState::SweepNoncesCollected { sweep_partials, .. } = &mut state {
+            *sweep_partials = initial_partials;
+        } else {
+            panic!("Expected SweepNoncesCollected state");
+        }
+
+        test_deposit_transition(DepositTransition {
+            from_state: state,
+            event: DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                partial_signature: incoming_partial,
+                operator_idx: incoming_idx,
+            }),
+            expected_state: DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: sweep_tx.clone(),
+                sweep_agg_nonce: agg_nonce.clone(),
+                sweep_nonces: nonces,
+                sweep_partials: all_partials.clone(),
+            },
+            expected_duties: vec![DepositDuty::PublishSweep {
+                deposit_outpoint: test_deposit_outpoint(),
+                agg_nonce,
+                collected_partials: all_partials,
+                sweep_tx: Box::new(sweep_tx),
+                ordered_pubkeys: test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+                    .btc_keys()
+                    .into_iter()
+                    .map(|pk| pk.x_only_public_key().0)
+                    .collect(),
+            }],
+            expected_signals: vec![],
+        });
+    }
+
+    /// tests duplicate detection: same operator sends a partial signature twice
+    #[test]
+    fn test_sweep_partial_received_duplicate() {
+        let (state, signers, key_agg_ctx, agg_nonce, message, _) =
+            create_sweep_partial_test_setup();
+
+        let sm = create_sm(state);
+        let mut sequence = EventSequence::new(sm, get_state);
+
+        // Generate a valid partial signature
+        let partial_sig = signers[TEST_ARBITRARY_OPERATOR_IDX as usize].sign(
+            &key_agg_ctx,
+            0,
+            &agg_nonce,
+            message,
+        );
+
+        let event = DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+            partial_signature: partial_sig,
+            operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+        });
+
+        sequence.process(test_deposit_sm_cfg(), event.clone());
+        sequence.assert_no_errors();
+        // Second submission from the same operator - should fail with Duplicate
+        sequence.process(test_deposit_sm_cfg(), event);
+
+        let errors = sequence.all_errors();
+        assert_eq!(
+            errors.len(),
+            1,
+            "Expected 1 error (duplicate), got {}",
+            errors.len()
+        );
+        assert!(
+            matches!(errors[0], DSMError::Duplicate { .. }),
+            "Expected Duplicate error, got {:?}",
+            errors[0]
+        );
+    }
+
+    /// tests that an invalid partial signature is rejected with Rejected error
+    #[test]
+    fn test_sweep_partial_received_invalid_signature() {
+        let (state, _, _, _, _, _) = create_sweep_partial_test_setup();
+
+        // Generate an invalid/random partial signature
+        let invalid_partial = generate_partial_signature();
+
+        test_deposit_invalid_transition(DepositInvalidTransition {
+            from_state: state,
+            event: DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                partial_signature: invalid_partial,
+                operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+            }),
+            expected_error: |e| {
+                matches!(
+                    e,
+                    DSMError::Rejected { reason, .. }
+                    if reason == "Partial Signature Verification Failed"
+                )
+            },
+        });
+    }
+
+    /// tests that invalid operator index is rejected
+    #[test]
+    fn test_invalid_operator_idx_in_sweep_partial_received() {
+        let (state, _, _, _, _, _) = create_sweep_partial_test_setup();
+
+        test_deposit_invalid_transition(DepositInvalidTransition {
+            from_state: state,
+            event: DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                partial_signature: generate_partial_signature(),
+                operator_idx: u32::MAX,
+            }),
+            expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+        });
+    }
+
+    /// tests that all states except SweepNoncesCollected reject SweepPartialReceived
+    #[test]
+    fn test_sweep_partial_received_invalid_from_other_states() {
+        let partial_sig = generate_partial_signature();
+
+        let invalid_states = [
+            DepositState::Created {
+                deposit_transaction: test_deposit_txn(),
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                claim_txids: BTreeMap::new(),
+            },
+            DepositState::Deposited {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+            },
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            },
+            DepositState::Aborted,
+        ];
+
+        for state in invalid_states {
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state,
+                event: DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                    partial_signature: partial_sig,
+                    operator_idx: TEST_ARBITRARY_OPERATOR_IDX,
+                }),
+                // Peer-facing errors are softened to Rejected by the state machine.
+                expected_error: |e| matches!(e, DSMError::Rejected { .. }),
+            });
+        }
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_request.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_request.rs
@@ -1,0 +1,168 @@
+//! Unit Tests for process_sweep_request
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::deposit::{
+        duties::DepositDuty,
+        errors::DSMError,
+        events::{DepositEvent, SweepRequestedEvent},
+        state::DepositState,
+        tests::*,
+    };
+
+    /// tests that a sweep request from Deposited builds the sweep tx and emits the nonce duty
+    #[test]
+    fn test_sweep_request_from_deposited() {
+        let desc = random_p2tr_desc();
+        let sweep_tx = test_sweep_txn(desc.clone());
+
+        let sweep_sighash = sweep_tx
+            .signing_info()
+            .first()
+            .expect("sweep transaction must have signing info")
+            .sighash;
+
+        test_deposit_transition(DepositTransition {
+            from_state: DepositState::Deposited {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+            },
+            event: DepositEvent::SweepRequested(SweepRequestedEvent {
+                safe_harbour_desc: desc,
+            }),
+            expected_state: DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx,
+                sweep_nonces: BTreeMap::new(),
+            },
+            expected_duties: vec![DepositDuty::PublishSweepNonce {
+                deposit_idx: TEST_DEPOSIT_IDX,
+                deposit_outpoint: test_deposit_outpoint(),
+                ordered_pubkeys: test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+                    .btc_keys()
+                    .into_iter()
+                    .map(|pk| pk.x_only_public_key().0)
+                    .collect(),
+                tweak: TaprootTweak::Key { tweak: None },
+                sweep_sighash,
+            }],
+            expected_signals: vec![],
+        });
+    }
+
+    /// tests that a re-emitted sweep request is a duplicate once the sweep is in progress or the
+    /// deposit is spent
+    #[test]
+    fn test_sweep_request_duplicate_in_sweep_and_spent_states() {
+        let desc = random_p2tr_desc();
+
+        let duplicate_states = [
+            DepositState::SweepNoncesPending {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(desc.clone()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(desc.clone()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+            DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            },
+        ];
+
+        for state in duplicate_states {
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state,
+                event: DepositEvent::SweepRequested(SweepRequestedEvent {
+                    safe_harbour_desc: desc.clone(),
+                }),
+                expected_error: |e| matches!(e, DSMError::Duplicate { .. }),
+            });
+        }
+    }
+
+    /// tests that all states except Deposited (and the sweep/spent states) reject SweepRequested
+    #[test]
+    fn test_sweep_request_invalid_from_other_states() {
+        let desc = random_p2tr_desc();
+
+        let invalid_states = [
+            DepositState::Created {
+                deposit_transaction: test_deposit_txn(),
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                claim_txids: BTreeMap::new(),
+            },
+            DepositState::GraphGenerated {
+                deposit_transaction: test_deposit_txn(),
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                claim_txids: BTreeMap::new(),
+                pubnonces: BTreeMap::new(),
+            },
+            DepositState::DepositNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                deposit_transaction: test_deposit_txn(),
+                pubnonces: BTreeMap::new(),
+                claim_txids: BTreeMap::new(),
+                agg_nonce: generate_agg_nonce(),
+                partial_signatures: BTreeMap::new(),
+            },
+            DepositState::DepositPartialsCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                deposit_transaction: test_deposit_txn().as_ref().clone(),
+            },
+            // Sweeping assigned and mid-payout deposits is not supported yet.
+            DepositState::Assigned {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                deadline: LATER_BLOCK_HEIGHT,
+                recipient_desc: desc.clone(),
+            },
+            DepositState::Fulfilled {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid: generate_txid(),
+                fulfillment_height: INITIAL_BLOCK_HEIGHT,
+                cooperative_payout_deadline: LATER_BLOCK_HEIGHT,
+            },
+            DepositState::PayoutDescriptorReceived {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid: generate_txid(),
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                cooperative_payout_tx: test_cooperative_payout_txn(desc.clone()),
+                payout_nonces: BTreeMap::new(),
+            },
+            DepositState::PayoutNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid: generate_txid(),
+                cooperative_payout_tx: test_cooperative_payout_txn(desc.clone()),
+                cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+                payout_nonces: BTreeMap::new(),
+                payout_aggregated_nonce: generate_agg_nonce(),
+                payout_partial_signatures: BTreeMap::new(),
+            },
+            DepositState::CooperativePathFailed {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid: generate_txid(),
+            },
+            DepositState::Aborted,
+        ];
+
+        for state in invalid_states {
+            test_deposit_invalid_transition(DepositInvalidTransition {
+                from_state: state,
+                event: DepositEvent::SweepRequested(SweepRequestedEvent {
+                    safe_harbour_desc: desc.clone(),
+                }),
+                expected_error: |e| matches!(e, DSMError::InvalidEvent { .. }),
+            });
+        }
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_request.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/process_sweep_request.rs
@@ -86,41 +86,18 @@ mod tests {
         }
     }
 
-    /// tests that all states except Deposited (and the sweep/spent states) reject SweepRequested
+    /// tests that a sweep request from every assigned/mid-payout live-UTXO state builds the same
+    /// sweep tx as from Deposited, discarding the withdrawal-progress fields
     #[test]
-    fn test_sweep_request_invalid_from_other_states() {
+    fn test_sweep_request_from_withdrawal_states_discards_progress() {
         let desc = random_p2tr_desc();
 
-        let invalid_states = [
-            DepositState::Created {
-                deposit_transaction: test_deposit_txn(),
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                claim_txids: BTreeMap::new(),
-            },
-            DepositState::GraphGenerated {
-                deposit_transaction: test_deposit_txn(),
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                claim_txids: BTreeMap::new(),
-                pubnonces: BTreeMap::new(),
-            },
-            DepositState::DepositNoncesCollected {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                deposit_transaction: test_deposit_txn(),
-                pubnonces: BTreeMap::new(),
-                claim_txids: BTreeMap::new(),
-                agg_nonce: generate_agg_nonce(),
-                partial_signatures: BTreeMap::new(),
-            },
-            DepositState::DepositPartialsCollected {
-                last_block_height: INITIAL_BLOCK_HEIGHT,
-                deposit_transaction: test_deposit_txn().as_ref().clone(),
-            },
-            // Sweeping assigned and mid-payout deposits is not supported yet.
+        let source_states = [
             DepositState::Assigned {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
                 assignee: TEST_ASSIGNEE,
                 deadline: LATER_BLOCK_HEIGHT,
-                recipient_desc: desc.clone(),
+                recipient_desc: random_p2tr_desc(),
             },
             DepositState::Fulfilled {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
@@ -151,6 +128,71 @@ mod tests {
                 last_block_height: INITIAL_BLOCK_HEIGHT,
                 assignee: TEST_ASSIGNEE,
                 fulfillment_txid: generate_txid(),
+            },
+        ];
+
+        for from_state in source_states {
+            let sweep_tx = test_sweep_txn(desc.clone());
+            let sweep_sighash = sweep_tx
+                .signing_info()
+                .first()
+                .expect("sweep transaction must have signing info")
+                .sighash;
+
+            test_deposit_transition(DepositTransition {
+                from_state,
+                event: DepositEvent::SweepRequested(SweepRequestedEvent {
+                    safe_harbour_desc: desc.clone(),
+                }),
+                expected_state: DepositState::SweepNoncesPending {
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    sweep_tx,
+                    sweep_nonces: BTreeMap::new(),
+                },
+                expected_duties: vec![DepositDuty::PublishSweepNonce {
+                    deposit_idx: TEST_DEPOSIT_IDX,
+                    deposit_outpoint: test_deposit_outpoint(),
+                    ordered_pubkeys: test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX)
+                        .btc_keys()
+                        .into_iter()
+                        .map(|pk| pk.x_only_public_key().0)
+                        .collect(),
+                    tweak: TaprootTweak::Key { tweak: None },
+                    sweep_sighash,
+                }],
+                expected_signals: vec![],
+            });
+        }
+    }
+
+    /// tests that the pre-deposit states and Aborted (no live deposit UTXO) reject SweepRequested
+    #[test]
+    fn test_sweep_request_invalid_from_other_states() {
+        let desc = random_p2tr_desc();
+
+        let invalid_states = [
+            DepositState::Created {
+                deposit_transaction: test_deposit_txn(),
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                claim_txids: BTreeMap::new(),
+            },
+            DepositState::GraphGenerated {
+                deposit_transaction: test_deposit_txn(),
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                claim_txids: BTreeMap::new(),
+                pubnonces: BTreeMap::new(),
+            },
+            DepositState::DepositNoncesCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                deposit_transaction: test_deposit_txn(),
+                pubnonces: BTreeMap::new(),
+                claim_txids: BTreeMap::new(),
+                agg_nonce: generate_agg_nonce(),
+                partial_signatures: BTreeMap::new(),
+            },
+            DepositState::DepositPartialsCollected {
+                last_block_height: INITIAL_BLOCK_HEIGHT,
+                deposit_transaction: test_deposit_txn().as_ref().clone(),
             },
             DepositState::Aborted,
         ];

--- a/crates/bridge-sm/src/deposit/tests/sweep/races.rs
+++ b/crates/bridge-sm/src/deposit/tests/sweep/races.rs
@@ -1,0 +1,180 @@
+//! SM-level race resolution between the sweep and an in-flight withdrawal: whichever
+//! transaction spends the deposit outpoint first, every ordering converges to `Spent`.
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use musig2::{AggNonce, aggregate_partial_signatures};
+
+    use crate::{
+        deposit::{
+            duties::DepositDuty,
+            events::{
+                DepositEvent, PayoutConfirmedEvent, SweepNonceReceivedEvent,
+                SweepPartialReceivedEvent, SweepRequestedEvent,
+            },
+            state::DepositState,
+            tests::*,
+        },
+        testing::transition::EventSequence,
+    };
+
+    /// A `PayoutNoncesCollected` state with a fully populated cooperative-payout session.
+    fn mid_payout_state() -> DepositState {
+        let nonces: BTreeMap<_, _> = (0..N_TEST_OPERATORS)
+            .map(|idx| (idx as u32, generate_pubnonce()))
+            .collect();
+        let payout_aggregated_nonce = AggNonce::sum(nonces.values().cloned());
+
+        DepositState::PayoutNoncesCollected {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            assignee: TEST_ASSIGNEE,
+            fulfillment_txid: generate_txid(),
+            cooperative_payout_tx: test_cooperative_payout_txn(random_p2tr_desc()),
+            cooperative_payment_deadline: LATER_BLOCK_HEIGHT,
+            payout_nonces: nonces,
+            payout_aggregated_nonce,
+            payout_partial_signatures: BTreeMap::new(),
+        }
+    }
+
+    /// Drives a full sweep round from `from_state`, finalizes the sweep transaction, confirms
+    /// it, and asserts the deposit lands in `Spent` with no preserved withdrawal info (the
+    /// sweep entry discarded it).
+    fn assert_sweep_completes_from(from_state: DepositState) {
+        let signers = test_operator_signers();
+        let desc = random_p2tr_desc();
+        let sweep_tx = test_sweep_txn(desc.clone());
+        let (key_agg_ctx, message) = get_sweep_signing_info(&sweep_tx, &signers);
+        let agg_pubkey = key_agg_ctx.aggregated_pubkey();
+        let nonce_counter = 0u64;
+
+        let sm = create_sm(from_state);
+        let mut seq = EventSequence::new(sm, get_state);
+
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::SweepRequested(SweepRequestedEvent {
+                safe_harbour_desc: desc.clone(),
+            }),
+        );
+
+        let nonces: BTreeMap<_, _> = signers
+            .iter()
+            .map(|s| (s.operator_idx(), s.pubnonce(agg_pubkey, nonce_counter)))
+            .collect();
+        for (operator_idx, sweep_nonce) in &nonces {
+            seq.process(
+                test_deposit_sm_cfg(),
+                DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                    sweep_nonce: sweep_nonce.clone(),
+                    operator_idx: *operator_idx,
+                }),
+            );
+        }
+        let agg_nonce = AggNonce::sum(nonces.values().cloned());
+
+        for signer in &signers {
+            let partial = signer.sign(&key_agg_ctx, nonce_counter, &agg_nonce, message);
+            seq.process(
+                test_deposit_sm_cfg(),
+                DepositEvent::SweepPartialReceived(SweepPartialReceivedEvent {
+                    partial_signature: partial,
+                    operator_idx: signer.operator_idx(),
+                }),
+            );
+        }
+
+        seq.assert_no_errors();
+
+        let duties = seq.all_duties();
+        let (duty_agg_nonce, collected_partials, duty_sweep_tx) = duties
+            .iter()
+            .find_map(|duty| match duty {
+                DepositDuty::PublishSweep {
+                    agg_nonce,
+                    collected_partials,
+                    sweep_tx,
+                    ..
+                } => Some((agg_nonce, collected_partials, sweep_tx)),
+                _ => None,
+            })
+            .expect("PublishSweep duty must be emitted");
+
+        let ordered_partials: Vec<_> = collected_partials.values().copied().collect();
+        let agg_signature = aggregate_partial_signatures(
+            &key_agg_ctx,
+            duty_agg_nonce,
+            ordered_partials,
+            message.as_ref(),
+        )
+        .expect("aggregated sweep signature must verify");
+        let finalized = (**duty_sweep_tx).clone().finalize(agg_signature);
+
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::PayoutConfirmed(PayoutConfirmedEvent { tx: finalized }),
+        );
+        seq.assert_no_errors()
+            .assert_final_state(&DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            });
+    }
+
+    /// Sweep-wins race: entering the sweep mid-payout abandons the in-flight cooperative-payout
+    /// session, and the full symmetric signing round completes exactly as from `Deposited`.
+    #[test]
+    fn test_sweep_wins_race_from_mid_payout_states() {
+        assert_sweep_completes_from(mid_payout_state());
+        assert_sweep_completes_from(DepositState::Fulfilled {
+            last_block_height: INITIAL_BLOCK_HEIGHT,
+            assignee: TEST_ASSIGNEE,
+            fulfillment_txid: generate_txid(),
+            fulfillment_height: INITIAL_BLOCK_HEIGHT,
+            cooperative_payout_deadline: LATER_BLOCK_HEIGHT,
+        });
+    }
+
+    /// Payout-wins race: the assignee finalizes the cooperative payout with the partials
+    /// gossiped before the sweep started, and its confirmation terminates the sweep flow.
+    #[test]
+    fn test_payout_wins_race_after_sweep_entry() {
+        let signers = test_operator_signers();
+        let desc = random_p2tr_desc();
+
+        let sm = create_sm(mid_payout_state());
+        let mut seq = EventSequence::new(sm, get_state);
+
+        // The sweep starts and collects one nonce, then the racing payout confirms.
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::SweepRequested(SweepRequestedEvent {
+                safe_harbour_desc: desc.clone(),
+            }),
+        );
+        let sweep_tx = test_sweep_txn(desc);
+        let (key_agg_ctx, _) = get_sweep_signing_info(&sweep_tx, &signers);
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::SweepNonceReceived(SweepNonceReceivedEvent {
+                sweep_nonce: signers[0].pubnonce(key_agg_ctx.aggregated_pubkey(), 0),
+                operator_idx: signers[0].operator_idx(),
+            }),
+        );
+
+        seq.process(
+            test_deposit_sm_cfg(),
+            DepositEvent::PayoutConfirmed(PayoutConfirmedEvent {
+                tx: test_payout_tx(test_deposit_outpoint()),
+            }),
+        );
+
+        // The payout won: terminal, with the withdrawal info already discarded at sweep entry.
+        seq.assert_no_errors()
+            .assert_final_state(&DepositState::Spent {
+                fulfillment_txid: None,
+                assignee: None,
+            });
+    }
+}

--- a/crates/bridge-sm/src/deposit/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/deposit/tests/tx_classifier.rs
@@ -146,12 +146,40 @@ mod tests {
         ]
     }
 
+    /// States between fulfillment and the payout signing round.
+    fn fulfillment_progress_states() -> Vec<DepositState> {
+        let h = LATER_BLOCK_HEIGHT;
+        vec![
+            DepositState::Fulfilled {
+                last_block_height: h,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid: generate_txid(),
+                fulfillment_height: h,
+                cooperative_payout_deadline: h + 1008,
+            },
+            DepositState::PayoutDescriptorReceived {
+                last_block_height: h,
+                assignee: TEST_ASSIGNEE,
+                fulfillment_txid: generate_txid(),
+                cooperative_payment_deadline: h + 1008,
+                cooperative_payout_tx: test_cooperative_payout_txn(
+                    Descriptor::new_op_return(&[0u8; 32]).unwrap(),
+                ),
+                payout_nonces: BTreeMap::new(),
+            },
+        ]
+    }
+
     /// States in which a deposit-outpoint spend must classify as `PayoutConfirmed`, i.e. the
     /// states where `has_live_deposit_utxo()` holds.
     fn live_deposit_utxo_states() -> Vec<DepositState> {
-        let mut states = vec![DepositState::Deposited {
-            last_block_height: LATER_BLOCK_HEIGHT,
-        }];
+        let mut states = vec![
+            DepositState::Deposited {
+                last_block_height: LATER_BLOCK_HEIGHT,
+            },
+            assigned_state(),
+        ];
+        states.extend(fulfillment_progress_states());
         states.extend(payout_pending_states());
         states.extend(sweep_states());
         states
@@ -165,23 +193,7 @@ mod tests {
             last_block_height: h,
         });
         states.push(assigned_state());
-        states.push(DepositState::Fulfilled {
-            last_block_height: h,
-            assignee: TEST_ASSIGNEE,
-            fulfillment_txid: generate_txid(),
-            fulfillment_height: h,
-            cooperative_payout_deadline: h + 1008,
-        });
-        states.push(DepositState::PayoutDescriptorReceived {
-            last_block_height: h,
-            assignee: TEST_ASSIGNEE,
-            fulfillment_txid: generate_txid(),
-            cooperative_payment_deadline: h + 1008,
-            cooperative_payout_tx: test_cooperative_payout_txn(
-                Descriptor::new_op_return(&[0u8; 32]).unwrap(),
-            ),
-            payout_nonces: BTreeMap::new(),
-        });
+        states.extend(fulfillment_progress_states());
         states.extend(payout_pending_states());
         states.extend(sweep_states());
         states.push(DepositState::Spent {

--- a/crates/bridge-sm/src/deposit/tests/tx_classifier.rs
+++ b/crates/bridge-sm/src/deposit/tests/tx_classifier.rs
@@ -128,6 +128,35 @@ mod tests {
         ]
     }
 
+    /// Sweep signing states.
+    fn sweep_states() -> Vec<DepositState> {
+        vec![
+            DepositState::SweepNoncesPending {
+                last_block_height: LATER_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_nonces: BTreeMap::new(),
+            },
+            DepositState::SweepNoncesCollected {
+                last_block_height: LATER_BLOCK_HEIGHT,
+                sweep_tx: test_sweep_txn(random_p2tr_desc()),
+                sweep_agg_nonce: generate_agg_nonce(),
+                sweep_nonces: BTreeMap::new(),
+                sweep_partials: BTreeMap::new(),
+            },
+        ]
+    }
+
+    /// States in which a deposit-outpoint spend must classify as `PayoutConfirmed`, i.e. the
+    /// states where `has_live_deposit_utxo()` holds.
+    fn live_deposit_utxo_states() -> Vec<DepositState> {
+        let mut states = vec![DepositState::Deposited {
+            last_block_height: LATER_BLOCK_HEIGHT,
+        }];
+        states.extend(payout_pending_states());
+        states.extend(sweep_states());
+        states
+    }
+
     /// One representative of every state variant.
     fn all_state_variants() -> Vec<DepositState> {
         let h = LATER_BLOCK_HEIGHT;
@@ -154,6 +183,7 @@ mod tests {
             payout_nonces: BTreeMap::new(),
         });
         states.extend(payout_pending_states());
+        states.extend(sweep_states());
         states.push(DepositState::Spent {
             fulfillment_txid: Some(generate_txid()),
             assignee: Some(TEST_ASSIGNEE),
@@ -219,9 +249,9 @@ mod tests {
     }
 
     #[test]
-    fn classify_tx_recognizes_payout_in_all_payout_pending_states() {
+    fn classify_tx_recognizes_deposit_spend_in_all_live_utxo_states() {
         let cfg = test_deposit_sm_cfg();
-        for state in payout_pending_states() {
+        for state in live_deposit_utxo_states() {
             let sm = create_sm(state);
             let payout_tx = test_payout_tx(sm.context().deposit_outpoint());
             let result = sm.classify_tx(&cfg, &payout_tx, LATER_BLOCK_HEIGHT);
@@ -322,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_tx_ignores_non_spending_tx_in_payout_states() {
+    fn classify_tx_ignores_non_spending_tx_in_live_utxo_states() {
         let cfg = test_deposit_sm_cfg();
         let random_outpoint = OutPoint {
             txid: generate_txid(),
@@ -330,7 +360,7 @@ mod tests {
         };
         let non_spending_tx = generate_spending_tx(random_outpoint, &[]);
 
-        for state in payout_pending_states() {
+        for state in live_deposit_utxo_states() {
             let sm = create_sm(state);
             let result = sm.classify_tx(&cfg, &non_spending_tx, LATER_BLOCK_HEIGHT);
             assert!(result.is_none(), "expected None but got {:?}", result);

--- a/crates/bridge-sm/src/deposit/transitions/common.rs
+++ b/crates/bridge-sm/src/deposit/transitions/common.rs
@@ -38,6 +38,12 @@ impl DepositSM {
             }
             | DepositState::CooperativePathFailed {
                 last_block_height, ..
+            }
+            | DepositState::SweepNoncesPending {
+                last_block_height, ..
+            }
+            | DepositState::SweepNoncesCollected {
+                last_block_height, ..
             } => {
                 *last_block_height = new_block.block_height;
 

--- a/crates/bridge-sm/src/deposit/transitions/mod.rs
+++ b/crates/bridge-sm/src/deposit/transitions/mod.rs
@@ -6,3 +6,4 @@
 mod common;
 mod deposit;
 mod payout;
+mod sweep;

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -66,11 +66,19 @@ impl DepositSM {
             | DepositState::PayoutDescriptorReceived { .. }
             | DepositState::PayoutNoncesCollected { .. }
             | DepositState::CooperativePathFailed { .. }
+            // ASM does not gate assignment creation on safe harbour.
+            | DepositState::SweepNoncesPending { .. }
+            | DepositState::SweepNoncesCollected { .. }
             | DepositState::Spent { .. } => {
                 return Err(DSMError::duplicate(self.state.clone(), assignment.into()));
             }
 
-            _ => {
+            // Exhaustive so a new state must be classified rather than inherit the fatal arm.
+            DepositState::Created { .. }
+            | DepositState::GraphGenerated { .. }
+            | DepositState::DepositNoncesCollected { .. }
+            | DepositState::DepositPartialsCollected { .. }
+            | DepositState::Aborted => {
                 return Err(DSMError::invalid_event(
                     self.state.clone(),
                     assignment.into(),

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -569,8 +569,11 @@ impl DepositSM {
         payout_confirmed: &PayoutConfirmedEvent,
     ) -> DSMResult<DSMOutput> {
         let (fulfillment_txid, assignee) = match self.state() {
-            // It must be the sweep transaction in case of a hard upgrade
-            DepositState::Deposited { .. } => (None, None),
+            // It must be the sweep transaction in case of a hard upgrade. The sweep states
+            // observe either their own sweep transaction or a racing payout confirming.
+            DepositState::Deposited { .. }
+            | DepositState::SweepNoncesPending { .. }
+            | DepositState::SweepNoncesCollected { .. } => (None, None),
             // It must be a cooperative payout transaction.
             // The assignee withholds their own partial and broadcasts the payout tx themselves,
             // In this case, we still want other nodes' state machines to transition from

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -563,7 +563,11 @@ impl DepositSM {
     ///   uncontested.
     /// - A contested payout transaction, if the assignee published a claim that was contested but
     ///   not successfully.
-    /// - A sweep transaction in the event of a hard upgrade (migration) of deposited UTXOs.
+    /// - A sweep transaction under safe harbour.
+    ///
+    /// The spend is terminal from every state holding a live deposit UTXO, regardless of which
+    /// of these transactions won; assignee/fulfillment info is preserved where the source state
+    /// carries it, for monitoring only.
     pub(crate) fn process_payout_confirmed(
         &mut self,
         payout_confirmed: &PayoutConfirmedEvent,
@@ -574,11 +578,25 @@ impl DepositSM {
             DepositState::Deposited { .. }
             | DepositState::SweepNoncesPending { .. }
             | DepositState::SweepNoncesCollected { .. } => (None, None),
+            // No fulfillment has happened yet; only a sweep (or a rogue pre-signed payout)
+            // can have spent the outpoint here.
+            DepositState::Assigned { assignee, .. } => (None, Some(*assignee)),
+            // The user has been fronted; a sweep or a racing payout spent the outpoint.
+            DepositState::Fulfilled {
+                fulfillment_txid,
+                assignee,
+                ..
+            }
+            | DepositState::PayoutDescriptorReceived {
+                fulfillment_txid,
+                assignee,
+                ..
+            }
             // It must be a cooperative payout transaction.
             // The assignee withholds their own partial and broadcasts the payout tx themselves,
             // In this case, we still want other nodes' state machines to transition from
             // `PayoutNoncesCollected` to `Spent`. This can also happen if there are network delays.
-            DepositState::PayoutNoncesCollected {
+            | DepositState::PayoutNoncesCollected {
                 fulfillment_txid,
                 assignee,
                 ..
@@ -598,7 +616,11 @@ impl DepositSM {
                     payout_confirmed.clone().into(),
                 ));
             }
-            _ => {
+            DepositState::Created { .. }
+            | DepositState::GraphGenerated { .. }
+            | DepositState::DepositNoncesCollected { .. }
+            | DepositState::DepositPartialsCollected { .. }
+            | DepositState::Aborted => {
                 return Err(DSMError::invalid_event(
                     self.state().clone(),
                     payout_confirmed.clone().into(),

--- a/crates/bridge-sm/src/deposit/transitions/payout.rs
+++ b/crates/bridge-sm/src/deposit/transitions/payout.rs
@@ -66,11 +66,17 @@ impl DepositSM {
             | DepositState::PayoutDescriptorReceived { .. }
             | DepositState::PayoutNoncesCollected { .. }
             | DepositState::CooperativePathFailed { .. }
-            // ASM does not gate assignment creation on safe harbour.
-            | DepositState::SweepNoncesPending { .. }
-            | DepositState::SweepNoncesCollected { .. }
             | DepositState::Spent { .. } => {
                 return Err(DSMError::duplicate(self.state.clone(), assignment.into()));
+            }
+
+            // ASM does not gate assignment on safe harbour.
+            DepositState::SweepNoncesPending { .. } | DepositState::SweepNoncesCollected { .. } => {
+                return Err(DSMError::rejected(
+                    self.state.clone(),
+                    assignment.into(),
+                    "reject assignment after safe harbour is activated",
+                ));
             }
 
             // Exhaustive so a new state must be classified rather than inherit the fatal arm.

--- a/crates/bridge-sm/src/deposit/transitions/sweep.rs
+++ b/crates/bridge-sm/src/deposit/transitions/sweep.rs
@@ -24,6 +24,11 @@ use crate::deposit::{
 impl DepositSM {
     /// Processes the event requesting that this deposit be swept to the safe-harbour descriptor.
     ///
+    /// Valid from every state holding a live deposit UTXO: the deposit outpoint is a fixed
+    /// N-of-N key-path output that withdrawal progress never touches, so the sweep transaction
+    /// is built identically from any source state and whatever withdrawal-progress the source
+    /// carried (assignee, fulfillment txid, in-flight payout session) is discarded.
+    ///
     /// Builds the sweep transaction and transitions to [`DepositState::SweepNoncesPending`],
     /// emitting a [`DepositDuty::PublishSweepNonce`] duty for every operator.
     pub(crate) fn process_sweep_request(
@@ -43,62 +48,83 @@ impl DepositSM {
             .map(|pk| pk.x_only_public_key().0)
             .collect();
 
-        match self.state() {
-            DepositState::Deposited { last_block_height } => {
-                let last_block_height = *last_block_height;
-
-                // Build the sweep transaction to the frozen safe-harbour descriptor
-                let deposit_connector =
-                    NOfNConnector::new(cfg.network(), n_of_n_pubkey, cfg.deposit_amount());
-                let sweep_tx = SweepTx::new(
-                    SweepData { deposit_outpoint },
-                    deposit_connector,
-                    sweep_request.safe_harbour_desc,
-                    ordered_pubkeys.clone(),
-                    cfg.sweep_fee_rate(),
-                );
-
-                let sweep_sighash = sweep_tx
-                    .signing_info()
-                    .first()
-                    .expect("sweep transaction must have signing info")
-                    .sighash;
-
-                // Transition to the SweepNoncesPending state
-                self.state = DepositState::SweepNoncesPending {
-                    last_block_height,
-                    sweep_tx,
-                    sweep_nonces: BTreeMap::new(),
-                };
-
-                // Dispatch the duty to publish the sweep nonce
-                Ok(DSMOutput::with_duties(vec![
-                    DepositDuty::PublishSweepNonce {
-                        deposit_idx,
-                        deposit_outpoint,
-                        ordered_pubkeys,
-                        // NOfNConnector uses key-path spend with no script tree
-                        tweak: TaprootTweak::Key { tweak: None },
-                        sweep_sighash,
-                    },
-                ]))
+        let last_block_height = match self.state() {
+            DepositState::Deposited { last_block_height }
+            | DepositState::Assigned {
+                last_block_height, ..
             }
+            | DepositState::Fulfilled {
+                last_block_height, ..
+            }
+            | DepositState::PayoutDescriptorReceived {
+                last_block_height, ..
+            }
+            | DepositState::PayoutNoncesCollected {
+                last_block_height, ..
+            }
+            | DepositState::CooperativePathFailed {
+                last_block_height, ..
+            } => *last_block_height,
 
-            // The per-block scan re-emits SweepRequested until the deposit leaves `Deposited`,
-            // so a sweep already in progress (or completed) is a duplicate, not an error.
+            // The per-block scan re-emits SweepRequested until the deposit leaves the live-UTXO
+            // states, so a sweep already in progress (or completed) is a duplicate, not an error.
             DepositState::SweepNoncesPending { .. }
             | DepositState::SweepNoncesCollected { .. }
-            | DepositState::Spent { .. } => Err(DSMError::duplicate(
-                self.state().clone(),
-                sweep_request.into(),
-            )),
+            | DepositState::Spent { .. } => {
+                return Err(DSMError::duplicate(
+                    self.state().clone(),
+                    sweep_request.into(),
+                ));
+            }
 
-            _ => Err(DSMError::invalid_event(
-                self.state().clone(),
-                sweep_request.into(),
-                None,
-            )),
-        }
+            DepositState::Created { .. }
+            | DepositState::GraphGenerated { .. }
+            | DepositState::DepositNoncesCollected { .. }
+            | DepositState::DepositPartialsCollected { .. }
+            | DepositState::Aborted => {
+                return Err(DSMError::invalid_event(
+                    self.state().clone(),
+                    sweep_request.into(),
+                    None,
+                ));
+            }
+        };
+
+        // Build the sweep transaction to the frozen safe-harbour descriptor
+        let deposit_connector =
+            NOfNConnector::new(cfg.network(), n_of_n_pubkey, cfg.deposit_amount());
+        let sweep_tx = SweepTx::new(
+            SweepData { deposit_outpoint },
+            deposit_connector,
+            sweep_request.safe_harbour_desc,
+            ordered_pubkeys.clone(),
+            cfg.sweep_fee_rate(),
+        );
+
+        let sweep_sighash = sweep_tx
+            .signing_info()
+            .first()
+            .expect("sweep transaction must have signing info")
+            .sighash;
+
+        // Transition to the SweepNoncesPending state
+        self.state = DepositState::SweepNoncesPending {
+            last_block_height,
+            sweep_tx,
+            sweep_nonces: BTreeMap::new(),
+        };
+
+        // Dispatch the duty to publish the sweep nonce
+        Ok(DSMOutput::with_duties(vec![
+            DepositDuty::PublishSweepNonce {
+                deposit_idx,
+                deposit_outpoint,
+                ordered_pubkeys,
+                // NOfNConnector uses key-path spend with no script tree
+                tweak: TaprootTweak::Key { tweak: None },
+                sweep_sighash,
+            },
+        ]))
     }
 
     /// Processes the event where an operator's sweep nonce is received.

--- a/crates/bridge-sm/src/deposit/transitions/sweep.rs
+++ b/crates/bridge-sm/src/deposit/transitions/sweep.rs
@@ -1,0 +1,334 @@
+//! Transitions for the safe-harbour sweep of the deposit UTXO.
+//!
+//! The sweep mirrors the cooperative payout signing round with two differences: the payout
+//! destination is the frozen safe-harbour descriptor injected via the seed event, and the
+//! round is symmetric — there is no assignee, so every operator publishes its partial and
+//! every operator finalizes and broadcasts the identical deterministic transaction.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use musig2::{AggNonce, verify_partial};
+use strata_bridge_connectors::n_of_n::NOfNConnector;
+use strata_bridge_primitives::{key_agg::create_agg_ctx, scripts::taproot::TaprootTweak};
+use strata_bridge_tx_graph::transactions::prelude::{SweepData, SweepTx};
+
+use crate::deposit::{
+    config::DepositSMCfg,
+    duties::DepositDuty,
+    errors::{DSMError, DSMResult},
+    events::{SweepNonceReceivedEvent, SweepPartialReceivedEvent, SweepRequestedEvent},
+    machine::{DSMOutput, DepositSM},
+    state::DepositState,
+};
+
+impl DepositSM {
+    /// Processes the event requesting that this deposit be swept to the safe-harbour descriptor.
+    ///
+    /// Builds the sweep transaction and transitions to [`DepositState::SweepNoncesPending`],
+    /// emitting a [`DepositDuty::PublishSweepNonce`] duty for every operator.
+    pub(crate) fn process_sweep_request(
+        &mut self,
+        cfg: Arc<DepositSMCfg>,
+        sweep_request: SweepRequestedEvent,
+    ) -> DSMResult<DSMOutput> {
+        // Extract values before the match to avoid borrow conflicts
+        let n_of_n_pubkey = self.context.operator_table().aggregated_btc_key().into();
+        let deposit_outpoint = self.context.deposit_outpoint();
+        let deposit_idx = self.context.deposit_idx();
+        let ordered_pubkeys: Vec<_> = self
+            .context
+            .operator_table()
+            .btc_keys()
+            .into_iter()
+            .map(|pk| pk.x_only_public_key().0)
+            .collect();
+
+        match self.state() {
+            DepositState::Deposited { last_block_height } => {
+                let last_block_height = *last_block_height;
+
+                // Build the sweep transaction to the frozen safe-harbour descriptor
+                let deposit_connector =
+                    NOfNConnector::new(cfg.network(), n_of_n_pubkey, cfg.deposit_amount());
+                let sweep_tx = SweepTx::new(
+                    SweepData { deposit_outpoint },
+                    deposit_connector,
+                    sweep_request.safe_harbour_desc,
+                    ordered_pubkeys.clone(),
+                    cfg.sweep_fee_rate(),
+                );
+
+                let sweep_sighash = sweep_tx
+                    .signing_info()
+                    .first()
+                    .expect("sweep transaction must have signing info")
+                    .sighash;
+
+                // Transition to the SweepNoncesPending state
+                self.state = DepositState::SweepNoncesPending {
+                    last_block_height,
+                    sweep_tx,
+                    sweep_nonces: BTreeMap::new(),
+                };
+
+                // Dispatch the duty to publish the sweep nonce
+                Ok(DSMOutput::with_duties(vec![
+                    DepositDuty::PublishSweepNonce {
+                        deposit_idx,
+                        deposit_outpoint,
+                        ordered_pubkeys,
+                        // NOfNConnector uses key-path spend with no script tree
+                        tweak: TaprootTweak::Key { tweak: None },
+                        sweep_sighash,
+                    },
+                ]))
+            }
+
+            // The per-block scan re-emits SweepRequested until the deposit leaves `Deposited`,
+            // so a sweep already in progress (or completed) is a duplicate, not an error.
+            DepositState::SweepNoncesPending { .. }
+            | DepositState::SweepNoncesCollected { .. }
+            | DepositState::Spent { .. } => Err(DSMError::duplicate(
+                self.state().clone(),
+                sweep_request.into(),
+            )),
+
+            _ => Err(DSMError::invalid_event(
+                self.state().clone(),
+                sweep_request.into(),
+                None,
+            )),
+        }
+    }
+
+    /// Processes the event where an operator's sweep nonce is received.
+    ///
+    /// Collects sweep nonces required for the sweep signing round. Once all nonces are
+    /// collected, transitions to [`DepositState::SweepNoncesCollected`] and emits a
+    /// [`DepositDuty::PublishSweepPartial`] duty for every operator (no assignee asymmetry).
+    pub(crate) fn process_sweep_nonce_received(
+        &mut self,
+        sweep_nonce: SweepNonceReceivedEvent,
+    ) -> DSMResult<DSMOutput> {
+        // Validate operator_idx is in the operator table
+        self.check_operator_idx(sweep_nonce.operator_idx, &sweep_nonce)?;
+
+        let operator_table_cardinality = self.context.operator_table().cardinality();
+
+        match self.state_mut() {
+            DepositState::SweepNoncesPending {
+                last_block_height,
+                sweep_tx,
+                sweep_nonces,
+            } => {
+                // Check for duplicate nonce submission. If an entry from the same operator exists,
+                // return with an error.
+                if sweep_nonces.contains_key(&sweep_nonce.operator_idx) {
+                    return Err(DSMError::duplicate(
+                        self.state().clone(),
+                        sweep_nonce.into(),
+                    ));
+                }
+                // Update the sweep nonces with the new nonce just received.
+                sweep_nonces.insert(sweep_nonce.operator_idx, sweep_nonce.sweep_nonce);
+
+                // Transition to the SweepNoncesCollected state if *all* the nonces have been
+                // received and dispatch the duty to publish the sweep partial signature.
+                if operator_table_cardinality == sweep_nonces.len() {
+                    // Compute the aggregated nonce from the collected nonces.
+                    let agg_nonce = AggNonce::sum(sweep_nonces.values());
+
+                    // Derive the sighash of the sweep transaction.
+                    let sweep_sighash = sweep_tx
+                        .signing_info()
+                        .first()
+                        .expect("sweep transaction must have signing info")
+                        .sighash;
+
+                    // Transition to the SweepNoncesCollected state.
+                    self.state = DepositState::SweepNoncesCollected {
+                        last_block_height: *last_block_height,
+                        sweep_tx: sweep_tx.clone(),
+                        sweep_agg_nonce: agg_nonce.clone(),
+                        sweep_nonces: sweep_nonces.clone(),
+                        sweep_partials: BTreeMap::new(),
+                    };
+
+                    // Unlike the cooperative payout, the sweep round is symmetric: *every*
+                    // operator publishes its partial signature.
+                    let ordered_pubkeys = self
+                        .context
+                        .operator_table()
+                        .btc_keys()
+                        .into_iter()
+                        .map(|pk| pk.x_only_public_key().0)
+                        .collect();
+
+                    Ok(DSMOutput::with_duties(vec![
+                        DepositDuty::PublishSweepPartial {
+                            deposit_idx: self.context.deposit_idx(),
+                            deposit_outpoint: self.context.deposit_outpoint(),
+                            sweep_sighash,
+                            agg_nonce,
+                            ordered_pubkeys,
+                        },
+                    ]))
+                }
+                // If all nonces are not yet collected, stay in the SweepNoncesPending state
+                // and dispatch no duties or signals.
+                else {
+                    Ok(DSMOutput::new())
+                }
+            }
+
+            state => {
+                if matches!(
+                    state,
+                    DepositState::Created { .. }
+                        | DepositState::GraphGenerated { .. }
+                        | DepositState::DepositNoncesCollected { .. }
+                        | DepositState::DepositPartialsCollected { .. }
+                ) {
+                    Err(DSMError::rejected(
+                        self.state().clone(),
+                        sweep_nonce.into(),
+                        "Inapplicable SweepNonce event in pre-deposit state; expected state(s): SweepNoncesPending",
+                    ))
+                } else {
+                    Err(DSMError::invalid_event(
+                        self.state().clone(),
+                        sweep_nonce.into(),
+                        None,
+                    ))
+                }
+            }
+        }
+    }
+
+    /// Processes the event where an operator's sweep partial signature is received.
+    ///
+    /// Verifies and collects sweep partial signatures. Once *all* partials are collected,
+    /// emits a [`DepositDuty::PublishSweep`] duty for every operator: the aggregated signature
+    /// and transaction are deterministic, so each operator broadcasts the identical sweep and
+    /// duplicates are rejected as already-known by the network.
+    pub(crate) fn process_sweep_partial_received(
+        &mut self,
+        sweep_partial: SweepPartialReceivedEvent,
+    ) -> DSMResult<DSMOutput> {
+        // Validate operator_idx is in the operator table
+        self.check_operator_idx(sweep_partial.operator_idx, &sweep_partial)?;
+
+        // Extract context values before the match to avoid borrow conflicts
+        let operator_table_cardinality = self.context.operator_table().cardinality();
+        let deposit_outpoint = self.context.deposit_outpoint();
+        let ordered_pubkeys: Vec<_> = self
+            .context
+            .operator_table()
+            .btc_keys()
+            .into_iter()
+            .map(|pk| pk.x_only_public_key().0)
+            .collect();
+        // NOfNConnector uses key-path spend with no script tree, so we use
+        // TaprootTweak::Key which applies with_unspendable_taproot_tweak()
+        let key_agg_ctx = create_agg_ctx(
+            self.context.operator_table().btc_keys(),
+            &TaprootTweak::Key { tweak: None },
+        )
+        .expect("must be able to create key aggregation context");
+        let operator_pubkey = self
+            .context
+            .operator_table
+            .idx_to_btc_key(&sweep_partial.operator_idx)
+            .expect("operator must be in table");
+
+        match self.state_mut() {
+            DepositState::SweepNoncesCollected {
+                sweep_tx,
+                sweep_agg_nonce,
+                sweep_nonces,
+                sweep_partials,
+                ..
+            } => {
+                // Check for duplicate partial signature submission. If an entry from the same
+                // operator exists, return with an error.
+                if sweep_partials.contains_key(&sweep_partial.operator_idx) {
+                    return Err(DSMError::duplicate(
+                        self.state().clone(),
+                        sweep_partial.into(),
+                    ));
+                }
+
+                // Get the sighash from the stored sweep transaction
+                let message = sweep_tx
+                    .signing_info()
+                    .first()
+                    .expect("sweep transaction must have signing info")
+                    .sighash;
+
+                // Get the operator's pubnonce for verification.
+                let operator_pubnonce = sweep_nonces
+                    .get(&sweep_partial.operator_idx)
+                    .expect("operator must have submitted nonce");
+
+                // Verify the partial signature.
+                if verify_partial(
+                    &key_agg_ctx,
+                    sweep_partial.partial_signature,
+                    sweep_agg_nonce,
+                    operator_pubkey,
+                    operator_pubnonce,
+                    message.as_ref(),
+                )
+                .is_err()
+                {
+                    return Err(DSMError::rejected(
+                        self.state().clone(),
+                        sweep_partial.into(),
+                        "Partial Signature Verification Failed",
+                    ));
+                }
+
+                // If the partial signature verification passes, add it to state
+                sweep_partials.insert(sweep_partial.operator_idx, sweep_partial.partial_signature);
+
+                // Unlike the cooperative payout (which waits for all partials except the
+                // assignee's), the sweep waits for *all* partials so that every operator can
+                // finalize and broadcast without a further signing step.
+                if operator_table_cardinality == sweep_partials.len() {
+                    Ok(DSMOutput::with_duties(vec![DepositDuty::PublishSweep {
+                        deposit_outpoint,
+                        agg_nonce: sweep_agg_nonce.clone(),
+                        collected_partials: sweep_partials.clone(),
+                        sweep_tx: Box::new(sweep_tx.clone()),
+                        ordered_pubkeys,
+                    }]))
+                } else {
+                    // If there are remaining partial signatures, stay in the same state.
+                    Ok(DSMOutput::new())
+                }
+            }
+
+            state => {
+                if matches!(
+                    state,
+                    DepositState::Created { .. }
+                        | DepositState::GraphGenerated { .. }
+                        | DepositState::DepositNoncesCollected { .. }
+                        | DepositState::DepositPartialsCollected { .. }
+                ) {
+                    Err(DSMError::rejected(
+                        self.state().clone(),
+                        sweep_partial.into(),
+                        "Inapplicable SweepPartial event in pre-deposit state; expected state(s): SweepNoncesCollected",
+                    ))
+                } else {
+                    Err(DSMError::invalid_event(
+                        self.state().clone(),
+                        sweep_partial.into(),
+                        None,
+                    ))
+                }
+            }
+        }
+    }
+}

--- a/crates/bridge-sm/src/deposit/tx_classifier.rs
+++ b/crates/bridge-sm/src/deposit/tx_classifier.rs
@@ -34,6 +34,17 @@ impl TxClassifier for DepositSM {
             }));
         }
 
+        // Any tx spending a live deposit outpoint is terminal for the deposit — a cooperative
+        // payout, a unilateral payout, or the safe-harbour sweep; `process_payout_confirmed`
+        // sorts out which.
+        if self.state().has_live_deposit_utxo()
+            && is_deposit_spend(self.context().deposit_outpoint, tx)
+        {
+            return Some(DepositEvent::PayoutConfirmed(PayoutConfirmedEvent {
+                tx: tx.clone(),
+            }));
+        }
+
         match self.state() {
             // initial states expect DRT spend but that is handled above.
             DepositState::Created { .. } => None,
@@ -48,8 +59,8 @@ impl TxClassifier for DepositSM {
                     deposit_transaction: tx.clone(),
                 }))
             }
-
-            DepositState::Deposited { .. } => None, // does not expect any txs
+            DepositState::DepositNoncesCollected { .. }
+            | DepositState::DepositPartialsCollected { .. } => None,
 
             // expects fulfillment
             DepositState::Assigned { recipient_desc, .. }
@@ -69,25 +80,21 @@ impl TxClassifier for DepositSM {
                     },
                 ))
             }
+            DepositState::Assigned { .. } => None,
 
             DepositState::Fulfilled { .. } => None, // does not expect any txs
             DepositState::PayoutDescriptorReceived { .. } => None, // does not expect any txs
 
-            // expect payout
-            DepositState::PayoutNoncesCollected { .. }
+            // deposit-outpoint spends are handled by the hoisted check above
+            DepositState::Deposited { .. }
+            | DepositState::PayoutNoncesCollected { .. }
             | DepositState::CooperativePathFailed { .. }
-                if is_deposit_spend(self.context().deposit_outpoint, tx) =>
-            {
-                Some(DepositEvent::PayoutConfirmed(PayoutConfirmedEvent {
-                    tx: tx.clone(),
-                }))
-            }
+            | DepositState::SweepNoncesPending { .. }
+            | DepositState::SweepNoncesCollected { .. } => None,
 
             // terminal states expect no txs
             DepositState::Spent { .. } => None,
             DepositState::Aborted => None,
-
-            _ => None,
         }
     }
 }

--- a/crates/bridge-sm/src/deposit/tx_classifier.rs
+++ b/crates/bridge-sm/src/deposit/tx_classifier.rs
@@ -82,11 +82,10 @@ impl TxClassifier for DepositSM {
             }
             DepositState::Assigned { .. } => None,
 
-            DepositState::Fulfilled { .. } => None, // does not expect any txs
-            DepositState::PayoutDescriptorReceived { .. } => None, // does not expect any txs
-
             // deposit-outpoint spends are handled by the hoisted check above
             DepositState::Deposited { .. }
+            | DepositState::Fulfilled { .. }
+            | DepositState::PayoutDescriptorReceived { .. }
             | DepositState::PayoutNoncesCollected { .. }
             | DepositState::CooperativePathFailed { .. }
             | DepositState::SweepNoncesPending { .. }

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -340,7 +340,7 @@ impl GraphDuty {
             | GraphDuty::PublishUnstakingBurn { .. }
             | GraphDuty::PublishContest { .. }
             | GraphDuty::PublishBridgeProofTimeout { .. }
-            | GraphDuty::GenerateAndPublishCounterProof { .. }
+            | GraphDuty::PotentialCounterProof { .. }
             | GraphDuty::PublishCounterProofAck { .. }
             | GraphDuty::PublishCounterProofNack { .. }
             | GraphDuty::PublishSlash { .. }

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -318,16 +318,16 @@ pub enum GraphDuty {
 }
 
 impl GraphDuty {
-    /// Whether this duty advances the graph owner's claim towards a payout spending the deposit
-    /// UTXO.
+    /// Whether to suppress this duty at dispatch while the safe harbour is active: true for the
+    /// duties advancing the graph owner's claim towards a payout spending the deposit UTXO, so
+    /// no claim advances while deposits are being swept.
     ///
-    /// Under safe harbour these duties are suppressed at dispatch so no claim advances while
-    /// deposits are being swept. The defensive duties — contest, counterproof, slash, and
+    /// The defensive duties — contest, counterproof, slash, and
     /// unstaking burn — challenge or punish a claim rather than pursue one and are **never**
     /// suppressed: they are the only funds defense when a rogue operator stalls the sweep and
     /// fires its pre-signed claim path. Graph setup duties are also never suppressed, since
     /// in-flight deposits must finish before they can be swept.
-    pub const fn is_withdrawal_path(&self) -> bool {
+    pub const fn should_suppress_under_safe_harbour(&self) -> bool {
         match self {
             GraphDuty::PublishClaim { .. }
             | GraphDuty::PublishUncontestedPayout { .. }

--- a/crates/bridge-sm/src/graph/duties.rs
+++ b/crates/bridge-sm/src/graph/duties.rs
@@ -317,6 +317,38 @@ pub enum GraphDuty {
     },
 }
 
+impl GraphDuty {
+    /// Whether this duty advances the graph owner's claim towards a payout spending the deposit
+    /// UTXO.
+    ///
+    /// Under safe harbour these duties are suppressed at dispatch so no claim advances while
+    /// deposits are being swept. The defensive duties — contest, counterproof, slash, and
+    /// unstaking burn — challenge or punish a claim rather than pursue one and are **never**
+    /// suppressed: they are the only funds defense when a rogue operator stalls the sweep and
+    /// fires its pre-signed claim path. Graph setup duties are also never suppressed, since
+    /// in-flight deposits must finish before they can be swept.
+    pub const fn is_withdrawal_path(&self) -> bool {
+        match self {
+            GraphDuty::PublishClaim { .. }
+            | GraphDuty::PublishUncontestedPayout { .. }
+            | GraphDuty::PublishContestedPayout { .. }
+            | GraphDuty::GenerateAndPublishBridgeProof { .. } => true,
+            GraphDuty::GenerateGraphData { .. }
+            | GraphDuty::VerifyAdaptors { .. }
+            | GraphDuty::PublishGraphNonces { .. }
+            | GraphDuty::PublishGraphPartials { .. }
+            | GraphDuty::PublishUnstakingBurn { .. }
+            | GraphDuty::PublishContest { .. }
+            | GraphDuty::PublishBridgeProofTimeout { .. }
+            | GraphDuty::GenerateAndPublishCounterProof { .. }
+            | GraphDuty::PublishCounterProofAck { .. }
+            | GraphDuty::PublishCounterProofNack { .. }
+            | GraphDuty::PublishSlash { .. }
+            | GraphDuty::Nag { .. } => false,
+        }
+    }
+}
+
 impl std::fmt::Display for GraphDuty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {

--- a/crates/bridge-sm/src/graph/handlers/nag.rs
+++ b/crates/bridge-sm/src/graph/handlers/nag.rs
@@ -98,7 +98,9 @@ impl GraphSM {
             NagRequestPayload::DepositNonce { .. }
             | NagRequestPayload::DepositPartial { .. }
             | NagRequestPayload::PayoutNonce { .. }
-            | NagRequestPayload::PayoutPartial { .. } => {
+            | NagRequestPayload::PayoutPartial { .. }
+            | NagRequestPayload::SweepNonce { .. }
+            | NagRequestPayload::SweepPartial { .. } => {
                 Err(self.reject_nag(&event, "Deposit-domain nag is not applicable to GraphSM"))
             }
             NagRequestPayload::UnstakingData { .. }

--- a/crates/bridge-sm/src/graph/tests/duties.rs
+++ b/crates/bridge-sm/src/graph/tests/duties.rs
@@ -1,4 +1,4 @@
-//! Unit tests for the GraphDuty withdrawal-path taxonomy.
+//! Unit tests for the GraphDuty safe-harbour suppression taxonomy.
 #[cfg(test)]
 mod tests {
     use bitcoin::hashes::{Hash, sha256};
@@ -19,13 +19,13 @@ mod tests {
         },
     };
 
-    /// Pins the withdrawal-path classification of every graph duty.
+    /// Pins the safe-harbour suppression classification of every graph duty.
     ///
     /// Only the duties advancing the owner's claim towards a payout are suppressible under safe
     /// harbour; the defensive duties (contest, counterproof, slash, unstaking burn) and the graph
     /// setup duties must never be.
     #[test]
-    fn test_is_withdrawal_path_per_graph_duty() {
+    fn test_should_suppress_under_safe_harbour_per_graph_duty() {
         let cfg = test_graph_sm_cfg();
         let ctx = test_graph_sm_ctx();
         let (deposit_params, game_graph) = test_graph_data(&cfg);
@@ -181,16 +181,16 @@ mod tests {
 
         for (duty, expected) in cases {
             assert_eq!(
-                duty.is_withdrawal_path(),
+                duty.should_suppress_under_safe_harbour(),
                 expected,
-                "unexpected withdrawal-path classification for {duty}"
+                "unexpected safe-harbour suppression for {duty}"
             );
         }
     }
 
     /// Graph nags solicit graph-setup progress, never withdrawal progress.
     #[test]
-    fn test_graph_nags_are_not_withdrawal_path() {
+    fn test_graph_nags_are_never_suppressed() {
         let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
         let operator_pubkey = operator_table
             .idx_to_p2p_key(&TEST_NONPOV_IDX)
@@ -219,8 +219,8 @@ mod tests {
         for nag in nags {
             let duty = GraphDuty::Nag { duty: nag };
             assert!(
-                !duty.is_withdrawal_path(),
-                "graph nag must not be withdrawal-path: {duty}"
+                !duty.should_suppress_under_safe_harbour(),
+                "graph nag must never be suppressed: {duty}"
             );
         }
     }

--- a/crates/bridge-sm/src/graph/tests/duties.rs
+++ b/crates/bridge-sm/src/graph/tests/duties.rs
@@ -1,0 +1,226 @@
+//! Unit tests for the GraphDuty withdrawal-path taxonomy.
+#[cfg(test)]
+mod tests {
+    use bitcoin::hashes::{Hash, sha256};
+    use strata_bridge_test_utils::{bitcoin::generate_txid, prelude::generate_signature};
+    use strata_bridge_tx_graph::{
+        game_graph::GameConnectors,
+        transactions::prelude::{
+            CounterproofNackData, CounterproofNackTx, UnstakingBurnData, UnstakingBurnTx,
+        },
+    };
+
+    use crate::graph::{
+        duties::{GraphDuty, NagDuty},
+        tests::{
+            INITIAL_BLOCK_HEIGHT, N_TEST_OPERATORS, TEST_NONPOV_IDX, TEST_POV_IDX, TestGraphTxKind,
+            dummy_proof_receipt, test_completed_signatures, test_deposit_outpoint, test_graph_data,
+            test_graph_sm_cfg, test_graph_sm_ctx, test_operator_table, test_stake_outpoint,
+        },
+    };
+
+    /// Pins the withdrawal-path classification of every graph duty.
+    ///
+    /// Only the duties advancing the owner's claim towards a payout are suppressible under safe
+    /// harbour; the defensive duties (contest, counterproof, slash, unstaking burn) and the graph
+    /// setup duties must never be.
+    #[test]
+    fn test_is_withdrawal_path_per_graph_duty() {
+        let cfg = test_graph_sm_cfg();
+        let ctx = test_graph_sm_ctx();
+        let (deposit_params, game_graph) = test_graph_data(&cfg);
+        let setup_params = ctx.generate_setup_params(&cfg, &deposit_params);
+        let connectors = GameConnectors::new(
+            deposit_params.game_index,
+            &cfg.game_graph_params,
+            &setup_params,
+        );
+        let graph_idx = ctx.graph_idx();
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+
+        let cases = vec![
+            (
+                GraphDuty::GenerateGraphData {
+                    graph_idx,
+                    deposit_outpoint: test_deposit_outpoint(),
+                    stake_outpoint: test_stake_outpoint(),
+                    unstaking_image: sha256::Hash::hash(&[0u8; 32]),
+                    operator_table: operator_table.clone(),
+                },
+                false,
+            ),
+            (
+                GraphDuty::VerifyAdaptors {
+                    graph_idx,
+                    watchtower_idx: TEST_NONPOV_IDX,
+                    sighashes: vec![],
+                    adaptor_pubkey: strata_bridge_test_utils::bitcoin::generate_xonly_pubkey(),
+                    fault_pubkey: strata_bridge_test_utils::bitcoin::generate_xonly_pubkey(),
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishGraphNonces {
+                    graph_idx,
+                    graph_inpoints: vec![],
+                    graph_tweaks: vec![],
+                    sighashes: vec![],
+                    ordered_pubkeys: vec![],
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishGraphPartials {
+                    graph_idx,
+                    agg_nonces: vec![],
+                    sighashes: vec![],
+                    graph_inpoints: vec![],
+                    graph_tweaks: vec![],
+                    claim_txid: generate_txid(),
+                    stake_outpoint: test_stake_outpoint(),
+                    ordered_pubkeys: vec![],
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishClaim {
+                    claim_tx: game_graph.claim,
+                },
+                true,
+            ),
+            (
+                GraphDuty::PublishUncontestedPayout {
+                    signed_uncontested_payout_tx: TestGraphTxKind::UncontestedPayout.into(),
+                },
+                true,
+            ),
+            (
+                GraphDuty::PublishUnstakingBurn {
+                    graph_idx,
+                    unstaking_burn_tx: UnstakingBurnTx::new(
+                        UnstakingBurnData {
+                            claim_txid: generate_txid(),
+                        },
+                        connectors.claim_payout,
+                    ),
+                    unstaking_preimage: [0u8; 32],
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishContest {
+                    contest_tx: game_graph.contest,
+                    n_of_n_signature: generate_signature(),
+                    watchtower_index: 0,
+                },
+                false,
+            ),
+            (
+                GraphDuty::GenerateAndPublishBridgeProof {
+                    graph_idx,
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
+                    contest_txid: generate_txid(),
+                    game_index: deposit_params.game_index,
+                    contest_proof_connector: connectors.contest_proof,
+                    operator_pubkey: ctx.owner_btc_x_only_key(),
+                },
+                true,
+            ),
+            (
+                GraphDuty::PublishBridgeProofTimeout {
+                    signed_timeout_tx: TestGraphTxKind::BridgeProofTimeout.into(),
+                },
+                false,
+            ),
+            (
+                GraphDuty::GenerateAndPublishCounterProof {
+                    graph_idx,
+                    game_index: deposit_params.game_index,
+                    counterproof_tx: game_graph.counterproofs[0].counterproof.clone(),
+                    n_of_n_signature: generate_signature(),
+                    proof: dummy_proof_receipt(),
+                    bridge_proof_tx: TestGraphTxKind::Claim.into(),
+                    operator_table: operator_table.clone(),
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishCounterProofAck {
+                    signed_counter_proof_ack_tx: TestGraphTxKind::CounterproofAck.into(),
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishCounterProofNack {
+                    deposit_idx: ctx.deposit_idx(),
+                    counterprover_idx: TEST_NONPOV_IDX,
+                    completed_signatures: test_completed_signatures(),
+                    counterproof_nack_tx: CounterproofNackTx::new(
+                        CounterproofNackData {
+                            counterproof_txid: generate_txid(),
+                        },
+                        connectors.counterproof[0],
+                    ),
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishSlash {
+                    signed_slash_tx: TestGraphTxKind::Slash.into(),
+                },
+                false,
+            ),
+            (
+                GraphDuty::PublishContestedPayout {
+                    signed_contested_payout_tx: TestGraphTxKind::ContestedPayout.into(),
+                },
+                true,
+            ),
+        ];
+
+        for (duty, expected) in cases {
+            assert_eq!(
+                duty.is_withdrawal_path(),
+                expected,
+                "unexpected withdrawal-path classification for {duty}"
+            );
+        }
+    }
+
+    /// Graph nags solicit graph-setup progress, never withdrawal progress.
+    #[test]
+    fn test_graph_nags_are_not_withdrawal_path() {
+        let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+        let operator_pubkey = operator_table
+            .idx_to_p2p_key(&TEST_NONPOV_IDX)
+            .expect("operator must be in the table")
+            .clone();
+        let graph_idx = test_graph_sm_ctx().graph_idx();
+
+        let nags = [
+            NagDuty::NagGraphData {
+                graph_idx,
+                operator_idx: TEST_NONPOV_IDX,
+                operator_pubkey: operator_pubkey.clone(),
+            },
+            NagDuty::NagGraphNonces {
+                graph_idx,
+                operator_idx: TEST_NONPOV_IDX,
+                operator_pubkey: operator_pubkey.clone(),
+            },
+            NagDuty::NagGraphPartials {
+                graph_idx,
+                operator_idx: TEST_NONPOV_IDX,
+                operator_pubkey,
+            },
+        ];
+
+        for nag in nags {
+            let duty = GraphDuty::Nag { duty: nag };
+            assert!(
+                !duty.is_withdrawal_path(),
+                "graph nag must not be withdrawal-path: {duty}"
+            );
+        }
+    }
+}

--- a/crates/bridge-sm/src/graph/tests/duties.rs
+++ b/crates/bridge-sm/src/graph/tests/duties.rs
@@ -133,8 +133,9 @@ mod tests {
                 false,
             ),
             (
-                GraphDuty::GenerateAndPublishCounterProof {
+                GraphDuty::PotentialCounterProof {
                     graph_idx,
+                    last_block_height: INITIAL_BLOCK_HEIGHT,
                     game_index: deposit_params.game_index,
                     counterproof_tx: game_graph.counterproofs[0].counterproof.clone(),
                     n_of_n_signature: generate_signature(),

--- a/crates/bridge-sm/src/graph/tests/mod.rs
+++ b/crates/bridge-sm/src/graph/tests/mod.rs
@@ -6,6 +6,7 @@ mod uncontested;
 pub(super) mod utils;
 
 mod deposit_signal;
+mod duties;
 mod notify_new_block;
 mod post_processor;
 mod process_payout;

--- a/crates/bridge-sm/src/stake/handlers/nag_received.rs
+++ b/crates/bridge-sm/src/stake/handlers/nag_received.rs
@@ -42,7 +42,9 @@ impl StakeSM {
             NagRequestPayload::DepositNonce { .. }
             | NagRequestPayload::DepositPartial { .. }
             | NagRequestPayload::PayoutNonce { .. }
-            | NagRequestPayload::PayoutPartial { .. } => {
+            | NagRequestPayload::PayoutPartial { .. }
+            | NagRequestPayload::SweepNonce { .. }
+            | NagRequestPayload::SweepPartial { .. } => {
                 Err(self.reject_nag(&event, "Deposit-domain nag is not applicable to StakeSM"))
             }
         }?;

--- a/crates/common/src/params.rs
+++ b/crates/common/src/params.rs
@@ -4,7 +4,7 @@
 //! result in a consensus failure among the bridge nodes.
 use std::{fs, path::Path, str::FromStr};
 
-use bitcoin::{hex::DisplayHex, Amount, Network};
+use bitcoin::{hex::DisplayHex, Amount, FeeRate, Network};
 use bitcoin_bosd::{Descriptor, DescriptorType};
 use libp2p::identity::ed25519::PublicKey as Libp2pKey;
 use secp256k1::XOnlyPublicKey;
@@ -72,6 +72,14 @@ pub struct ProtocolParams {
 
     /// The fee amount that the operator charges for fronting a user.
     pub operator_fee: Amount,
+
+    /// The fee rate (in sat/vb) that the safe-harbour sweep transaction pays.
+    ///
+    /// Every operator must build the identical sweep transaction for its MuSig2 partials to
+    /// aggregate, so the fee comes from this shared rate rather than per-node fee estimation.
+    #[serde(serialize_with = "serialize_fee_rate_sat_per_vb")]
+    #[serde(deserialize_with = "deserialize_fee_rate_sat_per_vb")]
+    pub sweep_fee_rate: FeeRate,
 
     /// The number of blocks after the deposit request after which the user can take back their
     /// deposit request.
@@ -284,6 +292,24 @@ where
     Ok(KeyParams { admin, covenant })
 }
 
+/// Serialize a [`FeeRate`] as a bare sat/vb integer (the TOML-facing unit).
+fn serialize_fee_rate_sat_per_vb<S>(fee_rate: &FeeRate, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_u64(fee_rate.to_sat_per_vb_ceil())
+}
+
+/// Deserialize a [`FeeRate`] from a bare sat/vb integer.
+fn deserialize_fee_rate_sat_per_vb<'de, D>(deserializer: D) -> Result<FeeRate, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let sat_per_vb = u64::deserialize(deserializer)?;
+    FeeRate::from_sat_per_vb(sat_per_vb)
+        .ok_or_else(|| serde::de::Error::custom("fee rate in sat/vb overflows"))
+}
+
 fn serialize_magic_bytes<S>(magic_bytes: &MagicBytes, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -302,7 +328,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::Amount;
+    use bitcoin::{Amount, FeeRate};
 
     use super::*;
 
@@ -343,6 +369,12 @@ mod tests {
         );
 
         assert_eq!(params.protocol.bury_depth, 6, "bury depth must round-trip");
+
+        assert_eq!(
+            FeeRate::from_sat_per_vb_unchecked(10),
+            params.protocol.sweep_fee_rate,
+            "sweep fee rate must round-trip"
+        );
 
         assert_eq!(
             params.keys.admin.threshold, 2,
@@ -479,6 +511,7 @@ mod tests {
             deposit_amount = {deposit_amount}
             stake_amount = 100_000_000
             operator_fee = 1_000_000
+            sweep_fee_rate = 10
             recovery_delay = 1_008
             contest_timelock = 144
             proof_timelock = 144

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -23,6 +23,7 @@ default = ["fdb"]
 fdb = ["foundationdb", "serde"]
 
 [dev-dependencies]
+strata-bridge-connectors.workspace = true
 strata-bridge-test-utils.workspace = true
 strata-bridge-tx-graph.workspace = true
 

--- a/crates/db/src/fdb/bridge_db.rs
+++ b/crates/db/src/fdb/bridge_db.rs
@@ -412,7 +412,7 @@ mod tests {
     use std::{collections::BTreeMap, num::NonZero, sync::OnceLock};
 
     use bitcoin::{
-        TapSighashType,
+        Network, TapSighashType,
         hashes::{Hash, sha256},
         taproot,
     };
@@ -421,6 +421,7 @@ mod tests {
         Keypair, Message, SECP256K1,
         rand::{random, thread_rng},
     };
+    use strata_bridge_connectors::n_of_n::NOfNConnector;
     use strata_bridge_primitives::{
         operator_table::{OperatorTable, prop_test_generators::arb_operator_table},
         types::{DepositIdx, OperatorIdx},
@@ -436,10 +437,12 @@ mod tests {
     use strata_bridge_test_utils::{
         arbitrary_generator::{arb_outpoint, arb_outpoints, arb_txid},
         bitcoin::{generate_tx, generate_xonly_pubkey},
+        bridge_fixtures::{TEST_DEPOSIT_AMOUNT, TEST_SWEEP_FEE_RATE, random_p2tr_desc},
         prelude::generate_txid,
     };
-    use strata_bridge_tx_graph::game_graph::{
-        CounterproofGraphSummary, DepositParams, GameGraphSummary,
+    use strata_bridge_tx_graph::{
+        game_graph::{CounterproofGraphSummary, DepositParams, GameGraphSummary},
+        transactions::sweep::{SweepData, SweepTx},
     };
 
     use super::*;
@@ -509,6 +512,22 @@ mod tests {
             },
             state,
         }
+    }
+
+    /// Builds a [`SweepTx`] for exercising the round-trip of the Psbt-carrying sweep states.
+    fn make_sweep_tx(deposit_outpoint: OutPoint) -> SweepTx {
+        let deposit_connector = NOfNConnector::new(
+            Network::Regtest,
+            generate_xonly_pubkey(),
+            TEST_DEPOSIT_AMOUNT,
+        );
+        SweepTx::new(
+            SweepData { deposit_outpoint },
+            deposit_connector,
+            random_p2tr_desc(),
+            vec![generate_xonly_pubkey()],
+            TEST_SWEEP_FEE_RATE,
+        )
     }
 
     /// Builds a [`StakeSM`] for the given operator from the operator table and state.
@@ -604,7 +623,7 @@ mod tests {
         fn deposit_state_roundtrip(
             deposit_idx in any::<DepositIdx>(),
             last_block_height in any::<u64>(),
-            variant_selector in 0u8..4,
+            variant_selector in 0u8..5,
             outpoint in arb_outpoint(),
             operator_table in arb_operator_table(),
         ) {
@@ -617,6 +636,12 @@ mod tests {
                 2 => DepositState::Spent {
                     fulfillment_txid: Some(generate_txid()),
                     assignee: Some(0),
+                },
+                // exercises the postcard round-trip of a Psbt-carrying variant
+                3 => DepositState::SweepNoncesPending {
+                    last_block_height,
+                    sweep_tx: make_sweep_tx(outpoint),
+                    sweep_nonces: BTreeMap::new(),
                 },
                 _ => DepositState::Aborted,
             };

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -336,11 +336,29 @@ pub(crate) fn classify_unsigned_gossip(
                 })
                 .collect(),
 
-            // TODO(STR-3937): classify into the deposit SM's sweep event once it exists.
-            MuSig2Nonce::Sweep { deposit_idx, .. } => {
-                warn!(%deposit_idx, "sweep nonces are not supported yet, discarding message");
-                Vec::new()
-            }
+            MuSig2Nonce::Sweep { deposit_idx, nonce } => sm_registry
+                .lookup_operator(&SMId::Deposit(*deposit_idx), key)
+                .into_iter()
+                .filter_map(|op_idx| {
+                    PubNonce::try_from(*nonce)
+                        .inspect_err(|_| {
+                            warn!(
+                                %deposit_idx, %op_idx,
+                                "Received invalid sweep nonce, discarding message"
+                            )
+                        })
+                        .ok()
+                        .map(|pubnonce| {
+                            DepositEvent::SweepNonceReceived(
+                                DepositEvents::SweepNonceReceivedEvent {
+                                    sweep_nonce: pubnonce,
+                                    operator_idx: op_idx,
+                                },
+                            )
+                            .into()
+                        })
+                })
+                .collect(),
         },
         UnsignedGossipsubMsg::Musig2SignaturesExchange(musig2_partial) => {
             match musig2_partial {
@@ -463,11 +481,32 @@ pub(crate) fn classify_unsigned_gossip(
                     })
                     .collect(),
 
-                // TODO(STR-3937): classify into the deposit SM's sweep event once it exists.
-                MuSig2Partial::Sweep { deposit_idx, .. } => {
-                    warn!(%deposit_idx, "sweep partials are not supported yet, discarding message");
-                    Vec::new()
-                }
+                MuSig2Partial::Sweep {
+                    deposit_idx,
+                    partial,
+                } => sm_registry
+                    .lookup_operator(&SMId::Deposit(*deposit_idx), key)
+                    .into_iter()
+                    .filter_map(|op_idx| {
+                        PartialSignature::try_from(*partial)
+                            .inspect_err(|_| {
+                                warn!(
+                                    %deposit_idx, %op_idx,
+                                    "Received invalid sweep partial signature, discarding message"
+                                )
+                            })
+                            .ok()
+                            .map(|partial_sig| {
+                                DepositEvent::SweepPartialReceived(
+                                    DepositEvents::SweepPartialReceivedEvent {
+                                        partial_signature: partial_sig,
+                                        operator_idx: op_idx,
+                                    },
+                                )
+                                .into()
+                            })
+                    })
+                    .collect(),
             }
         }
 
@@ -662,11 +701,15 @@ mod tests {
     use strata_bridge_primitives::types::{
         BitcoinBlockHeight, DepositIdx, GraphIdx, OperatorIdx, P2POperatorPubKey,
     };
-    use strata_bridge_test_utils::bitcoin::generate_xonly_pubkey;
+    use strata_bridge_test_utils::{
+        bitcoin::generate_xonly_pubkey,
+        musig2::{generate_partial_signature, generate_pubnonce},
+    };
 
     use super::*;
     use crate::testing::{
-        insert_deposit_with_graphs, random_p2tr_desc, test_empty_registry, test_populated_registry,
+        TEST_POV_IDX, insert_deposit_with_graphs, random_p2tr_desc, test_empty_registry,
+        test_populated_registry,
     };
 
     // ===== classify_assignment tests =====
@@ -970,6 +1013,144 @@ mod tests {
         assert!(
             events.is_empty(),
             "should reject payout descriptor with sender/operator mismatch"
+        );
+    }
+
+    // ===== sweep nonce/partial classification tests =====
+
+    fn sweep_nonce_msg(deposit_idx: DepositIdx) -> UnsignedGossipsubMsg {
+        UnsignedGossipsubMsg::Musig2NoncesExchange(MuSig2Nonce::Sweep {
+            deposit_idx,
+            nonce: generate_pubnonce().into(),
+        })
+    }
+
+    fn sweep_partial_msg(deposit_idx: DepositIdx) -> UnsignedGossipsubMsg {
+        UnsignedGossipsubMsg::Musig2SignaturesExchange(MuSig2Partial::Sweep {
+            deposit_idx,
+            partial: generate_partial_signature().into(),
+        })
+    }
+
+    /// Helper: the P2P key of the given operator in the populated test registry.
+    fn p2p_key_of(registry: &SMRegistry, operator_idx: OperatorIdx) -> P2POperatorPubKey {
+        registry
+            .get_deposit(&0)
+            .expect("deposit exists")
+            .context()
+            .operator_table()
+            .idx_to_p2p_key(&operator_idx)
+            .expect("operator exists")
+            .clone()
+    }
+
+    #[test]
+    fn classify_sweep_nonce_accepts_known_peer() {
+        let registry = test_populated_registry(1);
+        const OPERATOR_IDX: OperatorIdx = 1;
+        let sender_key = p2p_key_of(&registry, OPERATOR_IDX);
+
+        let events = classify_unsigned_gossip(
+            &registry,
+            &OperatorKey::Peer(&sender_key),
+            &sweep_nonce_msg(0),
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [SMEvent::Deposit(event)]
+                if matches!(**event, DepositEvent::SweepNonceReceived(ref evt)
+                    if evt.operator_idx == OPERATOR_IDX)
+        ));
+    }
+
+    #[test]
+    fn classify_sweep_nonce_rejects_unknown_sender() {
+        let registry = test_populated_registry(1);
+        let unknown_key = P2POperatorPubKey::from(vec![0xAA; 32]);
+
+        let events = classify_unsigned_gossip(
+            &registry,
+            &OperatorKey::Peer(&unknown_key),
+            &sweep_nonce_msg(0),
+        );
+        assert!(
+            events.is_empty(),
+            "should reject sweep nonce from unknown sender"
+        );
+    }
+
+    /// The symmetric sweep round hinges on self-published messages (ouroboros loopback)
+    /// classifying with the POV operator index.
+    #[test]
+    fn classify_sweep_nonce_accepts_pov_loopback() {
+        let registry = test_populated_registry(1);
+
+        let events = classify_unsigned_gossip(&registry, &OperatorKey::Pov, &sweep_nonce_msg(0));
+        assert!(matches!(
+            events.as_slice(),
+            [SMEvent::Deposit(event)]
+                if matches!(**event, DepositEvent::SweepNonceReceived(ref evt)
+                    if evt.operator_idx == TEST_POV_IDX)
+        ));
+    }
+
+    #[test]
+    fn classify_sweep_partial_accepts_known_peer() {
+        let registry = test_populated_registry(1);
+        const OPERATOR_IDX: OperatorIdx = 1;
+        let sender_key = p2p_key_of(&registry, OPERATOR_IDX);
+
+        let events = classify_unsigned_gossip(
+            &registry,
+            &OperatorKey::Peer(&sender_key),
+            &sweep_partial_msg(0),
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [SMEvent::Deposit(event)]
+                if matches!(**event, DepositEvent::SweepPartialReceived(ref evt)
+                    if evt.operator_idx == OPERATOR_IDX)
+        ));
+    }
+
+    #[test]
+    fn classify_sweep_partial_rejects_unknown_sender() {
+        let registry = test_populated_registry(1);
+        let unknown_key = P2POperatorPubKey::from(vec![0xAA; 32]);
+
+        let events = classify_unsigned_gossip(
+            &registry,
+            &OperatorKey::Peer(&unknown_key),
+            &sweep_partial_msg(0),
+        );
+        assert!(
+            events.is_empty(),
+            "should reject sweep partial from unknown sender"
+        );
+    }
+
+    #[test]
+    fn classify_sweep_partial_accepts_pov_loopback() {
+        let registry = test_populated_registry(1);
+
+        let events = classify_unsigned_gossip(&registry, &OperatorKey::Pov, &sweep_partial_msg(0));
+        assert!(matches!(
+            events.as_slice(),
+            [SMEvent::Deposit(event)]
+                if matches!(**event, DepositEvent::SweepPartialReceived(ref evt)
+                    if evt.operator_idx == TEST_POV_IDX)
+        ));
+    }
+
+    /// A sweep message for an unknown deposit produces no events.
+    #[test]
+    fn classify_sweep_nonce_unknown_deposit_returns_empty() {
+        let registry = test_populated_registry(1);
+
+        let events = classify_unsigned_gossip(&registry, &OperatorKey::Pov, &sweep_nonce_msg(99));
+        assert!(
+            events.is_empty(),
+            "should drop sweep nonce for unknown deposit"
         );
     }
 

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -335,6 +335,12 @@ pub(crate) fn classify_unsigned_gossip(
                     )
                 })
                 .collect(),
+
+            // TODO(STR-3937): classify into the deposit SM's sweep event once it exists.
+            MuSig2Nonce::Sweep { deposit_idx, .. } => {
+                warn!(%deposit_idx, "sweep nonces are not supported yet, discarding message");
+                Vec::new()
+            }
         },
         UnsignedGossipsubMsg::Musig2SignaturesExchange(musig2_partial) => {
             match musig2_partial {
@@ -456,6 +462,12 @@ pub(crate) fn classify_unsigned_gossip(
                         )
                     })
                     .collect(),
+
+                // TODO(STR-3937): classify into the deposit SM's sweep event once it exists.
+                MuSig2Partial::Sweep { deposit_idx, .. } => {
+                    warn!(%deposit_idx, "sweep partials are not supported yet, discarding message");
+                    Vec::new()
+                }
             }
         }
 

--- a/crates/orchestrator/src/events_classifier/offchain.rs
+++ b/crates/orchestrator/src/events_classifier/offchain.rs
@@ -515,7 +515,9 @@ pub(crate) fn classify_unsigned_gossip(
                 NagRequestPayload::DepositNonce { deposit_idx }
                 | NagRequestPayload::DepositPartial { deposit_idx }
                 | NagRequestPayload::PayoutNonce { deposit_idx }
-                | NagRequestPayload::PayoutPartial { deposit_idx } => SMId::Deposit(*deposit_idx),
+                | NagRequestPayload::PayoutPartial { deposit_idx }
+                | NagRequestPayload::SweepNonce { deposit_idx }
+                | NagRequestPayload::SweepPartial { deposit_idx } => SMId::Deposit(*deposit_idx),
                 NagRequestPayload::GraphData { graph_idx }
                 | NagRequestPayload::GraphNonces { graph_idx }
                 | NagRequestPayload::GraphPartials { graph_idx } => SMId::Graph(*graph_idx),
@@ -584,7 +586,9 @@ pub(crate) fn classify_unsigned_gossip(
                 NagRequestPayload::DepositNonce { .. }
                 | NagRequestPayload::DepositPartial { .. }
                 | NagRequestPayload::PayoutNonce { .. }
-                | NagRequestPayload::PayoutPartial { .. } => {
+                | NagRequestPayload::PayoutPartial { .. }
+                | NagRequestPayload::SweepNonce { .. }
+                | NagRequestPayload::SweepPartial { .. } => {
                     DepositEvent::NagReceived(DepositEvents::NagReceivedEvent {
                         payload: nag_request.payload.clone(),
                         sender_operator_idx,
@@ -1327,6 +1331,45 @@ mod tests {
                     other => panic!("Expected NagReceived, got {other}"),
                 },
                 _ => panic!("Expected Deposit event"),
+            }
+        }
+
+        /// Sweep nags are deposit-scoped and map to the deposit SM's NagReceived event.
+        #[test]
+        fn classify_sweep_nag_request_addressed_to_pov_creates_event() {
+            let mut registry = test_empty_registry();
+            let deposit_idx = 42u32;
+            insert_deposit_with_graphs(&mut registry, deposit_idx);
+
+            let operator_table = test_operator_table(N_TEST_OPERATORS, TEST_POV_IDX);
+            let pov_p2p_key: P2POperatorPubKey = operator_table.pov_p2p_key().clone();
+            let sender_idx = TEST_NONPOV;
+            let sender_p2p_key = operator_table.idx_to_p2p_key(&sender_idx).unwrap().clone();
+
+            for payload in [
+                NagRequestPayload::SweepNonce { deposit_idx },
+                NagRequestPayload::SweepPartial { deposit_idx },
+            ] {
+                let nag_request = NagRequest {
+                    recipient: pov_p2p_key.clone(),
+                    payload: payload.clone(),
+                };
+
+                let msg = UnsignedGossipsubMsg::NagRequestExchange(nag_request);
+                let result =
+                    classify_unsigned_gossip(&registry, &OperatorKey::Peer(&sender_p2p_key), &msg);
+
+                assert_eq!(result.len(), 1, "Should create exactly one event");
+                match &result[0] {
+                    SMEvent::Deposit(boxed) => match boxed.as_ref() {
+                        DepositEvent::NagReceived(evt) => {
+                            assert_eq!(evt.payload, payload);
+                            assert_eq!(evt.sender_operator_idx, sender_idx);
+                        }
+                        other => panic!("Expected NagReceived, got {other}"),
+                    },
+                    _ => panic!("Expected Deposit event"),
+                }
             }
         }
 

--- a/crates/orchestrator/src/events_router.rs
+++ b/crates/orchestrator/src/events_router.rs
@@ -92,7 +92,9 @@ fn route_gossipsub_msg(
             NagRequestPayload::DepositNonce { deposit_idx }
             | NagRequestPayload::DepositPartial { deposit_idx }
             | NagRequestPayload::PayoutNonce { deposit_idx }
-            | NagRequestPayload::PayoutPartial { deposit_idx } => SMId::Deposit(*deposit_idx),
+            | NagRequestPayload::PayoutPartial { deposit_idx }
+            | NagRequestPayload::SweepNonce { deposit_idx }
+            | NagRequestPayload::SweepPartial { deposit_idx } => SMId::Deposit(*deposit_idx),
             NagRequestPayload::GraphData { graph_idx }
             | NagRequestPayload::GraphNonces { graph_idx }
             | NagRequestPayload::GraphPartials { graph_idx } => SMId::Graph(*graph_idx),
@@ -202,6 +204,13 @@ mod tests {
             payload: NagRequestPayload::GraphNonces {
                 graph_idx: GraphIdx { deposit, operator },
             },
+        })
+    }
+
+    fn make_sweep_nag(deposit_idx: u32) -> UnsignedGossipsubMsg {
+        UnsignedGossipsubMsg::NagRequestExchange(NagRequest {
+            recipient: P2POperatorPubKey::from(vec![0u8; 32]),
+            payload: NagRequestPayload::SweepNonce { deposit_idx },
         })
     }
 
@@ -317,6 +326,15 @@ mod tests {
     fn route_gossip_deposit_nag_known() {
         let registry = test_populated_registry(1);
         let msg = make_deposit_nag(0);
+
+        let routed = route_gossipsub_msg(&registry, &msg);
+        assert_eq!(routed, vec![SMId::Deposit(0)]);
+    }
+
+    #[test]
+    fn route_gossip_sweep_nag_known() {
+        let registry = test_populated_registry(1);
+        let msg = make_sweep_nag(0);
 
         let routed = route_gossipsub_msg(&registry, &msg);
         assert_eq!(routed, vec![SMId::Deposit(0)]);

--- a/crates/orchestrator/src/events_router.rs
+++ b/crates/orchestrator/src/events_router.rs
@@ -71,6 +71,7 @@ fn route_gossipsub_msg(
         UnsignedGossipsubMsg::Musig2NoncesExchange(musig2_nonce) => match musig2_nonce {
             MuSig2Nonce::Deposit { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Nonce::Payout { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
+            MuSig2Nonce::Sweep { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Nonce::Graph { graph_idx, .. } => SMId::Graph(*graph_idx),
             MuSig2Nonce::Unstake { operator_idx, .. } => {
                 debug!(%operator_idx, "routing MuSig2Nonce::Unstake to stake SM");
@@ -80,6 +81,7 @@ fn route_gossipsub_msg(
         UnsignedGossipsubMsg::Musig2SignaturesExchange(musig2_partial) => match musig2_partial {
             MuSig2Partial::Deposit { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Partial::Payout { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
+            MuSig2Partial::Sweep { deposit_idx, .. } => SMId::Deposit(*deposit_idx),
             MuSig2Partial::Graph { graph_idx, .. } => SMId::Graph(*graph_idx),
             MuSig2Partial::Unstake { operator_idx, .. } => {
                 debug!(%operator_idx, "routing MuSig2Partial::Unstake to stake SM");
@@ -137,10 +139,13 @@ fn route_mosaic_event(registry: &SMRegistry, evt: &MosaicEvent) -> Vec<SMId> {
 #[cfg(test)]
 mod tests {
     use strata_asm_proto_bridge::AssignmentEntry;
-    use strata_bridge_p2p_types::{NagRequest, NagRequestPayload, PayoutDescriptor, PubNonce};
+    use strata_bridge_p2p_types::{
+        NagRequest, NagRequestPayload, PartialSignature, PayoutDescriptor, PubNonce,
+    };
     use strata_bridge_primitives::types::{GraphIdx, P2POperatorPubKey};
     use strata_bridge_test_utils::{
-        arbitrary_generator::ArbitraryGenerator, musig2::generate_pubnonce,
+        arbitrary_generator::ArbitraryGenerator,
+        musig2::{generate_partial_signature, generate_pubnonce},
     };
 
     use super::*;
@@ -160,6 +165,19 @@ mod tests {
         UnsignedGossipsubMsg::Musig2NoncesExchange(MuSig2Nonce::Graph {
             graph_idx: GraphIdx { deposit, operator },
             nonces: vec![nonce],
+        })
+    }
+
+    fn make_sweep_nonce(deposit_idx: u32) -> UnsignedGossipsubMsg {
+        let nonce: PubNonce = generate_pubnonce().into();
+        UnsignedGossipsubMsg::Musig2NoncesExchange(MuSig2Nonce::Sweep { deposit_idx, nonce })
+    }
+
+    fn make_sweep_partial(deposit_idx: u32) -> UnsignedGossipsubMsg {
+        let partial: PartialSignature = generate_partial_signature().into();
+        UnsignedGossipsubMsg::Musig2SignaturesExchange(MuSig2Partial::Sweep {
+            deposit_idx,
+            partial,
         })
     }
 
@@ -233,6 +251,33 @@ mod tests {
 
         let routed = route_gossipsub_msg(&registry, &msg);
         assert!(routed.is_empty());
+    }
+
+    #[test]
+    fn route_gossip_sweep_nonce_known() {
+        let registry = test_populated_registry(1);
+        let msg = make_sweep_nonce(0);
+
+        let routed = route_gossipsub_msg(&registry, &msg);
+        assert_eq!(routed, vec![SMId::Deposit(0)]);
+    }
+
+    #[test]
+    fn route_gossip_sweep_nonce_unknown() {
+        let registry = test_populated_registry(1);
+        let msg = make_sweep_nonce(99);
+
+        let routed = route_gossipsub_msg(&registry, &msg);
+        assert!(routed.is_empty());
+    }
+
+    #[test]
+    fn route_gossip_sweep_partial_known() {
+        let registry = test_populated_registry(1);
+        let msg = make_sweep_partial(0);
+
+        let routed = route_gossipsub_msg(&registry, &msg);
+        assert_eq!(routed, vec![SMId::Deposit(0)]);
     }
 
     #[test]

--- a/crates/orchestrator/src/testing.rs
+++ b/crates/orchestrator/src/testing.rs
@@ -37,7 +37,9 @@ pub(crate) use strata_bridge_test_utils::bridge_fixtures::{
     test_operator_table,
 };
 use strata_bridge_test_utils::{
-    bitcoin::generate_xonly_pubkey, bridge_fixtures::TEST_RECOVERY_DELAY, prelude::generate_txid,
+    bitcoin::generate_xonly_pubkey,
+    bridge_fixtures::{TEST_RECOVERY_DELAY, TEST_SWEEP_FEE_RATE},
+    prelude::generate_txid,
 };
 use strata_bridge_tx_graph::{
     game_graph::{AdminMultisig, ProtocolParams as GameProtocolParams},
@@ -69,6 +71,7 @@ pub(crate) fn test_deposit_sm_cfg() -> Arc<DepositSMCfg> {
         operator_fee: TEST_OPERATOR_FEE,
         magic_bytes: TEST_MAGIC_BYTES.into(),
         recovery_delay: TEST_RECOVERY_DELAY,
+        sweep_fee_rate: TEST_SWEEP_FEE_RATE,
     })
 }
 

--- a/crates/p2p-service/src/message_handler.rs
+++ b/crates/p2p-service/src/message_handler.rs
@@ -145,6 +145,38 @@ impl MessageHandler {
         self.dispatch(msg, peer, "payout partial").await;
     }
 
+    /// Sends a sweep nonce for safe-harbour sweep signing.
+    ///
+    /// If `peer` is `Some`, sends directly to that peer. If `None`, broadcasts to all.
+    pub async fn send_sweep_nonce(
+        &mut self,
+        deposit_idx: DepositIdx,
+        nonce: PubNonce,
+        peer: Option<oneshot::Sender<Vec<u8>>>,
+    ) {
+        let msg = UnsignedGossipsubMsg::Musig2NoncesExchange(MuSig2Nonce::Sweep {
+            deposit_idx,
+            nonce: nonce.into(),
+        });
+        self.dispatch(msg, peer, "sweep nonce").await;
+    }
+
+    /// Sends a sweep partial signature for safe-harbour sweep signing.
+    ///
+    /// If `peer` is `Some`, sends directly to that peer. If `None`, broadcasts to all.
+    pub async fn send_sweep_partial(
+        &mut self,
+        deposit_idx: DepositIdx,
+        partial: PartialSignature,
+        peer: Option<oneshot::Sender<Vec<u8>>>,
+    ) {
+        let msg = UnsignedGossipsubMsg::Musig2SignaturesExchange(MuSig2Partial::Sweep {
+            deposit_idx,
+            partial: partial.into(),
+        });
+        self.dispatch(msg, peer, "sweep partial").await;
+    }
+
     /// Sends a nag request for missing data.
     ///
     /// If `peer` is `Some`, sends directly to that peer. If `None`, broadcasts to all.

--- a/crates/p2p-service/src/tests/gossipsub.rs
+++ b/crates/p2p-service/src/tests/gossipsub.rs
@@ -159,7 +159,39 @@ async fn dispatch_all_message_types() -> anyhow::Result<()> {
     })
     .await?;
 
-    // 9. Nag request
+    // 9. Sweep nonce
+    for op in operators.iter_mut() {
+        op.handler
+            .send_sweep_nonce(deposit_idx, mock_nonce(), None)
+            .await;
+    }
+    verify_dispatch(&mut operators, OPERATORS_NUM, "sweep_nonce", |msg| {
+        matches!(
+            msg,
+            UnsignedGossipsubMsg::Musig2NoncesExchange(
+                strata_bridge_p2p_types::MuSig2Nonce::Sweep { .. }
+            )
+        )
+    })
+    .await?;
+
+    // 10. Sweep partial
+    for op in operators.iter_mut() {
+        op.handler
+            .send_sweep_partial(deposit_idx, mock_partial(), None)
+            .await;
+    }
+    verify_dispatch(&mut operators, OPERATORS_NUM, "sweep_partial", |msg| {
+        matches!(
+            msg,
+            UnsignedGossipsubMsg::Musig2SignaturesExchange(
+                strata_bridge_p2p_types::MuSig2Partial::Sweep { .. }
+            )
+        )
+    })
+    .await?;
+
+    // 11. Nag request
     for op in operators.iter_mut() {
         op.handler
             .send_nag_request(

--- a/crates/p2p-types/src/messages.rs
+++ b/crates/p2p-types/src/messages.rs
@@ -26,6 +26,8 @@ enum SigningContext {
     Graph = 0x02,
     /// Unstaking graph signing.
     Unstake = 0x03,
+    /// Safe-harbour sweep signing.
+    Sweep = 0x04,
 }
 
 /// Gossipsub message kind discriminator for cryptographic domain separation.
@@ -107,6 +109,13 @@ pub enum MuSig2Nonce {
         /// One nonce per transaction input in the unstaking graph.
         nonces: Vec<PubNonce>,
     },
+    /// Single nonce for safe-harbour sweep signing.
+    Sweep {
+        /// The deposit index for identifying the sweep transaction.
+        deposit_idx: DepositIdx,
+        /// The public nonce.
+        nonce: PubNonce,
+    },
 }
 
 impl MuSig2Nonce {
@@ -145,6 +154,11 @@ impl MuSig2Nonce {
                     buf.extend(nonce.to_bytes());
                 }
             }
+            Self::Sweep { deposit_idx, nonce } => {
+                buf.push(SigningContext::Sweep as u8);
+                buf.extend(deposit_idx.to_le_bytes());
+                buf.extend(nonce.to_bytes());
+            }
         }
         buf
     }
@@ -178,6 +192,9 @@ impl fmt::Debug for MuSig2Nonce {
                     operator_idx,
                     nonces.len()
                 )
+            }
+            Self::Sweep { deposit_idx, .. } => {
+                write!(f, "MuSig2Nonce::Sweep(deposit_idx: {deposit_idx})")
             }
         }
     }
@@ -213,6 +230,13 @@ pub enum MuSig2Partial {
         operator_idx: OperatorIdx,
         /// One partial signature per transaction input in the unstaking graph.
         partials: Vec<PartialSignature>,
+    },
+    /// Single partial for safe-harbour sweep signing.
+    Sweep {
+        /// The deposit index for identifying the sweep transaction.
+        deposit_idx: DepositIdx,
+        /// The partial signature.
+        partial: PartialSignature,
     },
 }
 
@@ -261,6 +285,14 @@ impl MuSig2Partial {
                     buf.extend(partial.to_bytes());
                 }
             }
+            Self::Sweep {
+                deposit_idx,
+                partial,
+            } => {
+                buf.push(SigningContext::Sweep as u8);
+                buf.extend(deposit_idx.to_le_bytes());
+                buf.extend(partial.to_bytes());
+            }
         }
         buf
     }
@@ -297,6 +329,9 @@ impl fmt::Debug for MuSig2Partial {
                     operator_idx,
                     partials.len()
                 )
+            }
+            Self::Sweep { deposit_idx, .. } => {
+                write!(f, "MuSig2Partial::Sweep(deposit_idx: {deposit_idx})")
             }
         }
     }
@@ -834,6 +869,14 @@ mod tests {
                 },
                 SigningContext::Unstake as u8,
             ),
+            (
+                "Sweep",
+                MuSig2Nonce::Sweep {
+                    deposit_idx: 44,
+                    nonce: test_pubnonce(),
+                },
+                SigningContext::Sweep as u8,
+            ),
         ];
 
         for (name, nonce, expected_prefix) in cases {
@@ -884,6 +927,14 @@ mod tests {
                     partials: vec![test_partial_signature()],
                 },
                 SigningContext::Unstake as u8,
+            ),
+            (
+                "Sweep",
+                MuSig2Partial::Sweep {
+                    deposit_idx: 44,
+                    partial: test_partial_signature(),
+                },
+                SigningContext::Sweep as u8,
             ),
         ];
 
@@ -1396,6 +1447,50 @@ mod tests {
             &content[1..5],
             &5u32.to_le_bytes(),
             "operator_idx should be serialized as little-endian u32"
+        );
+    }
+
+    // Verifies MuSig2Nonce::Sweep serializes with correct byte layout.
+    #[test]
+    fn musig2_nonce_sweep_serializes_correctly() {
+        let nonce = MuSig2Nonce::Sweep {
+            deposit_idx: 42,
+            nonce: test_pubnonce(),
+        };
+        let content = nonce.content_bytes();
+
+        assert_eq!(
+            content.len(),
+            1 + 4 + 66,
+            "Sweep content should be 71 bytes: discriminator (1) + deposit_idx (4) + nonce (66)"
+        );
+        assert_eq!(content[0], 0x04, "Sweep discriminator should be 0x04");
+        assert_eq!(
+            &content[1..5],
+            &42u32.to_le_bytes(),
+            "deposit_idx should be serialized as little-endian u32"
+        );
+    }
+
+    // Verifies MuSig2Partial::Sweep serializes with correct byte layout.
+    #[test]
+    fn musig2_partial_sweep_serializes_correctly() {
+        let partial = MuSig2Partial::Sweep {
+            deposit_idx: 42,
+            partial: test_partial_signature(),
+        };
+        let content = partial.content_bytes();
+
+        assert_eq!(
+            content.len(),
+            1 + 4 + 32,
+            "Sweep partial content should be 37 bytes: discriminator (1) + deposit_idx (4) + partial (32)"
+        );
+        assert_eq!(content[0], 0x04, "Sweep discriminator should be 0x04");
+        assert_eq!(
+            &content[1..5],
+            &42u32.to_le_bytes(),
+            "deposit_idx should be serialized as little-endian u32"
         );
     }
 

--- a/crates/p2p-types/src/messages.rs
+++ b/crates/p2p-types/src/messages.rs
@@ -76,6 +76,10 @@ enum NagPayloadKind {
     UnstakingNonces = 0x08,
     /// Request missing unstaking graph partial signatures.
     UnstakingPartials = 0x09,
+    /// Request missing sweep nonce.
+    SweepNonce = 0x0A,
+    /// Request missing sweep partial signature.
+    SweepPartial = 0x0B,
 }
 
 /// MuSig2 nonce variants for different signing contexts.
@@ -390,6 +394,16 @@ pub enum NagRequestPayload {
         /// The index of the staking operator whose unstaking graph partial signatures are missing.
         operator_idx: OperatorIdx,
     },
+    /// Request missing sweep nonce.
+    SweepNonce {
+        /// The deposit index for identifying the sweep.
+        deposit_idx: DepositIdx,
+    },
+    /// Request missing sweep partial signature.
+    SweepPartial {
+        /// The deposit index for identifying the sweep.
+        deposit_idx: DepositIdx,
+    },
 }
 
 impl NagRequestPayload {
@@ -442,6 +456,14 @@ impl NagRequestPayload {
             Self::UnstakingPartials { operator_idx } => {
                 buf.push(NagPayloadKind::UnstakingPartials as u8);
                 buf.extend(operator_idx.to_le_bytes());
+            }
+            Self::SweepNonce { deposit_idx } => {
+                buf.push(NagPayloadKind::SweepNonce as u8);
+                buf.extend(deposit_idx.to_le_bytes());
+            }
+            Self::SweepPartial { deposit_idx } => {
+                buf.push(NagPayloadKind::SweepPartial as u8);
+                buf.extend(deposit_idx.to_le_bytes());
             }
         }
         buf
@@ -515,6 +537,18 @@ impl fmt::Debug for NagRequestPayload {
                     f,
                     "NagRequestPayload::UnstakingPartials(operator_idx: {})",
                     operator_idx
+                )
+            }
+            Self::SweepNonce { deposit_idx } => {
+                write!(
+                    f,
+                    "NagRequestPayload::SweepNonce(deposit_idx: {deposit_idx})"
+                )
+            }
+            Self::SweepPartial { deposit_idx } => {
+                write!(
+                    f,
+                    "NagRequestPayload::SweepPartial(deposit_idx: {deposit_idx})"
                 )
             }
         }
@@ -1093,6 +1127,16 @@ mod tests {
                 "UnstakingPartials",
                 NagRequestPayload::UnstakingPartials { operator_idx: 13 },
                 NagPayloadKind::UnstakingPartials as u8,
+            ),
+            (
+                "SweepNonce",
+                NagRequestPayload::SweepNonce { deposit_idx: 14 },
+                NagPayloadKind::SweepNonce as u8,
+            ),
+            (
+                "SweepPartial",
+                NagRequestPayload::SweepPartial { deposit_idx: 15 },
+                NagPayloadKind::SweepPartial as u8,
             ),
         ];
 

--- a/crates/test-utils/src/bridge_fixtures.rs
+++ b/crates/test-utils/src/bridge_fixtures.rs
@@ -4,7 +4,7 @@
 //! (bridge-sm, orchestrator, etc.) need for testing. SM-specific config construction stays
 //! local to each consumer crate.
 
-use bitcoin::Amount;
+use bitcoin::{Amount, FeeRate};
 use bitcoin_bosd::Descriptor;
 use secp256k1::{SecretKey, SECP256K1};
 use strata_bridge_primitives::{
@@ -31,6 +31,9 @@ pub const TEST_OPERATOR_FEE: Amount = Amount::from_sat(10_000);
 
 /// Recovery delay (in blocks) used in tests.
 pub const TEST_RECOVERY_DELAY: u16 = 1008;
+
+/// Safe-harbour sweep fee rate used in tests.
+pub const TEST_SWEEP_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(10);
 
 // ===== Shared Test Helpers =====
 

--- a/crates/tx-graph/src/fee.rs
+++ b/crates/tx-graph/src/fee.rs
@@ -231,6 +231,12 @@ const COOPERATIVE_PAYOUT_VSIZE: u64 = 111;
 /// Structure: 1 input (CounterproofConnector script-path) + 1 P2TR output.
 const COUNTERPROOF_NACK_VSIZE: u64 = 111;
 
+/// Predicted vsize of [`crate::transactions::sweep::SweepTx`].
+///
+/// Structure: 1 input (deposit NOfN key path) + 2 P2TR outputs (safe-harbour payout + cpfp
+/// anchor).
+const SWEEP_VSIZE: u64 = 154;
+
 /// Deterministic x-only pubkey for the given seed. The tap tree's merkle structure is
 /// determined by the leaves' `TapLeafHash`es, so distinct watchtower pubkeys are required to
 /// reproduce the production tree shape — duplicate scripts would coalesce in the lookup.
@@ -363,6 +369,40 @@ pub const fn counterproof_nack_fee() -> Amount {
     fee_for_vsize(COUNTERPROOF_NACK_VSIZE)
 }
 
+/// Fee for [`crate::transactions::sweep::SweepTx`].
+///
+/// Unlike the presigned-tx fees, the sweep is built at sweep time from the
+/// `sweep_fee_rate` protocol param, not from [`FEE_RATE_SAT_PER_VB`]. `None` on overflow.
+pub(crate) fn sweep_fee(fee_rate: FeeRate) -> Option<Amount> {
+    fee_rate.fee_vb(SWEEP_VSIZE)
+}
+
+/// Value for the sweep tx's cpfp anchor.
+///
+/// Same relay-policy rule as [`anchor_dust_value`], but conditioned on the sweep's own fee
+/// rather than [`FEE_RATE_SAT_PER_VB`]: a zero-fee TRUC parent may carry a zero-value anchor
+/// (relying on CPFP only), while a fee-paying one must meet the dust floor.
+pub(crate) fn sweep_anchor_value(fee: Amount) -> Amount {
+    if fee == Amount::ZERO {
+        Amount::ZERO
+    } else {
+        PLACEHOLDER_P2TR_SCRIPT_PUBKEY.minimal_non_dust()
+    }
+}
+
+/// Value of the sweep tx's safe-harbour payout output: the deposit minus [`sweep_fee`] and
+/// [`sweep_anchor_value`].
+///
+/// `None` when `fee_rate` leaves no payout at or above the P2TR dust floor, letting callers
+/// validate `sweep_fee_rate` at load time.
+pub fn sweep_payout_value(fee_rate: FeeRate, deposit_amount: Amount) -> Option<Amount> {
+    let fee = sweep_fee(fee_rate)?;
+    let payout = deposit_amount
+        .checked_sub(fee)?
+        .checked_sub(sweep_anchor_value(fee))?;
+    (payout >= PLACEHOLDER_P2TR_SCRIPT_PUBKEY.minimal_non_dust()).then_some(payout)
+}
+
 // -------------------------------------------------------------------------------------------------
 // Connector surcharges. These are added to a connector's base value so the downstream
 // transaction's input arrives with the fee already included. Used for transactions whose
@@ -437,7 +477,7 @@ mod tests {
         },
         transactions::prelude::{
             CooperativePayoutData, CooperativePayoutTx, CounterproofNackData, CounterproofNackTx,
-            DepositData, DepositTx,
+            DepositData, DepositTx, SweepData, SweepTx,
         },
     };
 
@@ -818,6 +858,31 @@ mod tests {
             COOPERATIVE_PAYOUT_VSIZE,
             "cooperative_payout",
         );
+    }
+
+    #[test]
+    fn pin_sweep_vsize() {
+        let signer = TestSigner::generate(3);
+        let n_of_n = signer.n_of_n.x_only_public_key().0;
+        let operator_xonly = signer.operator.x_only_public_key().0;
+        let descriptor = Descriptor::new_p2tr(&operator_xonly.serialize()).unwrap();
+        let operator_pubkeys = signer
+            .watchtowers
+            .iter()
+            .map(|k| k.x_only_public_key().0)
+            .collect();
+        let deposit_connector = NOfNConnector::new(Network::Regtest, n_of_n, DEPOSIT_AMOUNT);
+        let signed = SweepTx::new(
+            SweepData {
+                deposit_outpoint: OutPoint::null(),
+            },
+            deposit_connector,
+            descriptor,
+            operator_pubkeys,
+            FeeRate::from_sat_per_vb_unchecked(2),
+        )
+        .finalize(dummy_sig());
+        pin(signed.weight().to_vbytes_ceil(), SWEEP_VSIZE, "sweep");
     }
 
     #[test]

--- a/crates/tx-graph/src/transactions/mod.rs
+++ b/crates/tx-graph/src/transactions/mod.rs
@@ -15,6 +15,7 @@ pub mod not_presigned;
 pub mod prelude;
 pub mod slash;
 pub mod stake;
+pub mod sweep;
 pub mod uncontested_payout;
 pub mod unstaking;
 pub mod unstaking_intent;

--- a/crates/tx-graph/src/transactions/prelude.rs
+++ b/crates/tx-graph/src/transactions/prelude.rs
@@ -3,6 +3,6 @@
 pub use super::{
     bridge_proof::*, bridge_proof_timeout::*, claim::*, contest::*, contested_payout::*,
     cooperative_payout::*, counterproof::*, counterproof_ack::*, deposit::*, not_presigned::*,
-    slash::*, stake::*, uncontested_payout::*, unstaking::*, unstaking_intent::*,
+    slash::*, stake::*, sweep::*, uncontested_payout::*, unstaking::*, unstaking_intent::*,
     withdrawal_fulfillment::*,
 };

--- a/crates/tx-graph/src/transactions/sweep.rs
+++ b/crates/tx-graph/src/transactions/sweep.rs
@@ -1,0 +1,244 @@
+//! This module contains the safe-harbour sweep transaction.
+
+use bitcoin::{
+    absolute,
+    sighash::{Prevouts, SighashCache},
+    transaction::Version,
+    Amount, FeeRate, OutPoint, Psbt, Transaction, TxIn, TxOut, XOnlyPublicKey,
+};
+use bitcoin_bosd::Descriptor;
+use secp256k1::schnorr;
+use serde::{Deserialize, Serialize};
+use strata_bridge_connectors::{
+    prelude::{MultiAnchor, NOfNConnector, NOfNSpend},
+    Connector, ParentTx, SigningInfo,
+};
+
+/// Data that is needed to construct a [`SweepTx`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SweepData {
+    /// The outpoint of the deposit UTXO being swept.
+    pub deposit_outpoint: OutPoint,
+}
+
+/// The safe-harbour sweep transaction.
+///
+/// This transaction spends the deposit UTXO via N-of-N key-path spend and pays out to the
+/// frozen safe-harbour descriptor. Since no operator can spend the safe-harbour output, it
+/// carries a dedicated operator-keyed CPFP anchor for fee bumping.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SweepTx {
+    /// The partially signed bitcoin transaction.
+    psbt: Psbt,
+    /// The prevouts for sighash computation.
+    prevouts: [TxOut; Self::N_INPUTS],
+    /// The connector for the deposit input.
+    deposit_connector: NOfNConnector,
+    /// The operator-keyed CPFP anchor connector.
+    cpfp_connector: MultiAnchor,
+}
+
+impl SweepTx {
+    /// Index of the safe-harbour payout output.
+    pub const PAYOUT_VOUT: u32 = 0;
+    /// Index of the CPFP output.
+    pub const CPFP_VOUT: u32 = 1;
+    /// Number of transaction inputs.
+    pub const N_INPUTS: usize = 1;
+
+    /// Creates a sweep transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The data needed to construct the transaction (deposit outpoint).
+    /// * `deposit_connector` - The N-of-N connector for the deposit input (contains amount).
+    /// * `safe_harbour_descriptor` - The frozen safe-harbour descriptor to sweep to.
+    /// * `operator_pubkeys` - The operator keys for the CPFP anchor (any operator can bump).
+    /// * `fee_rate` - The protocol `sweep_fee_rate` shared by all operators.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `fee_rate` leaves no payout above dust; validated at params load time.
+    pub fn new(
+        data: SweepData,
+        deposit_connector: NOfNConnector,
+        safe_harbour_descriptor: Descriptor,
+        operator_pubkeys: Vec<XOnlyPublicKey>,
+        fee_rate: FeeRate,
+    ) -> Self {
+        let fee = crate::fee::sweep_fee(fee_rate).expect("sweep fee must not overflow");
+        let payout_value = crate::fee::sweep_payout_value(fee_rate, deposit_connector.value())
+            .expect("sweep fee rate must leave a payout above dust");
+        let cpfp_connector = MultiAnchor::new(
+            deposit_connector.network(),
+            operator_pubkeys,
+            crate::fee::sweep_anchor_value(fee),
+        );
+
+        let prevouts = [deposit_connector.tx_out()];
+        let input = vec![TxIn {
+            previous_output: data.deposit_outpoint,
+            sequence: deposit_connector.sequence(NOfNSpend),
+            ..Default::default()
+        }];
+        let output = vec![
+            TxOut {
+                value: payout_value,
+                script_pubkey: safe_harbour_descriptor.to_script(),
+            },
+            cpfp_connector.tx_out(),
+        ];
+
+        let value_in: Amount = prevouts.iter().map(|x| x.value).sum();
+        let value_out: Amount = output.iter().map(|x| x.value).sum();
+        debug_assert!(
+            value_in == value_out + fee,
+            "tx must pay {fee} fees (value in = {value_in}, value out = {value_out})"
+        );
+
+        let tx = Transaction {
+            version: Version(3),
+            lock_time: absolute::LockTime::ZERO,
+            input,
+            output,
+        };
+        let mut psbt = Psbt::from_unsigned_tx(tx).expect("witness should be empty");
+
+        for (input, utxo) in psbt.inputs.iter_mut().zip(prevouts.clone()) {
+            input.witness_utxo = Some(utxo);
+        }
+
+        Self {
+            psbt,
+            prevouts,
+            deposit_connector,
+            cpfp_connector,
+        }
+    }
+
+    /// Finalizes the transaction with the given N-of-N aggregated signature.
+    ///
+    /// # Arguments
+    ///
+    /// * `n_of_n_signature` - The aggregated Schnorr signature from the N-of-N multisig.
+    ///
+    /// # Returns
+    ///
+    /// The finalized Bitcoin transaction ready for broadcast.
+    pub fn finalize(self, n_of_n_signature: schnorr::Signature) -> Transaction {
+        let mut psbt = self.psbt;
+
+        self.deposit_connector
+            .finalize_input(&mut psbt.inputs[0], &n_of_n_signature);
+
+        psbt.extract_tx().expect("should be able to extract tx")
+    }
+
+    /// Returns the signing info for the transaction input.
+    pub fn signing_info(&self) -> [SigningInfo; Self::N_INPUTS] {
+        let mut cache = SighashCache::new(&self.psbt.unsigned_tx);
+        [self.deposit_connector.get_signing_info(
+            &mut cache,
+            Prevouts::All(&self.prevouts),
+            NOfNSpend,
+            0,
+        )]
+    }
+}
+
+impl ParentTx for SweepTx {
+    type CpfpConnector = MultiAnchor;
+
+    fn cpfp_tx_out(&self) -> TxOut {
+        self.cpfp_connector.tx_out()
+    }
+
+    fn cpfp_outpoint(&self) -> OutPoint {
+        OutPoint {
+            txid: self.psbt.unsigned_tx.compute_txid(),
+            vout: Self::CPFP_VOUT,
+        }
+    }
+
+    fn cpfp_connector(&self) -> &Self::CpfpConnector {
+        &self.cpfp_connector
+    }
+}
+
+impl AsRef<Transaction> for SweepTx {
+    fn as_ref(&self) -> &Transaction {
+        &self.psbt.unsigned_tx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{Amount, Network, OutPoint};
+    use strata_bridge_primitives::scripts::prelude::get_aggregated_pubkey;
+    use strata_bridge_test_utils::bridge_fixtures::{
+        random_p2tr_desc, test_operator_table, TEST_POV_IDX,
+    };
+
+    use super::*;
+    use crate::fee::{sweep_fee, sweep_payout_value};
+
+    const DEPOSIT_AMOUNT: Amount = Amount::from_sat(10_000_000);
+    const FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(2);
+
+    fn test_sweep_tx(fee_rate: FeeRate) -> SweepTx {
+        let operator_table = test_operator_table(3, TEST_POV_IDX);
+        let n_of_n_pubkey = get_aggregated_pubkey(operator_table.btc_keys());
+        let operator_pubkeys = operator_table
+            .btc_keys()
+            .into_iter()
+            .map(|pk| pk.x_only_public_key().0)
+            .collect();
+        SweepTx::new(
+            SweepData {
+                deposit_outpoint: OutPoint::null(),
+            },
+            NOfNConnector::new(Network::Regtest, n_of_n_pubkey, DEPOSIT_AMOUNT),
+            random_p2tr_desc(),
+            operator_pubkeys,
+            fee_rate,
+        )
+    }
+
+    #[test]
+    fn sweep_pays_deposit_minus_fee_and_anchor() {
+        let tx = test_sweep_tx(FEE_RATE);
+        let outputs = &tx.as_ref().output;
+
+        assert_eq!(outputs.len(), 2);
+        let payout = &outputs[SweepTx::PAYOUT_VOUT as usize];
+        let anchor = &outputs[SweepTx::CPFP_VOUT as usize];
+        assert_eq!(
+            payout.value,
+            sweep_payout_value(FEE_RATE, DEPOSIT_AMOUNT).unwrap()
+        );
+        assert_eq!(*anchor, tx.cpfp_tx_out());
+        assert_eq!(
+            payout.value + anchor.value + sweep_fee(FEE_RATE).unwrap(),
+            DEPOSIT_AMOUNT
+        );
+    }
+
+    #[test]
+    fn zero_fee_rate_yields_zero_value_anchor() {
+        let tx = test_sweep_tx(FeeRate::ZERO);
+        let outputs = &tx.as_ref().output;
+
+        assert_eq!(outputs[SweepTx::CPFP_VOUT as usize].value, Amount::ZERO);
+        assert_eq!(outputs[SweepTx::PAYOUT_VOUT as usize].value, DEPOSIT_AMOUNT);
+    }
+
+    #[test]
+    fn sweep_payout_value_rejects_excessive_fee_rate() {
+        let absurd = FeeRate::from_sat_per_vb_unchecked(DEPOSIT_AMOUNT.to_sat());
+        assert_eq!(sweep_payout_value(absurd, DEPOSIT_AMOUNT), None);
+
+        // A rate whose payout would land below the P2TR dust floor is also rejected.
+        let dust_amount = sweep_fee(FEE_RATE).unwrap() + Amount::from_sat(100);
+        assert_eq!(sweep_payout_value(FEE_RATE, dust_amount), None);
+    }
+}

--- a/docker/vol/strata-bridge-1/params.toml
+++ b/docker/vol/strata-bridge-1/params.toml
@@ -32,6 +32,7 @@ magic_bytes = "ALPN"
 deposit_amount = 1_000_000_000
 stake_amount = 100_000_000
 operator_fee = 10_000_000
+sweep_fee_rate = 10
 recovery_delay = 1_008
 contest_timelock = 144
 proof_timelock = 144

--- a/docker/vol/strata-bridge-2/params.toml
+++ b/docker/vol/strata-bridge-2/params.toml
@@ -32,6 +32,7 @@ magic_bytes = "ALPN"
 deposit_amount = 1_000_000_000
 stake_amount = 100_000_000
 operator_fee = 10_000_000
+sweep_fee_rate = 10
 recovery_delay = 1_008
 contest_timelock = 144
 proof_timelock = 144

--- a/docker/vol/strata-bridge-3/params.toml
+++ b/docker/vol/strata-bridge-3/params.toml
@@ -32,6 +32,7 @@ magic_bytes = "ALPN"
 deposit_amount = 1_000_000_000
 stake_amount = 100_000_000
 operator_fee = 10_000_000
+sweep_fee_rate = 10
 recovery_delay = 1_008
 contest_timelock = 144
 proof_timelock = 144

--- a/functional-tests/factory/bridge_operator/params_cfg.py
+++ b/functional-tests/factory/bridge_operator/params_cfg.py
@@ -37,6 +37,7 @@ class BridgeProtocolParams:
     deposit_amount: int = 1_000_000_000
     stake_amount: int = 100_000_000
     operator_fee: int = 10_000_000
+    sweep_fee_rate: int = 10
     recovery_delay: int = 1_008
     contest_timelock: int = 45
     proof_timelock: int = 15


### PR DESCRIPTION
## Description
Second slice of the **Emergency Fund Sweep (Hard Bridge Upgrade)** work ([STR-3937]): the core mechanic that sweeps a deposit UTXO into the frozen safe-harbour address, plus the state-machine groundwork for sweeping **assigned / mid-payout** deposits.

The sweep is mechanically a cooperative payout whose destination is the safe-harbour descriptor, with two deliberate differences: the signing round is **symmetric** (no assignee — every operator publishes nonces and partials, and every operator finalizes and broadcasts the identical deterministic transaction), and the transaction carries an operator-keyed 1-of-N **`MultiAnchor` CPFP anchor** so any operator can fee-bump a stuck sweep later (spending the anchor is a follow-up on top of #572; the base sweep confirms on its own `sweep_fee_rate`).

**This PR is trigger-less by design.** Nothing in production emits `SweepRequested` yet and the
wiring that connects the safe-harbour latch from #733 to the sweep (per-block scan,
withdrawal-duty suppression) lands in follow-up PRs. 

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.
- [ ] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->


[STR-3937]: https://alpenlabs.atlassian.net/browse/STR-3937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ