### PR TITLE
fix(dev-cli): derive mock checkpoint inputs from params file

### DIFF
--- a/bin/dev-cli/README.md
+++ b/bin/dev-cli/README.md
@@ -28,12 +28,13 @@ dev-cli create-and-publish-mock-checkpoint \
   --btc-pass password \
   --num-withdrawals 1 \
   --epoch 1 \
-  --genesis-l1-height 101 \
   --ol-start-slot 0 \
   --ol-end-slot 1 \
   --assignee-node-idx 0 \
-  --network regtest
+  --params ./params.toml
 ```
+
+The network, magic bytes, withdrawal amount (`protocol.deposit_amount`) and default genesis L1 height (`genesis_height`, override with `--genesis-l1-height`) come from the params file.
 
 ### `claim`
 

--- a/bin/dev-cli/params.toml
+++ b/bin/dev-cli/params.toml
@@ -27,6 +27,7 @@ p2p = "aeabd3a377c160590a0927bca0cb315eaebf5acc87476fbb317c6260b6f123c6"
 payout_descriptor = "04b63fea4640fbbf630e2bd949a588b63426bb2ea2771ce5b2caf44dbfa90d6cd3"
 
 [protocol]
+bury_depth = 2
 magic_bytes = "ALPN"
 deposit_amount = 1_000_000_000
 stake_amount = 100_000_000

--- a/bin/dev-cli/src/cli.rs
+++ b/bin/dev-cli/src/cli.rs
@@ -81,8 +81,11 @@ pub(crate) struct CreateAndPublishMockCheckpointArgs {
     #[arg(long, default_value = "1", help = "checkpoint epoch")]
     pub(crate) epoch: u32,
 
-    #[arg(long, default_value = "101", help = "genesis L1 height")]
-    pub(crate) genesis_l1_height: u32,
+    #[arg(
+        long,
+        help = "genesis L1 height (defaults to `genesis_height` from the params file)"
+    )]
+    pub(crate) genesis_l1_height: Option<u32>,
 
     #[arg(long, help = "start OL block slot for the L2 range")]
     pub(crate) ol_start_slot: u64,
@@ -97,8 +100,8 @@ pub(crate) struct CreateAndPublishMockCheckpointArgs {
     )]
     pub(crate) assignee_node_idx: u32,
 
-    #[arg(long, default_value_t = Network::Regtest, help = "bitcoin network")]
-    pub(crate) network: Network,
+    #[arg(long, help = "the path to the params file")]
+    pub(crate) params: PathBuf,
 
     #[clap(flatten)]
     pub(crate) btc_args: BtcArgs,

--- a/bin/dev-cli/src/handlers/checkpoint/constants.rs
+++ b/bin/dev-cli/src/handlers/checkpoint/constants.rs
@@ -1,4 +1,3 @@
-pub(super) use strata_bridge_primitives::constants::BRIDGE_TAG;
 use strata_identifiers::AccountSerial;
 
 /// Bridge gateway account serial.

--- a/bin/dev-cli/src/handlers/checkpoint/mock_checkpoint.rs
+++ b/bin/dev-cli/src/handlers/checkpoint/mock_checkpoint.rs
@@ -1,3 +1,4 @@
+use bitcoin::Amount;
 use bitcoin_bosd::Descriptor;
 use k256::{
     ecdsa::signature::SignatureEncoding,
@@ -9,7 +10,6 @@ use strata_asm_checkpoint_types::{
     compute_asm_manifests_hash, CheckpointClaim, CheckpointPayload, CheckpointSidecar,
     CheckpointTip, L2BlockRange, OLLog, SimpleWithdrawalIntentLogData, TerminalHeaderComplement,
 };
-use strata_bridge_primitives::constants::BRIDGE_DENOMINATION;
 use strata_crypto::hash;
 use strata_identifiers::{Buf32, OLBlockCommitment, OLBlockId};
 use strata_test_utils_arb::ArbitraryGenerator;
@@ -64,11 +64,15 @@ impl MockCheckpointBuilder {
     }
 
     /// Generates a mock checkpoint payload signed by the checkpoint predicate.
+    ///
+    /// Every withdrawal intent log carries `withdrawal_amount`, which should be the bridge's
+    /// `deposit_amount` so that ASM assigns exactly one withdrawal per log.
     pub(crate) fn build_payload(
         &self,
         prev_tip: &CheckpointTip,
         new_tip: &CheckpointTip,
         num_withdrawals: usize,
+        withdrawal_amount: Amount,
         assignee_node_idx: u32,
     ) -> CheckpointPayload {
         let mut arb = ArbitraryGenerator::new();
@@ -86,7 +90,7 @@ impl MockCheckpointBuilder {
         let ol_logs: Vec<OLLog> = (0..num_withdrawals)
             .map(|_| {
                 let log_data = SimpleWithdrawalIntentLogData::new(
-                    BRIDGE_DENOMINATION.to_sat(),
+                    withdrawal_amount.to_sat(),
                     dest.to_bytes(),
                     assignee_node_idx,
                 )

--- a/bin/dev-cli/src/handlers/checkpoint/mod.rs
+++ b/bin/dev-cli/src/handlers/checkpoint/mod.rs
@@ -1,11 +1,11 @@
 use anyhow::{bail, Context, Result};
 use ssz::Encode;
 use strata_asm_checkpoint_types::CheckpointPayload;
+use strata_bridge_common::params::Params;
 use strata_codec::{encode_to_vec, Varint};
-use strata_l1_txfmt::MagicBytes;
 use tracing::info;
 
-use crate::{cli::CreateAndPublishMockCheckpointArgs, handlers::checkpoint::constants::BRIDGE_TAG};
+use crate::cli::CreateAndPublishMockCheckpointArgs;
 
 mod constants;
 pub(crate) mod envelope;
@@ -34,6 +34,14 @@ pub(crate) async fn handle_create_and_publish_mock_checkpoint(
         );
     }
 
+    let params = Params::from_path(&args.params).context("failed to load params file")?;
+    let withdrawal_amount = params.protocol.deposit_amount;
+    let genesis_l1_height = match args.genesis_l1_height {
+        Some(height) => height,
+        None => u32::try_from(params.genesis_height)
+            .context("params genesis_height does not fit in u32")?,
+    };
+
     // Connect to bitcoind.
     let btc_client = bitcoincore_rpc::Client::new(
         &args.btc_args.url,
@@ -45,7 +53,7 @@ pub(crate) async fn handle_create_and_publish_mock_checkpoint(
     let builder = mock_checkpoint::MockCheckpointBuilder::new();
     let (prev_tip, new_tip) = builder.gen_tips(
         args.epoch,
-        args.genesis_l1_height,
+        genesis_l1_height,
         args.ol_start_slot,
         args.ol_end_slot,
     );
@@ -53,6 +61,7 @@ pub(crate) async fn handle_create_and_publish_mock_checkpoint(
         &prev_tip,
         &new_tip,
         args.num_withdrawals,
+        withdrawal_amount,
         args.assignee_node_idx,
     );
 
@@ -61,18 +70,18 @@ pub(crate) async fn handle_create_and_publish_mock_checkpoint(
     info!(
         epoch = new_tip.epoch,
         num_withdrawals = args.num_withdrawals,
+        withdrawal_amount_sat = withdrawal_amount.to_sat(),
         payload_size = encoded_checkpoint.len(),
         "broadcasting mock checkpoint"
     );
 
-    let magic: MagicBytes = BRIDGE_TAG.parse().expect("valid magic bytes");
     let reveal_txid = envelope::build_and_broadcast_envelope_tx(
         &btc_client,
-        magic,
+        params.protocol.magic_bytes,
         CHECKPOINT_SUBPROTOCOL_ID,
         OL_STF_CHECKPOINT_TX_TYPE,
         &encoded_checkpoint,
-        args.network,
+        params.network,
     )
     .context("failed to broadcast checkpoint envelope")?;
 

--- a/functional-tests/utils/dev_cli.py
+++ b/functional-tests/utils/dev_cli.py
@@ -165,6 +165,8 @@ class DevCli:
             str(epoch),
             "--assignee-node-idx",
             str(assignee_node_idx),
+            "--params",
+            self.params_path,
         ]
 
         res = self._run_command(args)


### PR DESCRIPTION
## Description

The mock checkpoint hardcoded the withdrawal amount, magic bytes, network and genesis height even though the params file carries all four. Since ASM splits an intent into `amount / denomination` units, the 10 BTC constant against a 1 BTC denomination produced ten assignments per requested withdrawal.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)