### PR TITLE
STR-4292 feat(operator-wallet): persist wallet state via BDK SQLite persister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "bdk_core",
  "bitcoin",
  "miniscript 12.3.7",
+ "rusqlite",
  "serde",
 ]
 
@@ -4238,6 +4239,18 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fasm"
@@ -6371,6 +6384,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,7 +7555,9 @@ dependencies = [
  "bdk_wallet",
  "bitcoin-bosd",
  "corepc-node",
+ "operator-wallet",
  "serial_test",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9019,6 +9045,20 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -11683,6 +11723,7 @@ dependencies = [
  "strata-identifiers",
  "strata-l1-txfmt",
  "strata-mosaic-client-api",
+ "tempfile",
  "terrors",
  "thiserror 2.0.18",
  "tokio",
@@ -13414,6 +13455,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/bin/dev-cli/Cargo.toml
+++ b/bin/dev-cli/Cargo.toml
@@ -21,10 +21,10 @@ strata-bridge-tx-graph.workspace = true
 
 ssz.workspace = true
 strata-asm-admin-types.workspace = true
+strata-asm-checkpoint-types.workspace = true
 strata-asm-proto-admin-txs = { workspace = true, features = ["test-utils"] }
 strata-asm-proto-bridge-txs.workspace = true
 strata-asm-proto-checkpoint-txs.workspace = true
-strata-asm-checkpoint-types.workspace = true
 strata-codec.workspace = true
 strata-crypto.workspace = true
 strata-identifiers.workspace = true

--- a/bin/strata-bridge/Cargo.toml
+++ b/bin/strata-bridge/Cargo.toml
@@ -30,8 +30,8 @@ strata-bridge-tx-graph.workspace = true
 strata-mosaic-client.workspace = true
 strata-mosaic-client-api.workspace = true
 
-strata-asm-params.workspace = true
 strata-asm-bridge-types.workspace = true
+strata-asm-params.workspace = true
 strata-asm-rpc = { workspace = true, features = ["client"] }
 strata-p2p.workspace = true
 strata-predicate.workspace = true

--- a/bin/strata-bridge/src/config.rs
+++ b/bin/strata-bridge/src/config.rs
@@ -2,7 +2,7 @@
 //!
 //! These do not affect consensus between bridge nodes and can be set to different values by
 //! different operators.
-use std::{fmt, net::SocketAddr, path::PathBuf, time::Duration};
+use std::{fmt, net::SocketAddr, num::NonZeroU32, path::PathBuf, time::Duration};
 
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
@@ -268,6 +268,16 @@ pub(crate) struct OperatorWalletConfig {
     /// The size of the claim funding pool, i.e., the number of UTXOs to generate for funding claim
     /// transactions when they run out.
     pub claim_funding_pool_size: usize,
+
+    /// Directory holding the persisted chain state of the general and reserved wallets, one SQLite
+    /// file each. Created on first start if absent.
+    pub data_dir: PathBuf,
+
+    /// Number of applied blocks between commits of wallet state during a sync. Bounds the work a
+    /// crash mid-sync can lose. Defaults to
+    /// [`DEFAULT_PERSIST_EVERY_BLOCKS`](operator_wallet::DEFAULT_PERSIST_EVERY_BLOCKS).
+    #[serde(default)]
+    pub persist_every_blocks: Option<NonZeroU32>,
 }
 
 /// Configuration for the mosaic client.
@@ -370,6 +380,7 @@ pub(crate) fn test_config() -> Config {
 
             [operator_wallet]
             claim_funding_pool_size = 32
+            data_dir = "wallet-data"
 
             [mosaic]
             rpc_url = "http://localhost:7500"

--- a/bin/strata-bridge/src/mode/services/operator_wallet.rs
+++ b/bin/strata-bridge/src/mode/services/operator_wallet.rs
@@ -2,14 +2,17 @@
 
 use std::{num::NonZero, sync::Arc, time::Instant};
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use bdk_bitcoind_rpc::bitcoincore_rpc;
 use bitcoin::{
     Amount, XOnlyPublicKey,
     hashes::{Hash, sha256},
     relative,
 };
-use operator_wallet::{NativeGeneralWallet, OperatorWallet, OperatorWalletConfig, sync::Backend};
+use operator_wallet::{
+    DEFAULT_PERSIST_EVERY_BLOCKS, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
+    SqliteStore, WalletKind, sync::Backend,
+};
 use secret_service_client::SecretServiceClient;
 use secret_service_proto::v2::traits::{SchnorrSigner, SecretService};
 use strata_bridge_common::params::Params;
@@ -68,21 +71,50 @@ pub(in crate::mode) async fn init_operator_wallet(
     info!(%reserved_key, "operator wallet reserved key");
     let own_musig2_key = s2_client.musig2_signer().pubkey().await?;
     let claim_funding_utxo_value = compute_claim_funding_utxo_value(params, own_musig2_key);
-    let operator_wallet_config = OperatorWalletConfig::new(SEGWIT_MIN_AMOUNT, params.network);
+    let persist_every_blocks = config
+        .operator_wallet
+        .persist_every_blocks
+        .unwrap_or(DEFAULT_PERSIST_EVERY_BLOCKS);
+    let operator_wallet_config = OperatorWalletConfig::new(SEGWIT_MIN_AMOUNT, params.network)
+        .with_persist_every_blocks(persist_every_blocks);
     debug!(?operator_wallet_config, %claim_funding_utxo_value, "operator wallet config");
 
     let general_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
     let reserved_sync_backend = Backend::BitcoinCore(bitcoin_rpc_client.clone());
     debug!(?general_sync_backend, "operator wallet sync backend");
-    let general_wallet =
-        NativeGeneralWallet::new(general_key, params.network, general_sync_backend);
-    let wallet = OperatorWallet::new(
+
+    let data_dir = &config.operator_wallet.data_dir;
+    info!(data_dir = %data_dir.display(), "opening operator wallet stores");
+    let open_store = |kind| {
+        SqliteStore::open_in_dir(data_dir, kind)
+            .with_context(|| format!("opening {kind} wallet store"))
+    };
+    let general_store = open_store(WalletKind::General)?;
+    let reserved_store = open_store(WalletKind::Reserved)?;
+
+    // TODO: <https://alpenlabs.atlassian.net/browse/STR-4291>
+    // Derive the bootstrap checkpoint from the trusted-checkpoint
+    let bootstrap_checkpoint = None;
+    let general_wallet = NativeGeneralWallet::load_or_create(
+        general_key,
+        &operator_wallet_config,
+        general_sync_backend,
+        general_store,
+        bootstrap_checkpoint,
+    )
+    .await
+    .context("loading general wallet")?;
+    let wallet = OperatorWallet::load_or_create(
         general_wallet,
         reserved_key,
         operator_wallet_config,
         reserved_sync_backend,
+        reserved_store,
+        bootstrap_checkpoint,
         leased_outpoints,
-    );
+    )
+    .await
+    .context("loading reserved wallet")?;
     debug!("operator wallet initialized");
 
     Ok(InitializedOperatorWallet {

--- a/crates/asm-events/Cargo.toml
+++ b/crates/asm-events/Cargo.toml
@@ -9,8 +9,8 @@ workspace = true
 [dependencies]
 algebra.workspace = true
 btc-tracker.workspace = true
-strata-asm-proto-bridge.workspace = true
 strata-asm-bridge-types.workspace = true
+strata-asm-proto-bridge.workspace = true
 strata-asm-rpc = { workspace = true, features = ["client"] }
 strata-bridge-primitives.workspace = true
 strata-btc-types.workspace = true

--- a/crates/bridge-exec/Cargo.toml
+++ b/crates/bridge-exec/Cargo.toml
@@ -56,6 +56,8 @@ strata-bridge-test-utils.workspace = true
 
 bdk_bitcoind_rpc.workspace = true
 corepc-node.workspace = true
+operator-wallet = { workspace = true, features = ["test-utils"] }
+tempfile.workspace = true
 
 [features]
 default = []

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -11,7 +11,7 @@ use bitcoin::{
 use btc_tracker::event::TxStatus;
 use futures::{FutureExt, future::try_join_all};
 use musig2::{AggNonce, PartialSignature, PubNonce, secp256k1::Message};
-use operator_wallet::{GeneralUtxoPolicy, GeneralWallet, OperatorWallet, UtxoInfo};
+use operator_wallet::{GeneralUtxoPolicy, GeneralWallet, OperatorWallet, UtxoInfo, WalletStore};
 use secret_service_proto::v2::traits::{Musig2Params, Musig2Signer, SchnorrSigner, SecretService};
 use strata_bridge_db::{traits::BridgeDb, types::FundingAssignment};
 use strata_bridge_p2p_types::{GraphData, XOnlyPubKey};
@@ -275,8 +275,8 @@ async fn ensure_claim_funding_outpoint(
     Ok(assigned_outpoint)
 }
 
-async fn reconcile_claim_funding_leases_after_driver_failure<G: GeneralWallet>(
-    wallet: &mut OperatorWallet<G>,
+async fn reconcile_claim_funding_leases_after_driver_failure<G: GeneralWallet, P: WalletStore>(
+    wallet: &mut OperatorWallet<G, P>,
     spent: &[OutPoint],
 ) {
     if let Err(sync_err) = wallet.sync().await {

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -744,6 +744,7 @@ mod tests {
     use corepc_node::{Conf, Node};
     use operator_wallet::{
         FundedPsbt, GeneralWallet, OperatorWallet, OperatorWalletConfig, UtxoInfo, sync::Backend,
+        test_utils::MemoryStore,
     };
     use strata_bridge_test_utils::bridge_fixtures::test_operator_table;
 
@@ -807,12 +808,12 @@ mod tests {
         CoreRpcClient::new(bitcoind.rpc_url().as_str(), auth).expect("core rpc client")
     }
 
-    fn reconciliation_wallet(
+    async fn reconciliation_wallet(
         bitcoind: &Node,
         live_utxos: Vec<UtxoInfo>,
         sync_fails: bool,
         initial_leases: BTreeSet<OutPoint>,
-    ) -> OperatorWallet<ReconciliationGeneralWallet> {
+    ) -> OperatorWallet<ReconciliationGeneralWallet, MemoryStore> {
         let general = ReconciliationGeneralWallet {
             live_utxos,
             sync_fails,
@@ -820,13 +821,17 @@ mod tests {
         let config = OperatorWalletConfig::new(Amount::from_sat(330), Network::Regtest)
             .with_sync_policy(0, 1, Duration::ZERO);
 
-        OperatorWallet::new(
+        OperatorWallet::load_or_create(
             general,
             xonly_pubkey(42),
             config,
             Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
+            MemoryStore::new(),
+            None,
             initial_leases,
         )
+        .await
+        .expect("reserved wallet should initialise against an empty store")
     }
 
     fn test_utxo(outpoint: OutPoint) -> UtxoInfo {
@@ -866,7 +871,8 @@ mod tests {
             vec![test_utxo(live)],
             false,
             BTreeSet::from([spent, live]),
-        );
+        )
+        .await;
 
         reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &[spent, live]).await;
 
@@ -888,7 +894,8 @@ mod tests {
             vec![test_utxo(input)],
             true,
             BTreeSet::from([input]),
-        );
+        )
+        .await;
 
         reconcile_claim_funding_leases_after_driver_failure(&mut wallet, &[input]).await;
 

--- a/crates/bridge-exec/src/graph/common.rs
+++ b/crates/bridge-exec/src/graph/common.rs
@@ -232,13 +232,20 @@ async fn ensure_claim_funding_outpoint(
                     error!(?e, "could not sync wallet after refilling funding utxos");
                     ExecutorError::WalletErr(format!("wallet sync failed after refill: {e:?}"))
                 })?;
+                // The refilled pool members are unconfirmed, so they are only visible while the
+                // funding transaction is in the node's mempool. An eviction between the
+                // tx-driver's check and this sync leaves nothing to reserve; the duty retries.
                 wallet
                     .reserve_utxo_with_value(
                         cfg.claim_funding_utxo_value,
                         predicate::never::<UtxoInfo>,
                     )
                     .0
-                    .expect("funding utxos must be available after refill")
+                    .ok_or_else(|| {
+                        ExecutorError::WalletErr(
+                            "no claim-funding utxo available after refill".to_string(),
+                        )
+                    })?
             }
         }
     };
@@ -773,6 +780,10 @@ mod tests {
 
         fn list_utxos(&self) -> Vec<UtxoInfo> {
             self.live_utxos.clone()
+        }
+
+        fn unspent_outpoints(&self) -> Vec<OutPoint> {
+            self.live_utxos.iter().map(|utxo| utxo.outpoint).collect()
         }
 
         async fn fund_v3_transaction(

--- a/crates/bridge-exec/src/graph/unstaking_burn.rs
+++ b/crates/bridge-exec/src/graph/unstaking_burn.rs
@@ -518,9 +518,12 @@ mod tests {
         secp256k1::{Keypair, SECP256K1, SecretKey},
     };
     use corepc_node::{Conf, Node};
-    use operator_wallet::{NativeGeneralWallet, OperatorWalletConfig, sync::Backend};
+    use operator_wallet::{
+        NativeGeneralWallet, OperatorWalletConfig, SqliteStore, WalletKind, sync::Backend,
+    };
     use strata_bridge_connectors::prelude::ClaimPayoutConnector;
     use strata_bridge_tx_graph::transactions::prelude::UnstakingBurnData;
+    use tempfile::TempDir;
 
     use super::*;
 
@@ -555,19 +558,36 @@ mod tests {
         keypair.x_only_public_key().0
     }
 
-    fn wallet(bitcoind: &Node) -> NativeWallet {
-        let general = NativeGeneralWallet::new(
+    /// Builds a wallet over fresh SQLite stores in a temp dir. The [`TempDir`] must outlive the
+    /// wallet, so it is returned alongside.
+    async fn wallet(bitcoind: &Node) -> (NativeWallet, TempDir) {
+        let data_dir = tempfile::tempdir().expect("temp dir for wallet stores");
+        let general_store = SqliteStore::open_in_dir(data_dir.path(), WalletKind::General)
+            .expect("general store should open");
+        let reserved_store = SqliteStore::open_in_dir(data_dir.path(), WalletKind::Reserved)
+            .expect("reserved store should open");
+        let config = OperatorWalletConfig::new(Amount::from_sat(20_000), Network::Regtest);
+        let general = NativeGeneralWallet::load_or_create(
             xonly_pubkey(1),
-            Network::Regtest,
+            &config,
             Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
-        );
-        NativeWallet::new(
+            general_store,
+            None,
+        )
+        .await
+        .expect("general wallet should initialise against an empty store");
+        let wallet = NativeWallet::load_or_create(
             general,
             xonly_pubkey(2),
-            OperatorWalletConfig::new(Amount::from_sat(20_000), Network::Regtest),
+            config,
             Backend::BitcoinCore(Arc::new(core_rpc_client(bitcoind))),
+            reserved_store,
+            None,
             BTreeSet::new(),
         )
+        .await
+        .expect("reserved wallet should initialise against an empty store");
+        (wallet, data_dir)
     }
 
     fn fund_general_wallet(bitcoind: &Node, wallet: &NativeWallet, amount: Amount) {
@@ -665,7 +685,7 @@ mod tests {
     #[tokio::test]
     async fn select_funding_leases_utxo_that_can_fund_non_dust_output() {
         let bitcoind = setup_bitcoind();
-        let mut wallet = wallet(&bitcoind);
+        let (mut wallet, _data_dir) = wallet(&bitcoind).await;
         fund_general_wallet(&bitcoind, &wallet, Amount::from_sat(25_000));
 
         let unstaking_preimage = [8; 32];

--- a/crates/bridge-exec/src/output_handles.rs
+++ b/crates/bridge-exec/src/output_handles.rs
@@ -5,7 +5,7 @@ use std::{fmt, sync::Arc};
 use bitcoind_async_client::Client as BitcoinClient;
 use btc_tracker::tx_driver::TxDriver;
 use jsonrpsee::http_client::HttpClient;
-use operator_wallet::{NativeGeneralWallet, OperatorWallet};
+use operator_wallet::{NativeGeneralWallet, OperatorWallet, SqliteStore};
 use secret_service_client::SecretServiceClient;
 use strata_bridge_counterproof::BridgeCounterproofHost;
 use strata_bridge_db::fdb::client::FdbClient;
@@ -14,10 +14,16 @@ use strata_bridge_proof::BridgeProofHost;
 use strata_mosaic_client_api::MosaicClientApi;
 use tokio::sync::RwLock;
 
+/// Store for the general and reserved wallets' chain state.
+pub type NativeWalletStore = SqliteStore;
+
+/// General-wallet backend of [`NativeWallet`].
+pub type NativeGeneralWalletBackend = NativeGeneralWallet<NativeWalletStore>;
+
 /// Concrete operator-wallet type used by bridge-exec. Today the only general-wallet backend in
 /// use is [`NativeGeneralWallet`]; Fireblocks support (STR-3437) will add a sibling impl and
 /// the binary will pick between them at startup.
-pub type NativeWallet = OperatorWallet<NativeGeneralWallet>;
+pub type NativeWallet = OperatorWallet<NativeGeneralWalletBackend, NativeWalletStore>;
 
 /// The handles for external services that need to be accessed by the executors.
 ///

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -16,8 +16,9 @@ tracing.workspace = true
 
 [dev-dependencies]
 corepc-node.workspace = true
+operator-wallet = { path = ".", features = ["test-utils"] }
 serial_test.workspace = true
+tempfile.workspace = true
 
 [features]
-# Exposes `test_utils`, the in-memory store for tests.
 test-utils = []

--- a/crates/operator-wallet/Cargo.toml
+++ b/crates/operator-wallet/Cargo.toml
@@ -8,7 +8,7 @@ workspace = true
 
 [dependencies]
 bdk_bitcoind_rpc.workspace = true
-bdk_wallet.workspace = true
+bdk_wallet = { workspace = true, features = ["rusqlite"] }
 bitcoin-bosd.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -17,3 +17,7 @@ tracing.workspace = true
 [dev-dependencies]
 corepc-node.workspace = true
 serial_test.workspace = true
+
+[features]
+# Exposes `test_utils`, the in-memory store for tests.
+test-utils = []

--- a/crates/operator-wallet/src/config.rs
+++ b/crates/operator-wallet/src/config.rs
@@ -1,12 +1,12 @@
 //! Configuration knobs for [`crate::OperatorWallet`].
 //!
 //! Holds runtime parameters that don't change after construction (network, anchor-identification
-//! value, sync retry policy). Per-call parameters like UTXO denominations are passed to the
-//! relevant methods directly; this struct intentionally does not bake them in so the same
-//! composer can serve multiple use cases (claim funding, stake funding, etc.) without
+//! value, sync retry policy, persistence cadence). Per-call parameters like UTXO denominations are
+//! passed to the relevant methods directly; this struct intentionally does not bake them in so the
+//! same composer can serve multiple use cases (claim funding, stake funding, etc.) without
 //! conflating their denominations.
 
-use std::time::Duration;
+use std::{num::NonZeroU32, time::Duration};
 
 use bdk_wallet::bitcoin::{Amount, Network};
 
@@ -19,6 +19,10 @@ pub const DEFAULT_SYNC_BACKOFF: u32 = 3;
 
 /// Initial delay between sync retry attempts (multiplied by the exponential backoff).
 pub const DEFAULT_SYNC_BASE_DELAY: Duration = Duration::from_millis(100);
+
+/// How many applied blocks trigger a persist of staged wallet state during a sync.
+pub const DEFAULT_PERSIST_EVERY_BLOCKS: NonZeroU32 =
+    NonZeroU32::new(2_000).expect("persist cadence must be non-zero");
 
 /// Configuration for [`crate::OperatorWallet`].
 #[derive(Debug, Clone)]
@@ -35,12 +39,16 @@ pub struct OperatorWalletConfig {
     /// Initial delay before the first retry; multiplied by the exponential backoff on each
     /// subsequent attempt.
     pub(crate) sync_base_delay: Duration,
+    /// Number of applied blocks between persists of the reserved wallet's staged state during a
+    /// sync. See [`DEFAULT_PERSIST_EVERY_BLOCKS`].
+    pub(crate) persist_every_blocks: NonZeroU32,
 }
 
 impl OperatorWalletConfig {
     /// Creates a new config with the sync-retry knobs at their defaults
-    /// ([`DEFAULT_SYNC_RETRIES`] / [`DEFAULT_SYNC_BACKOFF`] / [`DEFAULT_SYNC_BASE_DELAY`]).
-    /// Use [`Self::with_sync_policy`] to override them.
+    /// ([`DEFAULT_SYNC_RETRIES`] / [`DEFAULT_SYNC_BACKOFF`] / [`DEFAULT_SYNC_BASE_DELAY`]) and the
+    /// persistence cadence at [`DEFAULT_PERSIST_EVERY_BLOCKS`]. Use [`Self::with_sync_policy`] and
+    /// [`Self::with_persist_every_blocks`] to override them.
     pub const fn new(cpfp_value: Amount, network: Network) -> Self {
         Self {
             cpfp_value,
@@ -48,6 +56,7 @@ impl OperatorWalletConfig {
             sync_retries: DEFAULT_SYNC_RETRIES,
             sync_backoff: DEFAULT_SYNC_BACKOFF,
             sync_base_delay: DEFAULT_SYNC_BASE_DELAY,
+            persist_every_blocks: DEFAULT_PERSIST_EVERY_BLOCKS,
         }
     }
 
@@ -63,5 +72,16 @@ impl OperatorWalletConfig {
         self.sync_backoff = sync_backoff;
         self.sync_base_delay = sync_base_delay;
         self
+    }
+
+    /// Returns a copy with the persistence cadence replaced.
+    pub const fn with_persist_every_blocks(mut self, persist_every_blocks: NonZeroU32) -> Self {
+        self.persist_every_blocks = persist_every_blocks;
+        self
+    }
+
+    /// Number of applied blocks between persists during a sync.
+    pub const fn persist_every_blocks(&self) -> NonZeroU32 {
+        self.persist_every_blocks
     }
 }

--- a/crates/operator-wallet/src/general.rs
+++ b/crates/operator-wallet/src/general.rs
@@ -9,11 +9,12 @@
 
 pub mod native;
 
-use std::error::Error as StdError;
+use std::{collections::HashSet, error::Error as StdError};
 
 use bdk_wallet::{
-    bitcoin::{Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut},
+    bitcoin::{Amount, FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Txid},
     chain::ChainPosition,
+    LocalOutput,
 };
 
 /// A backend that manages the operator's general-purpose Bitcoin funds.
@@ -46,6 +47,14 @@ pub trait GeneralWallet: Send + Sync {
     /// caller is responsible for filtering anchors, leases, and other domain-specific
     /// exclusions before requesting funding.
     fn list_utxos(&self) -> Vec<UtxoInfo>;
+
+    /// Every outpoint the wallet still holds unspent, including any [`Self::list_utxos`] leaves
+    /// out.
+    ///
+    /// Lease bookkeeping asks this rather than [`Self::list_utxos`]: a lease must only be released
+    /// once the outpoint has actually been spent, not because the wallet has stopped trusting it
+    /// for spending. Releasing early would let two callers lease the same outpoint.
+    fn unspent_outpoints(&self) -> Vec<OutPoint>;
 
     /// Builds a v3 TRUC funding transaction and signs the inputs it has key material for.
     ///
@@ -141,6 +150,19 @@ impl From<&UtxoInfo> for TxOut {
     }
 }
 
+/// Whether an output is spendable, given the mempool as of the last sync.
+///
+/// This BDK version cannot evict a transaction, so one reorged out of the chain and not
+/// re-broadcast stays canonical and its outputs keep looking spendable; an unconfirmed output
+/// therefore counts only while its transaction is in the mempool. An output *consumed* by such a
+/// transaction stays hidden, matching BDK's own coin selection, and returns on a store rebuild.
+pub(crate) fn is_spendable(output: &LocalOutput, mempool: &HashSet<Txid>) -> bool {
+    match output.chain_position {
+        ChainPosition::Confirmed { .. } => true,
+        ChainPosition::Unconfirmed { .. } => mempool.contains(&output.outpoint.txid),
+    }
+}
+
 /// Converts a BDK [`bdk_wallet::LocalOutput`] into a backend-neutral [`UtxoInfo`], computing
 /// confirmations against `tip_height`. Shared between the native general-wallet backend and
 /// the composer's reserved-wallet lookup since both are BDK-backed.
@@ -156,5 +178,203 @@ pub(crate) fn local_output_to_utxo_info(lo: &bdk_wallet::LocalOutput, tip_height
         amount: lo.txout.value,
         confirmations,
         script_pubkey: lo.txout.script_pubkey.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bdk_wallet::{
+        bitcoin::{
+            absolute::LockTime,
+            hashes::Hash,
+            secp256k1::{Keypair, Secp256k1, SecretKey},
+            transaction::Version,
+            Amount, BlockHash, FeeRate, Network, Sequence, TxIn, Witness,
+        },
+        chain::{BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate},
+        descriptor,
+        tx_builder::AddUtxoError,
+        KeychainKind, Update, Wallet,
+    };
+
+    use super::*;
+
+    fn block(height: u32, tag: u8) -> BlockId {
+        BlockId {
+            height,
+            hash: BlockHash::from_byte_array([tag; 32]),
+        }
+    }
+
+    /// A descriptor-only wallet and the script it owns.
+    fn wallet(seed: u8) -> (Wallet, ScriptBuf) {
+        let secret = SecretKey::from_slice(&[seed; 32]).expect("valid scalar");
+        let key = Keypair::from_secret_key(&Secp256k1::new(), &secret)
+            .x_only_public_key()
+            .0;
+        let (desc, ..) = descriptor!(tr(key)).expect("valid descriptor");
+        let wallet = Wallet::create_single(desc)
+            .network(Network::Regtest)
+            .create_wallet_no_persist()
+            .expect("wallet");
+        let script = wallet
+            .peek_address(KeychainKind::External, 0)
+            .address
+            .script_pubkey();
+        (wallet, script)
+    }
+
+    /// An arbitrary outpoint to spend. Never null: BDK treats a null input as a coinbase, which
+    /// it refuses to see unconfirmed.
+    fn source(tag: u8) -> OutPoint {
+        OutPoint {
+            txid: Txid::from_byte_array([tag; 32]),
+            vout: 0,
+        }
+    }
+
+    /// A transaction spending `source` and paying `sats` to `script`.
+    fn pay(source: OutPoint, script: &ScriptBuf, sats: u64) -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: source,
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(sats),
+                script_pubkey: script.clone(),
+            }],
+        }
+    }
+
+    /// Sets the wallet's chain to `blocks` and applies each transaction, anchored at the given
+    /// block or, with `None`, seen in the mempool.
+    fn apply(wallet: &mut Wallet, blocks: &[BlockId], txs: &[(&Transaction, Option<BlockId>)]) {
+        let mut update = TxUpdate::default();
+        for (tx, at) in txs {
+            update.txs.push(Arc::new((*tx).clone()));
+            match at {
+                Some(block) => {
+                    let anchor = ConfirmationBlockTime {
+                        block_id: *block,
+                        confirmation_time: u64::from(block.height) * 600,
+                    };
+                    update.anchors.insert((anchor, tx.compute_txid()));
+                }
+                None => {
+                    update.seen_ats.insert(tx.compute_txid(), 1_000);
+                }
+            }
+        }
+        wallet
+            .apply_update(Update {
+                chain: Some(CheckPoint::from_block_ids(blocks.iter().copied()).expect("ascending")),
+                tx_update: update,
+                ..Update::default()
+            })
+            .expect("apply update");
+    }
+
+    fn spendable(wallet: &Wallet, mempool: &HashSet<Txid>) -> Vec<LocalOutput> {
+        wallet
+            .list_unspent()
+            .filter(|output| is_spendable(output, mempool))
+            .collect()
+    }
+
+    /// A payment seen in the mempool, confirmed, then reorged out and gone from the mempool. BDK
+    /// keeps its stale mempool sighting, so only the current mempool tells it from a live payment.
+    #[test]
+    fn a_payment_reorged_out_of_the_chain_is_not_spendable() {
+        let (mut wallet, script) = wallet(9);
+        let genesis = wallet.latest_checkpoint().block_id();
+        let payment = pay(source(1), &script, 100_000);
+        let seen = HashSet::from([payment.compute_txid()]);
+        let h1 = block(1, 1);
+
+        apply(&mut wallet, &[genesis], &[(&payment, None)]);
+        assert_eq!(spendable(&wallet, &seen).len(), 1, "in the mempool");
+
+        apply(&mut wallet, &[genesis, h1], &[(&payment, Some(h1))]);
+        assert_eq!(spendable(&wallet, &HashSet::new()).len(), 1, "confirmed");
+
+        apply(&mut wallet, &[genesis, block(1, 11)], &[]);
+        assert!(
+            matches!(
+                wallet.transactions().next().expect("one tx").chain_position,
+                ChainPosition::Unconfirmed { last_seen: Some(_) }
+            ),
+            "BDK reports a stale sighting, not an absence"
+        );
+        assert!(
+            spendable(&wallet, &HashSet::new()).is_empty(),
+            "gone from the mempool, so not spendable"
+        );
+        assert_eq!(
+            spendable(&wallet, &seen).len(),
+            1,
+            "re-broadcast, so spendable"
+        );
+    }
+
+    /// A reorg replacing a payment with a conflicting one paying the same wallet: the replacement
+    /// counts and the original does not, so the two never both count.
+    #[test]
+    fn a_replaced_payment_leaves_only_the_replacement_spendable() {
+        let (mut wallet, script) = wallet(11);
+        let genesis = wallet.latest_checkpoint().block_id();
+        let source = source(7);
+        let original = pay(source, &script, 100_000);
+        let replacement = pay(source, &script, 80_000);
+        let (h1, h1b) = (block(1, 1), block(1, 11));
+
+        apply(&mut wallet, &[genesis, h1], &[(&original, Some(h1))]);
+        assert_eq!(spendable(&wallet, &HashSet::new()).len(), 1);
+
+        apply(&mut wallet, &[genesis, h1b], &[(&replacement, Some(h1b))]);
+        let spendable = spendable(&wallet, &HashSet::new());
+        assert_eq!(spendable.len(), 1, "never both");
+        assert_eq!(spendable[0].outpoint.txid, replacement.compute_txid());
+        assert_eq!(spendable[0].txout.value, Amount::from_sat(80_000));
+    }
+
+    /// The known limitation: an output consumed by a reorged-out spend stays hidden. Restoring it
+    /// would be pointless, since BDK's coin selection refuses to spend it.
+    #[test]
+    fn an_orphaned_spend_keeps_its_input_hidden() {
+        let (mut wallet, script) = wallet(10);
+        let genesis = wallet.latest_checkpoint().block_id();
+        let funding = pay(source(2), &script, 100_000);
+        let funded = OutPoint {
+            txid: funding.compute_txid(),
+            vout: 0,
+        };
+        let spend = pay(funded, &ScriptBuf::new(), 90_000);
+        let (h1, h2) = (block(1, 1), block(2, 2));
+
+        apply(
+            &mut wallet,
+            &[genesis, h1, h2],
+            &[(&funding, Some(h1)), (&spend, Some(h2))],
+        );
+        apply(&mut wallet, &[genesis, h1, block(2, 22)], &[]);
+
+        assert!(
+            spendable(&wallet, &HashSet::new()).is_empty(),
+            "the consumed output stays hidden"
+        );
+        let mut builder = wallet.build_tx();
+        builder.fee_rate(FeeRate::from_sat_per_vb(2).expect("fee rate"));
+        builder.add_recipient(script, Amount::from_sat(10_000));
+        assert!(
+            matches!(builder.add_utxo(funded), Err(AddUtxoError::UnknownUtxo(_))),
+            "and BDK would refuse to spend it anyway"
+        );
     }
 }

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -4,11 +4,15 @@
 //! never holds private keys. Per the [`GeneralWallet`] signing contract, every PSBT this impl
 //! returns carries `witness_utxo` and `tap_internal_key` on its inputs but no signatures —
 //! the caller signs downstream.
+//!
+//! Chain state lives in a BDK [`PersistedWallet`] backed by a caller-supplied [`WalletStore`], so
+//! a restart resumes from the last persisted checkpoint instead of rescanning from genesis.
 
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, num::NonZeroU32};
 
 use bdk_wallet::{
-    bitcoin::{FeeRate, Network, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    bitcoin::{FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    chain::BlockId,
     descriptor,
     error::CreateTxError,
     KeychainKind, TxOrdering, Wallet,
@@ -17,35 +21,45 @@ use thiserror::Error;
 use tracing::info;
 
 use crate::{
+    config::OperatorWalletConfig,
     general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    persist::{load_or_create, InitError, PersistedWallet, WalletStore},
     sync::{Backend, SyncError},
 };
 
 /// Native BDK-backed general wallet.
 #[derive(Debug)]
-pub struct NativeGeneralWallet {
+pub struct NativeGeneralWallet<P> {
     /// Cached at construction; the BDK descriptor doesn't change at runtime.
     script_pubkey: ScriptBuf,
-    wallet: Wallet,
+    wallet: PersistedWallet<P>,
+    store: P,
     sync_backend: Backend,
+    persist_every_blocks: NonZeroU32,
 }
 
-impl NativeGeneralWallet {
-    /// Constructs a native general wallet from the operator's general x-only public key.
-    pub fn new(general_pubkey: XOnlyPublicKey, network: Network, sync_backend: Backend) -> Self {
+impl<P: WalletStore> NativeGeneralWallet<P> {
+    /// Loads the general wallet for `general_pubkey` from `store`, or creates it when the store is
+    /// empty. Network and persistence cadence come from `config`, shared with the reserved wallet.
+    /// See [`load_or_create`] for the identity checks and the role of `bootstrap_checkpoint`.
+    pub async fn load_or_create(
+        general_pubkey: XOnlyPublicKey,
+        config: &OperatorWalletConfig,
+        sync_backend: Backend,
+        mut store: P,
+        bootstrap_checkpoint: Option<BlockId>,
+    ) -> Result<Self, InitError<P::Error>> {
         let (desc, ..) = descriptor!(tr(general_pubkey)).expect("valid tr() descriptor");
-        let wallet = Wallet::create_single(desc)
-            .network(network)
-            .create_wallet_no_persist()
-            .expect("wallet creation must not fail");
+        let wallet = load_or_create(&mut store, desc, config.network, bootstrap_checkpoint).await?;
         let address = wallet.peek_address(KeychainKind::External, 0).address;
         info!("general wallet address: {address}");
-        let script_pubkey = address.script_pubkey();
-        Self {
-            script_pubkey,
+        Ok(Self {
+            script_pubkey: address.script_pubkey(),
             wallet,
+            store,
             sync_backend,
-        }
+            persist_every_blocks: config.persist_every_blocks,
+        })
     }
 }
 
@@ -55,7 +69,7 @@ pub enum NativeGeneralError {
     /// BDK failed to build a transaction (insufficient funds, no UTXOs, ...).
     #[error("bdk create-tx: {0}")]
     CreateTx(#[from] CreateTxError),
-    /// Chain sync (block / mempool fetch) failed.
+    /// Chain sync (block / mempool fetch / persist) failed.
     #[error("wallet sync: {0:?}")]
     Sync(SyncError),
     /// CPFP-child building is intentionally unimplemented until STR-3439 lands.
@@ -63,12 +77,12 @@ pub enum NativeGeneralError {
     CpfpChildNotImplemented,
 }
 
-impl GeneralWallet for NativeGeneralWallet {
+impl<P: WalletStore> GeneralWallet for NativeGeneralWallet<P> {
     type Error = NativeGeneralError;
 
     async fn sync(&mut self) -> Result<(), Self::Error> {
         self.sync_backend
-            .sync_wallet(&mut self.wallet)
+            .sync_wallet(&mut self.wallet, &mut self.store, self.persist_every_blocks)
             .await
             .map_err(NativeGeneralError::Sync)
     }

--- a/crates/operator-wallet/src/general/native.rs
+++ b/crates/operator-wallet/src/general/native.rs
@@ -8,10 +8,13 @@
 //! Chain state lives in a BDK [`PersistedWallet`] backed by a caller-supplied [`WalletStore`], so
 //! a restart resumes from the last persisted checkpoint instead of rescanning from genesis.
 
-use std::{collections::BTreeSet, num::NonZeroU32};
+use std::{
+    collections::{BTreeSet, HashSet},
+    num::NonZeroU32,
+};
 
 use bdk_wallet::{
-    bitcoin::{FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    bitcoin::{FeeRate, OutPoint, Psbt, ScriptBuf, Transaction, TxOut, Txid, XOnlyPublicKey},
     chain::BlockId,
     descriptor,
     error::CreateTxError,
@@ -22,8 +25,8 @@ use tracing::info;
 
 use crate::{
     config::OperatorWalletConfig,
-    general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
-    persist::{load_or_create, InitError, PersistedWallet, WalletStore},
+    general::{is_spendable, local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    persist::{ensure_backend_not_behind, load_or_create, InitError, PersistedWallet, WalletStore},
     sync::{Backend, SyncError},
 };
 
@@ -36,6 +39,7 @@ pub struct NativeGeneralWallet<P> {
     store: P,
     sync_backend: Backend,
     persist_every_blocks: NonZeroU32,
+    mempool: HashSet<Txid>,
 }
 
 impl<P: WalletStore> NativeGeneralWallet<P> {
@@ -51,6 +55,7 @@ impl<P: WalletStore> NativeGeneralWallet<P> {
     ) -> Result<Self, InitError<P::Error>> {
         let (desc, ..) = descriptor!(tr(general_pubkey)).expect("valid tr() descriptor");
         let wallet = load_or_create(&mut store, desc, config.network, bootstrap_checkpoint).await?;
+        ensure_backend_not_behind(&sync_backend, &wallet).await?;
         let address = wallet.peek_address(KeychainKind::External, 0).address;
         info!("general wallet address: {address}");
         Ok(Self {
@@ -59,6 +64,7 @@ impl<P: WalletStore> NativeGeneralWallet<P> {
             store,
             sync_backend,
             persist_every_blocks: config.persist_every_blocks,
+            mempool: HashSet::new(),
         })
     }
 }
@@ -81,10 +87,15 @@ impl<P: WalletStore> GeneralWallet for NativeGeneralWallet<P> {
     type Error = NativeGeneralError;
 
     async fn sync(&mut self) -> Result<(), Self::Error> {
-        self.sync_backend
+        // Cleared first so a failed sync leaves no snapshot behind, since callers may carry on
+        // after one. Empty treats every unconfirmed output as unspendable.
+        self.mempool.clear();
+        self.mempool = self
+            .sync_backend
             .sync_wallet(&mut self.wallet, &mut self.store, self.persist_every_blocks)
             .await
-            .map_err(NativeGeneralError::Sync)
+            .map_err(NativeGeneralError::Sync)?;
+        Ok(())
     }
 
     fn script_pubkey(&self) -> ScriptBuf {
@@ -95,8 +106,13 @@ impl<P: WalletStore> GeneralWallet for NativeGeneralWallet<P> {
         let tip = self.wallet.latest_checkpoint().height();
         self.wallet
             .list_unspent()
+            .filter(|output| is_spendable(output, &self.mempool))
             .map(|lo| local_output_to_utxo_info(&lo, tip))
             .collect()
+    }
+
+    fn unspent_outpoints(&self) -> Vec<OutPoint> {
+        self.wallet.list_unspent().map(|lo| lo.outpoint).collect()
     }
 
     async fn fund_v3_transaction(
@@ -108,6 +124,7 @@ impl<P: WalletStore> GeneralWallet for NativeGeneralWallet<P> {
     ) -> Result<FundedPsbt, Self::Error> {
         let psbt = build_v3_psbt(
             &mut self.wallet,
+            &self.mempool,
             &outputs,
             explicit_inputs,
             fee_rate,
@@ -134,12 +151,21 @@ impl<P: WalletStore> GeneralWallet for NativeGeneralWallet<P> {
 /// auto-selection.
 fn build_v3_psbt(
     wallet: &mut Wallet,
+    mempool: &HashSet<Txid>,
     outputs: &[TxOut],
     explicit_inputs: Option<&[OutPoint]>,
     fee_rate: FeeRate,
     exclude: &[OutPoint],
 ) -> Result<Psbt, CreateTxError> {
-    let exclude_set: BTreeSet<OutPoint> = exclude.iter().copied().collect();
+    // BDK's own view still offers outputs `is_spendable` rejects, so the exclusion has to name
+    // them rather than rely on the caller, whose `exclude` was derived from the filtered list.
+    let mut exclude_set: BTreeSet<OutPoint> = exclude.iter().copied().collect();
+    exclude_set.extend(
+        wallet
+            .list_unspent()
+            .filter(|output| !is_spendable(output, mempool))
+            .map(|output| output.outpoint),
+    );
 
     let mut tx_builder = wallet.build_tx();
     tx_builder.version(3);
@@ -149,6 +175,9 @@ fn build_v3_psbt(
     match explicit_inputs {
         Some(inputs) => {
             for outpoint in inputs {
+                if exclude_set.contains(outpoint) {
+                    return Err(CreateTxError::UnknownUtxo);
+                }
                 tx_builder
                     .add_utxo(*outpoint)
                     .map_err(|_| CreateTxError::UnknownUtxo)?;
@@ -165,4 +194,147 @@ fn build_v3_psbt(
     }
 
     tx_builder.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use bdk_wallet::{
+        bitcoin::{
+            absolute::LockTime,
+            hashes::Hash,
+            secp256k1::{Keypair, Secp256k1, SecretKey},
+            transaction::Version,
+            Amount, BlockHash, Network, Sequence, TxIn, Witness,
+        },
+        chain::{BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate},
+        Update,
+    };
+
+    use super::*;
+
+    /// A wallet whose only output was paid by a transaction confirmed at height 1 and then reorged
+    /// out, along with that output's outpoint and the script the wallet owns.
+    fn wallet_with_a_reorged_out_payment() -> (Wallet, OutPoint, ScriptBuf, Txid) {
+        let secret = SecretKey::from_slice(&[31; 32]).expect("valid scalar");
+        let key = Keypair::from_secret_key(&Secp256k1::new(), &secret)
+            .x_only_public_key()
+            .0;
+        let (desc, ..) = descriptor!(tr(key)).expect("valid descriptor");
+        let mut wallet = Wallet::create_single(desc)
+            .network(Network::Regtest)
+            .create_wallet_no_persist()
+            .expect("wallet");
+        let genesis = wallet.latest_checkpoint().block_id();
+        let script = wallet
+            .peek_address(KeychainKind::External, 0)
+            .address
+            .script_pubkey();
+        let payment = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                // Never null: BDK treats a null input as a coinbase, which it refuses to see
+                // unconfirmed.
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([41; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000_000),
+                script_pubkey: script.clone(),
+            }],
+        };
+        let txid = payment.compute_txid();
+        let block = BlockId {
+            height: 1,
+            hash: BlockHash::from_byte_array([1; 32]),
+        };
+        let chain = |blocks: [BlockId; 2]| CheckPoint::from_block_ids(blocks).expect("ascending");
+        wallet
+            .apply_update(Update {
+                chain: Some(chain([genesis, block])),
+                tx_update: TxUpdate {
+                    txs: vec![Arc::new(payment)],
+                    anchors: [(
+                        ConfirmationBlockTime {
+                            block_id: block,
+                            confirmation_time: 600,
+                        },
+                        txid,
+                    )]
+                    .into_iter()
+                    .collect(),
+                    ..TxUpdate::default()
+                },
+                ..Update::default()
+            })
+            .expect("apply the payment");
+        wallet
+            .apply_update(Update {
+                chain: Some(chain([
+                    genesis,
+                    BlockId {
+                        height: 1,
+                        hash: BlockHash::from_byte_array([11; 32]),
+                    },
+                ])),
+                ..Update::default()
+            })
+            .expect("apply the replacement chain");
+        (wallet, OutPoint { txid, vout: 0 }, script, txid)
+    }
+
+    /// BDK's coin selection still offers an output `is_spendable` rejects, so the builder has to
+    /// exclude it itself rather than trust the caller's list.
+    #[test]
+    fn coin_selection_cannot_pick_a_reorged_out_output() {
+        let (mut wallet, stale, script, txid) = wallet_with_a_reorged_out_payment();
+        assert_eq!(
+            wallet.list_unspent().next().map(|o| o.outpoint),
+            Some(stale),
+            "BDK still offers it"
+        );
+        let recipient = [TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: script,
+        }];
+        let fee_rate = FeeRate::from_sat_per_vb(2).expect("fee rate");
+
+        let err = build_v3_psbt(
+            &mut wallet,
+            &HashSet::new(),
+            &recipient,
+            None,
+            fee_rate,
+            &[],
+        )
+        .expect_err("must not fund from a reorged-out output");
+        assert!(
+            matches!(err, CreateTxError::CoinSelection(_)),
+            "got {err:?}"
+        );
+
+        // Explicit selection of the same outpoint is refused too.
+        let err = build_v3_psbt(
+            &mut wallet,
+            &HashSet::new(),
+            &recipient,
+            Some(&[stale]),
+            fee_rate,
+            &[],
+        )
+        .expect_err("must not fund from a reorged-out output");
+        assert!(matches!(err, CreateTxError::UnknownUtxo), "got {err:?}");
+
+        // Back in the mempool, the same output funds normally.
+        let mempool = HashSet::from([txid]);
+        build_v3_psbt(&mut wallet, &mempool, &recipient, None, fee_rate, &[])
+            .expect("a mempool payment can fund");
+    }
 }

--- a/crates/operator-wallet/src/lib.rs
+++ b/crates/operator-wallet/src/lib.rs
@@ -1,7 +1,9 @@
 //! Operator wallet — composition over a swappable [`GeneralWallet`] backend.
 //!
-//! Callers hold an `OperatorWallet<G>` where `G: GeneralWallet`. The composer owns:
-//! - a descriptor-only reserved wallet (BDK), signed downstream by the caller,
+//! Callers hold an `OperatorWallet<G, P>` where `G: GeneralWallet` and `P: WalletStore`. The
+//! composer owns:
+//! - a descriptor-only reserved wallet (BDK), signed downstream by the caller and persisted through
+//!   `P`,
 //! - the in-memory lease set shared across both wallets,
 //! - CPFP-anchor identification and exclusion from input selection,
 //! - cross-wallet construction helpers that pay from the general wallet into reserved-wallet
@@ -10,11 +12,15 @@
 //! The [`GeneralWallet`] backend handles only what varies between implementations: its own
 //! UTXO discovery, its own signing, and the funding+CPFP construction primitives.
 //!
+//! Chain state for both wallets is persisted incrementally during sync (see [`persist`]) so a
+//! restart resumes from the last committed checkpoint instead of rescanning from genesis.
+//!
 //! Methods on [`OperatorWallet`] are `&mut self`. Callers serialize via an outer lock when
 //! they need a multi-step critical section (e.g. DB-lookup-then-fund-then-persist).
 
 pub mod config;
 pub mod general;
+pub mod persist;
 pub mod sync;
 pub mod wallet;
 
@@ -23,12 +29,17 @@ pub mod wallet;
 #[cfg(test)]
 use corepc_node as _;
 #[cfg(test)]
+use operator_wallet as _;
+#[cfg(test)]
 use serial_test as _;
 use thiserror::Error;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub use crate::persist::test_utils;
 pub use crate::{
-    config::OperatorWalletConfig,
+    config::{OperatorWalletConfig, DEFAULT_PERSIST_EVERY_BLOCKS},
     general::{native::NativeGeneralWallet, FundedPsbt, GeneralWallet, UtxoInfo},
+    persist::{load_or_create, InitError, SqliteStore, SqliteStoreError, WalletKind, WalletStore},
     sync::SyncError,
     wallet::{GeneralUtxoPolicy, OperatorWallet},
 };
@@ -63,6 +74,9 @@ pub enum Error {
     /// Reserved-wallet sync against the chain failed.
     #[error("reserved wallet sync: {0:?}")]
     Sync(SyncError),
+    /// The reserved wallet could not be loaded from or created in its store.
+    #[error("reserved wallet init: {0}")]
+    ReservedInit(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl Error {

--- a/crates/operator-wallet/src/persist.rs
+++ b/crates/operator-wallet/src/persist.rs
@@ -13,7 +13,7 @@ use bdk_wallet::{
     bitcoin::{constants::genesis_block, Network},
     chain::{local_chain::CannotConnectError, BlockId},
     descriptor::{DescriptorError, ExtendedDescriptor},
-    CreateWithPersistError, KeychainKind, LoadError, LoadWithPersistError, Update, Wallet,
+    KeychainKind, LoadError, LoadWithPersistError, Update, Wallet,
 };
 pub use bdk_wallet::{AsyncWalletPersister, ChangeSet, PersistedWallet};
 pub use sqlite::{SqliteStore, SqliteStoreError, WalletKind};
@@ -41,12 +41,12 @@ pub enum InitError<E: std::error::Error + 'static> {
     /// Persisted state is for another network, genesis, or descriptor, or is incomplete.
     #[error("persisted wallet state is invalid for this wallet: {0}")]
     InvalidState(Box<LoadError>),
-    /// The store was empty on load but not on create: a concurrent writer.
-    #[error("wallet store reported existing data while creating a fresh wallet")]
-    DataAlreadyExists,
     /// The descriptor is not valid for BDK.
     #[error("wallet descriptor: {0}")]
     Descriptor(DescriptorError),
+    /// The store reported no data straight after acknowledging the initial write.
+    #[error("wallet store reported no data after the initial write was acknowledged")]
+    StoreDroppedWrite,
     /// The bootstrap checkpoint is not above genesis.
     #[error("bootstrap checkpoint at height {0} must be above genesis")]
     BootstrapHeight(u32),
@@ -64,16 +64,6 @@ impl<E: std::error::Error + 'static> From<LoadWithPersistError<E>> for InitError
     }
 }
 
-impl<E: std::error::Error + 'static> From<CreateWithPersistError<E>> for InitError<E> {
-    fn from(e: CreateWithPersistError<E>) -> Self {
-        match e {
-            CreateWithPersistError::Persist(e) => Self::Store(e),
-            CreateWithPersistError::DataAlreadyExists(_) => Self::DataAlreadyExists,
-            CreateWithPersistError::Descriptor(e) => Self::Descriptor(e),
-        }
-    }
-}
-
 /// Loads the wallet for `descriptor` from `store`, or creates it when the store is empty.
 ///
 /// Loading verifies network, genesis hash, and descriptor identity; a mismatch fails without
@@ -86,11 +76,13 @@ pub async fn load_or_create<P: WalletStore>(
     network: Network,
     bootstrap_checkpoint: Option<BlockId>,
 ) -> Result<PersistedWallet<P>, InitError<P::Error>> {
-    let load_params = Wallet::load()
-        .descriptor(KeychainKind::External, Some(descriptor.clone()))
-        .check_network(network)
-        .check_genesis_hash(genesis_block(network).block_hash());
-    if let Some(wallet) = PersistedWallet::load_async(store, load_params).await? {
+    let load_params = || {
+        Wallet::load()
+            .descriptor(KeychainKind::External, Some(descriptor.clone()))
+            .check_network(network)
+            .check_genesis_hash(genesis_block(network).block_hash())
+    };
+    if let Some(wallet) = PersistedWallet::load_async(store, load_params()).await? {
         info!(
             tip_height = wallet.latest_checkpoint().height(),
             "loaded persisted wallet state"
@@ -98,34 +90,44 @@ pub async fn load_or_create<P: WalletStore>(
         return Ok(wallet);
     }
 
-    let create_params = Wallet::create_single(descriptor).network(network);
-    let mut wallet = PersistedWallet::create_async(store, create_params).await?;
+    // Build the whole initial state in memory and commit it once. Committing the wallet and the
+    // checkpoint separately would let a failure in between strand the wallet at genesis: the load
+    // path wins on the next start, so the checkpoint would never be applied.
+    let mut wallet = Wallet::create_single(descriptor.clone())
+        .network(network)
+        .create_wallet_no_persist()
+        .map_err(InitError::Descriptor)?;
+    if let Some(block) = bootstrap_checkpoint {
+        // `push` refuses a height at or below the current tip, which is genesis here.
+        let chain = wallet
+            .latest_checkpoint()
+            .push(block)
+            .map_err(|_| InitError::BootstrapHeight(block.height))?;
+        wallet
+            .apply_update(Update {
+                chain: Some(chain),
+                ..Update::default()
+            })
+            .map_err(InitError::Bootstrap)?;
+    }
+    let changeset = wallet
+        .take_staged()
+        .expect("a fresh wallet always stages its descriptor and network");
+    P::persist(store, &changeset)
+        .await
+        .map_err(InitError::Store)?;
+
     match bootstrap_checkpoint {
-        Some(block) => {
-            // `push` refuses a height at or below the current tip, which is genesis here.
-            let chain = wallet
-                .latest_checkpoint()
-                .push(block)
-                .map_err(|_| InitError::BootstrapHeight(block.height))?;
-            wallet
-                .apply_update(Update {
-                    chain: Some(chain),
-                    ..Update::default()
-                })
-                .map_err(InitError::Bootstrap)?;
-            wallet
-                .persist_async(store)
-                .await
-                .map_err(InitError::Store)?;
-            info!(
-                height = block.height,
-                hash = %block.hash,
-                "created wallet seeded with bootstrap checkpoint"
-            );
-        }
+        Some(block) => info!(
+            height = block.height,
+            hash = %block.hash,
+            "created wallet seeded with bootstrap checkpoint"
+        ),
         None => info!("created wallet at genesis"),
     }
-    Ok(wallet)
+    PersistedWallet::load_async(store, load_params())
+        .await?
+        .ok_or(InitError::StoreDroppedWrite)
 }
 
 #[cfg(test)]
@@ -247,7 +249,11 @@ mod tests {
             .await
             .expect("create with bootstrap");
         assert_eq!(wallet.latest_checkpoint().block_id(), block);
-        assert_eq!(store.persist_calls(), 2, "create, then bootstrap");
+        assert_eq!(
+            store.persist_calls(),
+            1,
+            "wallet and checkpoint commit together"
+        );
         drop(wallet);
 
         // A different checkpoint on load changes nothing: persisted state wins.
@@ -259,7 +265,41 @@ mod tests {
             .await
             .expect("load");
         assert_eq!(wallet.latest_checkpoint().block_id(), block);
-        assert_eq!(store.persist_calls(), 2, "loading never writes");
+        assert_eq!(store.persist_calls(), 1, "loading never writes");
+    }
+
+    #[tokio::test]
+    async fn a_bootstrap_create_is_a_single_commit() {
+        let block = BlockId {
+            height: 500,
+            hash: BlockHash::from_byte_array([7; 32]),
+        };
+
+        // A failed create leaves nothing behind, so the retry applies the checkpoint. Committing
+        // the wallet and the checkpoint separately would instead strand a genesis-only wallet that
+        // the load path prefers from then on, and the checkpoint would never be applied.
+        let mut store = MemoryStore::new();
+        store.fail_on_persist_call(1);
+        open(&mut store, 1, Network::Regtest, Some(block))
+            .await
+            .expect_err("injected");
+        assert!(
+            store.aggregate().is_empty(),
+            "nothing to load after a failed create"
+        );
+        let wallet = open(&mut store, 1, Network::Regtest, Some(block))
+            .await
+            .expect("retry");
+        assert_eq!(wallet.latest_checkpoint().block_id(), block);
+
+        // There is no second commit to fail: the whole initial state goes in one call.
+        let mut store = MemoryStore::new();
+        store.fail_on_persist_call(2);
+        let wallet = open(&mut store, 1, Network::Regtest, Some(block))
+            .await
+            .expect("create must not need a second commit");
+        assert_eq!(wallet.latest_checkpoint().block_id(), block);
+        assert_eq!(store.persist_calls(), 1);
     }
 
     #[tokio::test]

--- a/crates/operator-wallet/src/persist.rs
+++ b/crates/operator-wallet/src/persist.rs
@@ -11,14 +11,16 @@ pub mod test_utils;
 
 use bdk_wallet::{
     bitcoin::{constants::genesis_block, Network},
-    chain::{local_chain::CannotConnectError, BlockId},
+    chain::local_chain::CannotConnectError,
     descriptor::{DescriptorError, ExtendedDescriptor},
     KeychainKind, LoadError, LoadWithPersistError, Update, Wallet,
 };
-pub use bdk_wallet::{AsyncWalletPersister, ChangeSet, PersistedWallet};
+pub use bdk_wallet::{chain::BlockId, AsyncWalletPersister, ChangeSet, PersistedWallet};
 pub use sqlite::{SqliteStore, SqliteStoreError, WalletKind};
 use thiserror::Error;
 use tracing::info;
+
+use crate::sync::Backend;
 
 /// [`AsyncWalletPersister`] whose errors can be boxed and which can live behind an
 /// `Arc<RwLock<_>>` across tasks. Blanket-implemented; implement the BDK trait and this follows.
@@ -47,6 +49,17 @@ pub enum InitError<E: std::error::Error + 'static> {
     /// The store reported no data straight after acknowledging the initial write.
     #[error("wallet store reported no data after the initial write was acknowledged")]
     StoreDroppedWrite,
+    /// The backend's chain is shorter than the persisted tip.
+    #[error("node is at height {height}, behind the persisted wallet tip {tip}")]
+    BackendBehindTip {
+        /// Height of the persisted tip.
+        tip: u32,
+        /// Height of the backend's best chain.
+        height: u32,
+    },
+    /// The backend could not be asked for its height.
+    #[error("checking the persisted tip against the node: {0:?}")]
+    Backend(crate::sync::SyncError),
     /// The bootstrap checkpoint is not above genesis.
     #[error("bootstrap checkpoint at height {0} must be above genesis")]
     BootstrapHeight(u32),
@@ -66,10 +79,10 @@ impl<E: std::error::Error + 'static> From<LoadWithPersistError<E>> for InitError
 
 /// Loads the wallet for `descriptor` from `store`, or creates it when the store is empty.
 ///
-/// Loading verifies network, genesis hash, and descriptor identity; a mismatch fails without
-/// touching the store. Creating persists the descriptor, network, and genesis block, then seeds
-/// the local chain with `bootstrap_checkpoint` if given, so the first sync starts above it. The
-/// checkpoint is ignored on load: persisted state wins.
+/// Loading verifies network, genesis hash, and both keychains' descriptor identity; a mismatch
+/// fails without touching the store. Creating persists the descriptor, network, and genesis
+/// block, then seeds the local chain with `bootstrap_checkpoint` if given, so the first sync
+/// starts above it. The checkpoint is ignored on load: persisted state wins.
 pub async fn load_or_create<P: WalletStore>(
     store: &mut P,
     descriptor: ExtendedDescriptor,
@@ -79,6 +92,7 @@ pub async fn load_or_create<P: WalletStore>(
     let load_params = || {
         Wallet::load()
             .descriptor(KeychainKind::External, Some(descriptor.clone()))
+            .descriptor(KeychainKind::Internal, Option::<ExtendedDescriptor>::None)
             .check_network(network)
             .check_genesis_hash(genesis_block(network).block_hash())
     };
@@ -128,6 +142,24 @@ pub async fn load_or_create<P: WalletStore>(
     PersistedWallet::load_async(store, load_params())
         .await?
         .ok_or(InitError::StoreDroppedWrite)
+}
+
+/// Fails when the backend's chain is shorter than the wallet's tip.
+///
+/// A reorg is not a problem on its own: the emitter walks back to a block the backend still has
+/// and re-emits from there. It can only do that while the backend has blocks above that one, so a
+/// backend shorter than the stored tip, as after restoring an older node data directory, leaves
+/// the wallet's extra blocks in place with their transactions still looking confirmed.
+pub async fn ensure_backend_not_behind<P: WalletStore>(
+    backend: &Backend,
+    wallet: &PersistedWallet<P>,
+) -> Result<(), InitError<P::Error>> {
+    let tip = wallet.latest_checkpoint().height();
+    let height = backend.height().await.map_err(InitError::Backend)?;
+    if height >= tip {
+        return Ok(());
+    }
+    Err(InitError::BackendBehindTip { tip, height })
 }
 
 #[cfg(test)]
@@ -222,6 +254,41 @@ mod tests {
             "got {err:?}"
         );
         assert_eq!(store.persist_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn an_unexpected_change_descriptor_is_rejected() {
+        let mut store = MemoryStore::new();
+        open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect("create");
+
+        // A store carrying the expected external descriptor plus a change keychain must fail:
+        // these wallets never write one, and change would otherwise be derived from it.
+        let with_change_keychain = ChangeSet {
+            change_descriptor: Some(tr_descriptor(2)),
+            ..ChangeSet::default()
+        };
+        MemoryStore::persist(&mut store, &with_change_keychain)
+            .await
+            .unwrap();
+
+        let err = open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect_err("unexpected change keychain");
+        assert!(
+            matches!(
+                &err,
+                InitError::InvalidState(e) if matches!(
+                    **e,
+                    LoadError::Mismatch(LoadMismatch::Descriptor {
+                        keychain: KeychainKind::Internal,
+                        ..
+                    })
+                )
+            ),
+            "got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/operator-wallet/src/persist.rs
+++ b/crates/operator-wallet/src/persist.rs
@@ -1,0 +1,277 @@
+//! Persistence for the operator wallets.
+//!
+//! Both wallets are BDK [`PersistedWallet`]s behind the [`WalletStore`] seam. [`load_or_create`]
+//! is the shared entry point: load and validate persisted state, or create a fresh wallet when the
+//! store is empty. [`SqliteStore`] is the durable store; the `test_utils` module (feature
+//! `test-utils`) holds the in-memory one for tests.
+
+pub mod sqlite;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
+use bdk_wallet::{
+    bitcoin::{constants::genesis_block, Network},
+    chain::{local_chain::CannotConnectError, BlockId},
+    descriptor::{DescriptorError, ExtendedDescriptor},
+    CreateWithPersistError, KeychainKind, LoadError, LoadWithPersistError, Update, Wallet,
+};
+pub use bdk_wallet::{AsyncWalletPersister, ChangeSet, PersistedWallet};
+pub use sqlite::{SqliteStore, SqliteStoreError, WalletKind};
+use thiserror::Error;
+use tracing::info;
+
+/// [`AsyncWalletPersister`] whose errors can be boxed and which can live behind an
+/// `Arc<RwLock<_>>` across tasks. Blanket-implemented; implement the BDK trait and this follows.
+pub trait WalletStore:
+    AsyncWalletPersister<Error: std::error::Error + Send + Sync + 'static> + Send + Sync
+{
+}
+
+impl<P> WalletStore for P where
+    P: AsyncWalletPersister<Error: std::error::Error + Send + Sync + 'static> + Send + Sync
+{
+}
+
+/// Errors from [`load_or_create`]. None of them modifies the store.
+#[derive(Debug, Error)]
+pub enum InitError<E: std::error::Error + 'static> {
+    /// The store failed to read or write.
+    #[error("wallet store: {0}")]
+    Store(E),
+    /// Persisted state is for another network, genesis, or descriptor, or is incomplete.
+    #[error("persisted wallet state is invalid for this wallet: {0}")]
+    InvalidState(Box<LoadError>),
+    /// The store was empty on load but not on create: a concurrent writer.
+    #[error("wallet store reported existing data while creating a fresh wallet")]
+    DataAlreadyExists,
+    /// The descriptor is not valid for BDK.
+    #[error("wallet descriptor: {0}")]
+    Descriptor(DescriptorError),
+    /// The bootstrap checkpoint is not above genesis.
+    #[error("bootstrap checkpoint at height {0} must be above genesis")]
+    BootstrapHeight(u32),
+    /// The bootstrap checkpoint could not be connected to genesis.
+    #[error("bootstrap checkpoint does not connect to genesis: {0}")]
+    Bootstrap(CannotConnectError),
+}
+
+impl<E: std::error::Error + 'static> From<LoadWithPersistError<E>> for InitError<E> {
+    fn from(e: LoadWithPersistError<E>) -> Self {
+        match e {
+            LoadWithPersistError::Persist(e) => Self::Store(e),
+            LoadWithPersistError::InvalidChangeSet(e) => Self::InvalidState(Box::new(e)),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> From<CreateWithPersistError<E>> for InitError<E> {
+    fn from(e: CreateWithPersistError<E>) -> Self {
+        match e {
+            CreateWithPersistError::Persist(e) => Self::Store(e),
+            CreateWithPersistError::DataAlreadyExists(_) => Self::DataAlreadyExists,
+            CreateWithPersistError::Descriptor(e) => Self::Descriptor(e),
+        }
+    }
+}
+
+/// Loads the wallet for `descriptor` from `store`, or creates it when the store is empty.
+///
+/// Loading verifies network, genesis hash, and descriptor identity; a mismatch fails without
+/// touching the store. Creating persists the descriptor, network, and genesis block, then seeds
+/// the local chain with `bootstrap_checkpoint` if given, so the first sync starts above it. The
+/// checkpoint is ignored on load: persisted state wins.
+pub async fn load_or_create<P: WalletStore>(
+    store: &mut P,
+    descriptor: ExtendedDescriptor,
+    network: Network,
+    bootstrap_checkpoint: Option<BlockId>,
+) -> Result<PersistedWallet<P>, InitError<P::Error>> {
+    let load_params = Wallet::load()
+        .descriptor(KeychainKind::External, Some(descriptor.clone()))
+        .check_network(network)
+        .check_genesis_hash(genesis_block(network).block_hash());
+    if let Some(wallet) = PersistedWallet::load_async(store, load_params).await? {
+        info!(
+            tip_height = wallet.latest_checkpoint().height(),
+            "loaded persisted wallet state"
+        );
+        return Ok(wallet);
+    }
+
+    let create_params = Wallet::create_single(descriptor).network(network);
+    let mut wallet = PersistedWallet::create_async(store, create_params).await?;
+    match bootstrap_checkpoint {
+        Some(block) => {
+            // `push` refuses a height at or below the current tip, which is genesis here.
+            let chain = wallet
+                .latest_checkpoint()
+                .push(block)
+                .map_err(|_| InitError::BootstrapHeight(block.height))?;
+            wallet
+                .apply_update(Update {
+                    chain: Some(chain),
+                    ..Update::default()
+                })
+                .map_err(InitError::Bootstrap)?;
+            wallet
+                .persist_async(store)
+                .await
+                .map_err(InitError::Store)?;
+            info!(
+                height = block.height,
+                hash = %block.hash,
+                "created wallet seeded with bootstrap checkpoint"
+            );
+        }
+        None => info!("created wallet at genesis"),
+    }
+    Ok(wallet)
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::{
+        bitcoin::{
+            hashes::Hash,
+            secp256k1::{Keypair, Secp256k1, SecretKey},
+            BlockHash, XOnlyPublicKey,
+        },
+        chain::Merge,
+        descriptor, LoadMismatch,
+    };
+
+    use super::*;
+    use crate::persist::test_utils::{MemoryStore, MemoryStoreError};
+
+    fn xonly(seed: u8) -> XOnlyPublicKey {
+        let secret = SecretKey::from_slice(&[seed; 32]).expect("valid scalar");
+        Keypair::from_secret_key(&Secp256k1::new(), &secret)
+            .x_only_public_key()
+            .0
+    }
+
+    fn tr_descriptor(seed: u8) -> ExtendedDescriptor {
+        descriptor!(tr(xonly(seed))).expect("valid descriptor").0
+    }
+
+    async fn open(
+        store: &mut MemoryStore,
+        seed: u8,
+        network: Network,
+        bootstrap: Option<BlockId>,
+    ) -> Result<PersistedWallet<MemoryStore>, InitError<MemoryStoreError>> {
+        load_or_create(store, tr_descriptor(seed), network, bootstrap).await
+    }
+
+    #[tokio::test]
+    async fn create_then_load_persists_once() {
+        let mut store = MemoryStore::new();
+        let wallet = open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect("create");
+        assert_eq!(wallet.latest_checkpoint().height(), 0);
+        assert_eq!(store.persist_calls(), 1, "create persists once");
+        drop(wallet);
+
+        let wallet = open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect("load");
+        assert_eq!(wallet.latest_checkpoint().height(), 0);
+        assert_eq!(store.persist_calls(), 1, "loading never writes");
+    }
+
+    #[tokio::test]
+    async fn wrong_network_is_rejected_and_the_store_is_untouched() {
+        let mut store = MemoryStore::new();
+        open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect("create");
+
+        let err = open(&mut store, 1, Network::Signet, None)
+            .await
+            .expect_err("network mismatch");
+        assert!(
+            matches!(
+                &err,
+                InitError::InvalidState(e)
+                    if matches!(**e, LoadError::Mismatch(LoadMismatch::Network { .. }))
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(store.persist_calls(), 1, "rejected load must not write");
+    }
+
+    #[tokio::test]
+    async fn wrong_descriptor_is_rejected_and_the_store_is_untouched() {
+        let mut store = MemoryStore::new();
+        open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect("create");
+
+        let err = open(&mut store, 2, Network::Regtest, None)
+            .await
+            .expect_err("descriptor mismatch");
+        assert!(
+            matches!(
+                &err,
+                InitError::InvalidState(e)
+                    if matches!(**e, LoadError::Mismatch(LoadMismatch::Descriptor { .. }))
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(store.persist_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn store_failure_on_create_surfaces_as_store_error() {
+        let mut store = MemoryStore::new();
+        store.fail_on_persist_call(1);
+        let err = open(&mut store, 1, Network::Regtest, None)
+            .await
+            .expect_err("injected");
+        assert!(matches!(
+            err,
+            InitError::Store(MemoryStoreError { call: 1 })
+        ));
+        assert!(store.aggregate().is_empty());
+    }
+
+    #[tokio::test]
+    async fn bootstrap_checkpoint_seeds_the_chain_and_is_ignored_on_load() {
+        let mut store = MemoryStore::new();
+        let block = BlockId {
+            height: 500,
+            hash: BlockHash::from_byte_array([7; 32]),
+        };
+        let wallet = open(&mut store, 1, Network::Regtest, Some(block))
+            .await
+            .expect("create with bootstrap");
+        assert_eq!(wallet.latest_checkpoint().block_id(), block);
+        assert_eq!(store.persist_calls(), 2, "create, then bootstrap");
+        drop(wallet);
+
+        // A different checkpoint on load changes nothing: persisted state wins.
+        let other = BlockId {
+            height: 900,
+            hash: BlockHash::from_byte_array([9; 32]),
+        };
+        let wallet = open(&mut store, 1, Network::Regtest, Some(other))
+            .await
+            .expect("load");
+        assert_eq!(wallet.latest_checkpoint().block_id(), block);
+        assert_eq!(store.persist_calls(), 2, "loading never writes");
+    }
+
+    #[tokio::test]
+    async fn bootstrap_checkpoint_at_genesis_height_is_rejected() {
+        let mut store = MemoryStore::new();
+        let genesis_height = BlockId {
+            height: 0,
+            hash: BlockHash::from_byte_array([1; 32]),
+        };
+        let err = open(&mut store, 1, Network::Regtest, Some(genesis_height))
+            .await
+            .expect_err("height zero cannot sit above genesis");
+        assert!(matches!(err, InitError::BootstrapHeight(0)));
+    }
+}

--- a/crates/operator-wallet/src/persist/sqlite.rs
+++ b/crates/operator-wallet/src/persist/sqlite.rs
@@ -1,0 +1,322 @@
+//! SQLite-backed [`WalletStore`](super::WalletStore) on BDK's own persister.
+//!
+//! BDK owns the schema, its migrations, the changeset encoding, and the stored network and
+//! descriptor that [`load_or_create`](super::load_or_create) checks. This adapter adds only:
+//!
+//! - WAL journaling with full synchronous commits, so a persist that returned `Ok` survives a
+//!   crash;
+//! - `quick_check` at open, so a damaged file fails before anything reads or writes it;
+//! - a sync-to-async bridge that commits inline, since a batch commits in milliseconds.
+
+use std::{
+    fmt, fs,
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::{Mutex, MutexGuard, PoisonError},
+    time::Duration,
+};
+
+use bdk_wallet::{
+    rusqlite::{self, Connection},
+    AsyncWalletPersister, ChangeSet, WalletPersister,
+};
+use thiserror::Error;
+
+/// Lock wait before a busy connection errors. A safety net: only one process holds a store.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Which operator wallet a store belongs to. Selects the file name, so the two wallets can never
+/// open each other's state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WalletKind {
+    /// General-funds wallet.
+    General,
+    /// Reserved wallet holding the claim-funding pool.
+    Reserved,
+}
+
+impl WalletKind {
+    /// Both kinds, in a fixed order.
+    pub const ALL: [Self; 2] = [Self::General, Self::Reserved];
+
+    /// Store file name inside the data directory.
+    pub const fn file_name(self) -> &'static str {
+        match self {
+            Self::General => "general-wallet.sqlite",
+            Self::Reserved => "reserved-wallet.sqlite",
+        }
+    }
+
+    /// Store path inside `data_dir`.
+    pub fn path_in(self, data_dir: &Path) -> PathBuf {
+        data_dir.join(self.file_name())
+    }
+}
+
+impl fmt::Display for WalletKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::General => "general",
+            Self::Reserved => "reserved",
+        })
+    }
+}
+
+/// Errors from a [`SqliteStore`]. Every variant names the file so the operator can act on it.
+#[derive(Debug, Error)]
+pub enum SqliteStoreError {
+    /// The parent directory could not be created.
+    #[error("could not create wallet store directory {dir}: {source}")]
+    CreateDir {
+        /// Directory that could not be created.
+        dir: PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// SQLite failed: unreadable file, schema problem, or I/O error.
+    #[error("wallet store {path}: {source}")]
+    Sqlite {
+        /// Store file.
+        path: PathBuf,
+        /// Underlying SQLite error.
+        #[source]
+        source: rusqlite::Error,
+    },
+    /// `quick_check` found structural damage.
+    #[error("wallet store {path} failed its integrity check: {report}")]
+    Corrupt {
+        /// Store file.
+        path: PathBuf,
+        /// First line of the integrity report.
+        report: String,
+    },
+    /// WAL journaling could not be enabled, so commits would not be durable.
+    #[error("wallet store {path} could not enable WAL journaling (journal_mode is {mode})")]
+    JournalMode {
+        /// Store file.
+        path: PathBuf,
+        /// Journal mode SQLite reported instead.
+        mode: String,
+    },
+}
+
+/// SQLite-backed wallet store; see the [module docs](self) for what it adds over BDK's persister.
+pub struct SqliteStore {
+    path: PathBuf,
+    conn: Mutex<Connection>,
+}
+
+impl fmt::Debug for SqliteStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SqliteStore")
+            .field("path", &self.path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SqliteStore {
+    /// Opens the store at `path`, creating the file and its parent directory if needed.
+    ///
+    /// A new or empty file passes `quick_check` and loads as absent, which is the right outcome
+    /// for a crash between file creation and the first commit. Nothing is written to a file that
+    /// fails to open.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, SqliteStoreError> {
+        let path = path.into();
+        if let Some(dir) = path.parent().filter(|d| !d.as_os_str().is_empty()) {
+            fs::create_dir_all(dir).map_err(|source| SqliteStoreError::CreateDir {
+                dir: dir.to_path_buf(),
+                source,
+            })?;
+        }
+        let sqlite = |source| SqliteStoreError::Sqlite {
+            path: path.clone(),
+            source,
+        };
+
+        let conn = Connection::open(&path).map_err(sqlite)?;
+        conn.busy_timeout(BUSY_TIMEOUT).map_err(sqlite)?;
+        let mode: String = conn
+            .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+            .map_err(sqlite)?;
+        if !mode.eq_ignore_ascii_case("wal") {
+            return Err(SqliteStoreError::JournalMode { path, mode });
+        }
+        conn.pragma_update(None, "synchronous", "FULL")
+            .map_err(sqlite)?;
+        let report: String = conn
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .map_err(sqlite)?;
+        if report != "ok" {
+            return Err(SqliteStoreError::Corrupt { path, report });
+        }
+
+        Ok(Self {
+            path,
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Opens the store for `kind` inside `data_dir`. See [`Self::open`].
+    pub fn open_in_dir(data_dir: &Path, kind: WalletKind) -> Result<Self, SqliteStoreError> {
+        Self::open(kind.path_in(data_dir))
+    }
+
+    fn conn(&self) -> MutexGuard<'_, Connection> {
+        self.conn.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn sqlite_error(&self, source: rusqlite::Error) -> SqliteStoreError {
+        SqliteStoreError::Sqlite {
+            path: self.path.clone(),
+            source,
+        }
+    }
+}
+
+type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, SqliteStoreError>> + Send + 'a>>;
+
+impl AsyncWalletPersister for SqliteStore {
+    type Error = SqliteStoreError;
+
+    fn initialize<'a>(persister: &'a mut Self) -> StoreFuture<'a, ChangeSet>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move {
+            let mut conn = persister.conn();
+            WalletPersister::initialize(&mut *conn).map_err(|e| persister.sqlite_error(e))
+        })
+    }
+
+    fn persist<'a>(persister: &'a mut Self, changeset: &'a ChangeSet) -> StoreFuture<'a, ()>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move {
+            let mut conn = persister.conn();
+            WalletPersister::persist(&mut *conn, changeset).map_err(|e| persister.sqlite_error(e))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::{
+        bitcoin::{
+            secp256k1::{Keypair, Secp256k1, SecretKey},
+            Network, XOnlyPublicKey,
+        },
+        descriptor,
+        descriptor::ExtendedDescriptor,
+        LoadError, LoadMismatch,
+    };
+
+    use super::*;
+    use crate::persist::{load_or_create, InitError, PersistedWallet};
+
+    fn xonly(seed: u8) -> XOnlyPublicKey {
+        let secret = SecretKey::from_slice(&[seed; 32]).expect("valid scalar");
+        Keypair::from_secret_key(&Secp256k1::new(), &secret)
+            .x_only_public_key()
+            .0
+    }
+
+    fn tr_descriptor(seed: u8) -> ExtendedDescriptor {
+        descriptor!(tr(xonly(seed))).expect("valid descriptor").0
+    }
+
+    /// Opens the store for `kind` and loads or creates the wallet for `seed` in it.
+    async fn open_wallet(
+        dir: &Path,
+        kind: WalletKind,
+        seed: u8,
+    ) -> Result<(SqliteStore, PersistedWallet<SqliteStore>), InitError<SqliteStoreError>> {
+        let mut store = SqliteStore::open_in_dir(dir, kind).map_err(InitError::Store)?;
+        let wallet =
+            load_or_create(&mut store, tr_descriptor(seed), Network::Regtest, None).await?;
+        Ok((store, wallet))
+    }
+
+    #[tokio::test]
+    async fn create_then_reopen_loads_and_uses_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let (store, _) = open_wallet(dir.path(), WalletKind::General, 1)
+            .await
+            .unwrap();
+        assert!(dir.path().join("general-wallet.sqlite").exists());
+        let mode: String = store
+            .conn()
+            .query_row("PRAGMA journal_mode", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mode, "wal");
+        let sync: i64 = store
+            .conn()
+            .query_row("PRAGMA synchronous", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sync, 2, "FULL");
+        drop(store);
+
+        // A second open on a populated store can only succeed by loading: the create path would
+        // fail with `DataAlreadyExists`.
+        let (store, _) = open_wallet(dir.path(), WalletKind::General, 1)
+            .await
+            .unwrap();
+        let wallets: i64 = store
+            .conn()
+            .query_row("SELECT count(*) FROM bdk_wallet", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(wallets, 1, "one wallet row, written once");
+    }
+
+    #[test]
+    fn garbage_file_is_rejected_and_left_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = WalletKind::Reserved.path_in(dir.path());
+        let garbage = b"definitely not a sqlite database; padded well past the header\n".repeat(40);
+        fs::write(&path, &garbage).unwrap();
+
+        let err = SqliteStore::open(&path).expect_err("garbage must not open");
+        assert!(
+            matches!(
+                err,
+                SqliteStoreError::Sqlite { .. } | SqliteStoreError::Corrupt { .. }
+            ),
+            "got {err}"
+        );
+        assert!(err.to_string().contains("reserved-wallet.sqlite"), "{err}");
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            garbage,
+            "rejected file is left intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn kinds_use_distinct_files_and_never_share_state() {
+        let dir = tempfile::tempdir().unwrap();
+        open_wallet(dir.path(), WalletKind::General, 1)
+            .await
+            .unwrap();
+        open_wallet(dir.path(), WalletKind::Reserved, 2)
+            .await
+            .unwrap();
+        assert_ne!(
+            WalletKind::General.path_in(dir.path()),
+            WalletKind::Reserved.path_in(dir.path())
+        );
+
+        // Opening the general store with the reserved descriptor is a mismatch, not a load.
+        let err = open_wallet(dir.path(), WalletKind::General, 2)
+            .await
+            .expect_err("descriptor mismatch");
+        assert!(matches!(
+            err,
+            InitError::InvalidState(e) if matches!(*e, LoadError::Mismatch(LoadMismatch::Descriptor { .. }))
+        ));
+        open_wallet(dir.path(), WalletKind::Reserved, 2)
+            .await
+            .expect("own descriptor still loads");
+    }
+}

--- a/crates/operator-wallet/src/persist/sqlite.rs
+++ b/crates/operator-wallet/src/persist/sqlite.rs
@@ -137,6 +137,16 @@ impl SqliteStore {
 
         let conn = Connection::open(&path).map_err(sqlite)?;
         conn.busy_timeout(BUSY_TIMEOUT).map_err(sqlite)?;
+
+        // Before any mutating pragma: switching journal mode rewrites the header, which would
+        // modify a file this open is about to reject.
+        let report: String = conn
+            .query_row("PRAGMA quick_check", [], |row| row.get(0))
+            .map_err(sqlite)?;
+        if report != "ok" {
+            return Err(SqliteStoreError::Corrupt { path, report });
+        }
+
         let mode: String = conn
             .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
             .map_err(sqlite)?;
@@ -145,12 +155,6 @@ impl SqliteStore {
         }
         conn.pragma_update(None, "synchronous", "FULL")
             .map_err(sqlite)?;
-        let report: String = conn
-            .query_row("PRAGMA quick_check", [], |row| row.get(0))
-            .map_err(sqlite)?;
-        if report != "ok" {
-            return Err(SqliteStoreError::Corrupt { path, report });
-        }
 
         Ok(Self {
             path,
@@ -290,6 +294,59 @@ mod tests {
             fs::read(&path).unwrap(),
             garbage,
             "rejected file is left intact"
+        );
+    }
+
+    /// Offsets 18 and 19 of the SQLite header are the write and read format versions: 1 for a
+    /// rollback journal, 2 for WAL. `PRAGMA journal_mode=WAL` rewrites both.
+    fn header_format_versions(path: &Path) -> [u8; 2] {
+        let header = fs::read(path).unwrap();
+        [header[18], header[19]]
+    }
+
+    #[test]
+    fn structurally_damaged_file_is_rejected_before_the_journal_mode_is_changed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = WalletKind::General.path_in(dir.path());
+
+        // A rollback-journal database (as a restored backup or a file from another tool may be)
+        // with an intact header and a corrupted b-tree page: `quick_check` fails, but the
+        // journal-mode switch would have succeeded and rewritten the header first.
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode=DELETE; \
+             CREATE TABLE t(v TEXT); \
+             WITH RECURSIVE c(x) AS (SELECT 1 UNION ALL SELECT x + 1 FROM c WHERE x < 400) \
+             INSERT INTO t(v) SELECT hex(zeroblob(64)) FROM c;",
+        )
+        .unwrap();
+        drop(conn);
+        assert_eq!(header_format_versions(&path), [1, 1], "not WAL yet");
+        let mut bytes = fs::read(&path).unwrap();
+        assert!(
+            bytes.len() > 8192,
+            "table must span more than the first page"
+        );
+        bytes[4096] = 0xFF; // page 2's b-tree page type
+        fs::write(&path, &bytes).unwrap();
+
+        let err = SqliteStore::open(&path).expect_err("damaged file must not open");
+        assert!(
+            matches!(
+                err,
+                SqliteStoreError::Corrupt { .. } | SqliteStoreError::Sqlite { .. }
+            ),
+            "got {err}"
+        );
+        assert_eq!(
+            header_format_versions(&path),
+            [1, 1],
+            "a rejected file must not have its journal mode rewritten"
+        );
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            bytes,
+            "rejected file left untouched"
         );
     }
 

--- a/crates/operator-wallet/src/persist/test_utils.rs
+++ b/crates/operator-wallet/src/persist/test_utils.rs
@@ -1,0 +1,162 @@
+//! Test utilities for wallet persistence: an in-memory [`AsyncWalletPersister`] that records
+//! what was persisted and can be made to fail on demand.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+};
+
+use bdk_wallet::{chain::Merge, AsyncWalletPersister, ChangeSet};
+use thiserror::Error;
+
+/// In-memory store. Clones share one store, so a test can rebuild a wallet from a clone to
+/// simulate a restart. Records every persisted changeset and can fail one chosen `persist` call.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryStore {
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    /// Merge of every persisted changeset; what `initialize` returns.
+    aggregate: ChangeSet,
+    /// Every successfully persisted changeset, in call order.
+    history: Vec<ChangeSet>,
+    /// `persist` calls so far, including failed ones.
+    persist_calls: usize,
+    /// One-based index of the `persist` call that fails. Cleared once it fires.
+    fail_on_call: Option<usize>,
+}
+
+/// Error injected by [`MemoryStore::fail_on_persist_call`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("memory store: injected failure on persist call {call}")]
+pub struct MemoryStoreError {
+    /// One-based index of the persist call that failed.
+    pub call: usize,
+}
+
+impl MemoryStore {
+    /// Creates an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Makes the `call`-th (one-based) future `persist` call fail, once.
+    pub fn fail_on_persist_call(&self, call: usize) {
+        self.lock().fail_on_call = Some(call);
+    }
+
+    /// `persist` calls so far, including a failed one.
+    pub fn persist_calls(&self) -> usize {
+        self.lock().persist_calls
+    }
+
+    /// Every successfully persisted changeset, in call order.
+    pub fn history(&self) -> Vec<ChangeSet> {
+        self.lock().history.clone()
+    }
+
+    /// Merge of everything persisted so far, i.e. what `initialize` returns.
+    pub fn aggregate(&self) -> ChangeSet {
+        self.lock().aggregate.clone()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, MemoryStoreError>> + Send + 'a>>;
+
+impl AsyncWalletPersister for MemoryStore {
+    type Error = MemoryStoreError;
+
+    fn initialize<'a>(persister: &'a mut Self) -> StoreFuture<'a, ChangeSet>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move { Ok(persister.aggregate()) })
+    }
+
+    fn persist<'a>(persister: &'a mut Self, changeset: &'a ChangeSet) -> StoreFuture<'a, ()>
+    where
+        Self: 'a,
+    {
+        Box::pin(async move {
+            let mut inner = persister.lock();
+            inner.persist_calls += 1;
+            let call = inner.persist_calls;
+            if inner.fail_on_call == Some(call) {
+                inner.fail_on_call = None;
+                return Err(MemoryStoreError { call });
+            }
+            inner.aggregate.merge(changeset.clone());
+            inner.history.push(changeset.clone());
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::{
+        bitcoin::{hashes::Hash, BlockHash},
+        chain::local_chain,
+    };
+
+    use super::*;
+
+    fn chain_changeset(entries: impl IntoIterator<Item = (u32, Option<u8>)>) -> ChangeSet {
+        let blocks = entries
+            .into_iter()
+            .map(|(h, b)| (h, b.map(|b| BlockHash::from_byte_array([b; 32]))))
+            .collect();
+        ChangeSet {
+            local_chain: local_chain::ChangeSet { blocks },
+            ..ChangeSet::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn aggregates_and_records_history() {
+        let mut store = MemoryStore::new();
+        let first = chain_changeset([(0, Some(0)), (1, Some(1))]);
+        let second = chain_changeset([(2, Some(2))]);
+
+        MemoryStore::persist(&mut store, &first).await.unwrap();
+        MemoryStore::persist(&mut store, &second).await.unwrap();
+
+        let loaded = MemoryStore::initialize(&mut store).await.unwrap();
+        assert_eq!(loaded.local_chain.blocks.len(), 3);
+        assert_eq!(store.history(), vec![first, second]);
+        assert_eq!(store.persist_calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn injected_failure_fires_once_and_persists_nothing() {
+        let mut store = MemoryStore::new();
+        store.fail_on_persist_call(1);
+        let cs = chain_changeset([(0, Some(0))]);
+
+        let err = MemoryStore::persist(&mut store, &cs).await.unwrap_err();
+        assert_eq!(err, MemoryStoreError { call: 1 });
+        assert!(store.history().is_empty(), "failed call must not persist");
+        assert!(store.aggregate().is_empty());
+
+        MemoryStore::persist(&mut store, &cs).await.unwrap();
+        assert_eq!(store.history().len(), 1);
+        assert_eq!(store.persist_calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn clones_share_storage() {
+        let mut store = MemoryStore::new();
+        let twin = store.clone();
+        MemoryStore::persist(&mut store, &chain_changeset([(0, Some(0))]))
+            .await
+            .unwrap();
+        assert_eq!(twin.history().len(), 1);
+    }
+}

--- a/crates/operator-wallet/src/sync.rs
+++ b/crates/operator-wallet/src/sync.rs
@@ -1,12 +1,17 @@
 //! Operator wallet chain data sync module
-use std::{fmt::Debug, num::NonZeroU32, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    fmt::Debug,
+    num::NonZeroU32,
+    sync::Arc,
+};
 
 use bdk_bitcoind_rpc::{
-    bitcoincore_rpc::{self},
+    bitcoincore_rpc::{self, RpcApi},
     BlockEvent, Emitter,
 };
 use bdk_wallet::{
-    bitcoin::{Block, Transaction},
+    bitcoin::{Block, Transaction, Txid},
     chain::CheckPoint,
 };
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -34,12 +39,28 @@ pub enum Backend {
 }
 
 impl Backend {
+    /// The height of the backend's best chain.
+    pub async fn height(&self) -> Result<u32, SyncError> {
+        match self {
+            Backend::BitcoinCore(client) => with_bitcoin_core(client.clone(), |client| {
+                // Heights fit u32 long past any chain this runs against.
+                client.get_block_count().map(|height| height as u32)
+            })
+            .await
+            .map_err(|e| (Box::new(e) as BoxedErr).into()),
+        }
+    }
+
     /// Syncs a wallet using the configured backend.
     ///
-    /// Pulls new blocks + mempool state and applies them to the wallet's view. Staged changes are
-    /// persisted to `store` every `persist_every_blocks` blocks and once after the mempool, each
-    /// as a single persist call, so a crash between two calls resumes from the last one. A failed
-    /// persist returns `Err` with the changes still staged for the next attempt.
+    /// Pulls new blocks + mempool state and applies them to the wallet's view. Block-derived
+    /// changes are persisted to `store` every `persist_every_blocks` blocks, each as a single
+    /// persist call, so a crash between two calls resumes from the last one. A failed persist
+    /// returns `Err` with the changes still staged for the next attempt. Mempool state is applied
+    /// in memory only and re-fetched on every sync; only confirmed transactions are persisted.
+    ///
+    /// Returns the transaction ids in the node's mempool, which the caller keeps to tell a live
+    /// unconfirmed transaction from one reorged out of the chain.
     ///
     /// Lease cleanup (removing leases whose underlying outpoints have been observed spent) is the
     /// caller's responsibility — after this call, the caller compares its lease set against
@@ -49,7 +70,7 @@ impl Backend {
         wallet: &mut PersistedWallet<P>,
         store: &mut P,
         persist_every_blocks: NonZeroU32,
-    ) -> Result<(), SyncError> {
+    ) -> Result<HashSet<Txid>, SyncError> {
         let last_cp = wallet.latest_checkpoint();
         debug!(
             tip_height = last_cp.height(),
@@ -65,6 +86,7 @@ impl Backend {
         };
 
         let mut applied_since_persist = 0u32;
+        let mut mempool = HashSet::new();
         while let Some(update) = rx.recv().await {
             match update {
                 WalletUpdate::NewBlock(ev) => {
@@ -73,6 +95,7 @@ impl Backend {
                     wallet
                         .apply_block_connected_to(&ev.block, height, connected_to)
                         .expect("block to be added");
+                    stage_anchored_txs(wallet);
                     applied_since_persist += 1;
                     if applied_since_persist >= persist_every_blocks.get() {
                         persist(wallet, store).await?;
@@ -80,7 +103,13 @@ impl Backend {
                     }
                 }
                 WalletUpdate::MempoolTxs(txs) => {
+                    // Commit the blocks, then apply the mempool and drop everything it staged: a
+                    // persisted unconfirmed transaction could never be evicted, and the stream of
+                    // them is unbounded. The emitter re-sends the whole mempool every sync.
+                    persist(wallet, store).await?;
+                    mempool = txs.iter().map(|(tx, _)| tx.compute_txid()).collect();
                     wallet.apply_unconfirmed_txs(txs);
+                    let _ = wallet.take_staged();
                 }
             }
         }
@@ -90,7 +119,34 @@ impl Backend {
         persist(wallet, store).await?;
 
         handle.await.expect("thread to be fine")?;
-        Ok(())
+        Ok(mempool)
+    }
+}
+
+/// Stages the transaction behind every anchor the wallet has staged.
+///
+/// `TxGraph::insert_tx` yields nothing for a transaction the wallet already holds, so a block
+/// confirming one seen earlier in the mempool stages only its anchor. Mempool state is not
+/// persisted, so without this the store would hold an anchor whose transaction is missing, and the
+/// checkpoint above it would stop the block being scanned again.
+fn stage_anchored_txs<P: WalletStore>(wallet: &mut PersistedWallet<P>) {
+    let Some(stage) = wallet.staged() else { return };
+    let staged: BTreeSet<Txid> = stage
+        .tx_graph
+        .txs
+        .iter()
+        .map(|tx| tx.compute_txid())
+        .collect();
+    let missing: Vec<_> = stage
+        .tx_graph
+        .anchors
+        .iter()
+        .map(|(_, txid)| *txid)
+        .filter(|txid| !staged.contains(txid))
+        .filter_map(|txid| wallet.tx_graph().get_tx(txid))
+        .collect();
+    if let Some(stage) = wallet.staged_mut() {
+        stage.tx_graph.txs.extend(missing);
     }
 }
 

--- a/crates/operator-wallet/src/sync.rs
+++ b/crates/operator-wallet/src/sync.rs
@@ -1,5 +1,5 @@
 //! Operator wallet chain data sync module
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, num::NonZeroU32, sync::Arc};
 
 use bdk_bitcoind_rpc::{
     bitcoincore_rpc::{self},
@@ -8,9 +8,11 @@ use bdk_bitcoind_rpc::{
 use bdk_wallet::{
     bitcoin::{Block, Transaction},
     chain::CheckPoint,
-    Wallet,
 };
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tracing::debug;
+
+use crate::persist::{PersistedWallet, WalletStore};
 
 /// A message sent from a sync task to the syncer
 #[derive(Debug)]
@@ -34,12 +36,25 @@ pub enum Backend {
 impl Backend {
     /// Syncs a wallet using the configured backend.
     ///
-    /// Pulls new blocks + mempool state and applies them to the wallet's view. Lease
-    /// cleanup (removing leases whose underlying outpoints have been observed spent) is the
+    /// Pulls new blocks + mempool state and applies them to the wallet's view. Staged changes are
+    /// persisted to `store` every `persist_every_blocks` blocks and once after the mempool, each
+    /// as a single persist call, so a crash between two calls resumes from the last one. A failed
+    /// persist returns `Err` with the changes still staged for the next attempt.
+    ///
+    /// Lease cleanup (removing leases whose underlying outpoints have been observed spent) is the
     /// caller's responsibility — after this call, the caller compares its lease set against
     /// the wallet's `list_unspent()` and drops any lease whose outpoint is no longer present.
-    pub async fn sync_wallet(&self, wallet: &mut Wallet) -> Result<(), SyncError> {
+    pub async fn sync_wallet<P: WalletStore>(
+        &self,
+        wallet: &mut PersistedWallet<P>,
+        store: &mut P,
+        persist_every_blocks: NonZeroU32,
+    ) -> Result<(), SyncError> {
         let last_cp = wallet.latest_checkpoint();
+        debug!(
+            tip_height = last_cp.height(),
+            "syncing wallet from checkpoint"
+        );
         let (tx, mut rx) = unbounded_channel();
 
         let handle = match self {
@@ -49,6 +64,7 @@ impl Backend {
             }
         };
 
+        let mut applied_since_persist = 0u32;
         while let Some(update) = rx.recv().await {
             match update {
                 WalletUpdate::NewBlock(ev) => {
@@ -57,6 +73,11 @@ impl Backend {
                     wallet
                         .apply_block_connected_to(&ev.block, height, connected_to)
                         .expect("block to be added");
+                    applied_since_persist += 1;
+                    if applied_since_persist >= persist_every_blocks.get() {
+                        persist(wallet, store).await?;
+                        applied_since_persist = 0;
+                    }
                 }
                 WalletUpdate::MempoolTxs(txs) => {
                     wallet.apply_unconfirmed_txs(txs);
@@ -64,9 +85,31 @@ impl Backend {
             }
         }
 
+        // Persist what the loop applied since the last commit before surfacing an emitter
+        // failure, so a failed attempt never discards durable progress.
+        persist(wallet, store).await?;
+
         handle.await.expect("thread to be fine")?;
         Ok(())
     }
+}
+
+/// Writes the wallet's staged changeset to `store` if there is one.
+async fn persist<P: WalletStore>(
+    wallet: &mut PersistedWallet<P>,
+    store: &mut P,
+) -> Result<(), SyncError> {
+    let persisted = wallet
+        .persist_async(store)
+        .await
+        .map_err(|e| SyncError(Box::new(e)))?;
+    if persisted {
+        debug!(
+            tip_height = wallet.latest_checkpoint().height(),
+            "persisted staged wallet state"
+        );
+    }
+    Ok(())
 }
 
 type BoxedErrInner = dyn Debug + Send + Sync;
@@ -98,14 +141,18 @@ async fn sync_wallet_bitcoin_core(
     {
         let client = client.clone();
         async move {
-            let start_height = last_cp.height();
+            let start_height = scan_start_height(&last_cp);
             with_bitcoin_core(client, move |client| {
                 let mut emitter = Emitter::new(client, last_cp, start_height);
-                while let Some(ev) = emitter.next_block().unwrap() {
-                    send_update.send(WalletUpdate::NewBlock(ev)).unwrap();
+                while let Some(ev) = emitter.next_block()? {
+                    // A closed channel means the receiver gave up on this attempt (e.g. a persist
+                    // failure). Stop emitting instead of panicking on the dropped receiver.
+                    if send_update.send(WalletUpdate::NewBlock(ev)).is_err() {
+                        return Ok(());
+                    }
                 }
-                let mempool = emitter.mempool().unwrap();
-                send_update.send(WalletUpdate::MempoolTxs(mempool)).unwrap();
+                let mempool = emitter.mempool()?;
+                let _ = send_update.send(WalletUpdate::MempoolTxs(mempool));
                 Ok(())
             })
             .await
@@ -113,6 +160,20 @@ async fn sync_wallet_bitcoin_core(
     }
     .await
     .map_err(|e| (Box::new(e) as BoxedErr).into())
+}
+
+/// Height the emitter may skip forward to when its agreement point lies below it: the wallet's
+/// lowest non-genesis checkpoint, or 0 for a genesis-only chain.
+///
+/// Not the tip: after a reorg that leaves the node's chain shorter than the tip, a tip-based start
+/// makes the emitter skip the replacement blocks once the chain regrows, leaving stale blocks in
+/// the local chain.
+fn scan_start_height(tip: &CheckPoint) -> u32 {
+    tip.iter()
+        .map(|cp| cp.height())
+        .filter(|height| *height > 0)
+        .last()
+        .unwrap_or(0)
 }
 
 async fn with_bitcoin_core<T, F>(

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -3,7 +3,8 @@
 //! Composes a swappable [`crate::GeneralWallet`] backend with an always-native reserved wallet
 //! and shared in-memory lease bookkeeping. The composer owns:
 //!
-//! - the BDK descriptor-only reserved wallet (signed downstream by the caller),
+//! - the BDK descriptor-only reserved wallet (signed downstream by the caller, persisted through a
+//!   caller-supplied [`crate::WalletStore`]),
 //! - the lease set shared across both wallets,
 //! - anchor exclusion during input selection,
 //! - cross-wallet construction helpers that produce PSBTs paying from the general wallet into
@@ -16,7 +17,8 @@ use std::collections::BTreeSet;
 
 use bdk_wallet::{
     bitcoin::{Address, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
-    descriptor, KeychainKind, Wallet,
+    chain::BlockId,
+    descriptor, KeychainKind,
 };
 use bitcoin_bosd::Descriptor;
 use tokio::time::sleep;
@@ -25,6 +27,7 @@ use tracing::{error, info, warn};
 use crate::{
     config::OperatorWalletConfig,
     general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    persist::{load_or_create, PersistedWallet, WalletStore},
     sync::Backend,
     Error,
 };
@@ -41,45 +44,51 @@ pub enum GeneralUtxoPolicy {
 /// The operator's wallet: a [`GeneralWallet`] backend composed with the always-native reserved
 /// wallet, shared lease bookkeeping, and cross-wallet transaction construction helpers.
 #[derive(Debug)]
-pub struct OperatorWallet<G: GeneralWallet> {
+pub struct OperatorWallet<G, P> {
     general: G,
-    reserved: Wallet,
+    reserved: PersistedWallet<P>,
+    reserved_store: P,
     reserved_sync_backend: Backend,
     reserved_script_pubkey: ScriptBuf,
     config: OperatorWalletConfig,
     leased_outpoints: BTreeSet<OutPoint>,
 }
 
-impl<G: GeneralWallet> OperatorWallet<G> {
+impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
     /// Constructs an [`OperatorWallet`] from a [`GeneralWallet`] backend and a reserved-wallet
-    /// pubkey. `initial_leases` is the set of outpoints to seed the lease state with
-    /// (typically rehydrated from durable storage at startup).
-    pub fn new(
+    /// pubkey, loading the reserved wallet from `reserved_store` or creating it when the store is
+    /// empty (see [`load_or_create`]). `initial_leases` seeds the lease set, typically from durable
+    /// storage.
+    pub async fn load_or_create(
         general: G,
         reserved_pubkey: XOnlyPublicKey,
         config: OperatorWalletConfig,
         reserved_sync_backend: Backend,
+        mut reserved_store: P,
+        bootstrap_checkpoint: Option<BlockId>,
         initial_leases: BTreeSet<OutPoint>,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         let (reserved_desc, ..) =
             descriptor!(tr(reserved_pubkey)).expect("valid tr() descriptor for reserved");
-        let reserved_wallet = Wallet::create_single(reserved_desc)
-            .network(config.network)
-            .create_wallet_no_persist()
-            .expect("reserved wallet creation must not fail");
-        let reserved_addr = reserved_wallet
-            .peek_address(KeychainKind::External, 0)
-            .address;
+        let reserved = load_or_create(
+            &mut reserved_store,
+            reserved_desc,
+            config.network,
+            bootstrap_checkpoint,
+        )
+        .await
+        .map_err(|e| Error::ReservedInit(Box::new(e)))?;
+        let reserved_addr = reserved.peek_address(KeychainKind::External, 0).address;
         info!("reserved wallet address: {reserved_addr}");
-        let reserved_script_pubkey = reserved_addr.script_pubkey();
-        Self {
+        Ok(Self {
             general,
-            reserved: reserved_wallet,
+            reserved,
+            reserved_store,
             reserved_sync_backend,
-            reserved_script_pubkey,
+            reserved_script_pubkey: reserved_addr.script_pubkey(),
             config,
             leased_outpoints: initial_leases,
-        }
+        })
     }
 
     /// Returns a reference to the underlying [`GeneralWallet`] for callers that need
@@ -145,6 +154,11 @@ impl<G: GeneralWallet> OperatorWallet<G> {
     /// wallets advance together in [`sync`](Self::sync), so the reserved tip is representative.
     pub fn local_chain_tip_height(&self) -> u32 {
         self.reserved.latest_checkpoint().height()
+    }
+
+    /// Returns the block hash of the reserved wallet's local chain tip.
+    pub fn reserved_tip_hash(&self) -> bdk_wallet::bitcoin::BlockHash {
+        self.reserved.latest_checkpoint().hash()
     }
 
     // ── Reserved-wallet UTXO lookup ─────────────────────────────────────────
@@ -357,9 +371,9 @@ impl<G: GeneralWallet> OperatorWallet<G> {
 
     // ── Sync ───────────────────────────────────────────────────────────────
 
-    /// Syncs both wallets against their respective backends and then prunes the lease set:
-    /// any leased outpoint that is no longer in either wallet's spendable UTXO set is
-    /// dropped (it was observed spent on-chain).
+    /// Syncs both wallets against their respective backends, persisting their staged chain state
+    /// as it goes, and then prunes the lease set: any leased outpoint that is no longer in either
+    /// wallet's spendable UTXO set is dropped (it was observed spent on-chain).
     pub async fn sync(&mut self) -> Result<(), Error> {
         let mut attempt = 0u32;
         loop {
@@ -369,7 +383,11 @@ impl<G: GeneralWallet> OperatorWallet<G> {
             }
             if let Err(e) = self
                 .reserved_sync_backend
-                .sync_wallet(&mut self.reserved)
+                .sync_wallet(
+                    &mut self.reserved,
+                    &mut self.reserved_store,
+                    self.config.persist_every_blocks,
+                )
                 .await
             {
                 err = Some(Error::Sync(e));

--- a/crates/operator-wallet/src/wallet.rs
+++ b/crates/operator-wallet/src/wallet.rs
@@ -13,10 +13,12 @@
 //! Methods on [`OperatorWallet`] take `&mut self`; callers serialize via an outer lock when
 //! they need a multi-step critical section (e.g. DB-lookup-then-fund-then-persist).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 
 use bdk_wallet::{
-    bitcoin::{Address, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, XOnlyPublicKey},
+    bitcoin::{
+        Address, Amount, FeeRate, OutPoint, ScriptBuf, Transaction, TxOut, Txid, XOnlyPublicKey,
+    },
     chain::BlockId,
     descriptor, KeychainKind,
 };
@@ -26,8 +28,8 @@ use tracing::{error, info, warn};
 
 use crate::{
     config::OperatorWalletConfig,
-    general::{local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
-    persist::{load_or_create, PersistedWallet, WalletStore},
+    general::{is_spendable, local_output_to_utxo_info, FundedPsbt, GeneralWallet, UtxoInfo},
+    persist::{ensure_backend_not_behind, load_or_create, PersistedWallet, WalletStore},
     sync::Backend,
     Error,
 };
@@ -52,6 +54,7 @@ pub struct OperatorWallet<G, P> {
     reserved_script_pubkey: ScriptBuf,
     config: OperatorWalletConfig,
     leased_outpoints: BTreeSet<OutPoint>,
+    reserved_mempool: HashSet<Txid>,
 }
 
 impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
@@ -78,6 +81,9 @@ impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
         )
         .await
         .map_err(|e| Error::ReservedInit(Box::new(e)))?;
+        ensure_backend_not_behind(&reserved_sync_backend, &reserved)
+            .await
+            .map_err(|e| Error::ReservedInit(Box::new(e)))?;
         let reserved_addr = reserved.peek_address(KeychainKind::External, 0).address;
         info!("reserved wallet address: {reserved_addr}");
         Ok(Self {
@@ -88,6 +94,7 @@ impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
             reserved_script_pubkey: reserved_addr.script_pubkey(),
             config,
             leased_outpoints: initial_leases,
+            reserved_mempool: HashSet::new(),
         })
     }
 
@@ -172,6 +179,7 @@ impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
         let tip = self.reserved.latest_checkpoint().height();
         self.reserved
             .list_unspent()
+            .filter(|output| is_spendable(output, &self.reserved_mempool))
             .filter(|utxo| utxo.txout.value == value)
             .map(|lo| local_output_to_utxo_info(&lo, tip))
             .collect()
@@ -381,7 +389,9 @@ impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
             if let Err(e) = self.general.sync().await {
                 err = Some(Error::from_general(e));
             }
-            if let Err(e) = self
+            // Cleared per attempt, so a failure leaves no snapshot behind.
+            self.reserved_mempool.clear();
+            match self
                 .reserved_sync_backend
                 .sync_wallet(
                     &mut self.reserved,
@@ -390,7 +400,8 @@ impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
                 )
                 .await
             {
-                err = Some(Error::Sync(e));
+                Ok(mempool) => self.reserved_mempool = mempool,
+                Err(e) => err = Some(Error::Sync(e)),
             }
             match err {
                 Some(e) => {
@@ -406,14 +417,15 @@ impl<G: GeneralWallet, P: WalletStore> OperatorWallet<G, P> {
             }
         }
 
-        // Prune stale leases. After a successful sync, drop any leased outpoint whose
-        // underlying UTXO is no longer in either wallet's spendable set — it was observed
-        // spent on-chain (the on-chain spend supersedes our local lease bookkeeping).
+        // Prune stale leases. After a successful sync, drop any leased outpoint neither wallet
+        // still holds — it was observed spent (the spend supersedes our lease bookkeeping). This
+        // asks what the wallets hold, not what they will spend: an output the spendable filter
+        // rejects may yet come back, and releasing its lease early would let a second caller take
+        // an outpoint the first is still committed to.
         let live: BTreeSet<OutPoint> = self
             .general
-            .list_utxos()
+            .unspent_outpoints()
             .into_iter()
-            .map(|u| u.outpoint)
             .chain(self.reserved.list_unspent().map(|lo| lo.outpoint))
             .collect();
         self.leased_outpoints.retain(|o| live.contains(o));

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -1019,14 +1019,14 @@ async fn bootstrap_checkpoint_skips_history_below_it() {
         90,
         "fresh wallet starts at the checkpoint"
     );
-    // Create-time commits: descriptor/network/genesis, then the checkpoint.
+    // One create-time commit carrying descriptor, network, genesis and the checkpoint.
     let created = stores.reserved.history();
-    assert_eq!(created.len(), 2);
+    assert_eq!(created.len(), 1, "wallet and checkpoint commit together");
     assert_eq!(chain_heights(&created), BTreeSet::from([0, 90]));
 
     wallet.sync().await.expect("sync");
     assert_eq!(wallet.local_chain_tip_height(), 101);
-    let synced = &stores.reserved.history()[2..];
+    let synced = &stores.reserved.history()[created.len()..];
     let expected: BTreeSet<u32> = (91..=101).collect();
     assert_eq!(
         chain_heights(synced),

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -14,6 +14,10 @@
 //!   delta, and the wallet doesn't re-spend existing pool members back to itself.
 //! - **Sync prunes stale leases** so a long-running operator doesn't accumulate leases for
 //!   outpoints that the chain has already spent.
+//! - **Persistence**: a restart from the same stores resumes at the persisted tip and applies only
+//!   the chain delta; staged state is committed in bounded batches; a failed commit is retried
+//!   without gaps or duplicates; a reorg rolls the persisted chain back; a bootstrap checkpoint
+//!   skips history below it.
 //!
 //! Tests are `#[serial]` because `bitcoind` binds a fixed RPC port — parallel runs would
 //! collide. Each test spins up a fresh `bitcoind` so state doesn't leak between cases.
@@ -24,22 +28,47 @@
 //! signing with the same keypair the descriptor was constructed from (BIP-341 key-path with
 //! the empty-merkle-root tap-tweak).
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU32,
+    path::Path,
+    sync::Arc,
+};
 
-use bdk_wallet::bitcoin::{
-    hashes::Hash,
-    key::{Keypair, Secp256k1, TapTweak},
-    secp256k1::{Message, SecretKey},
-    sighash::{Prevouts, SighashCache},
-    taproot, Address, Amount, FeeRate, Network, OutPoint, Psbt, TapSighashType, Transaction,
-    Witness, XOnlyPublicKey,
+use bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi;
+use bdk_wallet::{
+    bitcoin::{
+        hashes::Hash,
+        key::{Keypair, Secp256k1, TapTweak},
+        secp256k1::{Message, SecretKey},
+        sighash::{Prevouts, SighashCache},
+        taproot, Address, Amount, BlockHash, FeeRate, Network, OutPoint, Psbt, TapSighashType,
+        Transaction, Witness, XOnlyPublicKey,
+    },
+    chain::{BlockId, Merge},
+    descriptor, ChangeSet,
 };
 use corepc_node::{Conf, Node};
 use operator_wallet::{
-    sync::Backend, Error as OperatorWalletError, GeneralUtxoPolicy, GeneralWallet,
-    NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
+    load_or_create, sync::Backend, test_utils::MemoryStore, Error as OperatorWalletError,
+    GeneralUtxoPolicy, GeneralWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
+    SqliteStore, WalletKind, DEFAULT_PERSIST_EVERY_BLOCKS,
 };
 use serial_test::serial;
+
+/// The concrete wallet type under test: native general wallet + in-memory stores.
+type TestWallet = OperatorWallet<NativeGeneralWallet<MemoryStore>, MemoryStore>;
+
+/// The production shape: native general wallet + one SQLite file per wallet.
+type SqliteWallet = OperatorWallet<NativeGeneralWallet<SqliteStore>, SqliteStore>;
+
+/// The pair of in-memory stores backing one operator wallet. Clones share storage, so keeping a
+/// `Stores` around and re-opening from it simulates a process restart.
+#[derive(Clone, Default)]
+struct Stores {
+    general: MemoryStore,
+    reserved: MemoryStore,
+}
 
 /// 1 sat — the smallest possible "anchor" value, used in tests where we don't actually
 /// want any UTXO to look like an anchor. `OperatorWallet`'s anchor exclusion filters on
@@ -75,10 +104,50 @@ fn keypair_from_seed(seed: u8) -> (Keypair, XOnlyPublicKey) {
     (kp, xonly)
 }
 
-/// Builds a fully-wired `OperatorWallet<NativeGeneralWallet>` for tests. Funds the general
-/// wallet with `general_funding_utxos` UTXOs of `general_funding_value` each via bitcoind's
-/// own wallet, then syncs. The reserved wallet is created from a separate deterministic
-/// keypair and starts empty.
+/// Opens (loads or creates) an operator wallet against `stores` without funding or syncing it.
+/// Returns the wallet plus the origin reported for the general and reserved wallets.
+async fn open_wallet(
+    bitcoind: &Node,
+    general_seed: u8,
+    reserved_seed: u8,
+    stores: &Stores,
+    bootstrap_checkpoint: Option<BlockId>,
+    persist_every_blocks: NonZeroU32,
+) -> TestWallet {
+    let (_, general_pubkey) = keypair_from_seed(general_seed);
+    let (_, reserved_pubkey) = keypair_from_seed(reserved_seed);
+
+    let general_backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
+    let reserved_backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
+    let config = OperatorWalletConfig::new(SENTINEL_ANCHOR_VALUE, Network::Regtest)
+        .with_persist_every_blocks(persist_every_blocks);
+    let general = NativeGeneralWallet::load_or_create(
+        general_pubkey,
+        &config,
+        general_backend,
+        stores.general.clone(),
+        bootstrap_checkpoint,
+    )
+    .await
+    .expect("general wallet init");
+    let wallet = OperatorWallet::load_or_create(
+        general,
+        reserved_pubkey,
+        config,
+        reserved_backend,
+        stores.reserved.clone(),
+        bootstrap_checkpoint,
+        BTreeSet::new(),
+    )
+    .await
+    .expect("reserved wallet init");
+    wallet
+}
+
+/// Builds a fully-wired [`TestWallet`] against fresh in-memory stores. Funds the general wallet
+/// with `general_funding_utxos` UTXOs of `general_funding_value` each via bitcoind's own wallet,
+/// then syncs. The reserved wallet is created from a separate deterministic keypair and starts
+/// empty.
 async fn build_operator_wallet(
     bitcoind: &Node,
     general_seed: u8,
@@ -86,24 +155,20 @@ async fn build_operator_wallet(
     general_funding_utxos: usize,
     general_funding_value: Amount,
 ) -> (
-    OperatorWallet<NativeGeneralWallet>,
+    TestWallet,
     Keypair, // general keypair, used by the test to sign funded PSBTs
     XOnlyPublicKey,
 ) {
     let (general_kp, general_pubkey) = keypair_from_seed(general_seed);
-    let (_reserved_kp, reserved_pubkey) = keypair_from_seed(reserved_seed);
-
-    let general_backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
-    let reserved_backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind)));
-    let general = NativeGeneralWallet::new(general_pubkey, Network::Regtest, general_backend);
-    let config = OperatorWalletConfig::new(SENTINEL_ANCHOR_VALUE, Network::Regtest);
-    let mut wallet = OperatorWallet::new(
-        general,
-        reserved_pubkey,
-        config,
-        reserved_backend,
-        BTreeSet::new(),
-    );
+    let mut wallet = open_wallet(
+        bitcoind,
+        general_seed,
+        reserved_seed,
+        &Stores::default(),
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
 
     // Fund the general wallet's address from bitcoind's own wallet.
     let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
@@ -635,4 +700,431 @@ async fn refill_workflow_skips_existing_pool_members() {
         4,
         "pool should now contain the original 2 + the 2 we just added"
     );
+}
+
+// ── Persistence ────────────────────────────────────────────────────────────
+
+/// Every block height mentioned (added or removed) across `changesets`.
+fn chain_heights(changesets: &[ChangeSet]) -> BTreeSet<u32> {
+    changesets
+        .iter()
+        .flat_map(|cs| cs.local_chain.blocks.keys().copied())
+        .collect()
+}
+
+/// Merges `changesets` in order into one, the way a store's aggregate view would.
+fn merged(changesets: &[ChangeSet]) -> ChangeSet {
+    let mut out = ChangeSet::default();
+    for cs in changesets {
+        out.merge(cs.clone());
+    }
+    out
+}
+
+/// Heights whose value is `Some` in the aggregate, i.e. blocks a restart would load.
+fn live_heights(aggregate: &ChangeSet) -> BTreeMap<u32, BlockHash> {
+    aggregate
+        .local_chain
+        .blocks
+        .iter()
+        .filter_map(|(h, hash)| hash.map(|hash| (*h, hash)))
+        .collect()
+}
+
+fn mine(bitcoind: &Node, n: usize) {
+    let addr = bitcoind.client.new_address().expect("miner address");
+    bitcoind
+        .client
+        .generate_to_address(n, &addr)
+        .expect("mine blocks");
+}
+
+#[tokio::test]
+#[serial]
+async fn restart_loads_persisted_state_and_applies_only_the_chain_delta() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        21,
+        22,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    for store in [&stores.general, &stores.reserved] {
+        assert_eq!(
+            store.history().len(),
+            1,
+            "a fresh store gets exactly the create commit"
+        );
+    }
+
+    // Fund the general wallet so there is transaction-graph state to carry across the restart.
+    let (_, general_pubkey) = keypair_from_seed(21);
+    let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
+    bitcoind
+        .client
+        .send_to_address(&general_address, Amount::from_btc(0.5).unwrap())
+        .expect("fund general wallet");
+    mine(&bitcoind, 1);
+    wallet.sync().await.expect("initial sync");
+
+    let tip_before = wallet.local_chain_tip_height();
+    let utxos_before: BTreeSet<OutPoint> = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .map(|u| u.outpoint)
+        .collect();
+    assert_eq!(utxos_before.len(), 1, "general wallet sees its funding");
+    let general_history_len = stores.general.history().len();
+    let reserved_history_len = stores.reserved.history().len();
+    drop(wallet);
+
+    // The chain moves on while the node is "down".
+    mine(&bitcoind, 5);
+
+    let mut wallet = open_wallet(
+        &bitcoind,
+        21,
+        22,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    assert_eq!(
+        stores.general.history().len(),
+        general_history_len,
+        "loading writes nothing"
+    );
+    assert_eq!(stores.reserved.history().len(), reserved_history_len);
+    assert_eq!(
+        wallet.local_chain_tip_height(),
+        tip_before,
+        "loaded wallet resumes at the persisted tip before syncing"
+    );
+    let utxos_after_load: BTreeSet<OutPoint> = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .map(|u| u.outpoint)
+        .collect();
+    assert_eq!(
+        utxos_after_load, utxos_before,
+        "transaction-graph state survives the restart"
+    );
+
+    wallet.sync().await.expect("post-restart sync");
+    assert_eq!(wallet.local_chain_tip_height(), tip_before + 5);
+
+    // Only the five new blocks were applied after the restart: no persisted changeset touches a
+    // height at or below the old tip.
+    let expected: BTreeSet<u32> = (tip_before + 1..=tip_before + 5).collect();
+    let general_new = &stores.general.history()[general_history_len..];
+    let reserved_new = &stores.reserved.history()[reserved_history_len..];
+    assert_eq!(chain_heights(general_new), expected);
+    assert_eq!(chain_heights(reserved_new), expected);
+}
+
+#[tokio::test]
+#[serial]
+async fn sync_commits_in_batches_bounded_by_the_cadence() {
+    let bitcoind = setup_bitcoind(); // 101 blocks
+    let stores = Stores::default();
+    let cadence = NonZeroU32::new(25).unwrap();
+    let mut wallet = open_wallet(&bitcoind, 23, 24, &stores, None, cadence).await;
+    wallet.sync().await.expect("sync");
+    let tip = wallet.local_chain_tip_height();
+    assert_eq!(tip, 101);
+
+    for store in [&stores.general, &stores.reserved] {
+        let history = store.history();
+        // First entry is the create-time changeset (descriptor, network, genesis block).
+        assert!(history[0].descriptor.is_some());
+        assert_eq!(history[0].local_chain.blocks.len(), 1);
+        for cs in &history[1..] {
+            assert!(
+                cs.local_chain.blocks.len() <= cadence.get() as usize,
+                "a batch must never exceed the cadence: {} blocks",
+                cs.local_chain.blocks.len()
+            );
+        }
+        let min_batches = (tip / cadence) as usize;
+        assert!(
+            history.len() > min_batches,
+            "expected the create commit plus at least {min_batches} batch commits, got {}",
+            history.len()
+        );
+        let all: BTreeSet<u32> = (0..=tip).collect();
+        assert_eq!(
+            chain_heights(&history),
+            all,
+            "every height committed exactly once overall"
+        );
+        assert_eq!(live_heights(&store.aggregate()).len(), all.len());
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn failed_commit_aborts_the_attempt_and_the_retry_leaves_no_gaps() {
+    let bitcoind = setup_bitcoind(); // 101 blocks
+    let (_, pubkey) = keypair_from_seed(25);
+    let (desc, ..) = descriptor!(tr(pubkey)).expect("descriptor");
+    let mut store = MemoryStore::new();
+    let mut wallet = load_or_create(&mut store, desc, Network::Regtest, None)
+        .await
+        .expect("create");
+    assert_eq!(store.persist_calls(), 1, "create persists once");
+
+    let cadence = NonZeroU32::new(25).unwrap();
+    // Call 1 was the create; call 2 is the batch ending at height 25; call 3 (height 50) fails.
+    store.fail_on_persist_call(3);
+    let backend = Backend::BitcoinCore(Arc::new(sync_rpc_client(&bitcoind)));
+
+    backend
+        .sync_wallet(&mut wallet, &mut store, cadence)
+        .await
+        .expect_err("injected persist failure must abort the attempt");
+    assert_eq!(
+        wallet.latest_checkpoint().height(),
+        50,
+        "applied up to the failed batch"
+    );
+    assert!(wallet.staged().is_some(), "failed batch stays staged");
+    let persisted_tip = *live_heights(&store.aggregate()).keys().last().unwrap();
+    assert_eq!(persisted_tip, 25, "only the successful batch is durable");
+
+    backend
+        .sync_wallet(&mut wallet, &mut store, cadence)
+        .await
+        .expect("retry succeeds");
+    assert!(
+        wallet.staged().is_none(),
+        "everything drained after a clean attempt"
+    );
+    let live = live_heights(&store.aggregate());
+    let expected: BTreeSet<u32> = (0..=101).collect();
+    assert_eq!(
+        live.keys().copied().collect::<BTreeSet<_>>(),
+        expected,
+        "no gaps"
+    );
+    assert_eq!(wallet.latest_checkpoint().height(), 101);
+    for (height, hash) in &live {
+        assert_eq!(
+            wallet.latest_checkpoint().get(*height).map(|cp| cp.hash()),
+            Some(*hash),
+            "persisted hash matches the wallet's chain at {height}"
+        );
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn reorg_rolls_back_the_persisted_chain_and_reanchors_reserved_utxos() {
+    let bitcoind = setup_bitcoind(); // 101 blocks
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        27,
+        28,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    let rpc = sync_rpc_client(&bitcoind);
+
+    // Fund the reserved wallet directly and confirm it at height 102.
+    let value = Amount::from_btc(0.01).unwrap();
+    let reserved_addr = Address::from_script(&wallet.reserved_script_pubkey(), Network::Regtest)
+        .expect("reserved address");
+    bitcoind
+        .client
+        .send_to_address(&reserved_addr, value)
+        .expect("fund reserved");
+    mine(&bitcoind, 3); // heights 102, 103, 104
+    wallet.sync().await.expect("sync");
+    assert_eq!(wallet.local_chain_tip_height(), 104);
+    let pool = wallet.reserved_utxos_with_value(value);
+    assert_eq!(pool.len(), 1);
+    assert_eq!(pool[0].confirmations, 3, "confirmed at 102, tip 104");
+    let reserved_history_len = stores.reserved.history().len();
+
+    // Reorg out 102..=104 and mine a single replacement block at 102. The funding tx returns to
+    // the mempool and is re-mined into the replacement block.
+    let old_102 = rpc.get_block_hash(102).expect("hash 102");
+    rpc.invalidate_block(&old_102).expect("invalidate");
+    mine(&bitcoind, 1);
+    let new_102 = rpc.get_block_hash(102).expect("new hash 102");
+    assert_ne!(new_102, old_102);
+
+    wallet.sync().await.expect("sync after reorg");
+    assert_eq!(wallet.local_chain_tip_height(), 102);
+    assert_eq!(wallet.reserved_tip_hash(), new_102);
+    let pool = wallet.reserved_utxos_with_value(value);
+    assert_eq!(pool.len(), 1, "the UTXO is still ours");
+    assert_eq!(
+        pool[0].confirmations, 1,
+        "re-anchored in the replacement block"
+    );
+
+    // The persisted rollback: 102 replaced, 103 and 104 removed.
+    let after = merged(&stores.reserved.history()[reserved_history_len..]);
+    assert_eq!(after.local_chain.blocks.get(&102), Some(&Some(new_102)));
+    assert_eq!(after.local_chain.blocks.get(&103), Some(&None));
+    assert_eq!(after.local_chain.blocks.get(&104), Some(&None));
+
+    // A restart from the stores lands on the new branch.
+    drop(wallet);
+    let wallet = open_wallet(
+        &bitcoind,
+        27,
+        28,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    assert_eq!(wallet.local_chain_tip_height(), 102);
+    assert_eq!(wallet.reserved_tip_hash(), new_102);
+    assert_eq!(wallet.reserved_utxos_with_value(value).len(), 1);
+}
+
+#[tokio::test]
+#[serial]
+async fn bootstrap_checkpoint_skips_history_below_it() {
+    let bitcoind = setup_bitcoind(); // 101 blocks
+    let rpc = sync_rpc_client(&bitcoind);
+    let checkpoint = BlockId {
+        height: 90,
+        hash: rpc.get_block_hash(90).expect("hash 90"),
+    };
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        29,
+        30,
+        &stores,
+        Some(checkpoint),
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    assert_eq!(
+        wallet.local_chain_tip_height(),
+        90,
+        "fresh wallet starts at the checkpoint"
+    );
+    // Create-time commits: descriptor/network/genesis, then the checkpoint.
+    let created = stores.reserved.history();
+    assert_eq!(created.len(), 2);
+    assert_eq!(chain_heights(&created), BTreeSet::from([0, 90]));
+
+    wallet.sync().await.expect("sync");
+    assert_eq!(wallet.local_chain_tip_height(), 101);
+    let synced = &stores.reserved.history()[2..];
+    let expected: BTreeSet<u32> = (91..=101).collect();
+    assert_eq!(
+        chain_heights(synced),
+        expected,
+        "only blocks above the checkpoint are fetched and committed"
+    );
+    let live = live_heights(&stores.reserved.aggregate());
+    assert!(
+        (1..90).all(|h| !live.contains_key(&h)),
+        "history below the checkpoint is never persisted"
+    );
+}
+
+/// Opens (loads or creates) a [`SqliteWallet`] whose two stores live in `data_dir`.
+async fn open_sqlite_wallet(
+    bitcoind: &Node,
+    general_seed: u8,
+    reserved_seed: u8,
+    data_dir: &Path,
+) -> SqliteWallet {
+    let (_, general_pubkey) = keypair_from_seed(general_seed);
+    let (_, reserved_pubkey) = keypair_from_seed(reserved_seed);
+    let general_store =
+        SqliteStore::open_in_dir(data_dir, WalletKind::General).expect("open general");
+    let reserved_store =
+        SqliteStore::open_in_dir(data_dir, WalletKind::Reserved).expect("open reserved");
+    let config = OperatorWalletConfig::new(SENTINEL_ANCHOR_VALUE, Network::Regtest);
+    let general = NativeGeneralWallet::load_or_create(
+        general_pubkey,
+        &config,
+        Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind))),
+        general_store,
+        None,
+    )
+    .await
+    .expect("general wallet init");
+    let wallet = OperatorWallet::load_or_create(
+        general,
+        reserved_pubkey,
+        config,
+        Backend::BitcoinCore(Arc::new(sync_rpc_client(bitcoind))),
+        reserved_store,
+        None,
+        BTreeSet::new(),
+    )
+    .await
+    .expect("reserved wallet init");
+    wallet
+}
+
+#[tokio::test]
+#[serial]
+async fn sqlite_store_survives_a_restart_and_resumes_at_the_persisted_tip() {
+    let bitcoind = setup_bitcoind();
+    let data_dir = tempfile::tempdir().expect("temp dir");
+    let mut wallet = open_sqlite_wallet(&bitcoind, 31, 32, data_dir.path()).await;
+    assert!(WalletKind::General.path_in(data_dir.path()).exists());
+    assert!(WalletKind::Reserved.path_in(data_dir.path()).exists());
+
+    let (_, general_pubkey) = keypair_from_seed(31);
+    let general_address = Address::p2tr(&Secp256k1::new(), general_pubkey, None, Network::Regtest);
+    bitcoind
+        .client
+        .send_to_address(&general_address, Amount::from_btc(0.5).unwrap())
+        .expect("fund general wallet");
+    mine(&bitcoind, 1);
+    wallet.sync().await.expect("initial sync");
+    let tip_before = wallet.local_chain_tip_height();
+    let utxos_before: BTreeSet<OutPoint> = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .map(|u| u.outpoint)
+        .collect();
+    assert_eq!(utxos_before.len(), 1);
+    drop(wallet); // closes both SQLite connections, as a process exit would
+
+    mine(&bitcoind, 5);
+
+    let mut wallet = open_sqlite_wallet(&bitcoind, 31, 32, data_dir.path()).await;
+    // Reopening a populated store can only succeed by loading: the create path would fail with
+    // `DataAlreadyExists`. The tip proves which state was loaded.
+    assert_eq!(
+        wallet.local_chain_tip_height(),
+        tip_before,
+        "resumes at persisted tip"
+    );
+    let utxos_after_load: BTreeSet<OutPoint> = wallet
+        .general()
+        .list_utxos()
+        .into_iter()
+        .map(|u| u.outpoint)
+        .collect();
+    assert_eq!(
+        utxos_after_load, utxos_before,
+        "graph state reloaded from SQLite"
+    );
+
+    wallet.sync().await.expect("post-restart sync");
+    assert_eq!(wallet.local_chain_tip_height(), tip_before + 5);
 }

--- a/crates/operator-wallet/tests/operator_wallet_e2e.rs
+++ b/crates/operator-wallet/tests/operator_wallet_e2e.rs
@@ -29,13 +29,13 @@
 //! the empty-merkle-root tap-tweak).
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     num::NonZeroU32,
     path::Path,
     sync::Arc,
 };
 
-use bdk_bitcoind_rpc::bitcoincore_rpc::RpcApi;
+use bdk_bitcoind_rpc::bitcoincore_rpc::{json::CreateRawTransactionInput, RpcApi};
 use bdk_wallet::{
     bitcoin::{
         hashes::Hash,
@@ -43,7 +43,7 @@ use bdk_wallet::{
         secp256k1::{Message, SecretKey},
         sighash::{Prevouts, SighashCache},
         taproot, Address, Amount, BlockHash, FeeRate, Network, OutPoint, Psbt, TapSighashType,
-        Transaction, Witness, XOnlyPublicKey,
+        Transaction, Txid, Witness, XOnlyPublicKey,
     },
     chain::{BlockId, Merge},
     descriptor, ChangeSet,
@@ -51,8 +51,8 @@ use bdk_wallet::{
 use corepc_node::{Conf, Node};
 use operator_wallet::{
     load_or_create, sync::Backend, test_utils::MemoryStore, Error as OperatorWalletError,
-    GeneralUtxoPolicy, GeneralWallet, NativeGeneralWallet, OperatorWallet, OperatorWalletConfig,
-    SqliteStore, WalletKind, DEFAULT_PERSIST_EVERY_BLOCKS,
+    GeneralUtxoPolicy, GeneralWallet, InitError, NativeGeneralWallet, OperatorWallet,
+    OperatorWalletConfig, SqliteStore, WalletKind, DEFAULT_PERSIST_EVERY_BLOCKS,
 };
 use serial_test::serial;
 
@@ -78,7 +78,9 @@ const SENTINEL_ANCHOR_VALUE: Amount = Amount::from_sat(330);
 
 /// Boots a fresh regtest `bitcoind`, mines coinbase maturity, and returns the node.
 fn setup_bitcoind() -> Node {
-    let bitcoind = Node::with_conf("bitcoind", &Conf::default()).expect("bitcoind must start");
+    let mut conf = Conf::default();
+    conf.args.push("-txindex=1");
+    let bitcoind = Node::with_conf("bitcoind", &conf).expect("bitcoind must start");
     let mining_address = bitcoind.client.new_address().expect("mining address");
     bitcoind
         .client
@@ -993,6 +995,371 @@ async fn reorg_rolls_back_the_persisted_chain_and_reanchors_reserved_utxos() {
     assert_eq!(wallet.local_chain_tip_height(), 102);
     assert_eq!(wallet.reserved_tip_hash(), new_102);
     assert_eq!(wallet.reserved_utxos_with_value(value).len(), 1);
+}
+
+#[tokio::test]
+#[serial]
+async fn an_unconfirmed_payment_is_not_spendable_after_a_restart() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        33,
+        34,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    wallet.sync().await.expect("initial sync");
+
+    // A payment to the reserved script that later leaves the mempool cannot be evicted from the
+    // wallet with this BDK version, so its mempool timestamp is kept in memory only.
+    let value = Amount::from_btc(0.01).unwrap();
+    let reserved_addr = Address::from_script(&wallet.reserved_script_pubkey(), Network::Regtest)
+        .expect("reserved address");
+    bitcoind
+        .client
+        .send_to_address(&reserved_addr, value)
+        .expect("send to reserved script");
+    wallet
+        .sync()
+        .await
+        .expect("sync with the payment in the mempool");
+
+    let pool = wallet.reserved_utxos_with_value(value);
+    assert_eq!(pool.len(), 1, "unconfirmed payment visible in memory");
+    assert_eq!(pool[0].confirmations, 0);
+    let txid = pool[0].outpoint.txid;
+
+    // Nothing about it reaches the store, so repeated payments that never confirm cannot grow it.
+    let aggregate = stores.reserved.aggregate();
+    assert!(
+        !aggregate
+            .tx_graph
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == txid),
+        "an unconfirmed transaction must not be persisted"
+    );
+    assert!(
+        aggregate.tx_graph.last_seen.is_empty(),
+        "mempool timestamps must not be persisted"
+    );
+
+    // So a restart cannot hand the payment out as a pool member.
+    drop(wallet);
+    let wallet = open_wallet(
+        &bitcoind,
+        33,
+        34,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    assert!(
+        wallet.reserved_utxos_with_value(value).is_empty(),
+        "an unconfirmed payment must not be spendable after a restart"
+    );
+    assert!(
+        stores.reserved.aggregate().tx_graph.txs.is_empty(),
+        "the store holds no unanchored transactions"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn a_payment_seen_in_the_mempool_survives_confirmation_and_restart() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        35,
+        36,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    wallet.sync().await.expect("initial sync");
+
+    let value = Amount::from_btc(0.02).unwrap();
+    let reserved_addr = Address::from_script(&wallet.reserved_script_pubkey(), Network::Regtest)
+        .expect("reserved address");
+    bitcoind
+        .client
+        .send_to_address(&reserved_addr, value)
+        .expect("send to reserved script");
+
+    // Seen unconfirmed first, then confirmed: applying the block stages only the anchor, because
+    // the transaction is already in the wallet's graph.
+    wallet
+        .sync()
+        .await
+        .expect("sync with the payment in the mempool");
+    mine(&bitcoind, 1);
+    wallet
+        .sync()
+        .await
+        .expect("sync with the payment confirmed");
+    let pool = wallet.reserved_utxos_with_value(value);
+    assert_eq!(pool.len(), 1);
+    assert_eq!(pool[0].confirmations, 1);
+
+    drop(wallet);
+    let wallet = open_wallet(
+        &bitcoind,
+        35,
+        36,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    let pool = wallet.reserved_utxos_with_value(value);
+    assert_eq!(
+        pool.len(),
+        1,
+        "a confirmed payment first seen in the mempool must survive a restart"
+    );
+    assert!(pool[0].confirmations >= 1);
+}
+
+/// Spends `txid`'s first input again, paying the node's own wallet a much higher fee, so `txid` is
+/// replaced and leaves the mempool. `txid` must not be confirmed.
+fn replace(bitcoind: &Node, rpc: &bdk_bitcoind_rpc::bitcoincore_rpc::Client, txid: Txid) {
+    let input = rpc
+        .get_raw_transaction_info(&txid, None)
+        .expect("tx info")
+        .vin[0]
+        .clone();
+    let spent = OutPoint {
+        txid: input.txid.expect("input txid"),
+        vout: input.vout.expect("input vout"),
+    };
+    let value = rpc
+        .get_raw_transaction_info(&spent.txid, None)
+        .expect("input tx info")
+        .vout[spent.vout as usize]
+        .value;
+    let sink = bitcoind.client.new_address().expect("sink address");
+    let outputs = HashMap::from([(
+        sink.to_string(),
+        value - Amount::from_btc(0.001).expect("fee"),
+    )]);
+    let conflicting = rpc
+        .create_raw_transaction(
+            &[CreateRawTransactionInput {
+                txid: spent.txid,
+                vout: spent.vout,
+                sequence: None,
+            }],
+            &outputs,
+            None,
+            None,
+        )
+        .expect("build conflicting tx");
+    let signed = rpc
+        .sign_raw_transaction_with_wallet(&conflicting, None, None)
+        .expect("sign")
+        .transaction()
+        .expect("signed tx");
+    rpc.send_raw_transaction(&signed).expect("replace");
+}
+
+#[tokio::test]
+#[serial]
+async fn a_reorged_out_payment_stops_being_spendable() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        37,
+        38,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    let rpc = sync_rpc_client(&bitcoind);
+    wallet.sync().await.expect("initial sync");
+
+    // Confirm a payment to the reserved script.
+    let value = Amount::from_btc(0.03).unwrap();
+    let reserved_addr = Address::from_script(&wallet.reserved_script_pubkey(), Network::Regtest)
+        .expect("reserved address");
+    bitcoind
+        .client
+        .send_to_address(&reserved_addr, value)
+        .expect("send to reserved script");
+    mine(&bitcoind, 1);
+    wallet
+        .sync()
+        .await
+        .expect("sync with the payment confirmed");
+    let pool = wallet.reserved_utxos_with_value(value);
+    assert_eq!(pool.len(), 1, "payment confirmed and visible");
+
+    // Take the block back out and double-spend the payment's input, so it ends up neither in the
+    // chain nor in the mempool.
+    let height = rpc.get_block_count().expect("block count");
+    rpc.invalidate_block(&rpc.get_block_hash(height).expect("block hash"))
+        .expect("invalidate");
+    replace(&bitcoind, &rpc, pool[0].outpoint.txid);
+    mine(&bitcoind, 2);
+
+    wallet.sync().await.expect("sync after the reorg");
+    assert!(
+        wallet.reserved_utxos_with_value(value).is_empty(),
+        "a reorged-out payment must not stay spendable"
+    );
+
+    drop(wallet);
+    let wallet = open_wallet(
+        &bitcoind,
+        37,
+        38,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    assert!(
+        wallet.reserved_utxos_with_value(value).is_empty(),
+        "and must not come back after a restart"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn a_store_ahead_of_the_node_is_refused() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        39,
+        40,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    wallet.sync().await.expect("sync");
+    let tip = wallet.local_chain_tip_height();
+    assert!(tip > 0);
+    drop(wallet);
+
+    // Roll the node back below the persisted tip, as restoring an older data directory would.
+    let rpc = sync_rpc_client(&bitcoind);
+    rpc.invalidate_block(&rpc.get_block_hash(u64::from(tip) - 2).expect("block hash"))
+        .expect("invalidate");
+    assert!(rpc.get_block_count().expect("count") < u64::from(tip));
+
+    let (_, general_pubkey) = keypair_from_seed(39);
+    let err = NativeGeneralWallet::load_or_create(
+        general_pubkey,
+        &OperatorWalletConfig::new(SENTINEL_ANCHOR_VALUE, Network::Regtest),
+        Backend::BitcoinCore(Arc::new(sync_rpc_client(&bitcoind))),
+        stores.general.clone(),
+        None,
+    )
+    .await
+    .expect_err("a store ahead of the node must be refused");
+    assert!(
+        matches!(err, InitError::BackendBehindTip { tip: stored, .. } if stored == tip),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn a_lease_survives_its_funding_leaving_the_mempool() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        43,
+        44,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    let rpc = sync_rpc_client(&bitcoind);
+    wallet.sync().await.expect("initial sync");
+
+    // An unconfirmed payment to the reserved script, leased as the claim-funding path would.
+    let value = Amount::from_btc(0.04).unwrap();
+    let reserved_addr = Address::from_script(&wallet.reserved_script_pubkey(), Network::Regtest)
+        .expect("reserved address");
+    bitcoind
+        .client
+        .send_to_address(&reserved_addr, value)
+        .expect("send to reserved script");
+    wallet.sync().await.expect("sync with the payment pending");
+    let leased = wallet
+        .reserve_utxo_with_value(value, |_| false)
+        .0
+        .expect("an unconfirmed pool member is reservable");
+    assert!(wallet.leased_outpoints().contains(&leased));
+
+    // The payment leaves the mempool, so it is no longer spendable, but nothing has spent it.
+    replace(&bitcoind, &rpc, leased.txid);
+    wallet.sync().await.expect("sync with the payment gone");
+    assert!(
+        wallet.reserved_utxos_with_value(value).is_empty(),
+        "gone from the mempool, so not offered for spending"
+    );
+    assert!(
+        wallet.leased_outpoints().contains(&leased),
+        "but the lease must hold: another graph must not be handed the same outpoint"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn a_reorg_across_a_restart_reconciles() {
+    let bitcoind = setup_bitcoind();
+    let stores = Stores::default();
+    let mut wallet = open_wallet(
+        &bitcoind,
+        41,
+        42,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    wallet.sync().await.expect("sync");
+    let tip = wallet.local_chain_tip_height();
+    let tip_hash = wallet.reserved_tip_hash();
+    drop(wallet);
+
+    // While stopped, the stored tip is reorged away and the node builds past it.
+    let rpc = sync_rpc_client(&bitcoind);
+    rpc.invalidate_block(&rpc.get_block_hash(u64::from(tip)).expect("block hash"))
+        .expect("invalidate");
+    mine(&bitcoind, 2);
+    assert_ne!(
+        rpc.get_block_hash(u64::from(tip)).expect("new hash"),
+        tip_hash,
+        "the stored tip's block is gone"
+    );
+
+    // The node is no shorter than the store, so the emitter can reconcile and startup proceeds.
+    let mut wallet = open_wallet(
+        &bitcoind,
+        41,
+        42,
+        &stores,
+        None,
+        DEFAULT_PERSIST_EVERY_BLOCKS,
+    )
+    .await;
+    wallet.sync().await.expect("sync after the reorg");
+    assert_eq!(wallet.local_chain_tip_height(), tip + 1);
+    assert_ne!(wallet.reserved_tip_hash(), tip_hash);
 }
 
 #[tokio::test]

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -17,9 +17,9 @@ strata-bridge-primitives.workspace = true
 strata-bridge-sm.workspace = true
 strata-bridge-tx-graph.workspace = true
 
+strata-asm-bridge-types.workspace = true
 strata-asm-proto-bridge.workspace = true
 strata-asm-proto-bridge-txs.workspace = true
-strata-asm-bridge-types.workspace = true
 strata-l1-txfmt.workspace = true
 strata-mosaic-client-api.workspace = true
 strata-p2p.workspace = true

--- a/docker/README.md
+++ b/docker/README.md
@@ -103,6 +103,22 @@ just docker
 
 to rebuild and restart the stack without deleting persisted state.
 
+### Wallet State
+
+Each bridge node persists its two BDK wallets as SQLite files under `operator_wallet.data_dir`,
+`/app/data/wallet` in the checked-in configs, which is `docker/vol/strata-bridge-{1,2,3}/data/wallet/`
+on the host. The directory is gitignored, survives `just docker`, and is removed by `just clean-docker`.
+
+A node that cannot open a store (damaged file, or one written for another network or key) stops
+at startup naming the file. To rebuild, move the stores aside and restart:
+
+```sh
+docker compose stop bridge-1
+mkdir -p docker/vol/strata-bridge-1/data/wallet/retired
+mv docker/vol/strata-bridge-1/data/wallet/*.sqlite* docker/vol/strata-bridge-1/data/wallet/retired/
+docker compose up -d bridge-1
+```
+
 ### FoundationDB
 
 The bridge nodes use FoundationDB for persistent storage. The Docker workflow automatically:

--- a/docker/vol/strata-bridge-1/config.toml
+++ b/docker/vol/strata-bridge-1/config.toml
@@ -56,6 +56,7 @@ sequence_connection_string = "tcp://host.docker.internal:28336"
 
 [operator_wallet]
 claim_funding_pool_size = 32
+data_dir = "/app/data/wallet"
 
 [mosaic]
 rpc_url = "http://mosaic-1:8000"

--- a/docker/vol/strata-bridge-2/config.toml
+++ b/docker/vol/strata-bridge-2/config.toml
@@ -56,6 +56,7 @@ sequence_connection_string = "tcp://host.docker.internal:28336"
 
 [operator_wallet]
 claim_funding_pool_size = 32
+data_dir = "/app/data/wallet"
 
 [mosaic]
 rpc_url = "http://mosaic-2:8000"

--- a/docker/vol/strata-bridge-3/config.toml
+++ b/docker/vol/strata-bridge-3/config.toml
@@ -56,6 +56,7 @@ sequence_connection_string = "tcp://host.docker.internal:28336"
 
 [operator_wallet]
 claim_funding_pool_size = 32
+data_dir = "/app/data/wallet"
 
 [mosaic]
 rpc_url = "http://mosaic-3:8000"

--- a/functional-tests/factory/bridge_operator/__init__.py
+++ b/functional-tests/factory/bridge_operator/__init__.py
@@ -149,6 +149,8 @@ class BridgeOperatorFactory(flexitest.Factory):
         props = {
             "rpc_port": rpc_port,
             "logfile": logfile_path,
+            "config_path": config_toml_path,
+            "wallet_data_dir": str((Path(config_toml_path).parent / "wallet").resolve()),
             "reserved_wallet_address": current_operator_key.RESERVED_WALLET,
             "general_wallet_address": current_operator_key.GENERAL_WALLET,
         }

--- a/functional-tests/factory/bridge_operator/config_cfg.py
+++ b/functional-tests/factory/bridge_operator/config_cfg.py
@@ -83,6 +83,8 @@ class AsmRpcConfig:
 @dataclass
 class OperatorWalletConfig:
     claim_funding_pool_size: int
+    data_dir: str
+    persist_every_blocks: int | None = None
 
 
 @dataclass

--- a/functional-tests/factory/bridge_operator/utils.py
+++ b/functional-tests/factory/bridge_operator/utils.py
@@ -53,8 +53,13 @@ def generate_config_toml(
     mosaic_rpc: str,
     heartbeat_delay_factor: int = 1,  # no delay by default
     metrics_listener_addr: str | None = None,
+    wallet_data_dir: str | None = None,
 ):
     mtls_dir = Path(tls_dir)
+    # Wallet chain state persists next to the node's config by default, so a restarted node in a
+    # test resumes from where it stopped exactly as a deployed node would.
+    if wallet_data_dir is None:
+        wallet_data_dir = str((Path(output_path).parent / "wallet").resolve())
     total_peers = len(other_p2p_addrs) + 1  # +1 for self
 
     # Read connection details from props; defaults preserve the spawn-path behavior.
@@ -141,7 +146,7 @@ def generate_config_toml(
                 bitcoind_props["zmq_sequence"], zmq_host
             ),
         ),
-        operator_wallet=OperatorWalletConfig(claim_funding_pool_size=32),
+        operator_wallet=OperatorWalletConfig(claim_funding_pool_size=32, data_dir=wallet_data_dir),
         mosaic=MosaicConfig(
             rpc_url=mosaic_rpc,
             peer_ids=mosaic_peers,

--- a/functional-tests/tests/wallet/fn_wallet_store_recovery_test.py
+++ b/functional-tests/tests/wallet/fn_wallet_store_recovery_test.py
@@ -1,0 +1,122 @@
+"""
+Wallet Persistence: Store Recovery Test
+
+Verifies the failure and rebuild paths of the persisted wallet stores. Evidence is read from
+the SQLite store files themselves, not from the node's logs.
+
+Test flow:
+1. Bring up the network and wait for staking, so every operator has populated stores.
+2. Stop operator-0 and overwrite its reserved store with garbage. Start it: the node must exit
+   non-zero and the file must be left byte-for-byte intact.
+3. Move both store files aside, as the documented rebuild procedure says. Start the node: fresh
+   stores for the same descriptors must appear and sync to the chain.
+4. Replace operator-0's reserved store with operator-1's, a store for the same network but
+   another key. Start operator-0: it must exit non-zero and leave the file untouched. Restore
+   operator-0's own file and confirm the node runs on it again.
+"""
+
+import shutil
+
+import flexitest
+
+from envs import BridgeNetworkEnv
+from envs.base_test import StrataTestBase
+from utils.bridge import get_bridge_nodes_and_rpcs
+from utils.utils import wait_until_bridge_ready
+from utils.wallet_store import (
+    GENERAL_STORE,
+    RESERVED_STORE,
+    read_store,
+    store_path,
+    wait_until_exited,
+    wait_until_store_synced,
+)
+
+GARBAGE = b"this is not a sqlite database; padded well past the header\n" * 64
+
+
+@flexitest.register
+class WalletStoreRecoveryTest(StrataTestBase):
+    """Damaged or foreign wallet stores fail closed; moving them aside rebuilds."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(BridgeNetworkEnv())
+
+    def main(self, ctx: flexitest.RunContext):
+        bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        node0, rpc0 = bridge_nodes[0], bridge_rpcs[0]
+        node1, rpc1 = bridge_nodes[1], bridge_rpcs[1]
+        bitcoin_rpc = ctx.get_service("bitcoin").create_rpc()
+        general0 = store_path(node0, GENERAL_STORE)
+        reserved0 = store_path(node0, RESERVED_STORE)
+        own_general = read_store(general0)
+        own_reserved = read_store(reserved0)
+
+        # --- 1. Damaged reserved store: refused, file untouched ---
+        self.logger.info("stopping operator-0 and corrupting its reserved wallet store")
+        node0.stop()
+        reserved0.write_bytes(GARBAGE)
+        self._start_and_expect_crash(node0)
+        assert reserved0.read_bytes() == GARBAGE, "a failed start must not modify the store"
+        assert read_store(general0) == own_general, "the general store must be left as it was"
+        self.logger.info("corrupt store rejected; file left intact")
+
+        # --- 2. Operator moves both stores aside; next start rebuilds both wallets ---
+        retired_dir = reserved0.parent / "retired"
+        retired_dir.mkdir()
+        for store in (general0, reserved0):
+            shutil.move(store, retired_dir / store.name)
+        assert (retired_dir / RESERVED_STORE).read_bytes() == GARBAGE, (
+            "moving the store aside must keep the damaged bytes for diagnosis"
+        )
+
+        self._start_and_expect_synced(node0, rpc0, bitcoin_rpc, [general0, reserved0])
+        for path, own in ((general0, own_general), (reserved0, own_reserved)):
+            fresh = read_store(path)
+            assert fresh.descriptor == own.descriptor and fresh.network == own.network, (
+                f"{path.name} was rebuilt for a different wallet: {fresh}"
+            )
+        self.logger.info("stores moved aside; node rebuilt both wallets on fresh files")
+
+        # --- 3. Another operator's store is rejected ---
+        self.logger.info("swapping operator-1's reserved store into operator-0")
+        node0.stop()
+        node1.stop()  # clean close checkpoints the WAL so the main file is self-contained
+        own_backup = reserved0.with_name(RESERVED_STORE + ".own")
+        shutil.move(reserved0, own_backup)
+        shutil.copyfile(store_path(node1, RESERVED_STORE), reserved0)
+        foreign = read_store(reserved0)
+        assert foreign.network == own_reserved.network, "same network, so only the key differs"
+        assert foreign.descriptor != own_reserved.descriptor, "operator-1's store must differ"
+        node1.start()
+        wait_until_bridge_ready(rpc1)
+
+        self._start_and_expect_crash(node0)
+        assert read_store(reserved0) == foreign, "a refused foreign store must be left untouched"
+        self.logger.info("foreign reserved store rejected")
+
+        # Restore the operator's own file: the node runs on it again.
+        shutil.move(own_backup, reserved0)
+        self._start_and_expect_synced(node0, rpc0, bitcoin_rpc, [general0, reserved0])
+        assert read_store(reserved0).descriptor == own_reserved.descriptor
+
+        self.logger.info(
+            "STORE RECOVERY VERIFIED: damaged and foreign stores fail closed with the file "
+            "preserved, and moving the stores aside rebuilds both wallets"
+        )
+        return True
+
+    def _start_and_expect_crash(self, node):
+        """Start `node` and wait for it to exit on its own with a non-zero code."""
+        node.start()
+        rc = wait_until_exited(node)
+        node.stop()  # record the exit and clear the handle so the node can be started again
+        assert rc != 0, f"node should have refused to start (exit code {rc})"
+
+    def _start_and_expect_synced(self, node, rpc, bitcoin_rpc, stores):
+        """Start `node`, wait for readiness, and for every store to catch up to the chain."""
+        target = bitcoin_rpc.proxy.getblockcount()
+        node.start()
+        wait_until_bridge_ready(rpc)
+        for path in stores:
+            wait_until_store_synced(path, target)

--- a/functional-tests/tests/wallet/fn_wallet_warm_restart_test.py
+++ b/functional-tests/tests/wallet/fn_wallet_warm_restart_test.py
@@ -1,0 +1,95 @@
+"""
+Wallet Persistence: Warm Restart Test
+
+Verifies that a bridge node's two BDK wallets (general and reserved) persist their chain state
+and resume from it across restarts. Evidence is read from the SQLite store files themselves,
+not from the node's logs.
+
+Test flow:
+1. Bring up the network and wait for staking, which syncs and funds both wallets. Both store
+   files must hold a regtest wallet with a tip above genesis.
+2. Restart operator-0 gracefully (SIGTERM). The committed tip must survive the stop, the node
+   must come back on the same files, and both stores must catch up to the chain.
+3. Repeat with a forced termination (SIGKILL), which exercises SQLite WAL recovery.
+
+A populated store can only be loaded: BDK refuses to create a wallet over existing data. So a
+node that reaches ready on the same files, with the tip never regressing, resumed from them.
+"""
+
+import flexitest
+
+from envs import BridgeNetworkEnv
+from envs.base_test import StrataTestBase
+from utils.bridge import get_bridge_nodes_and_rpcs
+from utils.utils import wait_until_bridge_ready
+from utils.wallet_store import (
+    GENERAL_STORE,
+    RESERVED_STORE,
+    read_store,
+    store_path,
+    wait_until_store_synced,
+)
+
+
+@flexitest.register
+class WalletWarmRestartTest(StrataTestBase):
+    """Both wallets resume from their persisted tip after graceful and forced restarts."""
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(BridgeNetworkEnv())
+
+    def main(self, ctx: flexitest.RunContext):
+        bridge_nodes, bridge_rpcs = get_bridge_nodes_and_rpcs(ctx)
+        node, rpc = bridge_nodes[0], bridge_rpcs[0]
+        bitcoin_rpc = ctx.get_service("bitcoin").create_rpc()
+        stores = [store_path(node, GENERAL_STORE), store_path(node, RESERVED_STORE)]
+
+        # --- First start populated both stores for this network ---
+        initial = [read_store(path) for path in stores]
+        for path, state in zip(stores, initial, strict=True):
+            assert state.network == "regtest", f"{path.name} is for {state.network}"
+            assert state.tip_height > 0, f"{path.name} never synced past genesis"
+        inodes = [path.stat().st_ino for path in stores]
+        self.logger.info(f"stores populated; tips {[s.tip_height for s in initial]}")
+
+        self._restart_and_verify(node, rpc, bitcoin_rpc, stores, inodes, initial, forced=False)
+        self._restart_and_verify(node, rpc, bitcoin_rpc, stores, inodes, initial, forced=True)
+
+        self.logger.info(
+            "WARM RESTART VERIFIED: both wallets kept their committed state across a graceful "
+            "and a forced restart and resumed on the same store files"
+        )
+        return True
+
+    def _restart_and_verify(self, node, rpc, bitcoin_rpc, stores, inodes, initial, forced: bool):
+        how = "SIGKILL" if forced else "SIGTERM"
+        committed = [read_store(path).tip_height for path in stores]
+        self.logger.info(f"restarting operator-0 via {how}; committed tips {committed}")
+
+        if forced:
+            node.proc.kill()
+            node.proc.wait(timeout=30)
+        node.stop()
+
+        # Nothing committed is lost at shutdown, graceful or not. SQLite recovers any WAL frames
+        # a killed process left behind when the file is next opened.
+        after_stop = [read_store(path).tip_height for path in stores]
+        for path, before, after in zip(stores, committed, after_stop, strict=True):
+            assert after >= before, f"{path.name} lost commits on {how}: {before} -> {after}"
+
+        target = bitcoin_rpc.proxy.getblockcount()
+        node.start()
+        wait_until_bridge_ready(rpc)
+        for path in stores:
+            wait_until_store_synced(path, target)
+
+        # Same files, same wallets, tip monotonic: the node resumed from the persisted state.
+        assert [path.stat().st_ino for path in stores] == inodes, "store files were replaced"
+        for path, state, before in zip(stores, initial, after_stop, strict=True):
+            now = read_store(path)
+            assert now.descriptor == state.descriptor, f"{path.name} descriptor changed"
+            assert now.tip_height >= before, f"{path.name} regressed below {before}"
+        self.logger.info(
+            f"{how} restart: stores intact and synced to at least {target}; "
+            f"tips {[read_store(p).tip_height for p in stores]}"
+        )

--- a/functional-tests/utils/wallet_store.py
+++ b/functional-tests/utils/wallet_store.py
@@ -1,0 +1,74 @@
+"""Helpers for the persisted operator-wallet stores under a bridge node's wallet data dir.
+
+The bridge node keeps one SQLite file per wallet (general, reserved) under
+`operator_wallet.data_dir`. The operator factory places that directory at
+`<service dir>/wallet` and exposes it as `props["wallet_data_dir"]`. Tests read the files
+directly with `sqlite3`; BDK's schema is stable (`bdk_blocks`, `bdk_wallet`) and SQLite's WAL
+mode allows a concurrent reader while the node runs.
+"""
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from utils.utils import wait_until
+
+GENERAL_STORE = "general-wallet.sqlite"
+RESERVED_STORE = "reserved-wallet.sqlite"
+
+
+@dataclass(frozen=True)
+class StoreState:
+    """What a wallet store says about itself, read straight from the file."""
+
+    tip_height: int
+    network: str
+    descriptor: str
+
+
+def wallet_data_dir(node) -> Path:
+    return Path(node.props["wallet_data_dir"])
+
+
+def store_path(node, store_file: str) -> Path:
+    return wallet_data_dir(node) / store_file
+
+
+def read_store(path: Path) -> StoreState:
+    """Read the persisted tip, network, and descriptor from a BDK SQLite store.
+
+    Raises if the file is missing rather than letting sqlite3 create an empty one.
+    """
+    if not path.exists():
+        raise FileNotFoundError(path)
+    con = sqlite3.connect(str(path), timeout=5)
+    try:
+        (tip,) = con.execute("SELECT MAX(block_height) FROM bdk_blocks").fetchone()
+        network, descriptor = con.execute("SELECT network, descriptor FROM bdk_wallet").fetchone()
+    finally:
+        con.close()
+    return StoreState(tip_height=tip, network=network, descriptor=descriptor)
+
+
+def wait_until_store_synced(path: Path, height: int, timeout: int = 180):
+    """Wait until the store on disk has committed a tip at or above `height`."""
+    wait_until(
+        lambda: read_store(path).tip_height >= height,
+        timeout=timeout,
+        error_msg=f"{path.name} did not reach height {height}",
+    )
+
+
+def wait_until_exited(node, timeout: int = 120) -> int:
+    """Wait for a started service process to exit on its own and return its exit code.
+
+    Call `node.stop()` afterwards so flexitest records the exit and clears the process handle.
+    """
+    proc = node.proc
+    assert proc is not None, "service has no process handle; was it started?"
+    wait_until(
+        lambda: proc.poll() is not None,
+        timeout=timeout,
+        error_msg="bridge node did not exit",
+    )
+    return proc.returncode


### PR DESCRIPTION
## Description

Both BDK wallets were created without persistence, so every start rescanned from genesis. They now persist through BDK's SQLite persister, one file per wallet under the new required `operator_wallet.data_dir`, committing every 2000 blocks during sync. A store that fails to open or belongs to another network or key aborts startup and is left untouched.

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New or updated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
