### PR TITLE
fix(ci): address zizmor findings

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,10 @@ self-hosted-runner:
   labels:
     - ubuntu-latest-m
     - 16-core-runner
+
+# actionlint 1.7.12 predates GitHub's $/ self-repository syntax.
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      - 'specifying action "\$/\.github/actions/.+" in invalid format because ref is missing'
+      - 'reusable workflow call "\$/\.github/workflows/.+" at "uses" is not following the format'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   crate-checks:
     name: Check that crates compile on their own
@@ -67,7 +67,7 @@ jobs:
           version: "v0.10.0" # sccache version
 
       - name: Install FoundationDB
-        uses: ./.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
 
       - name: Check crates compile
         run: cargo hack check

--- a/.github/workflows/docker-publish-ecr.yml
+++ b/.github/workflows/docker-publish-ecr.yml
@@ -139,7 +139,7 @@ jobs:
           path: build-src
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Validate AWS publish configuration
         env:
@@ -189,7 +189,7 @@ jobs:
       # .trivyignore.yaml comes from the root (main) checkout — untrusted build refs cannot suppress CVEs.
       - name: Scan ${{ matrix.display_name }} with Trivy
         id: trivy
-        uses: ./.github/actions/trivy-scan # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/trivy-scan # zizmor: ignore[unpinned-uses]
         with:
           image_ref: ${{ env.LOCAL_TAG }}
           display_name: ${{ matrix.display_name }}
@@ -275,7 +275,7 @@ jobs:
           path: build-src
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Validate AWS publish configuration
         env:
@@ -329,7 +329,7 @@ jobs:
       # .trivyignore.yaml comes from the root (main) checkout — untrusted build refs cannot suppress CVEs.
       - name: Scan ${{ matrix.display_name }} with Trivy
         id: trivy
-        uses: ./.github/actions/trivy-scan # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/trivy-scan # zizmor: ignore[unpinned-uses]
         with:
           image_ref: ${{ matrix.local_tag }}
           display_name: ${{ matrix.display_name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   docker-build:
     name: Test Docker builds
@@ -41,7 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -59,7 +59,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install FoundationDB
-        uses: ./.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
 
       - name: Cache Docker layers
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   docs:
     name: Generate docs
@@ -51,7 +51,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install FoundationDB
-        uses: ./.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
 
       - name: Check docs leaving the dependencies out
         run: cargo doc --workspace --no-deps

--- a/.github/workflows/functional-sp1-proofs.yml
+++ b/.github/workflows/functional-sp1-proofs.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   run:
     name: Run ${{ matrix.test }} with real SP1 proving
@@ -103,7 +103,7 @@ jobs:
           echo "$OPENSSL_INSTALL_DIR/bin" >> "$GITHUB_PATH"
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Install bitcoind
         env:
@@ -144,10 +144,10 @@ jobs:
           sudo apt-get install -y libclang-dev
 
       - name: Setup FoundationDB client
-        uses: ./.github/actions/setup-foundationdb
+        uses: $/.github/actions/setup-foundationdb
 
       - name: Setup FoundationDB server
-        uses: ./.github/actions/setup-foundationdb-server
+        uses: $/.github/actions/setup-foundationdb-server
 
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -280,7 +280,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Send Slack alert
-        uses: ./.github/actions/notify-slack # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/notify-slack # zizmor: ignore[unpinned-uses]
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           message: ${{ steps.msg.outputs.text }}

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   discover-groups:
     name: Discover functional test groups
@@ -134,7 +134,7 @@ jobs:
           echo "$OPENSSL_INSTALL_DIR/bin" >> "$GITHUB_PATH"
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Install bitcoind
         env:
@@ -180,10 +180,10 @@ jobs:
           sudo apt-get install -y libclang-dev
 
       - name: Setup FoundationDB client
-        uses: ./.github/actions/setup-foundationdb
+        uses: $/.github/actions/setup-foundationdb
 
       - name: Setup FoundationDB server
-        uses: ./.github/actions/setup-foundationdb-server
+        uses: $/.github/actions/setup-foundationdb-server
 
       - name: Build Cargo project
         run: |

--- a/.github/workflows/guest-build.yml
+++ b/.github/workflows/guest-build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   sp1-guest-build:
     name: Build SP1 bridge-proof and counterproof guests with bundled stub params

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   clippy:
     name: Run clippy on crates
@@ -51,7 +51,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install FoundationDB
-        uses: ./.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/publish-guests-and-circuit.yml
+++ b/.github/workflows/publish-guests-and-circuit.yml
@@ -45,7 +45,7 @@ permissions: {}
 jobs:
   guest-build:
     name: Guest build
-    uses: ./.github/workflows/publish-sp1-bridge-guests.yml
+    uses: $/.github/workflows/publish-sp1-bridge-guests.yml
     permissions:
       contents: read
       id-token: write
@@ -60,7 +60,7 @@ jobs:
     needs: guest-build
     # No `env:` input — circuit-gen reads it from the manifest in guest-build's
     # artifact, so the circuit key can't name a different env than the bridge tree.
-    uses: ./.github/workflows/circuit-gen.yml
+    uses: $/.github/workflows/circuit-gen.yml
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish-sp1-bridge-guests.yml
+++ b/.github/workflows/publish-sp1-bridge-guests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   publish-sp1-bridge-guests:
     name: Build and publish SP1 bridge-proof and counterproof ELFs

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -26,10 +26,10 @@ permissions: {}
 
 jobs:
   unit-tests:
-    uses: ./.github/workflows/unit.yml
+    uses: $/.github/workflows/unit.yml
 
   functional-tests:
-    uses: ./.github/workflows/functional.yml
+    uses: $/.github/workflows/functional.yml
 
   publish-coverage:
     name: Check that unit tests pass

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract Rust version
         id: extract-version
-        uses: ./.github/actions/extract-rust-version
+        uses: $/.github/actions/extract-rust-version
 
   test:
     name: Run unit tests and generate report
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Install bitcoind
         env:
@@ -80,10 +80,10 @@ jobs:
           cache-on-failure: true
 
       - name: Install FoundationDB Client
-        uses: ./.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/setup-foundationdb # zizmor: ignore[unpinned-uses]
 
       - name: Install FoundationDB Server
-        uses: ./.github/actions/setup-foundationdb-server # zizmor: ignore[unpinned-uses]
+        uses: $/.github/actions/setup-foundationdb-server # zizmor: ignore[unpinned-uses]
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
## Description

zizmor 1.30.0 (released 2026-08-30) added the `self-repository` audit, and `zizmor.yml` installs latest, so every PR has failed that check since Aug 31 on 32 findings. Switch every local action and reusable-workflow reference to GitHub's `$/` self-repository syntax, and add the two actionlint ignores because `lint-actions.yml` runs actionlint 1.7.12 with `fail_level: any` and it predates the syntax.

Same fix as alpenlabs/asm#257, alpenlabs/alpen#2254, alpenlabs/mosaic#344, alpenlabs/strata-p2p#135 and alpenlabs/zkaleido#184. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
