### PR TITLE
fix(dev-cli): remove private field from derive-keys output

### DIFF
--- a/bin/dev-cli/src/handlers/derive_keys.rs
+++ b/bin/dev-cli/src/handlers/derive_keys.rs
@@ -64,9 +64,8 @@ pub(crate) fn handle_derive_keys(args: DeriveKeysArgs) -> Result<()> {
     let ed_keypair = EdKeypair::from(ed_secret);
     let p2p_pubkey = ed_keypair.public().to_bytes().to_lower_hex_string();
 
-    // Output the JSON entry
+    // Output public operator material only; never include the input seed.
     let output = json!({
-        "seed": seed.to_lower_hex_string(),
         "general_wallet_address": general_wallet_addr.to_string(),
         "general_wallet_descriptor": general_wallet_descriptor.to_string(),
         "reserved_wallet_address": reserved_wallet,

--- a/bin/dev-cli/tests/derive_keys_output.rs
+++ b/bin/dev-cli/tests/derive_keys_output.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+#[test]
+fn derive_keys_output_does_not_expose_seed() {
+    let test_seed = "000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f";
+    let output = Command::new(env!("CARGO_BIN_EXE_dev-cli"))
+        .args(["derive-keys", test_seed, "regtest"])
+        .output()
+        .expect("failed to run dev-cli derive-keys");
+
+    assert!(
+        output.status.success(),
+        "derive-keys failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("derive-keys output must be valid JSON");
+
+    assert!(
+        json.get("seed").is_none(),
+        "derive-keys output must never contain private seed material"
+    );
+
+    for field in [
+        "general_wallet_address",
+        "general_wallet_descriptor",
+        "reserved_wallet_address",
+        "musig2_key",
+        "p2p_key",
+    ] {
+        assert!(json.get(field).is_some(), "missing public field: {field}");
+    }
+}


### PR DESCRIPTION
## Summary

- stop `derive-keys` from returning the private input value in its JSON output
- preserve the existing public output fields
- add a regression test covering the output schema

## Validation

The new integration test runs `derive-keys`, parses the JSON output, checks that the private field is absent, and verifies the expected public fields remain present.

CI pending.