### PR TITLE
chore(deps): bump mosaic to recent main (758492b4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -808,7 +808,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.4",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1048,7 +1048,7 @@ checksum = "eed3ed3300a998f88639ed619fdbbd88bd82865e00c6a8ecb796c99eb12358f6"
 dependencies = [
  "alloy-json-rpc 2.0.4",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.2",
  "serde_json",
  "tower 0.5.2",
@@ -3125,7 +3125,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3666,7 +3666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4169,7 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5899,7 +5899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.4",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "mosaic-adaptor-sigs"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6804,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "mosaic-cac-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "mosaic-common"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6834,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "mosaic-heap-array"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "ark-serialize 0.6.0",
  "serde",
@@ -6843,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "mosaic-net-svc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "ark-serialize 0.6.0",
  "ed25519-dalek",
@@ -6855,7 +6855,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-api"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "bitcoin",
  "jsonrpsee",
@@ -6865,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "mosaic-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "bitcoin",
  "ckt-fmtv5-types",
@@ -6882,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "mosaic-vs3"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/mosaic?tag=v0.3.0-rc.2#27d619b91cb4d9a19f6f27608e85d57b9c40217e"
+source = "git+https://github.com/alpenlabs/mosaic?rev=758492b4af94f56c86b1db4ff2fa74f8c4464f57#758492b4af94f56c86b1db4ff2fa74f8c4464f57"
 dependencies = [
  "ark-ec",
  "ark-ff 0.6.0",
@@ -8434,7 +8434,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9033,7 +9033,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9101,7 +9101,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9122,7 +9122,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12476,7 +12476,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13614,7 +13614,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,10 +109,10 @@ strata-asm-spec = { git = "https://github.com/alpenlabs/asm", rev = "9d2eb77585c
 strata-asm-worker = { git = "https://github.com/alpenlabs/asm", rev = "9d2eb77585ceb3ca414aa7a9113a1cb1b7f7307c" }
 strata-test-utils-arb = { git = "https://github.com/alpenlabs/asm", rev = "9d2eb77585ceb3ca414aa7a9113a1cb1b7f7307c" }
 
-# Dependencies from alpenlabs/mosaic
-mosaic-common = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.2" }
-mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.2" }
-mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", tag = "v0.3.0-rc.2" }
+# Dependencies from alpenlabs/mosaic pinned to commit 758492b4 (main @ 2026-08-08)
+mosaic-common = { git = "https://github.com/alpenlabs/mosaic", rev = "758492b4af94f56c86b1db4ff2fa74f8c4464f57" }
+mosaic-rpc-api = { git = "https://github.com/alpenlabs/mosaic", rev = "758492b4af94f56c86b1db4ff2fa74f8c4464f57" }
+mosaic-rpc-types = { git = "https://github.com/alpenlabs/mosaic", rev = "758492b4af94f56c86b1db4ff2fa74f8c4464f57" }
 
 # Dependencies from alpenlabs/strata-common
 strata-btc-types = { git = "https://github.com/alpenlabs/strata-common", tag = "v0.3.0-rc.2" }

--- a/compose.yml
+++ b/compose.yml
@@ -48,7 +48,7 @@ x-base-bridge-node: &base-bridge-node
 
 x-base-mosaic: &base-mosaic
   build:
-    context: https://github.com/alpenlabs/mosaic.git#v0.3.0-rc.2
+    context: https://github.com/alpenlabs/mosaic.git#758492b4af94f56c86b1db4ff2fa74f8c4464f57
     dockerfile: docker/Dockerfile
   depends_on:
     foundationdb:


### PR DESCRIPTION
## Description

Moves the `alpenlabs/mosaic` dependencies off the `v0.3.0-rc.2` tag and onto the current `main` commit `758492b4af94f56c86b1db4ff2fa74f8c4464f57` (2026-08-08) 

### Type of Change

- [x] Dependency Update

## Checklist

- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/strata-bridge/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
