### PR TITLE
chore(cargo): enforce 14-day min-publish-age for crates.io deps

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,3 +11,9 @@ min-publish-age = true
 
 [registry]
 global-min-publish-age = "14 days"
+
+# Reject too-new versions even when a user-level cargo config sets "allow".
+# The CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE environment variable still
+# overrides this for one-off updates.
+[resolver]
+incompatible-publish-age = "deny"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# Cooldown for crates.io dependencies (RFC 3923, `min-publish-age`).
+# Versions published less than 14 days ago are not selected by the resolver
+# unless they are already in `Cargo.lock`. Matches the Dependabot cooldown.
+# Urgent override for a single resolve:
+#   CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update -p <crate>
+
+# Stable cargo ignores this table. Nightly cargo needs it until the feature
+# is stable (Rust 1.100, 2026-11-12); remove it once the toolchain has it.
+[unstable]
+min-publish-age = true
+
+[registry]
+global-min-publish-age = "14 days"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,5 +56,7 @@ jobs:
       - name: Check docs leaving the dependencies out
         run: cargo doc --workspace --no-deps
         env:
-          RUSTDOCFLAGS: --show-type-layout --enable-index-page -Zunstable-options -A rustdoc::private-doc-tests -D warnings
+          # generic_const_exprs is not yet supported by the globally enabled next-generation trait
+          # solver. See https://github.com/rust-lang/rust/issues/160895.
+          RUSTDOCFLAGS: --show-type-layout --enable-index-page -Zunstable-options -Znext-solver=coherence -A rustdoc::private-doc-tests -D warnings
           DATABASE_URL: sqlite://./operator.db

--- a/crates/algebra/src/predicate.rs
+++ b/crates/algebra/src/predicate.rs
@@ -25,13 +25,13 @@ pub fn and<A>(f: impl Fn(&A) -> bool, g: impl Fn(&A) -> bool) -> impl for<'a> Fn
 
 /// Predicate combinator for the || operation.
 #[inline(always)]
-pub fn or<A>(f: impl Fn(&A) -> bool, g: impl Fn(&A) -> bool) -> impl for<'a> Fn(&A) -> bool {
+pub fn or<A>(f: impl Fn(&A) -> bool, g: impl Fn(&A) -> bool) -> impl Fn(&A) -> bool {
     move |a| f(a) || g(a)
 }
 
 /// Predicate combinator for the xor operation.
 #[inline(always)]
-pub fn xor<A>(f: impl Fn(&A) -> bool, g: impl Fn(&A) -> bool) -> impl for<'a> Fn(&A) -> bool {
+pub fn xor<A>(f: impl Fn(&A) -> bool, g: impl Fn(&A) -> bool) -> impl Fn(&A) -> bool {
     move |a| f(a) ^ g(a)
 }
 

--- a/crates/bridge-sm/src/lib.rs
+++ b/crates/bridge-sm/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(bool_to_result)]
 //! This crate implements state machines for managing bridge operations.
 //!
 //! The state machines in the bridge are a cooperating automata that together implement the overall

--- a/crates/db/src/fdb/row_spec/funds.rs
+++ b/crates/db/src/fdb/row_spec/funds.rs
@@ -39,7 +39,7 @@ fn deserialize_outpoints(bytes: &[u8]) -> Result<Vec<OutPoint>, InvalidOutPointB
         return Err(InvalidOutPointBytes { len: bytes.len() });
     }
     let mut outpoints = Vec::with_capacity(bytes.len() / SERIALIZED_OUTPOINT_SIZE);
