### PR TITLE
fix(bridge-proof): bind bridge proof deposit idx to the graph's expected index

### DIFF
--- a/crates/bridge-exec/src/graph/counterproof.rs
+++ b/crates/bridge-exec/src/graph/counterproof.rs
@@ -14,7 +14,8 @@ use strata_asm_rpc::traits::AsmProofApiClient;
 use strata_bridge_connectors::prelude::{ContestCounterproofWitness, ContestProofConnector};
 use strata_bridge_counterproof::{
     BitcoinTxOut, BridgeCounterproofHost, CounterproofInput, CounterproofMode, CounterproofProgram,
-    HeavierChainProof, RawBitcoinTx, statements::leq_little_endian,
+    HeavierChainProof, RawBitcoinTx,
+    statements::{commits_to_different_game, leq_little_endian},
 };
 use strata_bridge_primitives::{
     operator_table::OperatorTable,
@@ -57,7 +58,13 @@ pub(super) async fn evaluate_and_publish_counterproof(
 ) -> Result<(), ExecutorError> {
     info!(%deposit_idx, %operator_idx, %game_index, "evaluating potential counterproof for graph");
 
-    let mode = if verify_bridge_proof(&cfg.graph_sm_cfg.bridge_proof_predicate, &proof) {
+    let mode = if commits_to_different_game(&proof, game_index.get()) {
+        info!(%deposit_idx, %operator_idx, %game_index, "bridge proof commits to a different game; publishing counterproof");
+        CounterproofMode::InvalidBridgeProof
+    } else if !verify_bridge_proof(&cfg.graph_sm_cfg.bridge_proof_predicate, &proof) {
+        info!(%deposit_idx, %operator_idx, %game_index, "bridge proof failed verification; publishing counterproof");
+        CounterproofMode::InvalidBridgeProof
+    } else {
         let Some(heavier_chain_proof) = detect_heavier_chain(
             output_handles,
             deposit_idx,
@@ -77,10 +84,6 @@ pub(super) async fn evaluate_and_publish_counterproof(
         };
         info!(%deposit_idx, %operator_idx, %game_index, "heavier contradicting chain detected; publishing counterproof");
         CounterproofMode::HeavierChain(heavier_chain_proof)
-    } else {
-        // Invalid proof: challenge it outright.
-        info!(%deposit_idx, %operator_idx, %game_index, "bridge proof failed verification; publishing counterproof");
-        CounterproofMode::InvalidBridgeProof
     };
 
     generate_and_publish_counterproof(

--- a/crates/proofs/bridge-counterproof/src/statements.rs
+++ b/crates/proofs/bridge-counterproof/src/statements.rs
@@ -84,13 +84,7 @@ fn process_counterproof_inner(zkvm: &impl ZkVmEnv, genesis: &BridgeCounterproofG
             };
 
             // Immediately succeed if the bridge proof commits to a different game
-            if BridgeProofOutput::from_ssz_bytes(bridge_proof_receipt.public_values().as_bytes())
-                .ok()
-                .and_then(|output| {
-                    decode_buf_exact::<OperatorClaimUnlock>(&output.claim_unlock).ok()
-                })
-                .is_some_and(|claim_unlock| claim_unlock.deposit_idx + 1 != game_idx)
-            {
+            if commits_to_different_game(bridge_proof_receipt, game_idx) {
                 break 'invalid_bridge_proof;
             }
 
@@ -310,6 +304,14 @@ pub fn leq_little_endian(lhs: &[u8; 32], rhs: &[u8; 32]) -> bool {
     lhs.iter().rev().cmp(rhs.iter().rev()).is_le()
 }
 
+/// Returns `true` if the bridge proof is for a different game than `game_idx`
+pub fn commits_to_different_game(bridge_proof_receipt: &ProofReceipt, game_idx: u32) -> bool {
+    BridgeProofOutput::from_ssz_bytes(bridge_proof_receipt.public_values().as_bytes())
+        .ok()
+        .and_then(|output| decode_buf_exact::<OperatorClaimUnlock>(&output.claim_unlock).ok())
+        .is_some_and(|claim_unlock| claim_unlock.deposit_idx + 1 != game_idx)
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::LazyLock;
@@ -470,6 +472,37 @@ mod tests {
             "low-order byte does not dominate"
         );
         assert!(!leq_little_endian(&big, &one), "high-order byte dominates");
+    }
+
+    #[test]
+    fn commits_to_different_game_flags_mismatched_deposit() {
+        let receipt = |deposit_idx: u32| {
+            let output = BridgeProofOutput {
+                total_pow: BRIDGE_PROOF_POW,
+                claim_unlock: encode_to_vec(&OperatorClaimUnlock::new(deposit_idx, 0)).unwrap(),
+                mmr_idx: 0,
+            };
+            ProofReceipt::new(Proof::new(vec![]), PublicValues::new(output.as_ssz_bytes()))
+        };
+
+        // deposit_idx + 1 == game_idx: the proof backs the contested game.
+        assert!(!commits_to_different_game(
+            &receipt(CONTESTED_DEPOSIT_IDX),
+            GAME_IDX.get()
+        ));
+        // deposit_idx + 1 != game_idx: the proof commits to a different game.
+        assert!(commits_to_different_game(
+            &receipt(DIFFERENT_GAME_DEPOSIT_IDX),
+            GAME_IDX.get()
+        ));
+    }
+
+    #[test]
+    fn commits_to_different_game_is_false_for_undecodable_output() {
+        // An output that cannot be decoded is left to the normal verification path, not treated
+        // as a different-game commitment.
+        let receipt = ProofReceipt::new(Proof::new(vec![]), PublicValues::new(vec![]));
+        assert!(!commits_to_different_game(&receipt, GAME_IDX.get()));
     }
 
     #[test]

--- a/crates/proofs/bridge-counterproof/src/statements.rs
+++ b/crates/proofs/bridge-counterproof/src/statements.rs
@@ -309,7 +309,7 @@ pub fn commits_to_different_game(bridge_proof_receipt: &ProofReceipt, game_idx: 
     BridgeProofOutput::from_ssz_bytes(bridge_proof_receipt.public_values().as_bytes())
         .ok()
         .and_then(|output| decode_buf_exact::<OperatorClaimUnlock>(&output.claim_unlock).ok())
-        .is_some_and(|claim_unlock| claim_unlock.deposit_idx + 1 != game_idx)
+        .is_some_and(|claim_unlock| claim_unlock.deposit_idx != game_idx - 1)
 }
 
 #[cfg(test)]
@@ -495,6 +495,22 @@ mod tests {
             &receipt(DIFFERENT_GAME_DEPOSIT_IDX),
             GAME_IDX.get()
         ));
+    }
+
+    #[test]
+    fn commits_to_different_game_does_not_overflow_on_max_deposit_idx() {
+        // A `u32::MAX` deposit index is operator-controlled and must not overflow
+        // (`deposit_idx + 1` would panic in overflow-checked builds before verification).
+        let output = BridgeProofOutput {
+            total_pow: BRIDGE_PROOF_POW,
+            claim_unlock: encode_to_vec(&OperatorClaimUnlock::new(u32::MAX, 0)).unwrap(),
+            mmr_idx: 0,
+        };
+        let receipt =
+            ProofReceipt::new(Proof::new(vec![]), PublicValues::new(output.as_ssz_bytes()));
+
+        // `u32::MAX != GAME_IDX - 1`, so this is a different game.
+        assert!(commits_to_different_game(&receipt, GAME_IDX.get()));
     }
 
     #[test]

--- a/crates/proofs/bridge-counterproof/src/statements.rs
+++ b/crates/proofs/bridge-counterproof/src/statements.rs
@@ -83,6 +83,17 @@ fn process_counterproof_inner(zkvm: &impl ZkVmEnv, genesis: &BridgeCounterproofG
                 break 'invalid_bridge_proof;
             };
 
+            // Immediately succeed if the bridge proof commits to a different game
+            if BridgeProofOutput::from_ssz_bytes(bridge_proof_receipt.public_values().as_bytes())
+                .ok()
+                .and_then(|output| {
+                    decode_buf_exact::<OperatorClaimUnlock>(&output.claim_unlock).ok()
+                })
+                .is_some_and(|claim_unlock| claim_unlock.deposit_idx + 1 != game_idx)
+            {
+                break 'invalid_bridge_proof;
+            }
+
             assert!(
                 genesis
                     .bridge_proof_vk
@@ -324,6 +335,8 @@ mod tests {
     use crate::{BitcoinTxOut, CounterproofMode, RawBitcoinTx};
 
     const GAME_IDX: NonZero<u32> = NonZero::new(7).unwrap();
+    const CONTESTED_DEPOSIT_IDX: u32 = GAME_IDX.get() - 1;
+    const DIFFERENT_GAME_DEPOSIT_IDX: u32 = CONTESTED_DEPOSIT_IDX + 1;
     const PROOF_TIMELOCK: relative::Height = relative::Height::from_height(100);
     const TXIN_IDX: u32 = 0;
 
@@ -345,7 +358,7 @@ mod tests {
     });
     static PREVOUTS: LazyLock<[TxOut; 1]> = LazyLock::new(|| [CONTEST_PROOF_CONNECTOR.tx_out()]);
     static BRIDGE_PROOF_CLAIM_UNLOCK: LazyLock<OperatorClaimUnlock> =
-        LazyLock::new(|| OperatorClaimUnlock::new(0, 0));
+        LazyLock::new(|| OperatorClaimUnlock::new(CONTESTED_DEPOSIT_IDX, 0));
     static HEAVIER_CHAIN_CLAIM_UNLOCK: LazyLock<OperatorClaimUnlock> =
         LazyLock::new(|| OperatorClaimUnlock::new(0, 1));
     const BRIDGE_PROOF_POW: [u8; 32] = [
@@ -356,27 +369,27 @@ mod tests {
         1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0,
     ];
-    static BRIDGE_PROOF_TX_UNSIGNED: LazyLock<BridgeProofTx> = LazyLock::new(|| {
+
+    fn bridge_proof_tx(claim_unlock: &OperatorClaimUnlock) -> BridgeProofTx {
         let bridge_proof_output = BridgeProofOutput {
             total_pow: BRIDGE_PROOF_POW,
-            claim_unlock: encode_to_vec::<OperatorClaimUnlock>(&BRIDGE_PROOF_CLAIM_UNLOCK).unwrap(),
+            claim_unlock: encode_to_vec::<OperatorClaimUnlock>(claim_unlock).unwrap(),
             mmr_idx: 0,
         };
         let receipt = ProofReceipt::new(
             Proof::new(vec![]),
             PublicValues::new(bridge_proof_output.as_ssz_bytes()),
         );
-        let proof_bytes = borsh::to_vec(&receipt).unwrap();
         let data = BridgeProofData {
             contest_txid: Txid::all_zeros(),
-            proof_bytes,
+            proof_bytes: borsh::to_vec(&receipt).unwrap(),
             game_index: GAME_IDX,
         };
 
         BridgeProofTx::new(data, *CONTEST_PROOF_CONNECTOR)
-    });
-    static BRIDGE_PROOF_TX_SIGNED: LazyLock<Transaction> = LazyLock::new(|| {
-        let tx = BRIDGE_PROOF_TX_UNSIGNED.clone();
+    }
+
+    fn sign_bridge_proof_tx(tx: BridgeProofTx) -> Transaction {
         let signing_info = tx.signing_info_partial();
         let tweaked_operator_key = OPERATOR_KEYPAIR
             .add_xonly_tweak(
@@ -386,19 +399,16 @@ mod tests {
             .expect("game-idx tweak is valid");
 
         tx.finalize_partial(signing_info.sign(&tweaked_operator_key))
-    });
+    }
+
+    static BRIDGE_PROOF_TX_UNSIGNED: LazyLock<BridgeProofTx> =
+        LazyLock::new(|| bridge_proof_tx(&BRIDGE_PROOF_CLAIM_UNLOCK));
+    static BRIDGE_PROOF_TX_SIGNED: LazyLock<Transaction> =
+        LazyLock::new(|| sign_bridge_proof_tx(BRIDGE_PROOF_TX_UNSIGNED.clone()));
     static BRIDGE_PROOF_TX_SIGNED_BUT_INVALID_FORMAT: LazyLock<Transaction> = LazyLock::new(|| {
         let mut tx = BRIDGE_PROOF_TX_UNSIGNED.clone();
         tx.as_mut().output[0].script_pubkey = ScriptBuf::new();
-        let signing_info = tx.signing_info_partial();
-        let tweaked_operator_key = OPERATOR_KEYPAIR
-            .add_xonly_tweak(
-                SECP256K1,
-                &ContestProofConnector::operator_key_tweak(GAME_IDX),
-            )
-            .expect("game-idx tweak is valid");
-
-        tx.finalize_partial(signing_info.sign(&tweaked_operator_key))
+        sign_bridge_proof_tx(tx)
     });
     static BRIDGE_PROOF_TX_SIGNED_BUT_INVALID_PROOF: LazyLock<Transaction> = LazyLock::new(|| {
         let receipt = ProofReceipt::new(Proof::new(vec![]), PublicValues::new(vec![]));
@@ -407,16 +417,13 @@ mod tests {
             proof_bytes: borsh::to_vec(&receipt).unwrap(),
             game_index: GAME_IDX,
         };
-        let tx = BridgeProofTx::new(data, *CONTEST_PROOF_CONNECTOR);
-        let signing_info = tx.signing_info_partial();
-        let tweaked_operator_key = OPERATOR_KEYPAIR
-            .add_xonly_tweak(
-                SECP256K1,
-                &ContestProofConnector::operator_key_tweak(GAME_IDX),
-            )
-            .expect("game-idx tweak is valid");
-
-        tx.finalize_partial(signing_info.sign(&tweaked_operator_key))
+        sign_bridge_proof_tx(BridgeProofTx::new(data, *CONTEST_PROOF_CONNECTOR))
+    });
+    static BRIDGE_PROOF_TX_SIGNED_DIFFERENT_GAME: LazyLock<Transaction> = LazyLock::new(|| {
+        sign_bridge_proof_tx(bridge_proof_tx(&OperatorClaimUnlock::new(
+            DIFFERENT_GAME_DEPOSIT_IDX,
+            0,
+        )))
     });
 
     fn op_return_script(data: Vec<u8>) -> ScriptBuf {
@@ -757,6 +764,29 @@ mod tests {
                 moho_vk: PredicateKey::never_accept(),
             });
             assert_eq!(output.game_idx, GAME_IDX.get());
+        }
+
+        #[test]
+        fn counterproof_valid_if_bridge_proof_commits_to_different_game() {
+            let mut input = INPUT_FOR_INVALID_BRIDGE_PROOF.clone();
+            input.bridge_proof_tx =
+                RawBitcoinTx::from(BRIDGE_PROOF_TX_SIGNED_DIFFERENT_GAME.clone());
+            // Guard: the tx is well-formed, so a valid output can only come from the
+            // different-game short-circuit, not from an unparsable bridge proof receipt.
+            assert!(
+                extract_bridge_proof(&BRIDGE_PROOF_TX_SIGNED_DIFFERENT_GAME, TXIN_IDX).is_some()
+            );
+
+            // `always_accept` would otherwise trigger the "bridge proof is valid" panic;
+            // the counterproof still succeeds because the bridge proof commits to a
+            // different game.
+            let output = run_counterproof(RuntimeArgs {
+                input,
+                bridge_proof_vk: PredicateKey::always_accept(),
+                moho_vk: PredicateKey::never_accept(),
+            });
+            assert_eq!(output.game_idx, GAME_IDX.get());
+            assert_eq!(output.operator_pubkey, (*OPERATOR_PUBKEY).into());
         }
 
         #[test]


### PR DESCRIPTION
## Description
The bridge proof verifier only checked that the SNARK was valid for the public values the prover supplied. The proof's public output is `OperatorClaimUnlock { deposit_idx, operator_idx } (plus total_pow)`, all chosen by the prover. This PR binds the proof to the graph index being defended

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

### Related Issues
#680 