### PR TITLE
fix(proofs): anchor moho proof to the trusted genesis state

### DIFF
--- a/crates/proofs/bridge-counterproof/src/statements.rs
+++ b/crates/proofs/bridge-counterproof/src/statements.rs
@@ -123,7 +123,7 @@ fn process_counterproof_inner(zkvm: &impl ZkVmEnv, genesis: &BridgeCounterproofG
             verify_moho_proof(
                 &heavier_moho_state,
                 &heavier_moho_proof,
-                genesis.genesis_moho_state.reference(),
+                &genesis.genesis_moho_state,
                 genesis.moho_vk.clone(),
                 "invalid heavier chain: invalid moho proof",
             );
@@ -835,9 +835,23 @@ mod tests {
 
     /// Unit tests for [`CounterproofMode::HeavierChain`].
     mod heavier_chain {
+        use moho_types::{
+            MohoStateCommitment, RecursiveMohoAttestation, RecursiveMohoProof, StateRefAttestation,
+        };
         use strata_merkle::MerkleProofB32;
 
         use super::*;
+
+        // Re-anchors a Moho proof onto `genesis_state`, leaving the proven state untouched.
+        fn reanchor(
+            moho_proof: &RecursiveMohoProof,
+            genesis_state: StateRefAttestation,
+        ) -> RecursiveMohoProof {
+            RecursiveMohoProof::new(
+                RecursiveMohoAttestation::new(genesis_state, *moho_proof.attestation().proven()),
+                moho_proof.proof().to_vec(),
+            )
+        }
 
         #[test]
         fn counterproof_valid_if_bridge_proof_tx_malformed() {
@@ -893,6 +907,27 @@ mod tests {
                 input,
                 bridge_proof_vk: PredicateKey::always_accept(),
                 moho_vk: PredicateKey::never_accept(),
+            });
+        }
+
+        #[test]
+        #[should_panic(expected = "moho proof doesn't build on given genesis")]
+        fn counterproof_invalid_if_heavier_genesis_state_forged() {
+            let mut input = INPUT_FOR_HEAVIER_CHAIN.clone();
+            // A genesis state of the watchtower's choosing, kept under the real genesis reference.
+            let forged_genesis_state = StateRefAttestation::new(
+                *MOHO_GENESIS_ATTESTATION.reference(),
+                MohoStateCommitment::new([0xab; 32]),
+            );
+            if let CounterproofMode::HeavierChain(ref mut heavier_chain) = input.mode {
+                heavier_chain.moho_proof =
+                    reanchor(&heavier_chain.moho_proof, forged_genesis_state);
+            }
+
+            let _ = run_counterproof(RuntimeArgs {
+                input,
+                bridge_proof_vk: PredicateKey::always_accept(),
+                moho_vk: PredicateKey::always_accept(),
             });
         }
 

--- a/crates/proofs/bridge-proof/src/statements.rs
+++ b/crates/proofs/bridge-proof/src/statements.rs
@@ -45,7 +45,7 @@ fn process_bridge_proof_inner(zkvm: &impl ZkVmEnv, genesis: &BridgeProofGenesis)
     verify_moho_proof(
         &moho_state,
         &moho_proof,
-        genesis.genesis_moho_state.reference(),
+        &genesis.genesis_moho_state,
         genesis.moho_vk.clone(),
         "invalid bridge proof: invalid moho proof",
     );
@@ -76,7 +76,10 @@ fn process_bridge_proof_inner(zkvm: &impl ZkVmEnv, genesis: &BridgeProofGenesis)
 
 #[cfg(test)]
 mod tests {
-    use moho_types::{ExportContainer, MohoState};
+    use moho_types::{
+        ExportContainer, MohoState, MohoStateCommitment, RecursiveMohoAttestation,
+        RecursiveMohoProof, StateRefAttestation,
+    };
     use ssz::{Decode, Encode};
     use strata_bridge_proof_common::{MOHO_GENESIS_ATTESTATION, generate_moho_state};
     use strata_codec::encode_to_vec;
@@ -102,6 +105,17 @@ mod tests {
         machine.write_slice(input.as_ssz_bytes());
         process_bridge_proof_inner(&machine, genesis);
         BridgeProofOutput::from_ssz_bytes(&machine.state.borrow().output).unwrap()
+    }
+
+    // Re-anchors a Moho proof onto `genesis_state`, leaving the proven state untouched.
+    fn reanchor(
+        moho_proof: &RecursiveMohoProof,
+        genesis_state: StateRefAttestation,
+    ) -> RecursiveMohoProof {
+        RecursiveMohoProof::new(
+            RecursiveMohoAttestation::new(genesis_state, *moho_proof.attestation().proven()),
+            moho_proof.proof().to_vec(),
+        )
     }
 
     fn bridge_container(moho_state: &MohoState) -> &ExportContainer {
@@ -156,6 +170,29 @@ mod tests {
         assert_eq!(output.claim_unlock, encode_to_vec(&claim).unwrap());
         assert_eq!(output.mmr_idx, 0);
         assert_eq!(output.total_pow, [0u8; 32]);
+    }
+
+    #[test]
+    #[should_panic(expected = "moho proof doesn't build on given genesis")]
+    fn test_process_bridge_proof_inner_forged_genesis_state() {
+        let genesis = make_genesis();
+        let claim = OperatorClaimUnlock::new(42, 7);
+        let (moho_state, moho_proof, [inclusion_proof]) =
+            generate_moho_state([claim.clone()], [0u8; 32]);
+
+        // A genesis state of the operator's choosing, kept under the real genesis reference.
+        let forged_genesis_state = StateRefAttestation::new(
+            *MOHO_GENESIS_ATTESTATION.reference(),
+            MohoStateCommitment::new([0xab; 32]),
+        );
+        let input = BridgeProofInput {
+            moho_state,
+            moho_proof: reanchor(&moho_proof, forged_genesis_state),
+            claim_unlock: encode_to_vec(&claim).unwrap(),
+            claim_unlock_inclusion_proof: inclusion_proof,
+        };
+
+        let _ = run_bridge_proof(&genesis, input);
     }
 
     #[test]

--- a/crates/proofs/common/src/lib.rs
+++ b/crates/proofs/common/src/lib.rs
@@ -139,7 +139,7 @@ pub fn verify_claim_unlock_inclusion(
 }
 
 /// Verifies a recursive Moho proof against the supplied trusted genesis
-/// reference and verifier key.
+/// attestation and verifier key.
 ///
 /// # Panics
 ///
@@ -147,16 +147,16 @@ pub fn verify_claim_unlock_inclusion(
 pub fn verify_moho_proof(
     moho_state: &MohoState,
     moho_proof: &RecursiveMohoProof,
-    moho_genesis: &StateReference,
+    moho_genesis: &StateRefAttestation,
     moho_vk: PredicateKey,
     error_message: &str,
 ) {
     let attestation = moho_proof.attestation();
 
     assert_eq!(
-        attestation.genesis().reference(),
+        attestation.genesis(),
         moho_genesis,
-        "{error_message}: moho proof doesn't reference given genesis",
+        "{error_message}: moho proof doesn't build on given genesis",
     );
     assert_eq!(
         attestation.proven().commitment(),


### PR DESCRIPTION
## Description

When verifying the recursive Moho proof, the bridge proof compared only the genesis `StateReference` and ignored the genesis state commitment, so the proof could be anchored on any genesis state. `verify_moho_proof` now takes the full `StateRefAttestation` and compares it whole, binding the proof to the genesis state carried by the verifying key. The counterproof's heavier-chain path is updated the same way.

Includes regression tests in both proof crates that keep the genesis reference intact, swap the genesis state commitment, and assert the proof is rejected.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Related Issues

closes #655

🤖 This PR was written primarily by Claude Code and reviewed by Codex.
