### PR TITLE
fix(fntests): raise bridge readiness timeout to 300s

### DIFF
--- a/functional-tests/utils/utils.py
+++ b/functional-tests/utils/utils.py
@@ -176,7 +176,7 @@ def wait_for_log_capture(
     return captured["value"]
 
 
-def wait_until_bridge_ready(rpc_client, timeout: int = 120, step: int = 1):
+def wait_until_bridge_ready(rpc_client, timeout: int = 300, step: int = 1):
     """
     Waits until the bridge client reports readiness.
 


### PR DESCRIPTION
## Description

Under `SP1_PROVER=network` the bridge node builds an `SP1Host` for the bridge-proof and counterproof ELFs before it binds its RPC server, and each `SP1Host::init` costs roughly 70 seconds. The node therefore cannot answer `stratabridge_uptime` for about 135 seconds, while `wait_until_bridge_ready` allowed 120. `BridgeNetworkEnv.init` gave up seconds before the node came up, so `fn_bridge_proof` and `fn_counterproof` both failed during environment setup rather than in the test body.


### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

🤖 This PR was written primarily by Claude Code.
