### PR TITLE
fix(ci): cap SP1 proof runs at 3h and report cancellations to Slack

### DIFF
--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -1,8 +1,8 @@
 # Runs the SP1 proof functional tests with real Succinct network proving, on a
 # schedule and on manual dispatch.
 #
-# Scheduled runs execute once per day. Failures are reported to Slack through
-# the SLACK_WEBHOOK_URL secret.
+# Scheduled runs execute once per day. Failures, timeouts, and cancellations are
+# reported to Slack through the SLACK_WEBHOOK_URL secret.
 name: Functional tests (SP1 proofs)
 
 on:
@@ -20,7 +20,7 @@ env:
   CARGO_TERM_COLOR: always
   SP1_VERSION: v6.2.0
 
-# Scheduled ticks queue behind an in-flight (up to 6 h) proving run instead of
+# Scheduled ticks queue behind an in-flight (up to 3 h) proving run instead of
 # cancelling it; manual dispatch keeps the cancel-and-restart behavior.
 concurrency:
   group: functional-sp1-proofs
@@ -48,7 +48,7 @@ jobs:
     name: Run ${{ matrix.test }} with real SP1 proving
     runs-on: 16-core-runner
     needs: [extract-rust-version]
-    timeout-minutes: 360
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -189,6 +189,7 @@ jobs:
       - name: Run ${{ matrix.test }}
         id: funcTestsRun
         continue-on-error: true
+        timeout-minutes: 160
         env:
           RUST_LOG: ${{ inputs.RUST_LOG || 'info' }} # inputs is empty on schedule events
           NO_COLOR: "1"
@@ -213,7 +214,7 @@ jobs:
         run: python3 .github/scripts/render_sp1_proof_summary.py
 
       - name: Zip log files on failure
-        if: steps.funcTestsRun.outcome == 'failure'
+        if: always() && steps.funcTestsRun.outcome != 'success' && steps.funcTestsRun.outcome != 'skipped'
         # Create a zip archive (logs.zip) that includes only service.log files,
         # preserving the folder structure starting from functional-tests/_dd
         run: |
@@ -221,7 +222,7 @@ jobs:
           zip -r logs.zip functional-tests/_dd -i '*/logs/*.log'
 
       - name: Upload logs as build artifact on failure
-        if: steps.funcTestsRun.outcome == 'failure'
+        if: always() && steps.funcTestsRun.outcome != 'success' && steps.funcTestsRun.outcome != 'skipped'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fntest_dd-${{ matrix.test }}
@@ -244,7 +245,7 @@ jobs:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
     needs: [extract-rust-version, run]
-    if: failure()
+    if: failure() || cancelled()
     timeout-minutes: 5
     steps:
       - name: Checkout repository
@@ -261,12 +262,18 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           EVENT_NAME: ${{ github.event_name }}
+          RUN_RESULT: ${{ needs.run.result }}
+          EXTRACT_RESULT: ${{ needs.extract-rust-version.result }}
         run: |
+          STATUS="failed"
+          if [ "$RUN_RESULT" = "cancelled" ] || [ "$EXTRACT_RESULT" = "cancelled" ]; then
+            STATUS="was cancelled (timeout or manual cancel)"
+          fi
           # shellcheck disable=SC2016 # backticks are literal Slack mrkdwn
           {
             echo "text<<MSG_EOF"
-            printf '🚨 *%s failed* — commit `%s` (%s run)\n<%s|View run>\n' \
-              "$WORKFLOW_NAME" "${COMMIT_SHA:0:7}" "$EVENT_NAME" "$RUN_URL"
+            printf '🚨 *%s %s* — commit `%s` (%s run)\n<%s|View run>\n' \
+              "$WORKFLOW_NAME" "$STATUS" "${COMMIT_SHA:0:7}" "$EVENT_NAME" "$RUN_URL"
             echo "MSG_EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/functional-tests/sp1-env.bash.sample
+++ b/functional-tests/sp1-env.bash.sample
@@ -18,6 +18,10 @@ export NETWORK_PRIVATE_KEY=${NETWORK_PRIVATE_KEY:-}   # required for SP1_PROVER=
 # Set 0 to fall back to native Schnorr attestations (Bip340Schnorr) for the ASM/Moho layer.
 export BRIDGE_PROOF_SP1_ASM=${BRIDGE_PROOF_SP1_ASM:-1}
 
+# The freshly built counterproof ELF never matches the Mosaic circuit fixture's zero
+# vkey, so skip the bridge startup checks (see _dev_mode_from_env, STR-3889).
+export BRIDGE_DEV_MODE=${BRIDGE_DEV_MODE:-1}
+
 # --- External regtest bitcoind (network-extbtc env) ---
 export BRIDGE_EXTERNAL_BITCOIN=${BRIDGE_EXTERNAL_BITCOIN:-1}
 export BITCOIN_RPC_URL=${BITCOIN_RPC_URL:-http://127.0.0.1:18443}


### PR DESCRIPTION
## Description

This PR improves the daily SP1 proof functional-test workflow. Runs are now capped at 3 hours, and a run that times out or is cancelled still uploads its service logs and reports to Slack instead of terminating silently.

It also defaults `BRIDGE_DEV_MODE=1` in the SP1 env files so local proof runs skip the startup consistency checks, matching what CI already does.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update