-    for chunk in bytes.chunks_exact(SERIALIZED_OUTPOINT_SIZE) {
+    for chunk in bytes.as_chunks::<SERIALIZED_OUTPOINT_SIZE>().0 {
         let txid = Txid::from_slice(&chunk[..SERIALIZED_TXID_SIZE]).unwrap_or_else(|_| {
             panic!(
                 "Invalid Txid bytes: expected {} bytes, got {}",

--- a/crates/primitives/src/scripts/taproot.rs
+++ b/crates/primitives/src/scripts/taproot.rs
@@ -264,7 +264,8 @@ impl<'a> Arbitrary<'a> for TaprootWitness {
         match choice {
             0 => Ok(TaprootWitness::Key),
             1 => {
-                let script_len = usize::arbitrary(u)? % 100; // Limit the length of the script for practicality
+                let script_len = usize::arbitrary(u)? % 100; // Limit the length of the script for
+                                                             // practicality
                 let script_bytes = u.bytes(script_len)?; // Generate random bytes for the script
                 let script_buf = ScriptBuf::from(script_bytes.to_vec());
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-07-01"
+channel = "nightly-2026-09-01"
 components = [
   "cargo",
   "clippy",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-05-01"
+channel = "nightly-2026-09-01"
 components = [
   "cargo",
   "clippy",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2026-09-01"
+channel = "nightly-2026-07-01"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
## Description

Adds a 14-day cooldown for crates.io dependencies through Cargo's new `min-publish-age` setting (RFC 3923), in a root `.cargo/config.toml`:

```toml
[unstable]
min-publish-age = true

[registry]
global-min-publish-age = "14 days"
```

Dependabot already waits 14 days before proposing a bump. This makes plain `cargo add`, `cargo update`, and hand-edited version requirements follow the same rule, so a freshly published (and possibly compromised) release can't slip in through a developer's PR. Versions already in `Cargo.lock` are left alone. For an urgent fix there is a one-off escape hatch:

```
CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow cargo update -p <crate>
```

The pinned nightly predates the feature, so the first commit bumps it to nightly-2026-09-01, matching alpen. That bump is what makes the cooldown active here. On that nightly rustdoc fails on every crate that depends on ssz (E0284 on the generic_const_exprs bound in ssz's BitVectorRefIter impl) because the globally enabled next-generation trait solver does not support that feature yet (rust-lang/rust#160895). The last commit passes `-Znext-solver=coherence` to rustdoc in the docs workflow, the same fix alpen applied in alpenlabs/alpen#2267. There is a detour in the history where I tried nightly-2026-07-01 first; the final state is 09-01 plus the flag. Moving from nightly-2026-05-01 brought small lint and formatting fallout, all in the first commit: two redundant `for<'a>` bounds dropped in `crates/algebra/src/predicate.rs`, the `bool_to_result` feature gate removed in `crates/bridge-sm/src/lib.rs` since it is stable now, `chunks_exact` swapped for `as_chunks` in `crates/db/src/fdb/row_spec/funds.rs` (same behavior, the length is checked right above), and one comment re-wrapped by rustfmt. Clippy and rustfmt pass on nightly-2026-09-01, and the previously failing crates document locally with the new flag. CI also runs cargo from the `g16/` checkout; that repo gets the same config in its own PR.

Tracking: STR-3852.

Update: a follow-up commit also sets `[resolver] incompatible-publish-age = "deny"`. That is cargo's default, but spelling it out in the repo config means a developer with `allow` in their user-level `~/.cargo/config.toml` no longer switches the cooldown off here. The `CARGO_RESOLVER_INCOMPATIBLE_PUBLISH_AGE=allow` escape hatch still works, since environment variables take precedence over both. Robin's suggestion from the Slack thread.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

One gap worth knowing about: versions already in `Cargo.lock` are exempt by design, so a lockfile produced with the override still passes `cargo build --locked` in CI. If we want CI to catch that, `cargo update --dry-run` prints a `Downgrading` line for every locked version that violates the policy and can be turned into a check. That is out of scope for this PR.

The `[unstable]` table is temporary. Stable cargo ignores it, and nightly cargo needs it until the feature reaches stable in Rust 1.100 (2026-11-12). After that it can be dropped.

Verified locally with `cargo update --dry-run --workspace`:

```
Locking 0 packages to highest compatible versions as of 14 days ago
note: pass `--verbose` to see 451 unchanged dependencies behind latest
warning: not updating lockfile due to dry run
```

AI disclosure: the change and this PR body were produced with Claude Code and Codex, then reviewed and tested by me.

Is this PR addressing any specification, design doc or external reference document?

- [x]  Yes
- [ ]  No

If yes, please add relevant links:

- https://rust-lang.github.io/rfcs/3923-cargo-min-publish-age.html
- https://github.com/rust-lang/cargo/pull/17335

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
- [x] I have [disclosed my use of AI](https://github.com/alpenlabs/alpen/blob/main/CONTRIBUTING.md#ai-assistance-notice) in the body of this PR.

## Related Issues

STR-3852



